### PR TITLE
feature(@nestjs) Enable inheritance for controllers

### DIFF
--- a/src/common/test/decorators/route-params.decorator.spec.ts
+++ b/src/common/test/decorators/route-params.decorator.spec.ts
@@ -182,3 +182,27 @@ describe('@Patch', () => {
     expect(path).to.be.eql('/');
   });
 });
+
+
+describe('Inheritance', () => {
+  const requestPath = 'test';
+  const requestProps = {
+    path: requestPath,
+    method: RequestMethod.GET,
+  };
+
+  it('should enhance subclass with expected request metadata', () => {
+    class Parent {
+      @Get(requestPath)
+      public static test() {}
+    }
+
+    class Test extends Parent {}
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+
+    expect(method).to.be.eql(requestProps.method);
+    expect(path).to.be.eql(requestPath);
+  });
+});

--- a/src/core/metadata-scanner.ts
+++ b/src/core/metadata-scanner.ts
@@ -12,16 +12,27 @@ export class MetadataScanner {
     prototype,
     callback: (name: string) => R,
   ): R[] {
-    return iterate(Object.getOwnPropertyNames(prototype))
-      .filter(method => {
-        const descriptor = Object.getOwnPropertyDescriptor(prototype, method);
-        if (descriptor.set || descriptor.get) {
-          return false;
-        }
-        return !isConstructor(method) && isFunction(prototype[method]);
-      })
+    return iterate(this.getAllFilteredMethodNames_(prototype))
       .map(callback)
       .filter(metadata => !isNil(metadata))
       .toArray();
+  }
+
+  private getAllFilteredMethodNames_(prototype): string[] {
+    let methods: string[] = [];
+    do {
+      iterate(Object.getOwnPropertyNames(prototype))
+      .filter(prop => {
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, prop);
+        if (descriptor.set || descriptor.get) {
+          return false;
+        }
+        return !isConstructor(prop) && isFunction(prototype[prop]);
+      })
+      .forEach(method => {
+        methods.push(method);
+      });
+    } while ((prototype = Reflect.getPrototypeOf(prototype)) && prototype != Object.prototype)
+    return methods;
   }
 }

--- a/src/core/test/metadata-scanner.spec.ts
+++ b/src/core/test/metadata-scanner.spec.ts
@@ -7,8 +7,20 @@ describe('MetadataScanner', () => {
     scanner = new MetadataScanner();
   });
   describe('scanFromPrototype', () => {
-    class Test {
+    class Parent {
       constructor() {}
+      public testParent() {}
+      public testParent2() {}
+      get propParent() {
+        return '';
+      }
+      set valParent(value) {}
+    }
+    
+    class Test extends Parent {
+      constructor() {
+        super();
+      }
       get prop() {
         return '';
       }
@@ -16,13 +28,14 @@ describe('MetadataScanner', () => {
       public test() {}
       public test2() {}
     }
+
     it('should returns only methods', () => {
       const methods = scanner.scanFromPrototype(
         new Test(),
         Test.prototype,
         a => a,
       );
-      expect(methods).to.eql(['test', 'test2']);
+      expect(methods).to.eql(['test', 'test2', 'testParent', 'testParent2']);
     });
   });
 });


### PR DESCRIPTION
Changes to metadataScanner to enable scanning of Parent classes.
Linked to issue #228 