### PR TITLE
feature(@nestjs/common) add im a teapot exception

### DIFF
--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -1,0 +1,18 @@
+import { HttpException } from './http.exception';
+import { HttpStatus } from '../enums/http-status.enum';
+import { createHttpExceptionBody } from '../utils/http-exception-body.util';
+
+/**
+ * Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot".
+ * The resulting entity body MAY be short and stout.
+ *
+ * http://save418.com/
+ */
+export class ImATeapotException extends HttpException {
+  constructor(message?: string | object | any, error = 'I\'m a teapot') {
+    super(
+      createHttpExceptionBody(message, error, HttpStatus.I_AM_A_TEAPOT),
+      HttpStatus.I_AM_A_TEAPOT,
+    );
+  }
+}

--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -16,3 +16,4 @@ export * from './not-implemented.exception';
 export * from './bad-gateway.exception';
 export * from './service-unavailable.exception';
 export * from './gateway-timeout.exception';
+export * from './im-a-teapot.exception';


### PR DESCRIPTION
### Any attempt to brew coffee with a teapot should result in the error code "418 I'm a teapot".
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines => Done
- [x] Tests for the changes have been added (for bug fixes / features) => Is it needed?
- [x] Docs have been added / updated (for bug fixes / features) => Not needed. It is an easter egg


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
It does not support any "I'm a teapot" exceptions :(


## What is the new behavior?
It adds a "ImATeapotException"

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

It’s a reminder that the underlying processes of computers are still made by humans. It'd be a real shame to see 418 go.

http://save418.com/