### PR TITLE
Allow Compatible Subscribe Decorators To Contain Extra Data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/examples/02-gateways/src/common/adapters/ws-adapter.ts
+++ b/examples/02-gateways/src/common/adapters/ws-adapter.ts
@@ -9,6 +9,7 @@ import 'rxjs/add/operator/filter';
 
 export class WsAdapter implements WebSocketAdapter {
   public create(port: number) {
+    console.log(port);
     return new WebSocket.Server({ port });
   }
 

--- a/examples/02-gateways/src/events/events.gateway.ts
+++ b/examples/02-gateways/src/events/events.gateway.ts
@@ -8,12 +8,13 @@ import {
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/from';
 import 'rxjs/add/operator/map';
+import { SubscribeWsMessage } from '../common/adapters/subscribe-ws-message.decorator';
 
-@WebSocketGateway()
+@WebSocketGateway({ port: 8090 })
 export class EventsGateway {
   @WebSocketServer() server;
 
-  @SubscribeMessage('events')
+  @SubscribeWsMessage('events', 'channel')
   onEvent(client, data): Observable<WsResponse<number>> {
     const event = 'events';
     const response = [1, 2, 3];

--- a/examples/02-gateways/src/main.ts
+++ b/examples/02-gateways/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { ApplicationModule } from './app.module';
+import { WsAdapter } from './common/adapters/ws-adapter';
 
 async function bootstrap() {
   const app = await NestFactory.create(ApplicationModule);
+  app.useWebSocketAdapter(new WsAdapter());
   await app.listen(3000);
 }
 bootstrap();

--- a/lib/websockets/gateway-metadata-explorer.d.ts
+++ b/lib/websockets/gateway-metadata-explorer.d.ts
@@ -11,4 +11,7 @@ export declare class GatewayMetadataExplorer {
 export interface MessageMappingProperties {
     message: string;
     callback: (...args) => Observable<any> | Promise<any> | void;
+
+    // allow any number of additional properties for metadata
+    [key: string]: any;
 }

--- a/lib/websockets/gateway-metadata-explorer.js
+++ b/lib/websockets/gateway-metadata-explorer.js
@@ -17,10 +17,16 @@ class GatewayMetadataExplorer {
             return null;
         }
         const message = Reflect.getMetadata(constants_1.MESSAGE_METADATA, callback);
-        return {
+        const otherKeys = Reflect.getOwnMetadataKeys(callback)
+            .filter(key => key !== constants_1.MESSAGE_METADATA && key !== constants_1.MESSAGE_MAPPING_METADATA);
+        const result = {
             callback,
-            message,
+            message
         };
+        for (const key of otherKeys) {
+            result[key] = Reflect.getMetadata(key, callback);
+        }
+        return result;
     }
     *scanForServerHooks(instance) {
         for (const propertyKey in instance) {

--- a/lib/websockets/web-sockets-controller.js
+++ b/lib/websockets/web-sockets-controller.js
@@ -38,10 +38,13 @@ class WebSocketsController {
     }
     subscribeObservableServer(instance, namespace, port, module) {
         const plainMessageHandlers = this.metadataExplorer.explore(instance);
-        const messageHandlers = plainMessageHandlers.map(({ callback, message }) => ({
-            message,
-            callback: this.contextCreator.create(instance, callback, module),
-        }));
+        const messageHandlers = plainMessageHandlers.map((handler) => {
+            const { callback } = handler;
+            const result = Object.assign({}, handler, {
+                callback: this.contextCreator.create(instance, callback, module)
+            });
+            return result;
+        });
         const observableServer = this.socketServerProvider.scanForSocketServer(namespace, port);
         this.injectMiddlewares(observableServer, instance, module);
         this.hookServerToProperties(instance, observableServer.server);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1816,12 +1816,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-      "dev": true
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -3214,12 +3208,6 @@
         "samsam": "1.3.0"
       }
     },
-    "formidable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.0.tgz",
-      "integrity": "sha512-hr9aT30rAi7kf8Q2aaTpSP7xGMhlJ+MdrUDVZs3rxbD3L/K46A86s2VY7qC2D2kGYGBtiT/3j6wTx1eeUq5xAQ==",
-      "dev": true
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -3270,7 +3258,7 @@
     },
     "fsevents": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "resolved": "http://192.168.228.42:5000/fsevents/-/fsevents-1.1.3.tgz",
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
@@ -4669,13 +4657,13 @@
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "resolved": "http://192.168.228.42:5000/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "http://192.168.228.42:5000/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -4687,13 +4675,13 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://192.168.228.42:5000/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "http://192.168.228.42:5000/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -4763,7 +4751,7 @@
     },
     "gulp-diff": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-diff/-/gulp-diff-1.0.0.tgz",
+      "resolved": "http://192.168.228.42:5000/gulp-diff/-/gulp-diff-1.0.0.tgz",
       "integrity": "sha1-EBsjcS3WsQe9B9BauI6jrEhf7Xc=",
       "dev": true,
       "requires": {
@@ -4776,7 +4764,7 @@
       "dependencies": {
         "diff": {
           "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "resolved": "http://192.168.228.42:5000/diff/-/diff-2.2.3.tgz",
           "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
           "dev": true
         }
@@ -6999,7 +6987,7 @@
     },
     "nan": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "resolved": "http://192.168.228.42:5000/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
@@ -9019,7 +9007,7 @@
     },
     "pkginfo": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "resolved": "http://192.168.228.42:5000/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
       "dev": true
     },
@@ -10189,7 +10177,7 @@
     },
     "stream-combiner2": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "resolved": "http://192.168.228.42:5000/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
       "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
       "dev": true,
       "requires": {
@@ -10199,7 +10187,7 @@
       "dependencies": {
         "duplexer2": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "resolved": "http://192.168.228.42:5000/duplexer2/-/duplexer2-0.1.4.tgz",
           "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
           "dev": true,
           "requires": {
@@ -10216,7 +10204,7 @@
     },
     "stream-equal": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/stream-equal/-/stream-equal-0.1.6.tgz",
+      "resolved": "http://192.168.228.42:5000/stream-equal/-/stream-equal-0.1.6.tgz",
       "integrity": "sha1-zFIvqzhRYBLk1O5HUTsUe3I1kBk=",
       "dev": true
     },
@@ -10354,71 +10342,6 @@
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
           "dev": true
         }
-      }
-    },
-    "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.2",
-        "formidable": "1.2.0",
-        "methods": "1.1.2",
-        "mime": "1.4.1",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "form-data": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.17"
-          }
-        },
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        }
-      }
-    },
-    "supertest": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
-      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
-      "dev": true,
-      "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.2"
       }
     },
     "supports-color": {

--- a/src/websockets/gateway-metadata-explorer.ts
+++ b/src/websockets/gateway-metadata-explorer.ts
@@ -70,4 +70,7 @@ export class GatewayMetadataExplorer {
 export interface MessageMappingProperties {
   message: string;
   callback: (...args) => Observable<any> | Promise<any> | void;
+
+  // allow any number of additional properties for metadata
+  [key: string]: any;
 }

--- a/src/websockets/gateway-metadata-explorer.ts
+++ b/src/websockets/gateway-metadata-explorer.ts
@@ -35,10 +35,19 @@ export class GatewayMetadataExplorer {
       return null;
     }
     const message = Reflect.getMetadata(MESSAGE_METADATA, callback);
-    return {
+    const otherKeys = Reflect.getOwnMetadataKeys(callback)
+                        .filter(key => key !== MESSAGE_METADATA && key !== MESSAGE_MAPPING_METADATA);
+
+    const result = {
       callback,
-      message,
+      message
     };
+
+    for (const key of otherKeys) {
+      result[key] = Reflect.getMetadata(key, callback);
+    }
+
+    return result;
   }
 
   public *scanForServerHooks(instance: NestGateway): IterableIterator<string> {

--- a/src/websockets/test/fixtures/extra-message.decorator.ts
+++ b/src/websockets/test/fixtures/extra-message.decorator.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '@nestjs/websockets/constants';
+import { isObject, isUndefined } from '@nestjs/common/utils/shared.utils';
+
+export const ExtraMessage = (
+  message?: { value: string } | string,
+  extra?: { value: string } | string
+): MethodDecorator => {
+  return (target, key, descriptor: PropertyDescriptor) => {
+    Reflect.defineMetadata(MESSAGE_MAPPING_METADATA, true, descriptor.value);
+    Reflect.defineMetadata(MESSAGE_METADATA, message, descriptor.value);
+    Reflect.defineMetadata('extra', extra, descriptor.value);
+    return descriptor;
+  };
+};

--- a/src/websockets/test/gateway-metadata-explorer.spec.ts
+++ b/src/websockets/test/gateway-metadata-explorer.spec.ts
@@ -5,10 +5,12 @@ import { WebSocketServer } from '../utils/gateway-server.decorator';
 import { SubscribeMessage } from '../utils/subscribe-message.decorator';
 import { GatewayMetadataExplorer } from '../gateway-metadata-explorer';
 import { MetadataScanner } from '../../core/metadata-scanner';
+import { ExtraMessage } from './fixtures/extra-message.decorator';
 
 describe('GatewayMetadataExplorer', () => {
   const message = 'test';
   const secMessage = 'test2';
+  const extra = 'hotness';
 
   @WebSocketGateway()
   class Test {
@@ -27,6 +29,9 @@ describe('GatewayMetadataExplorer', () => {
 
     @SubscribeMessage({ value: secMessage })
     public testSec() {}
+
+    @ExtraMessage({ value: secMessage }, extra)
+    public testExtra() {}
 
     public noMessage() {}
   }
@@ -64,6 +69,12 @@ describe('GatewayMetadataExplorer', () => {
       const metadata = instance.exploreMethodMetadata(test, 'test');
       expect(metadata).to.have.keys(['callback', 'message']);
       expect(metadata.message).to.eql(message);
+    });
+    it(`should return extra metadata for compatible decorators`, () => {
+      const metadata = instance.exploreMethodMetadata(test, 'testExtra');
+      expect(metadata).to.have.keys(['callback', 'message', 'extra']);
+      expect(metadata.message).to.eql(message);
+      expect(metadata.extra).to.eql(extra);
     });
   });
   describe('scanForServerHooks', () => {

--- a/src/websockets/test/gateway-metadata-explorer.spec.ts
+++ b/src/websockets/test/gateway-metadata-explorer.spec.ts
@@ -30,7 +30,7 @@ describe('GatewayMetadataExplorer', () => {
     @SubscribeMessage({ value: secMessage })
     public testSec() {}
 
-    @ExtraMessage({ value: secMessage }, extra)
+    @ExtraMessage(message, extra)
     public testExtra() {}
 
     public noMessage() {}

--- a/src/websockets/web-sockets-controller.ts
+++ b/src/websockets/web-sockets-controller.ts
@@ -59,10 +59,14 @@ export class WebSocketsController {
   ) {
     const plainMessageHandlers = this.metadataExplorer.explore(instance);
     const messageHandlers = plainMessageHandlers.map(
-      ({ callback, message }) => ({
-        message,
-        callback: this.contextCreator.create(instance, callback, module),
-      }),
+      (handler) => {
+        const { callback } = handler;
+        const result = Object.assign({}, handler, {
+          callback: this.contextCreator.create(instance, callback, module)
+        });
+
+        return result;
+      }
     );
     const observableServer = this.socketServerProvider.scanForSocketServer(
       namespace,


### PR DESCRIPTION
This PR proposes to add the ability for both the metadata explorer and the websocket controller to allow custom, compatible `SubscribeMessage` variant decorators additional metadata.

### Targeted Problem

Both `WebSocketsController` and `GatewayMetadataExplorer` are locked into a single-use paradigm: they assume that a subscribe decorator will never provide more data than the message name (aka type). This means that decorators which seek to extend functionality are locked into an inflexible paradigm, making extending such decorators with additional metadata extremely difficult.

### Use Case

We're currently developing a robust adapter for `ws`. The `ws` module differs from `socket.io` in several ways. One such way is the notable absence of "namespaces,"  which in `ws` can be handled simply by filtering and inspecting the `pathname` of a connected child `WebSocket`. 

Consider the following decorator:

```js
import 'reflect-metadata';
import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '@nestjs/websockets/constants';
import { isObject, isUndefined } from '@nestjs/common/utils/shared.utils';
const MESSAGE_CHANNEL = 'channel';

export const SubscribeWsMessage = (
  message?: string,
  channel?: string,
): MethodDecorator => {
  let metadata = isObject(message) ? message.value : message;
  metadata = isUndefined(metadata) ? '' : metadata;

  return (target, key, descriptor: PropertyDescriptor) => {
    Reflect.defineMetadata(MESSAGE_MAPPING_METADATA, true, descriptor.value);
    Reflect.defineMetadata(MESSAGE_METADATA, metadata, descriptor.value);
    Reflect.defineMetadata(MESSAGE_CHANNEL, channel || 'default', descriptor.value);
    return descriptor;
  };
};
```

It's compatible with `SubscribeMessage` and adds additional `channel` data. This data will then be used by `WsAdapter` to filter child `WebSocket` connections, and subsequently only make calls to the associated callback(s) if the client sending a message happens to be on a particular channel. 

The merits of our approach could surely be debated, there may even be better ways to go about this. However, the core issue remains - modifying the code to allow extra metadata to be passed along in `handlers` is a small cost for a large win for extensibility. 