### PR TITLE
chore: clone only the last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
       - "8"
       - "9"
+git:
+     depth: 5
 addons:
      firefox: "latest"
 before_script:


### PR DESCRIPTION
By default the last 50 commits are cloned. Cloning much less also decreases the time needed for each build.