### PR TITLE
Fix for @Param() decorator

### DIFF
--- a/src/core/router/router-execution-context.ts
+++ b/src/core/router/router-execution-context.ts
@@ -35,12 +35,12 @@ export class RouterExecutionContext {
         private readonly interceptorsContextCreator: InterceptorsContextCreator,
         private readonly interceptorsConsumer: InterceptorsConsumer) {}
 
-    public create(instance: Controller, callback: (...args) => any, module: string, requestMethod: RequestMethod) {
-        const metadata = this.reflectCallbackMetadata(instance, callback) || {};
+    public create(instance: Controller, callback: (...args) => any, methodName: string, module: string, requestMethod: RequestMethod) {
+        const metadata = this.reflectCallbackMetadata(instance, methodName) || {};
         const keys = Object.keys(metadata);
         const argsLength = this.getArgumentsLength(keys, metadata);
         const pipes = this.pipesContextCreator.create(instance, callback);
-        const paramtypes = this.reflectCallbackParamtypes(instance, callback);
+        const paramtypes = this.reflectCallbackParamtypes(instance, methodName);
         const guards = this.guardsContextCreator.create(instance, callback, module);
         const interceptors = this.interceptorsContextCreator.create(instance, callback, module);
         const httpCode = this.reflectHttpStatusCode(callback);
@@ -79,12 +79,12 @@ export class RouterExecutionContext {
         return Number(keyPair[0]);
     }
 
-    public reflectCallbackMetadata(instance: Controller, callback: (...args) => any): RouteParamsMetadata {
-        return Reflect.getMetadata(ROUTE_ARGS_METADATA, instance, callback.name);
+    public reflectCallbackMetadata(instance: Controller, methodName: string): RouteParamsMetadata {
+        return Reflect.getMetadata(ROUTE_ARGS_METADATA, instance, methodName);
     }
 
-    public reflectCallbackParamtypes(instance: Controller, callback: (...args) => any): any[] {
-        return Reflect.getMetadata(PARAMTYPES_METADATA, instance, callback.name);
+    public reflectCallbackParamtypes(instance: Controller, methodName: string): any[] {
+        return Reflect.getMetadata(PARAMTYPES_METADATA, instance, methodName);
     }
 
     public reflectHttpStatusCode(callback: (...args) => any): number {

--- a/src/core/router/router-explorer.ts
+++ b/src/core/router/router-explorer.ts
@@ -75,9 +75,10 @@ export class ExpressRouterExplorer implements RouterExplorer {
 
         const requestMethod: RequestMethod = Reflect.getMetadata(METHOD_METADATA, targetCallback);
         return {
-            targetCallback,
-            requestMethod,
             path: this.validateRoutePath(routePath),
+            requestMethod,
+            targetCallback,
+            methodName,
         };
     }
 
@@ -100,15 +101,15 @@ export class ExpressRouterExplorer implements RouterExplorer {
         instance: Controller,
         module: string) {
 
-        const { path, requestMethod, targetCallback } = pathProperties;
+        const { path, requestMethod, targetCallback, methodName } = pathProperties;
 
         const routerMethod = this.routerMethodFactory.get(router, requestMethod).bind(router);
-        const proxy = this.createCallbackProxy(instance, targetCallback, module, requestMethod);
+        const proxy = this.createCallbackProxy(instance, targetCallback, methodName, module, requestMethod);
         routerMethod(path, proxy);
     }
 
-    private createCallbackProxy(instance: Controller, callback: RouterProxyCallback, module: string, requestMethod) {
-        const executionContext = this.executionContextCreator.create(instance, callback, module, requestMethod);
+    private createCallbackProxy(instance: Controller, callback: RouterProxyCallback, methodName: string, module: string, requestMethod) {
+        const executionContext = this.executionContextCreator.create(instance, callback, methodName, module, requestMethod);
         const exceptionFilter = this.exceptionsFilter.create(instance, callback);
 
         return this.routerProxy.createProxy(executionContext, exceptionFilter);
@@ -131,4 +132,5 @@ export interface RoutePathProperties {
     path: string;
     requestMethod: RequestMethod;
     targetCallback: RouterProxyCallback;
+    methodName: string;
 }

--- a/src/core/test/router/router-execution-context.spec.ts
+++ b/src/core/test/router/router-execution-context.spec.ts
@@ -57,7 +57,7 @@ describe('RouterExecutionContext', () => {
             it('should call "exchangeKeysForValues" with expected arguments', (done) => {
                 const keys = Object.keys(metadata);
 
-                contextCreator.create({ foo: 'bar' }, callback as any, '', 0);
+                contextCreator.create({ foo: 'bar' }, callback as any, '', '', 0);
                 expect(exchangeKeysForValuesSpy.called).to.be.true;
                 expect(
                     exchangeKeysForValuesSpy.calledWith(keys, metadata),
@@ -70,7 +70,7 @@ describe('RouterExecutionContext', () => {
 
                 beforeEach(() => {
                     instance = { foo: 'bar' };
-                    proxyContext = contextCreator.create(instance, callback as any, '', 0);
+                    proxyContext = contextCreator.create(instance, callback as any, '', '', 0);
                 });
                 it('should be a function', () => {
                     expect(proxyContext).to.be.a('function');
@@ -109,7 +109,7 @@ describe('RouterExecutionContext', () => {
         }
         it('should returns ROUTE_ARGS_METADATA callback metadata', () => {
             const instance = new TestController();
-            const metadata = contextCreator.reflectCallbackMetadata(instance, instance.callback);
+            const metadata = contextCreator.reflectCallbackMetadata(instance, 'callback');
             const expectedMetadata = {
                 [`${RouteParamtypes.REQUEST}:0`]: {
                     index: 0,


### PR DESCRIPTION
I was trying out the @Param() decorator with the latest code @nestjs/core@4.1.3 and found it wasn't working. Its not mentioned in your documentation at https://docs.nestjs.com/components but there is a reference to it in `cats.controller.ts` in the `01-cats-app` example:

```
  @Get(':id')
  findOne(@Param('id', new ParseIntPipe()) id) {
    // logic
  }
```

In any case, I tracked the issue down to code in `router-execution-context.ts` and `router-explorer.ts` where `callback.name` was not defined for the follow two ReflectMetadata calls: 

`return Reflect.getMetadata(ROUTE_ARGS_METADATA, instance, callback.name);`

and

`return Reflect.getMetadata(PARAMTYPES_METADATA, instance, callback.name);`.

This PR fixes it by passing the `methodName` from `router-explorer.ts` to the `create` function in `router-execution-context.ts` and down to these two calls which now look like:

`return Reflect.getMetadata(ROUTE_ARGS_METADATA, instance, methodName);`

and

`return Reflect.getMetadata(PARAMTYPES_METADATA, instance, methodName);`

This fixes the issue and my code which looks like the following now gets the `:id` parameter string from the route:

```
@Controller('foo')
export class FooController {
  @Get('get/:id')
  get(@Param('id') id: string): any {
    console.log(id);
    return null;
  }
}
```


