### PR TITLE
Export the metatype interface

### DIFF
--- a/bundle/common/interfaces/index.d.ts
+++ b/bundle/common/interfaces/index.d.ts
@@ -28,3 +28,4 @@ export * from './http/http-server-factory.interface';
 export * from './features/arguments-host.interface';
 export * from './nest-express-application.interface';
 export * from './nest-fastify-application.interface';
+export * from './metatype.interface';


### PR DESCRIPTION
Minor issue the Metatype interface was not exported at it's root and the [CQRS module](https://github.com/nestjs/cqrs/blob/c6777de1bd5f4383853bd9b369a467e2094a6ca4/src/command-bus.ts#L7) refers to it.