### PR TITLE
Fix: ECONNREFUSED killing TCP microservice

### DIFF
--- a/src/microservices/client/client-tcp.ts
+++ b/src/microservices/client/client-tcp.ts
@@ -26,6 +26,7 @@ export class ClientTCP extends ClientProxy {
 
     public init(): Promise<{}> {
         this.socket = this.createSocket();
+        this.socket.on(ERROR_EVENT, (err) => this.logger.error(err));
         return new Promise((resolve) => {
              this.socket.on(CONNECT_EVENT, () => {
                  this.isConnected = true;
@@ -72,7 +73,6 @@ export class ClientTCP extends ClientProxy {
     }
 
     public bindEvents(socket) {
-        socket.on(ERROR_EVENT, (err) => this.logger.error(err));
         socket.on(CLOSE_EVENT, () => {
             this.isConnected = false;
             this.socket = null;


### PR DESCRIPTION
Connecting to a microservice which is not up via TCP caused an ECONNREFUSED error bying thrown, which bubbled up and killed the nodejs process. see: #288 

I suggest the following fix: attaching the listener for ERROR_EVENT earlier.  
Is the suggested fix ok or should the listener be attached inside the promise's executor?