### PR TITLE
fix(FileInterceptor): throw multer errors #437

### DIFF
--- a/src/common/interceptors/file.interceptor.ts
+++ b/src/common/interceptors/file.interceptor.ts
@@ -13,9 +13,12 @@ export function FileInterceptor(fieldName: string, options?: MulterOptions) {
       context,
       stream$: Observable<any>,
     ): Promise<Observable<any>> {
-      await new Promise((resolve, reject) =>
+      const fileOrError = await new Promise((resolve, reject) =>
         this.upload.single(fieldName)(request, request.res, resolve),
       );
+      if (fileOrError instanceof Error) {
+        throw fileOrError;
+      }
       return stream$;
     }
   });

--- a/src/common/interceptors/files.interceptor.ts
+++ b/src/common/interceptors/files.interceptor.ts
@@ -12,9 +12,12 @@ export function FilesInterceptor(fieldName: string, maxCount?: number, options?:
       context,
       stream$: Observable<any>,
     ): Promise<Observable<any>> {
-      await new Promise((resolve, reject) =>
+      const filesOrError = await new Promise((resolve, reject) =>
         this.upload.array(fieldName, maxCount)(request, request.res, resolve),
       );
+      if (filesOrError instanceof Error) {
+        throw filesOrError;
+      }
       return stream$;
     }
   };


### PR DESCRIPTION
Fix for https://github.com/nestjs/nest/issues/437

Multer exceptions never got thrown, that's why they weren't visible.

@kamilmysliwiec As errors aren't instace of `HttpException` default filter won't catch them. Is that okey?