### PR TITLE
chore(@nestjs/core) update debug dependency due to security flaw

### DIFF
--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -5,7 +5,7 @@
   "author": "Kamil Mysliwiec",
   "license": "MIT",
   "dependencies": {
-    "body-parser": "1.17.2",
+    "body-parser": "1.18.2",
     "cors": "2.8.4",
     "express": "4.16.2",
     "iterare": "0.0.8",


### PR DESCRIPTION
According to node security project
534 - Regular Expression Denial of Service
Vulnerable: <= 2.6.8 || >= 3.0.0 <= 3.0.1 - Patched: >= 2.6.9 < 3.0.0 || >= 3.1.0 - Path: @nestjs/core@4.6.4 > body-parser@1.17.2 > debug@2.6.7

How to fix
Upgrade to version 2.6.9 or greater if you are on the 2.6.x series or 3.1.0 or greater.