### PR TITLE
bugfix(@nestjs/microservices): messagePattern string key

### DIFF
--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -1,7 +1,13 @@
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { isFunction } from '@nestjs/common/utils/shared.utils';
-import { EMPTY as empty, Observable, Subscription, from as fromPromise, of } from 'rxjs';
+import {
+  EMPTY as empty,
+  Observable,
+  Subscription,
+  from as fromPromise,
+  of,
+} from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 import { MessageHandlers } from '../interfaces/message-handlers.interface';
 import { MicroserviceOptions, WritePacket } from './../interfaces';
@@ -24,7 +30,8 @@ export abstract class Server {
     pattern: any,
     callback: (data) => Promise<Observable<any>>,
   ) {
-    this.messageHandlers[JSON.stringify(pattern)] = callback;
+    const key = typeof pattern === 'string' ? pattern : JSON.stringify(pattern);
+    this.messageHandlers[key] = callback;
   }
 
   public send(

--- a/packages/microservices/test/server/server.spec.ts
+++ b/packages/microservices/test/server/server.spec.ts
@@ -11,7 +11,7 @@ class TestServer extends Server {
 describe('Server', () => {
   const server = new TestServer();
   const callback = () => {},
-    pattern = { test: 'test' };
+    pattern = { test: 'test pattern' };
 
   describe('add', () => {
     it(`should add handler as a stringified pattern key`, () => {
@@ -19,6 +19,12 @@ describe('Server', () => {
 
       const handlers = server.getHandlers();
       expect(handlers[JSON.stringify(pattern)]).to.equal(callback);
+    });
+
+    it(`should add handler as string pattern key`, () => {
+      server.addHandler(pattern.test, callback as any);
+      const handlers = server.getHandlers();
+      expect(handlers[pattern.test]).to.equal(callback);
     });
   });
   describe('send', () => {
@@ -73,9 +79,7 @@ describe('Server', () => {
         it('should returns Observable', async () => {
           const value = 100;
           expect(
-            await server
-              .transformToObservable(of(value))
-              .toPromise(),
+            await server.transformToObservable(of(value)).toPromise(),
           ).to.be.eq(100);
         });
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [V] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [V] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[V] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`@MessagePattern("cmd")
testPath(): void {

}
`
Will cause the Server not to find the handler, because the string key was stringified resulting with extra parentheses.

Issue Number: N/A


## What is the new behavior?
Before adding the handler, Server will verify if pattern is a string before JSON.stringifiy

## Does this PR introduce a breaking change?
```
[ ] Yes
[V] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information