### PR TITLE
disallow non-integer vals in parseIntPipe

### DIFF
--- a/src/common/pipes/parse-int.pipe.ts
+++ b/src/common/pipes/parse-int.pipe.ts
@@ -5,8 +5,8 @@ import { Pipe, ArgumentMetadata } from '../index';
 @Pipe()
 export class ParseIntPipe implements PipeTransform<string> {
   public async transform(value: string, metadata: ArgumentMetadata) {
-    const val = parseInt(value, 10);
-    if (isNaN(val)) {
+    const val = +value;
+    if (isNaN(val) || !Number.isInteger(val)) {
       throw new BadRequestException('Validation failed');
     }
     return val;

--- a/src/common/pipes/parse-int.pipe.ts
+++ b/src/common/pipes/parse-int.pipe.ts
@@ -5,10 +5,14 @@ import { Pipe, ArgumentMetadata } from '../index';
 @Pipe()
 export class ParseIntPipe implements PipeTransform<string> {
   public async transform(value: string, metadata: ArgumentMetadata) {
-    const val = +value;
-    if (isNaN(val) || !Number.isInteger(val)) {
-      throw new BadRequestException('Validation failed');
+    if (value.trim().length === value.length) {
+      const num = +value;
+
+      if (Number.isInteger(num)) {
+        return num;
+      }
     }
-    return val;
+
+    throw new BadRequestException('Validation failed');
   }
 }


### PR DESCRIPTION
javascript's implementation annoyingly allows values like `1das` or `12.32`