### PR TITLE
Allow providing server port as a string

### DIFF
--- a/src/common/interfaces/nest-application.interface.ts
+++ b/src/common/interfaces/nest-application.interface.ts
@@ -44,8 +44,8 @@ export interface INestApplication extends INestApplicationContext {
    * @param  {Function} callback Optional callback
    * @returns Promise
    */
-  listen(port: number, callback?: () => void): Promise<any>;
-  listen(port: number, hostname: string, callback?: () => void): Promise<any>;
+  listen(port: number | string, callback?: () => void): Promise<any>;
+  listen(port: number | string, hostname: string, callback?: () => void): Promise<any>;
 
   /**
    * Starts the application and can be awaited.
@@ -54,7 +54,7 @@ export interface INestApplication extends INestApplicationContext {
    * @param  {string} hostname (optional)
    * @returns Promise
    */
-  listenAsync(port: number, hostname?: string): Promise<any>;
+  listenAsync(port: number | string, hostname?: string): Promise<any>;
 
   /**
    * Setups the prefix for the every HTTP route path


### PR DESCRIPTION
Microsoft IIS uses strings such as "\\.\pipe\d226d7b0-64a0-4d04-96d4-a75e1278b7a9" instead of port numbers. When you create nodejs app on Azure this is problematic as nestjs would only expect a number. 

ps.
Thanks for an amazing framework!

Best regards,
Przemek