### PR TITLE
feature(@nestjs/common) add file-fields interceptor

### DIFF
--- a/bundle/common/interceptors/file-fields.interceptor.d.ts
+++ b/bundle/common/interceptors/file-fields.interceptor.d.ts
@@ -1,0 +1,10 @@
+import * as multer from 'multer';
+import { Observable } from 'rxjs';
+import { MulterOptions } from '../interfaces/external/multer-options.interface';
+import { ExecutionContext } from '../interfaces';
+export declare function FileFieldsInterceptor(uploadFields: multer.Field[], options?: MulterOptions): {
+    new (): {
+        readonly upload: any;
+        intercept(context: ExecutionContext, call$: Observable<any>): Promise<Observable<any>>;
+    };
+};

--- a/bundle/common/interceptors/file-fields.interceptor.js
+++ b/bundle/common/interceptors/file-fields.interceptor.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const multer = require("multer");
+const multer_utils_1 = require("./multer/multer.utils");
+function FileFieldsInterceptor(uploadFields, options) {
+    const Interceptor = class {
+        constructor() {
+            this.upload = multer(options);
+        }
+        async intercept(context, call$) {
+            const ctx = context.switchToHttp();
+            await new Promise((resolve, reject) => this.upload.fields(uploadFields)(ctx.getRequest(), ctx.getResponse(), err => {
+                if (err) {
+                    const error = multer_utils_1.transformException(err);
+                    return reject(error);
+                }
+                resolve();
+            }));
+            return call$;
+        }
+    };
+    return Interceptor;
+}
+exports.FileFieldsInterceptor = FileFieldsInterceptor;

--- a/packages/common/interceptors/file-fields.interceptor.ts
+++ b/packages/common/interceptors/file-fields.interceptor.ts
@@ -1,0 +1,38 @@
+import * as multer from 'multer';
+import { NestInterceptor } from './../interfaces/features/nest-interceptor.interface';
+import { Observable } from 'rxjs';
+import { MulterOptions } from '../interfaces/external/multer-options.interface';
+import { transformException } from './multer/multer.utils';
+import { ExecutionContext } from '../interfaces';
+
+export function FileFieldsInterceptor(
+  uploadFields: multer.Field[],
+  options?: MulterOptions
+) {
+  const Interceptor = class implements NestInterceptor {
+    readonly upload = multer(options);
+
+    async intercept(
+      context: ExecutionContext,
+      call$: Observable<any>,
+    ): Promise<Observable<any>> {
+      const ctx = context.switchToHttp();
+
+      await new Promise((resolve, reject) =>
+        this.upload.fields(uploadFields)(
+          ctx.getRequest(),
+          ctx.getResponse(),
+          err => {
+            if (err) {
+              const error = transformException(err);
+              return reject(error);
+            }
+            resolve();
+          },
+        ),
+      );
+      return call$;
+    }
+  };
+  return Interceptor;
+}

--- a/packages/common/test/interceptors/file-fields.interceptor.spec.ts
+++ b/packages/common/test/interceptors/file-fields.interceptor.spec.ts
@@ -1,0 +1,57 @@
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+import { FileFieldsInterceptor } from './../../interceptors/file-fields.interceptor';
+import { Observable, of } from 'rxjs';
+import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context.host';
+
+describe('FileFieldsInterceptor', () => {
+  it('should return metatype with expected structure', async () => {
+    const targetClass = FileFieldsInterceptor([{name: 'file', maxCount: 1}, {name: 'anotherFile', maxCount: 1}]);
+    expect(targetClass.prototype.intercept).to.not.be.undefined;
+  });
+  describe('intercept', () => {
+    let stream$;
+    beforeEach(() => {
+      stream$ = of('test');
+    });
+    it('should call object with expected params', async () => {
+      const fieldName1 = 'file';
+      const maxCount1 = 1;
+      const fieldName2 = 'anotherFile';
+      const maxCount2 = 2;
+      const argument = [
+        {name: fieldName1, maxCount: maxCount1},
+        {name: fieldName2, maxCount: maxCount2}
+      ]
+      const target = new (FileFieldsInterceptor(argument))();
+
+      const callback = (req, res, next) => next();
+      const fieldsSpy = sinon
+        .stub((target as any).upload, 'fields')
+        .returns(callback);
+
+      await target.intercept(new ExecutionContextHost([]), stream$);
+
+      expect(fieldsSpy.called).to.be.true;
+      expect(fieldsSpy.calledWith(argument)).to.be.true;
+    });
+    it('should transform exception', async () => {
+      const fieldName1 = 'file';
+      const maxCount1 = 1;
+      const fieldName2 = 'anotherFile';
+      const maxCount2 = 2;
+      const argument = [
+        {name: fieldName1, maxCount: maxCount1},
+        {name: fieldName2, maxCount: maxCount2}
+      ]
+      const target = new (FileFieldsInterceptor(argument));
+      const err = {};
+      const callback = (req, res, next) => next(err);
+
+      (target as any).fields = {
+        array: () => callback,
+      };
+      expect(target.intercept(new ExecutionContextHost([]), stream$)).to.eventually.throw();
+    });
+  });
+});


### PR DESCRIPTION
usage will be like:
```import {FileFieldsInterceptor} from '@nest/common';

@UseInterceptors(FileFieldsInterceptor([{name: 'avatar', maxCount: 1},
{name: 'passport', maxCount: 1}]))
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
there are two interceptors FileInterceptor and FilesInterceptor based on multer.uploadSingle and multer.uploadArray. they allow uploading a single file, or multiple files with same field name. however if say there is a form with two different filed name to be uploaded. like "avatar" and "passport". currently there is not support for multer.fields which addresses this requirement.

Issue Number: #741 


## What is the new behavior?
```import {FileFieldsInterceptor} from '@nest/common';

@UseInterceptors(FileFieldsInterceptor([{name: 'avatar', maxCount: 1}, {name: 'passport', maxCount: 1}]))
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```