### PR TITLE
feature(core): exclude route path from prefix

### DIFF
--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -6,6 +6,7 @@ import { ExceptionFilter, INestMicroservice, PipeTransform } from './index';
 import { MicroserviceOptions } from './microservices/microservice-configuration.interface';
 import { INestApplicationContext } from './nest-application-context.interface';
 import { WebSocketAdapter } from './websockets/web-socket-adapter.interface';
+import { RouteInfo } from '@nestjs/common/interfaces';
 
 export interface INestApplication extends INestApplicationContext {
   /**
@@ -60,7 +61,7 @@ export interface INestApplication extends INestApplicationContext {
    * @param  {string} prefix The prefix for the every HTTP route path (for example `/v1/api`)
    * @returns {void}
    */
-  setGlobalPrefix(prefix: string): this;
+  setGlobalPrefix(prefix: string, globalPrefixConfig: { exclude: Array<string | RouteInfo> }): this;
 
   /**
    * Setup Ws Adapter which will be used inside Gateways.

--- a/packages/core/application-config.ts
+++ b/packages/core/application-config.ts
@@ -6,6 +6,11 @@ import {
   CanActivate,
 } from '@nestjs/common';
 import { ConfigurationProvider } from '@nestjs/common/interfaces/configuration-provider.interface';
+import { RouteInfo } from '@nestjs/common/interfaces';
+
+export interface GlobalPrefixConfig {
+  readonly exclude: Array<RouteInfo>;
+}
 
 export class ApplicationConfig implements ConfigurationProvider {
   private globalPipes: PipeTransform<any>[] = [];
@@ -13,6 +18,7 @@ export class ApplicationConfig implements ConfigurationProvider {
   private globalInterceptors: NestInterceptor[] = [];
   private globalGuards: CanActivate[] = [];
   private globalPrefix = '';
+  private globalPrefixConfig: GlobalPrefixConfig = { exclude: [] };
 
   constructor(private ioAdapter: WebSocketAdapter | null = null) {}
 
@@ -22,6 +28,14 @@ export class ApplicationConfig implements ConfigurationProvider {
 
   public getGlobalPrefix() {
     return this.globalPrefix;
+  }
+
+  public setGlobalPrefixConfig(globalPrefixConfig: GlobalPrefixConfig) {
+    this.globalPrefixConfig = globalPrefixConfig;
+  }
+
+  public getGlobalPrefixConfig() {
+    return this.globalPrefixConfig;
   }
 
   public setIoAdapter(ioAdapter: WebSocketAdapter) {

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -7,7 +7,7 @@ import {
   PipeTransform,
   WebSocketAdapter,
 } from '@nestjs/common';
-import { HttpServer } from '@nestjs/common/interfaces';
+import { HttpServer, RouteInfo } from '@nestjs/common/interfaces';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { ServeStaticOptions } from '@nestjs/common/interfaces/external/serve-static-options.interface';
 import { MicroserviceOptions } from '@nestjs/common/interfaces/microservices/microservice-configuration.interface';
@@ -29,7 +29,7 @@ import iterate from 'iterare';
 import * as optional from 'optional';
 import { ExpressAdapter } from './adapters/express-adapter';
 import { FastifyAdapter } from './adapters/fastify-adapter';
-import { ApplicationConfig } from './application-config';
+import { ApplicationConfig, GlobalPrefixConfig } from './application-config';
 import { messages } from './constants';
 import { NestContainer } from './injector/container';
 import { MiddlewareContainer } from './middleware/container';
@@ -37,6 +37,7 @@ import { MiddlewareModule } from './middleware/middleware-module';
 import { NestApplicationContext } from './nest-application-context';
 import { Resolver } from './router/interfaces/resolver.interface';
 import { RoutesResolver } from './router/routes-resolver';
+import { RoutesMapper } from './middleware/routes-mapper';
 
 const { SocketModule } =
   optional('@nestjs/websockets/socket-module') || ({} as any);
@@ -57,6 +58,7 @@ export class NestApplication extends NestApplicationContext
     : null;
   private readonly socketModule = SocketModule ? new SocketModule() : null;
   private readonly routesResolver: Resolver;
+  private readonly routesMapper: RoutesMapper;
   private readonly microservices = [];
   private httpServer: http.Server;
   private isInitialized = false;
@@ -72,7 +74,7 @@ export class NestApplication extends NestApplicationContext
     this.applyOptions();
     this.selectContextModule();
     this.registerHttpServer();
-
+    this.routesMapper = new RoutesMapper(this.container);
     this.routesResolver = new RoutesResolver(this.container, this.config);
   }
 
@@ -315,8 +317,15 @@ export class NestApplication extends NestApplicationContext
     await super.close();
   }
 
-  public setGlobalPrefix(prefix: string): this {
+  public setGlobalPrefix(prefix: string, globalPrefixConfig?: { exclude: Array<string | RouteInfo> }): this {
     this.config.setGlobalPrefix(prefix);
+    if (globalPrefixConfig) {
+      const routeInfos = globalPrefixConfig.exclude.map(route =>
+        this.routesMapper.mapRouteToRouteInfo(route),
+      );
+      const excludedRoutes = routeInfos.reduce((a, b) => a.concat(b));
+      this.config.setGlobalPrefixConfig({exclude: excludedRoutes});
+    }
     return this;
   }
 

--- a/packages/core/test/application-config.spec.ts
+++ b/packages/core/test/application-config.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { ApplicationConfig } from '../application-config';
+import { ApplicationConfig, GlobalPrefixConfig } from '../application-config';
+import { RequestMethod } from '@nestjs/common';
 
 describe('ApplicationConfig', () => {
   let appConfig: ApplicationConfig;
@@ -7,15 +8,32 @@ describe('ApplicationConfig', () => {
   beforeEach(() => {
     appConfig = new ApplicationConfig();
   });
-  describe('globalPath', () => {
-    it('should set global path', () => {
+  describe('globalPrefix', () => {
+    it('should set global prefix', () => {
       const path = 'test';
       appConfig.setGlobalPrefix(path);
 
       expect(appConfig.getGlobalPrefix()).to.be.eql(path);
     });
-    it('should has empty string as a global path by default', () => {
+    it('should has empty string as a global prefix by default', () => {
       expect(appConfig.getGlobalPrefix()).to.be.eql('');
+    });
+  });
+  describe('globalPrefixConfig', () => {
+    it('should set global prefix config', () => {
+      const globalPrefixConfig: GlobalPrefixConfig = {
+        exclude: [
+          {
+            path: '/health',
+            method: RequestMethod.GET,
+          },
+        ],
+      };
+      appConfig.setGlobalPrefixConfig(globalPrefixConfig);
+      expect(appConfig.getGlobalPrefixConfig()).to.be.eql(globalPrefixConfig);
+    });
+    it('should has be empty array as a global prefix exclude by default', () => {
+      expect(appConfig.getGlobalPrefixConfig()).to.be.eql({ exclude: [] });
     });
   });
   describe('IOAdapter', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #963 

## What is the new behavior?

Following the same behavior than Middleware path exclusions allowing string or RouteInfo to describe exclusions:
```js
.setGlobalPrefix('v1', { exclude: [
  '/monitoring',
  { path: '/health', method: RequestMethod.GET }
]});
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information