### PR TITLE
feature(core): Add module context name to UnknownDependenciesMessage

### DIFF
--- a/packages/core/errors/exceptions/undefined-dependency.exception.ts
+++ b/packages/core/errors/exceptions/undefined-dependency.exception.ts
@@ -1,12 +1,14 @@
 import { InjectorDependencyContext } from '../../injector/injector';
 import { UNKNOWN_DEPENDENCIES_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
+import { Module } from '../../injector/module';
 
 export class UndefinedDependencyException extends RuntimeException {
   constructor(
     type: string,
     undefinedDependencyContext: InjectorDependencyContext,
+    module?: Module,
   ) {
-    super(UNKNOWN_DEPENDENCIES_MESSAGE(type, undefinedDependencyContext));
+    super(UNKNOWN_DEPENDENCIES_MESSAGE(type, undefinedDependencyContext, module));
   }
 }

--- a/packages/core/errors/exceptions/unknown-dependencies.exception.ts
+++ b/packages/core/errors/exceptions/unknown-dependencies.exception.ts
@@ -1,12 +1,14 @@
 import { InjectorDependencyContext } from '../../injector/injector';
 import { UNKNOWN_DEPENDENCIES_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
+import { Module } from '../../injector/module';
 
 export class UnknownDependenciesException extends RuntimeException {
   constructor(
     type: string,
     unknownDependencyContext: InjectorDependencyContext,
+    module?: Module,
   ) {
-    super(UNKNOWN_DEPENDENCIES_MESSAGE(type, unknownDependencyContext));
+    super(UNKNOWN_DEPENDENCIES_MESSAGE(type, unknownDependencyContext, module));
   }
 }

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -3,19 +3,34 @@ import {
   InjectorDependency,
   InjectorDependencyContext,
 } from '../injector/injector';
+import { Module } from '../injector/module';
+
+// TODO: Replace `any` with `unknown` type when TS 3.0.0 is supported
+/**
+ * Returns the name of an instance
+ * @param instance The instance which should get the name from
+ */
+const getInstanceName = (instance: any) =>
+  (instance && (instance as Type<any>).name);
 
 /**
  * Returns the name of the dependency
  * Tries to get the class name, otherwise the string value
  * (= injection token). As fallback it returns '+'
- * @param dependency The dependency whichs name shoul get displayed
+ * @param dependency The dependency whichs name should get displayed
  */
-const getDependencyName = (dependency: InjectorDependency) =>
-  (dependency && (dependency as Type<any>).name) || dependency || '+';
+const getDependencyName = (dependency: InjectorDependency) => getInstanceName(dependency) || dependency || '+';
+/**
+ * Returns the name of the module
+ * Tries to get the class name. As fallback it returns 'current'.
+ * @param module The module which should get displayed
+ */
+const getModuleName = (module: Module) => (module && getInstanceName(module.metatype)) || 'current';
 
 export const UNKNOWN_DEPENDENCIES_MESSAGE = (
   type: string,
   unknownDependencyContext: InjectorDependencyContext,
+  module: Module,
 ) => {
   const { index, dependencies } = unknownDependencyContext;
   let message = `Nest can't resolve dependencies of the ${type}`;
@@ -25,7 +40,7 @@ export const UNKNOWN_DEPENDENCIES_MESSAGE = (
   dependenciesName[index] = '?';
   message += dependenciesName.join(', ');
 
-  message += `). Please make sure that the argument at index [${index}] is available in the current context.`;
+  message += `). Please make sure that the argument at index [${index}] is available in the ${getModuleName(module)} context.`;
   return message;
 };
 

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -217,7 +217,7 @@ export class Injector {
     module: Module,
   ) {
     if (isUndefined(param)) {
-      throw new UndefinedDependencyException(wrapper.name, dependencyContext);
+      throw new UndefinedDependencyException(wrapper.name, dependencyContext, module);
     }
     const token = this.resolveParamToken(wrapper, param);
     return await this.resolveComponentInstance<T>(
@@ -289,7 +289,7 @@ export class Injector {
       dependencyContext.name,
     );
     if (isNil(instanceWrapper)) {
-      throw new UnknownDependenciesException(wrapper.name, dependencyContext);
+      throw new UnknownDependenciesException(wrapper.name, dependencyContext, module);
     }
     return instanceWrapper;
   }

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { UnknownDependenciesException } from '../../../errors/exceptions/unknown-dependencies.exception';
+import { Module } from '../../../injector/module';
 
 describe('UnknownDependenciesMessage', () => {
   const index = 0;
@@ -28,5 +29,21 @@ describe('UnknownDependenciesMessage', () => {
       'Nest can\'t resolve dependencies of the CatService (?, +). ' +
       'Please make sure that the argument at index [0] is available in the current context.';
     expect(new UnknownDependenciesException('CatService', { index, dependencies: ['', undefined] }).message).to.equal(expectedResult);
+  });
+  it('should display the module name', () => {
+    const expectedResult =
+      'Nest can\'t resolve dependencies of the CatService (?, MY_TOKEN). ' +
+      'Please make sure that the argument at index [0] is available in the TestModule context.';
+    class MetaType {
+      name: string;
+    }
+    class TestModule {
+      metatype: MetaType;
+    }
+    const myModule = new TestModule();
+    const myMetaType = new MetaType();
+    myMetaType.name = 'TestModule';
+    myModule.metatype = myMetaType;
+    expect(new UnknownDependenciesException('CatService', { index, dependencies: ['', 'MY_TOKEN'] }, myModule as Module).message).to.equal(expectedResult);
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The error when a injection dependency is missing does not show from which Module it is talking about

Issue Number: N/A


## What is the new behavior?
It tries to parse the current module context name and shows the error message (note the `CatsModule` in the message):

```
[Nest] 20205   - 2018-10-2 11:56:51   [ExceptionHandler] Nest can't resolve dependencies of the CatsController (?). Please make sure that the argument at index [0] is available in the CatsModule context. +27ms
```

In case the module name can not be parsed somehow, it will use the string 'current' as fallback name for the module, as it used to be.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
