### PR TITLE
feature(core): allow Array in request mapping decorator

### DIFF
--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -10,7 +10,8 @@ const defaultMetadata = {
 export const RequestMapping = (
   metadata: RequestMappingMetadata = defaultMetadata,
 ): MethodDecorator => {
-  const path = metadata[PATH_METADATA] || '/';
+  const pathMetaData = metadata[PATH_METADATA];
+  const path = pathMetaData && pathMetaData.length ? pathMetaData : false || '/';
   const requestMethod = metadata[METHOD_METADATA] || RequestMethod.GET;
 
   return (target, key, descriptor: PropertyDescriptor) => {
@@ -21,7 +22,7 @@ export const RequestMapping = (
 };
 
 const createMappingDecorator = (method: RequestMethod) => (
-  path?: string,
+  path?: string | string[],
 ): MethodDecorator => {
   return RequestMapping({
     [PATH_METADATA]: path,

--- a/packages/common/interfaces/request-mapping-metadata.interface.ts
+++ b/packages/common/interfaces/request-mapping-metadata.interface.ts
@@ -1,6 +1,6 @@
 import { RequestMethod } from '../enums/request-method.enum';
 
 export interface RequestMappingMetadata {
-  path?: string;
+  path?: string | string[];
   method?: RequestMethod;
 }

--- a/packages/common/test/decorators/request-mapping.decorator.spec.ts
+++ b/packages/common/test/decorators/request-mapping.decorator.spec.ts
@@ -8,36 +8,55 @@ describe('@RequestMapping', () => {
     method: RequestMethod.ALL,
   };
 
+  const requestPropsUsingArray = {
+    path: ['foo', 'bar'],
+    method: RequestMethod.ALL,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @RequestMapping(requestProps)
-      public static test() {}
+      public static test() { }
+
+      @RequestMapping(requestPropsUsingArray)
+      public static testUsingArray() { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestProps.path);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPropsUsingArray.path);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set request method on GET by default', () => {
     class Test {
       @RequestMapping({ path: '' })
-      public static test() {}
+      public static test() { }
     }
 
     const method = Reflect.getMetadata('method', Test.test);
+
     expect(method).to.be.eql(RequestMethod.GET);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @RequestMapping({})
-      public static test() {}
+      public static test() { }
+
+      @RequestMapping({ path: [] })
+      public static testUsingArray() { }
     }
 
-    const method = Reflect.getMetadata('path', Test.test);
-    expect(method).to.be.eql('/');
+    const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
+    expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -11,26 +11,46 @@ describe('@Get', () => {
     method: RequestMethod.GET,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.GET,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @Get(requestPath)
-      public static test(@Param('id') params) {}
+      public static test(@Param('id') params) { }
+
+      @Get(requestPathUsingArray)
+      public static testUsingArray(@Param('id') params) { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @Get()
-      public static test() {}
+      public static test() { }
+
+      @Get([])
+      public static testUsingArray() { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -41,26 +61,46 @@ describe('@Post', () => {
     method: RequestMethod.POST,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.POST,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @Post(requestPath)
-      public static test() {}
+      public static test() { }
+
+      @Post(requestPathUsingArray)
+      public static testUsingArray() { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @Post()
-      public static test(@Query() query) {}
+      public static test(@Query() query) { }
+
+      @Post([])
+      public static testUsingArray(@Query() query) { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -71,26 +111,46 @@ describe('@Delete', () => {
     method: RequestMethod.DELETE,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.DELETE,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @Delete(requestPath)
-      public static test(@Body() body) {}
+      public static test(@Body() body) { }
+
+      @Delete(requestPathUsingArray)
+      public static testUsingArray(@Body() body) { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @Delete()
-      public static test() {}
+      public static test() { }
+
+      @Delete([])
+      public static testUsingArray() { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -101,26 +161,46 @@ describe('@All', () => {
     method: RequestMethod.ALL,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.ALL,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @All(requestPath)
-      public static test() {}
+      public static test() { }
+
+      @All(requestPathUsingArray)
+      public static testUsingArray() { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @All()
-      public static test() {}
+      public static test() { }
+
+      @All([])
+      public static testUsingArray() { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -131,26 +211,46 @@ describe('@Put', () => {
     method: RequestMethod.PUT,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.PUT,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @Put(requestPath)
-      public static test() {}
+      public static test() { }
+
+      @Put(requestPathUsingArray)
+      public static testUsingArray() { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @Put()
-      public static test() {}
+      public static test() { }
+
+      @Put([])
+      public static testUsingArray() { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -161,26 +261,46 @@ describe('@Patch', () => {
     method: RequestMethod.PATCH,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.PATCH,
+  };
+
   it('should enhance class with expected request metadata', () => {
     class Test {
       @Patch(requestPath)
-      public static test() {}
+      public static test() { }
+
+      @Patch(requestPathUsingArray)
+      public static testUsingArray() { }
     }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
   it('should set path on "/" by default', () => {
     class Test {
       @Patch()
-      public static test() {}
+      public static test() { }
+
+      @Patch([])
+      public static testUsingArray() { }
     }
+
     const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
     expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
   });
 });
 
@@ -191,18 +311,31 @@ describe('Inheritance', () => {
     method: RequestMethod.GET,
   };
 
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.GET,
+  };
+
   it('should enhance subclass with expected request metadata', () => {
     class Parent {
       @Get(requestPath)
-      public static test() {}
+      public static test() { }
+
+      @Get(requestPathUsingArray)
+      public static testUsingArray() { }
     }
 
-    class Test extends Parent {}
+    class Test extends Parent { }
 
     const path = Reflect.getMetadata('path', Test.test);
     const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
 
-    expect(method).to.be.eql(requestProps.method);
     expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 });

--- a/packages/core/middleware/routes-mapper.ts
+++ b/packages/core/middleware/routes-mapper.ts
@@ -37,11 +37,11 @@ export class RoutesMapper {
       Object.create(route),
       route.prototype,
     );
-    return paths.map(item => ({
-      path:
-        this.validateGlobalPath(routePath) + this.validateRoutePath(item.path),
+    const reducer = (accumulator, currentValue) => accumulator.concat(currentValue);
+    return paths.map(item => item.path.map(p => ({
+      path: this.validateGlobalPath(routePath) + this.validateRoutePath(p),
       method: item.requestMethod,
-    }));
+    }))).reduce(reducer, []);
   }
 
   private isRouteInfo(

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -3,7 +3,7 @@ import { RequestMethod } from '@nestjs/common/enums/request-method.enum';
 import { Controller } from '@nestjs/common/interfaces/controllers/controller.interface';
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { Logger } from '@nestjs/common/services/logger.service';
-import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
+import { isString, isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
 import { ApplicationConfig } from '../application-config';
 import { UnknownRequestMappingException } from '../errors/exceptions/unknown-request-mapping.exception';
 import { GuardsConsumer } from '../guards/guards-consumer';
@@ -22,7 +22,7 @@ import { RouterExecutionContext } from './router-execution-context';
 import { RouterProxy, RouterProxyCallback } from './router-proxy';
 
 export interface RoutePathProperties {
-  path: string;
+  path: string[];
   requestMethod: RequestMethod;
   targetCallback: RouterProxyCallback;
   methodName: string;
@@ -111,8 +111,11 @@ export class RouterExplorer {
       METHOD_METADATA,
       targetCallback,
     );
+    const path = isString(routePath) ?
+      [this.validateRoutePath(routePath)] :
+      routePath.map(p => this.validateRoutePath(p));
     return {
-      path: this.validateRoutePath(routePath),
+      path,
       requestMethod,
       targetCallback,
       methodName,
@@ -135,7 +138,7 @@ export class RouterExplorer {
         module,
         basePath,
       );
-      this.logger.log(ROUTE_MAPPED_MESSAGE(path, requestMethod));
+      path.forEach(p => this.logger.log(ROUTE_MAPPED_MESSAGE(p, requestMethod)));
     });
   }
 
@@ -160,8 +163,10 @@ export class RouterExplorer {
     );
     const stripSlash = str =>
       str[str.length - 1] === '/' ? str.slice(0, str.length - 1) : str;
-    const fullPath = stripSlash(basePath) + path;
-    routerMethod(stripSlash(fullPath) || '/', proxy);
+    path.forEach(p => {
+      const fullPath = stripSlash(basePath) + p;
+      routerMethod(stripSlash(fullPath) || '/', proxy);
+    });
   }
 
   private createCallbackProxy(


### PR DESCRIPTION
This feature was requested in the issue #1343. When routing, besides using a single string, you can
now use an array of strings in the Post, Get, ... decorators.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1343


## What is the new behavior?
When routing, besides using a single string, you can now use an array of strings in the Post, Get, ... decorators.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information