### PR TITLE
Feature/grpc cancellation

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -25,7 +25,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
     this.grpcClient = this.createClient();
   }
 
-  public getService<T = any>(name: string): T {
+  public getService<T extends {}>(name: keyof T): T {
     const { options } = this.options as GrpcOptions;
     if (!this.grpcClient[name]) {
       throw new InvalidGrpcServiceException();

--- a/packages/microservices/interfaces/client-grpc.interface.ts
+++ b/packages/microservices/interfaces/client-grpc.interface.ts
@@ -1,3 +1,3 @@
 export interface ClientGrpc {
-  getService<T = any>(name: string): T;
+  getService<T extends {}>(name: keyof T): T;
 }

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -149,12 +149,18 @@ describe('ServerGrpc', () => {
     });
     describe('on call', () => {
       it('should call native method', async () => {
-        const call = { write: sinon.spy(), end: sinon.spy() };
+        const call = {
+          write: sinon.spy(),
+          end: sinon.spy(),
+          addListener: sinon.spy(),
+          removeListener: sinon.spy(),
+        };
         const callback = sinon.spy();
         const native = sinon.spy();
 
         await server.createStreamServiceMethod(native)(call, callback);
         expect(native.called).to.be.true;
+        expect(call.addListener.calledWith('cancelled')).to.be.true;
       });
     });
   });

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -1,7 +1,7 @@
 import { ServerGrpc } from '../../server/server-grpc';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { Observable } from 'rxjs';
+import { of } from 'rxjs';
 import { join } from 'path';
 import { InvalidGrpcPackageException } from '../../exceptions/invalid-grpc-package.exception';
 
@@ -161,6 +161,24 @@ describe('ServerGrpc', () => {
         await server.createStreamServiceMethod(native)(call, callback);
         expect(native.called).to.be.true;
         expect(call.addListener.calledWith('cancelled')).to.be.true;
+        expect(call.removeListener.calledWith('cancelled')).to.be.true;
+      });
+
+      it(`should close the result observable when receiving an 'cancelled' event from the client`, async () => {
+        let cancelCb: () => void;
+        const call = {
+          write: sinon.stub().onSecondCall().callsFake(() => cancelCb()),
+          end: sinon.spy(),
+          addListener: (name, cb) => cancelCb = cb,
+          removeListener: sinon.spy(),
+        };
+        const result$ = of(1, 2, 3);
+        const callback = sinon.spy();
+        const native = sinon.stub().returns(new Promise((resolve, reject) => resolve(result$)));
+
+        await server.createStreamServiceMethod(native)(call, callback);
+        expect(call.write.calledTwice).to.be.true;
+        expect(call.end.called).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When a connected `ClientGrpcProxy` unsubscribes the Observable  returned for an stream gRPC method the upstream connection stays untouched and the server continuous to send updates, even if no-one's listening.
Likewise the Observables `complete` is not getting called.

Issue Number: #773


## What is the new behavior?
When the client cancels the `ServerGrpc` stops consuming it's Observable and the client's `complete` gets called.
Also:
- all eventListener on `call` get cleaned up
- Argument type of `getService<T>` got tighten, as it [can only be a `keyof T`](https://github.com/nestjs/nest/blob/master/packages/microservices/client/client-grpc.ts#L30-L32) - get more help from the comiler

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information