### PR TITLE
docs(contributing) fix comments issues in lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 We would love for you to contribute to Nest and help make it even better than it is
 today! As a contributor, here are the guidelines we would like you to follow:
 
-* [Code of Conduct](#coc)
+<!--* [Code of Conduct](#coc)-->
 * [Question or Problem?](#question)
 * [Issues and Bugs](#issue)
 * [Feature Requests](#feature)
@@ -76,10 +76,15 @@ You can file new issues by filling out our [new issue form](https://github.com/n
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
+<!--
+To the first point
+
+1. Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
+We cannot accept code without this.
+-->
+
 1. Search [GitHub](https://github.com/nestjs/nest/pulls) for an open or closed PR
    that relates to your submission. You don't want to duplicate effort.
-   <!-- 1. Please sign our [Contributor License Agreement (CLA)](#cla) before sending PRs.
-  We cannot accept code without this. -->
 1. Fork the nestjs/nest repo.
 1. Make your changes in a new git branch:
 
@@ -195,10 +200,11 @@ $ npm run lint
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
-* All features or bug fixes **must be tested** by one or more specs (unit-tests).
-  <!--
+<!--
 // We're working on auto-documentation.
 * All public API methods **must be documented**. (Details TBC). -->
+
+* All features or bug fixes **must be tested** by one or more specs (unit-tests).
 * We follow [Google's JavaScript Style Guide][js-style-guide], but wrap all code at
   **100 characters**. An automated formatter is available, see
   [DEVELOPER.md](docs/DEVELOPER.md#clang-format).
@@ -272,8 +278,8 @@ There are currently a few exceptions to the "use package name" rule:
 * **packaging**: used for changes that change the npm package layout in all of our packages, e.g. public path changes, package.json changes done to all packages, d.ts file/format changes, changes to bundles, etc.
 * **changelog**: used for updating the release notes in CHANGELOG.md
 * **sample/#**: for the example apps directory, replacing # with the example app number
-  <!-- * **aio**: used for docs-app (angular.io) related changes within the /aio directory of the repo -->
 * none/empty string: useful for `style`, `test` and `refactor` changes that are done across all packages (e.g. `style: add missing semicolons`)
+<!-- * **aio**: used for docs-app (angular.io) related changes within the /aio directory of the repo -->
 
 ### Subject
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior

Current version of contributing was broken. There is no way (I think) to use comments inside of lists in markdown. The old version is the one on the left. Also I've commented out Code of Conduct from list because it is not ready yet.

![screenshot 2018-11-25 at 18 18 43](https://user-images.githubusercontent.com/14861637/48982175-44f3c600-f0df-11e8-9831-d62807ba0bcd.png)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I wasn't able to run integration tests because of this problem:
![screenshot 2018-11-25 at 18 25 16](https://user-images.githubusercontent.com/14861637/48982203-900dd900-f0df-11e8-9ed1-026e3a523b4f.png)

Node version: v8.12.0

I've tried to run tests using scripts (prepare, test, run-integration).

By the way - great work Kamil 🚀