### PR TITLE
feature(common): add alias named Router for the Controller decorator

### DIFF
--- a/bundle/common/decorators/core/index.d.ts
+++ b/bundle/common/decorators/core/index.d.ts
@@ -2,6 +2,7 @@ export * from './bind.decorator';
 export * from './catch.decorator';
 export * from './component.decorator';
 export * from './controller.decorator';
+export * from './router.decorator';
 export * from './dependencies.decorator';
 export * from './exception-filters.decorator';
 export * from './inject.decorator';

--- a/bundle/common/decorators/core/index.js
+++ b/bundle/common/decorators/core/index.js
@@ -7,6 +7,7 @@ __export(require("./bind.decorator"));
 __export(require("./catch.decorator"));
 __export(require("./component.decorator"));
 __export(require("./controller.decorator"));
+__export(require("./router.decorator"));
 __export(require("./dependencies.decorator"));
 __export(require("./exception-filters.decorator"));
 __export(require("./inject.decorator"));

--- a/bundle/common/decorators/core/router.decorator.d.ts
+++ b/bundle/common/decorators/core/router.decorator.d.ts
@@ -1,0 +1,7 @@
+import 'reflect-metadata';
+import { Controller } from './controller.decorator';
+/**
+ * Defines the Controller. The controller can inject dependencies through constructor.
+ * Those dependencies have to belong to the same module.
+ */
+export declare const Router: typeof Controller;

--- a/bundle/common/decorators/core/router.decorator.js
+++ b/bundle/common/decorators/core/router.decorator.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+require("reflect-metadata");
+const controller_decorator_1 = require("./controller.decorator");
+/**
+ * Defines the Controller. The controller can inject dependencies through constructor.
+ * Those dependencies have to belong to the same module.
+ */
+exports.Router = controller_decorator_1.Controller;

--- a/packages/common/decorators/core/index.ts
+++ b/packages/common/decorators/core/index.ts
@@ -2,6 +2,7 @@ export * from './bind.decorator';
 export * from './catch.decorator';
 export * from './component.decorator';
 export * from './controller.decorator';
+export * from './router.decorator';
 export * from './dependencies.decorator';
 export * from './exception-filters.decorator';
 export * from './inject.decorator';

--- a/packages/common/decorators/core/router.decorator.ts
+++ b/packages/common/decorators/core/router.decorator.ts
@@ -1,0 +1,8 @@
+import 'reflect-metadata';
+import { Controller } from './controller.decorator';
+
+/**
+ * Defines the Controller. The controller can inject dependencies through constructor.
+ * Those dependencies have to belong to the same module.
+ */
+export const Router = Controller;


### PR DESCRIPTION
In express terminology, Router is the class to add new routing for the new resource, So I wanted to allow users from express to have the same terminology while not breaking anything

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) - Didn't find test to any decorators
- [ ] Docs have been added / updated (for bug fixes / features) - Wanted to discuss before


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is Controller decorator to declare new router
Issue Number: N/A


## What is the new behavior?
The same Controller decorator is available, and an alias for it named Router

## Does this PR introduce a breaking change?
```
[ X ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The reason for this PR is to allow the same terminology of express to nest.js, and if it get popular maybe change the file naming to component.router instead of component.controller