### PR TITLE
feat(microservices): add kafka consumer CustomTransportStrategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "fast-safe-stringify": "^1.2.0",
     "iterare": "0.0.8",
     "json-socket": "^0.2.1",
+    "kafka-node": "^2.4.1",
     "multer": "^1.3.0",
     "opencollective": "^1.0.3",
     "optional": "^0.1.4",

--- a/src/microservices/server/server-kafka.ts
+++ b/src/microservices/server/server-kafka.ts
@@ -1,0 +1,48 @@
+import { Client, Consumer } from 'kafka-node';
+import { Server, CustomTransportStrategy, MicroserviceConfiguration } from '@nestjs/microservices';
+
+const DEFAULT_HOST = 'localhost:2181';
+const MESSAGE_EVENT = 'message';
+const ERROR_EVENT = 'error';
+
+export class ServerKafka extends Server implements CustomTransportStrategy {
+    private readonly host: string;
+    private consumer: Consumer;
+    private topics: object[];
+
+    constructor(config: MicroserviceConfiguration) {
+        super();
+        this.host = config.host || DEFAULT_HOST;
+    }
+
+    public listen(callback: () => void) {
+        this.start(callback);
+    }
+
+    public start(callback?: () => void) {
+        this.topics = Object.keys(this.getHandlers())
+            .map(pattern => JSON.parse(pattern))
+            .filter(pattern => pattern.topic);
+
+        this.consumer = new Consumer(new Client(this.host), this.topics, { autoCommit: false });
+        this.consumer.on(MESSAGE_EVENT, this.handleMessageEvent.bind(this));
+        this.consumer.on(ERROR_EVENT, this.handleErrorEvent.bind(this));
+
+        callback();
+    }
+
+    public close() {
+        this.consumer.close(() => {});
+    }
+
+    private async handleMessageEvent(message) {
+        const pattern: string = JSON.stringify({topic: message.topic});
+        const handler: any = this.messageHandlers[pattern];
+        await handler(JSON.parse(message.value));
+        this.consumer.commit(message, () => {});
+    }
+
+    private handleErrorEvent(err) {
+        this.logger.error(err);
+    }
+}


### PR DESCRIPTION
Support for a potentially common use-case of microservice controllers consuming topic messages off of kafka.

Controller method is decorated with @MessagePattern({ topic: <topicName> }) and gets routed JSON encoded message to the topic as javascript object. Messages are committed to kafka upon successful handling of the message.