### PR TITLE
fix(core): Fix express adapter

### DIFF
--- a/packages/core/adapters/express-adapter.ts
+++ b/packages/core/adapters/express-adapter.ts
@@ -99,15 +99,15 @@ export class ExpressAdapter implements HttpServer {
   }
 
   enable(...args) {
-    return this.instance.set(...args);
+    return this.instance.enable(...args);
   }
 
   disable(...args) {
-    return this.instance.set(...args);
+    return this.instance.disable(...args);
   }
 
   engine(...args) {
-    return this.instance.set(...args);
+    return this.instance.engine(...args);
   }
 
   useStaticAssets(path: string, options: ServeStaticOptions) {


### PR DESCRIPTION
The express adapter is incorrectly calling `use` for a couple of methods. Fixed those to use the correct express methods.