### PR TITLE
fix(@nest/core): fix `express.enable()` typo

### DIFF
--- a/src/core/nest-application.ts
+++ b/src/core/nest-application.ts
@@ -198,7 +198,7 @@ export class NestApplication extends NestApplicationContext
   }
 
   public enable(...args) {
-    this.express.disable(...args);
+    this.express.enable(...args);
   }
 
   public async listen(port: number | string, callback?: () => void);


### PR DESCRIPTION
There is was a Typo error of [app.enable(name)](http://expressjs.com/en/api.html#app.enable) in the public api