### PR TITLE
fix(@nestjs/core) application context, support symbol

### DIFF
--- a/src/core/nest-application-context.ts
+++ b/src/core/nest-application-context.ts
@@ -26,11 +26,11 @@ export class NestApplicationContext implements INestApplicationContext {
           : null;
     }
 
-    public get<T>(metatypeOrToken: Metatype<T> | string): T {
+    public get<T>(metatypeOrToken: Metatype<T> | string | symbol): T {
         return this.findInstanceByPrototypeOrToken<T>(metatypeOrToken);
     }
 
-    private findInstanceByPrototypeOrToken<T>(metatypeOrToken: Metatype<T> | string) {
+    private findInstanceByPrototypeOrToken<T>(metatypeOrToken: Metatype<T> | string | symbol) {
         const dependencies = new Map([
             ...this.contextModule.components,
             ...this.contextModule.routes,


### PR DESCRIPTION
Update application context to support retrieving a module using a symbol. The injector already supports the use of symbols when declaring modules for DI.