### PR TITLE
bugfix(@nestjs/core): use ForbiddenException instead of HttpException

### DIFF
--- a/packages/core/helpers/external-context-creator.ts
+++ b/packages/core/helpers/external-context-creator.ts
@@ -5,7 +5,7 @@ import { InterceptorsContextCreator } from './../interceptors/interceptors-conte
 import { InterceptorsConsumer } from './../interceptors/interceptors-consumer';
 import { Controller } from '@nestjs/common/interfaces';
 import { FORBIDDEN_MESSAGE } from '../guards/constants';
-import { HttpStatus, HttpException } from '@nestjs/common';
+import { ForbiddenException } from '@nestjs/common';
 import { Module } from './../injector/module';
 import { ModulesContainer } from './../injector/modules-container';
 
@@ -38,7 +38,7 @@ export class ExternalContextCreator {
         callback,
       );
       if (!canActivate) {
-        throw new HttpException(FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+        throw new ForbiddenException(FORBIDDEN_MESSAGE);
       }
       const handler = () => callback.apply(instance, args);
       return await this.interceptorsConsumer.intercept(

--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -21,9 +21,8 @@ import { PipesConsumer } from './../pipes/pipes-consumer';
 import {
   ParamData,
   PipeTransform,
-  HttpStatus,
   RequestMethod,
-  HttpException,
+  ForbiddenException,
   HttpServer,
 } from '@nestjs/common';
 import { GuardsContextCreator } from '../guards/guards-context-creator';
@@ -238,7 +237,7 @@ export class RouterExecutionContext {
         callback,
       );
       if (!canActivate) {
-        throw new HttpException(FORBIDDEN_MESSAGE, HttpStatus.FORBIDDEN);
+        throw new ForbiddenException(FORBIDDEN_MESSAGE);
       }
     };
     return guards.length ? canActivateFn : null;


### PR DESCRIPTION
Two modified files are the only places in the whole framework where HttpException specifically is used
and used to be used wrong. It's easier to handle and catch ForbiddenException (and other HttpException
child) rather than having to compare HttpStatus to catch it. As ForbiddenException extends HttpException
and provides same HttpStatus, old code catching HttpException still works.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Two guards throw HttpException with "Forbidden resource" message and FORBIDDEN http status.

## What is the new behavior?
Two guards throw ForbiddenException with "Forbidden resource" message and FORBIDDEN http status.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```