### PR TITLE
fix(common): expose http module and service

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -7,6 +7,7 @@
 
 export * from './decorators';
 export * from './enums';
+export * from './http';
 export {
   NestModule,
   INestApplication,


### PR DESCRIPTION
Exporting the HTTP module and service in common so it is available in the main import.