### PR TITLE
fix(core): Make nest compatible with fuse-box bundler

### DIFF
--- a/src/core/middlewares/utils.ts
+++ b/src/core/middlewares/utils.ts
@@ -1,15 +1,15 @@
 import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { Metatype } from '@nestjs/common/interfaces';
 
-export const filterMiddlewares = middlewares => {
+export function filterMiddlewares(middlewares) {
   return []
     .concat(middlewares)
     .filter(isFunction)
     .map(middleware => mapToClass(middleware));
 };
 
-export const mapToClass = middleware => {
-  if (this.isClass(middleware)) {
+export function mapToClass(middleware) {
+  if (isClass(middleware)) {
     return middleware;
   }
   return assignToken(
@@ -20,12 +20,16 @@ export const mapToClass = middleware => {
   );
 };
 
-export const isClass = middleware => {
+export function isClass(middleware) {
   return middleware.toString().substring(0, 5) === 'class';
 };
 
-export const assignToken = (metatype): Metatype<any> => {
-  this.id = this.id || 1;
-  Object.defineProperty(metatype, 'name', { value: ++this.id });
-  return metatype;
-};
+function assignTokenFactory() {
+  let id = 1;
+  return (metatype): Metatype<any> => {
+    Object.defineProperty(metatype, 'name', { value: ++id });
+    return metatype;
+  }
+}
+
+export const assignToken = assignTokenFactory();

--- a/src/core/test/middlewares/utils.spec.ts
+++ b/src/core/test/middlewares/utils.spec.ts
@@ -18,6 +18,8 @@ describe('middleware utils', () => {
     });
     it('should returns filtered middlewares', () => {
       expect(filterMiddlewares(middlewares)).to.have.length(2);
+      expect(middlewares[0].name).to.eq('Test');
+      expect(middlewares[1].name).to.eq('fnMiddleware');
     });
   });
   describe('mapToClass', () => {
@@ -25,21 +27,25 @@ describe('middleware utils', () => {
       it('should returns identity', () => {
         const type = mapToClass(Test);
         expect(type).to.eql(Test);
+        expect(type.name).to.eq('Test');
       });
     });
     describe('when middleware is a function', () => {
       it('should returns metatype', () => {
         const metatype = mapToClass(fnMiddleware);
         expect(metatype).to.not.eql(fnMiddleware);
+        expect(metatype.name).to.eq(4);
       });
       it('should define `resolve` method', () => {
         const metatype = mapToClass(fnMiddleware);
         expect(new metatype().resolve).to.exist;
+        expect(metatype.name).to.eq(5);
       });
       it('should encapsulate function', () => {
         const spy = sinon.spy();
         const metatype = mapToClass(spy);
         new metatype().resolve()();
+        expect(metatype.name).to.eq(6);
         expect(spy.called).to.be.true;
       });
     });
@@ -61,6 +67,7 @@ describe('middleware utils', () => {
       const anonymousType = class {};
       assignToken(anonymousType);
       expect(anonymousType.name).to.exist;
+      expect(anonymousType.name).to.eq(2);
     });
   });
 });


### PR DESCRIPTION
In order to package a nest application into a binary, tools like nexe use a bundler. Unfortunately bundlers don't always interpret the 'this' keyword appropriately. This removes the use of 'this' to avoid confusing a bundler, and adds assertions to the existing test suite to ensure the behavior remains the same.

This PR will fix #391 