### PR TITLE
feature(@nestjs/websocket) ws support for connection req

### DIFF
--- a/packages/websockets/interfaces/nest-gateway.interface.ts
+++ b/packages/websockets/interfaces/nest-gateway.interface.ts
@@ -1,5 +1,5 @@
 export interface NestGateway {
   afterInit?: (server: any) => void;
-  handleConnection?: (client: any) => void;
+  handleConnection?: (client: any, req?: any) => void;
   handleDisconnect?: (client: any) => void;
 }

--- a/packages/websockets/interfaces/on-gateway-connection.interface.ts
+++ b/packages/websockets/interfaces/on-gateway-connection.interface.ts
@@ -1,3 +1,3 @@
 export interface OnGatewayConnection<T = any> {
-  handleConnection(client: T);
+  handleConnection(client: T, req?: any);
 }

--- a/packages/websockets/web-sockets-controller.ts
+++ b/packages/websockets/web-sockets-controller.ts
@@ -103,8 +103,11 @@ export class WebSocketsController {
     connection: Subject<any>,
   ) {
     const adapter = this.config.getIoAdapter();
-    return client => {
-      connection.next(client);
+    return (client, req) => {
+      // here different websocket implements may have different args
+      // `ws` will have two args applied to this callback
+      connection.next({ client, req });
+      
       context.subscribeMessages(messageHandlers, client, instance);
 
       const disconnectHook = adapter.bindClientDisconnect;
@@ -123,7 +126,9 @@ export class WebSocketsController {
     if (instance.handleConnection) {
       event
         .pipe(distinctUntilChanged())
-        .subscribe(instance.handleConnection.bind(instance));
+        .subscribe((args: { client: any, req: any }) => {
+          instance.handleConnection.bind(instance)(args.client, args.req);
+        });
     }
   }
 


### PR DESCRIPTION
add a second arg of `handleConnection` to support  (client, req) => {} callback of the `connection` event

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current `handleConnection` of the websocket gateway just apply 1 arg `client`, which depends on different websocket implements. For `socket.io` there is only `client`, but for `ws`, there're 2 args of the `connection` event: `client`, `req`.

Issue Number: 813

## What is the new behavior?
`handleConnection` now accept 2 args.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
## Other information