### PR TITLE
fix(release): second argument should be optional

### DIFF
--- a/lib/common/exceptions/http.exception.d.ts
+++ b/lib/common/exceptions/http.exception.d.ts
@@ -16,7 +16,7 @@ export declare class HttpException extends Error {
      * statusCode: X
      * ```
      */
-    constructor(response: string | object, status: number);
+    constructor(response: string | object, status?: number);
     getResponse(): string | object;
     getStatus(): number;
 }


### PR DESCRIPTION
As [docs](https://docs.nestjs.com/exception-filters) says, HttpException can only one argument when response (first argument) is object.