### PR TITLE
bugfix(@nestjs/common) changes the types of arguments in createParamD…

### DIFF
--- a/bundle/common/decorators/http/create-route-param-metadata.decorator.d.ts
+++ b/bundle/common/decorators/http/create-route-param-metadata.decorator.d.ts
@@ -1,13 +1,14 @@
 import { CustomParamFactory } from '../../interfaces/features/custom-route-param-factory.interface';
 import { PipeTransform } from '../../index';
+import { Type } from '../../interfaces';
 /**
  * Creates HTTP route param decorator
  * @param factory
  */
-export declare function createParamDecorator(factory: CustomParamFactory): (data?: any, ...pipes: PipeTransform<any>[]) => ParameterDecorator;
+export declare function createParamDecorator(factory: CustomParamFactory): (data?: any, ...pipes: (Type<PipeTransform> | PipeTransform)[]) => ParameterDecorator;
 /**
  * Creates HTTP route param decorator
  * @deprecated
  * @param factory
  */
-export declare function createRouteParamDecorator(factory: CustomParamFactory): (data?: any, ...pipes: PipeTransform<any>[]) => ParameterDecorator;
+export declare function createRouteParamDecorator(factory: CustomParamFactory): (data?: any, ...pipes: (Type<PipeTransform> | PipeTransform)[]) => ParameterDecorator;

--- a/packages/common/decorators/http/create-route-param-metadata.decorator.ts
+++ b/packages/common/decorators/http/create-route-param-metadata.decorator.ts
@@ -7,6 +7,7 @@ import { CustomParamFactory } from '../../interfaces/features/custom-route-param
 import { RouteParamsMetadata, ParamData } from './route-params.decorator';
 import { PipeTransform } from '../../index';
 import { isNil, isString } from '../../utils/shared.utils';
+import { Type } from '../../interfaces';
 
 const assignCustomMetadata = (
   args: RouteParamsMetadata,
@@ -14,7 +15,7 @@ const assignCustomMetadata = (
   index: number,
   factory: CustomParamFactory,
   data?: ParamData,
-  ...pipes: PipeTransform<any>[],
+  ...pipes: (Type<PipeTransform> | PipeTransform)[],
 ) => ({
   ...args,
   [`${paramtype}${CUSTOM_ROUTE_AGRS_METADATA}:${index}`]: {
@@ -36,9 +37,9 @@ const randomString = () =>
  */
 export function createParamDecorator(
   factory: CustomParamFactory,
-): (data?: any, ...pipes: PipeTransform<any>[]) => ParameterDecorator {
+): (data?: any, ...pipes: (Type<PipeTransform> | PipeTransform)[]) => ParameterDecorator {
   const paramtype = randomString() + randomString();
-  return (data?, ...pipes: PipeTransform<any>[]): ParameterDecorator => (
+  return (data?, ...pipes: (Type<PipeTransform> | PipeTransform)[]): ParameterDecorator => (
     target,
     key,
     index,
@@ -61,7 +62,7 @@ export function createParamDecorator(
  */
 export function createRouteParamDecorator(
   factory: CustomParamFactory,
-): (data?: any, ...pipes: PipeTransform<any>[]) => ParameterDecorator {
+): (data?: any, ...pipes: (Type<PipeTransform> | PipeTransform)[]) => ParameterDecorator {
   deprecate(
     'The "createRouteParamDecorator" function is deprecated and will be removed within next major release. Use "createParamDecorator" instead.',
   );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

```typescript
@Put(':id/actions')
public async getForm(@ApplyPipe(null, DataPipe) data: any) {
    return this.formService.applyActions(data);
}
```

```
Argument of type 'typeof DataPipe' is not assignable to parameter of type 'PipeTransform<any, any>'.
  Property 'transform' is missing in type 'typeof DataPipe'.

31                        @ApplyPipe(null, DataPipe) data: any,
```

Issue Number: N/A


## What is the new behavior?

Pass the class (not instance), leaving framework the instantiation responsibility and enabling dependency injection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```



## Other information