### PR TITLE
fix(core): support symbols

### DIFF
--- a/src/common/utils/shared.utils.ts
+++ b/src/common/utils/shared.utils.ts
@@ -8,3 +8,4 @@ export const validatePath = (path): string =>
   path.charAt(0) !== '/' ? '/' + path : path;
 export const isNil = (obj): boolean => isUndefined(obj) || obj === null;
 export const isEmpty = (array): boolean => !(array && array.length > 0);
+export const isSymbol = (fn): boolean => typeof fn === 'symbol';

--- a/src/core/injector/module.ts
+++ b/src/core/injector/module.ts
@@ -9,6 +9,7 @@ import {
   isNil,
   isUndefined,
   isString,
+  isSymbol,
 } from '@nestjs/common/utils/shared.utils';
 import { RuntimeException } from '../errors/exceptions/runtime.exception';
 import { Reflector } from '../services/reflector.service';
@@ -255,7 +256,7 @@ export class Module {
     exportedComponent: CustomFactory | CustomValue | CustomClass,
   ) {
     const provide = exportedComponent.provide;
-    if (isString(provide)) {
+    if (isString(provide) || isSymbol(provide)) {
       return this._exports.add(provide);
     }
     this._exports.add(provide.name);

--- a/src/core/test/injector/module.spec.ts
+++ b/src/core/test/injector/module.spec.ts
@@ -222,6 +222,16 @@ describe('Module', () => {
       module.addExportedComponent({ provide: 'test' } as any);
       expect(addCustomExportedComponentSpy.called).to.be.true;
     });
+    it('should support symbols', () => {
+      const addCustomExportedComponentSpy = sinon.spy(
+        module,
+        'addCustomExportedComponent',
+      );
+      const symb = Symbol('test');
+      module.addExportedComponent({ provide: symb } as any);
+      expect(addCustomExportedComponentSpy.called).to.be.true;
+      expect((module as any)._exports.has(symb)).to.be.true;
+    });
   });
 
   describe('replace', () => {


### PR DESCRIPTION
Support for the use of symbols as the `provide` in module exports was
broken as a result of
`https://github.com/nestjs/nest/compare/v4.5.5...master#diff-f52585e35398d156c2cd41f3863d4c52R184`.
This bugfix corrects the issue by updating the changed code to test for
and support symbols.
  