### PR TITLE
fix(common): making http service methods generic

### DIFF
--- a/src/common/http/http.service.ts
+++ b/src/common/http/http.service.ts
@@ -18,41 +18,41 @@ export class HttpService {
     return Observable.fromPromise(axios.get<T>(url, config));
   }
 
-  delete(
+  delete<T = any>(
     url: string,
     config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<any>> {
+  ): Observable<AxiosResponse<T>> {
     return Observable.fromPromise(axios.delete(url, config));
   }
 
-  head(
+  head<T = any>(
     url: string,
     config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<any>> {
+  ): Observable<AxiosResponse<T>> {
     return Observable.fromPromise(axios.head(url, config));
   }
 
-  post(
+  post<T = any>(
     url: string,
     data?,
     config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<any>> {
+  ): Observable<AxiosResponse<T>> {
     return Observable.fromPromise(axios.post(url, data, config));
   }
 
-  put(
+  put<T = any>(
     url: string,
     data?,
     config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<any>> {
+  ): Observable<AxiosResponse<T>> {
     return Observable.fromPromise(axios.post(url, data, config));
   }
 
-  patch(
+  patch<T = any>(
     url: string,
     data?,
     config?: AxiosRequestConfig,
-  ): Observable<AxiosResponse<any>> {
+  ): Observable<AxiosResponse<T>> {
     return Observable.fromPromise(axios.post(url, data, config));
   }
 }


### PR DESCRIPTION
Currently, on the `request` method of the HttpService is generic. This PR makes all methods of the HttpService generic.