### PR TITLE
refactor(core) rephrase error messages

### DIFF
--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -10,7 +10,7 @@ export const UnknownDependenciesMessage = (
   args[index] = '?';
   message += args.join(', ');
 
-  message += `). Please verify whether [${index}] argument is available in the current context.`;
+  message += `). Please make sure that the argument at index [${index}] is available in the current context.`;
   return message;
 };
 
@@ -18,13 +18,13 @@ export const InvalidMiddlewareMessage = (name: string) =>
   `The middleware doesn't provide the 'resolve' method (${name})`;
 
 export const InvalidModuleMessage = (scope: string) =>
-  `Nest cannot create the module instance. The frequent reason of this exception is the circular dependency between modules. Use forwardRef() to avoid it (read more https://docs.nestjs.com/advanced/circular-dependency). Scope [${scope}]`;
+  `Nest cannot create the module instance. Often, this is because of a circular dependency between modules. Use forwardRef() to avoid it. (Read more https://docs.nestjs.com/advanced/circular-dependency.) Scope [${scope}]`;
 
 export const UnknownExportMessage = (module: string) =>
-  `Nest cannot export component/module that is not a part of the currently proccessed module (${module}). Please verify whether each exported unit is available in this particular context.`;
+  `Nest cannot export a component/module that is not a part of the currently processed module (${module}). Please verify whether each exported unit is available in this particular context.`;
 
 export const INVALID_MIDDLEWARE_CONFIGURATION = `Invalid middleware configuration passed inside the module 'configure()' method.`;
 export const UNKNOWN_REQUEST_MAPPING = `Request mapping properties not defined in the @RequestMapping() annotation!`;
 export const UNHANDLED_RUNTIME_EXCEPTION = `Unhandled Runtime Exception.`;
 export const INVALID_EXCEPTION_FILTER = `Invalid exception filters (@UseFilters()).`;
-export const MICROSERVICES_PACKAGE_NOT_FOUND_EXCEPTION = `Unable to load @nestjs/microservices package (please, make sure whether it's installed already).`;
+export const MICROSERVICES_PACKAGE_NOT_FOUND_EXCEPTION = `Unable to load @nestjs/microservices package. (Please make sure that it's already installed.)`;


### PR DESCRIPTION
Fixes typo, clarifies what actions are expected.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- ~~Tests for the changes have been added (for bug fixes / features)~~
- ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other: Error messages refactor
```

## What is the current behavior?
There was a typo in an error message (["proccessed"](https://github.com/nestjs/nest/blob/master/packages/core/errors/messages.ts#L24) instead of "processed").

Some messages did not clearly state what do check for (["verify whether"](https://github.com/nestjs/nest/blob/master/packages/core/errors/messages.ts#L13) instead of "make sure that").

Parentheses were inlined in the sentence (like this). (Instead of this.)

## What is the new behavior?
Typo is fixed and I tried to make some other messages more "actionable" by not only indicating what part to check, but also what to check for ("verify whether available" -> "make sure it is available"). (I hope I didn't actually make them worse. :grin: I am open to criticism.)

I extracted parentheses from the sentence, since they are self-contained.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information