### PR TITLE
Removed unused import

### DIFF
--- a/examples/13-mongo-typeorm/src/modules/photo/photo.entity.ts
+++ b/examples/13-mongo-typeorm/src/modules/photo/photo.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, ObjectIdColumn, ObjectID } from 'typeorm';
+import { Entity, Column, ObjectIdColumn, ObjectID } from 'typeorm';
 
 @Entity()
 export class Photo {


### PR DESCRIPTION
`PrimaryGeneratedColumn` is not  being used in `photo.entity.ts` because the example uses mongodb.