### PR TITLE
chore: upgrade grpc

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "fastify": "^1.1.1",
     "fastify-formbody": "^2.0.0",
     "fastify-multipart": "^0.4.1",
-    "grpc": "^1.10.0",
+    "grpc": "^1.11.3",
     "iterare": "0.0.8",
     "json-socket": "^0.2.1",
     "mqtt": "^2.16.0",


### PR DESCRIPTION
Currently there is a bug with Nodejs 10 in grpc which is fixed in the latest release.

> npm ERR! grpc@1.10.0 install: `node-pre-gyp install --fallback-to-build --library=static_library`