### PR TITLE
feature(common): add transformOptions to ValidationPipeOptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,30 +5,21 @@
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "precommit": "lint-staged",
-    "test":
-      "nyc --require ts-node/register mocha packages/**/*.spec.ts --reporter spec --require 'node_modules/reflect-metadata/Reflect.js'",
-    "integration-test":
-      "mocha integration/**/*.spec.ts --reporter spec --require ts-node/register --require 'node_modules/reflect-metadata/Reflect.js'",
-    "lint":
-      "tslint -p tsconfig.json -c tslint.json \"packages/**/*.ts\" -e \"*.spec.ts\"",
-    "format":
-      "prettier **/**/*.ts --ignore-path ./.prettierignore --write && git status",
+    "test": "nyc --require ts-node/register mocha packages/**/*.spec.ts --reporter spec --require 'node_modules/reflect-metadata/Reflect.js'",
+    "integration-test": "mocha integration/**/*.spec.ts --reporter spec --require ts-node/register --require 'node_modules/reflect-metadata/Reflect.js'",
+    "lint": "tslint -p tsconfig.json -c tslint.json \"packages/**/*.ts\" -e \"*.spec.ts\"",
+    "format": "prettier **/**/*.ts --ignore-path ./.prettierignore --write && git status",
     "clean": "gulp clean:bundle",
     "build": "npm run clean && gulp build",
     "prebuild:dev": "rm -rf node_modules/@nestjs",
     "build:dev": "gulp build --dist node_modules/@nestjs && gulp move",
     "postinstall": "opencollective",
     "prerelease": "gulp copy-misc && gulp build --dist node_modules/@nestjs",
-    "publish":
-      "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --force-publish --exact -m \"chore(@nestjs) publish %s release\"",
-    "publish:rc":
-      "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=rc -m \"chore(@nestjs) publish %s release\"",
-    "publish:next":
-      "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=next --skip-git -m \"chore(@nestjs) publish %s release\"",
-    "publish:beta":
-      "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=beta -m \"chore(@nestjs) publish %s release\"",
-    "publish:test":
-      "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --force-publish --npm-tag=test --skip-git -m \"chore(@nestjs) publish %s release\""
+    "publish": "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --force-publish --exact -m \"chore(@nestjs) publish %s release\"",
+    "publish:rc": "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=rc -m \"chore(@nestjs) publish %s release\"",
+    "publish:next": "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=next --skip-git -m \"chore(@nestjs) publish %s release\"",
+    "publish:beta": "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --npm-tag=beta -m \"chore(@nestjs) publish %s release\"",
+    "publish:test": "npm run prerelease && npm run build && ./node_modules/.bin/lerna publish --force-publish --npm-tag=test --skip-git -m \"chore(@nestjs) publish %s release\""
   },
   "engines": {
     "node": ">= 8.9.0"
@@ -141,7 +132,9 @@
     }
   },
   "nyc": {
-    "include": ["packages/**/*.ts"],
+    "include": [
+      "packages/**/*.ts"
+    ],
     "exclude": [
       "node_modules/",
       "packages/**/*.spec.ts",
@@ -161,13 +154,23 @@
       "packages/common/serializer/**/*",
       "packages/common/services/logger.service.ts"
     ],
-    "extension": [".ts"],
-    "require": ["ts-node/register"],
-    "reporter": ["text-summary", "html"],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "text-summary",
+      "html"
+    ],
     "sourceMap": true,
     "instrument": true
   },
   "lint-staged": {
-    "packages/**/*.{ts,json}": ["npm run format", "git add"]
+    "packages/**/*.{ts,json}": [
+      "npm run format",
+      "git add"
+    ]
   }
 }

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -6,6 +6,7 @@ import {
   ValidationError,
 } from '../index';
 import { ValidatorOptions } from '../interfaces/external/validator-options.interface';
+import { ClassTransformOptions } from '../interfaces/external/class-transform-options.interface';
 import { PipeTransform } from '../interfaces/features/pipe-transform.interface';
 import { loadPackage } from '../utils/load-package.util';
 import { isNil } from '../utils/shared.utils';
@@ -13,6 +14,7 @@ import { isNil } from '../utils/shared.utils';
 export interface ValidationPipeOptions extends ValidatorOptions {
   transform?: boolean;
   disableErrorMessages?: boolean;
+  transformOptions?: ClassTransformOptions;
   exceptionFactory?: (errors: ValidationError[]) => any;
 }
 
@@ -24,13 +26,20 @@ export class ValidationPipe implements PipeTransform<any> {
   protected isTransformEnabled: boolean;
   protected isDetailedOutputDisabled?: boolean;
   protected validatorOptions: ValidatorOptions;
+  protected transformOptions: ClassTransformOptions;
   protected exceptionFactory: (errors: ValidationError[]) => any;
 
   constructor(@Optional() options?: ValidationPipeOptions) {
     options = options || {};
-    const { transform, disableErrorMessages, ...validatorOptions } = options;
+    const {
+      transform,
+      disableErrorMessages,
+      transformOptions,
+      ...validatorOptions
+    } = options;
     this.isTransformEnabled = !!transform;
     this.validatorOptions = validatorOptions;
+    this.transformOptions = transformOptions;
     this.isDetailedOutputDisabled = disableErrorMessages;
     this.exceptionFactory =
       options.exceptionFactory ||
@@ -52,6 +61,7 @@ export class ValidationPipe implements PipeTransform<any> {
     const entity = classTransformer.plainToClass(
       metatype,
       this.toEmptyIfNil(value),
+      this.transformOptions
     );
     const errors = await classValidator.validate(entity, this.validatorOptions);
     if (errors.length > 0) {
@@ -60,8 +70,8 @@ export class ValidationPipe implements PipeTransform<any> {
     return this.isTransformEnabled
       ? entity
       : Object.keys(this.validatorOptions).length > 0
-      ? classTransformer.classToPlain(entity)
-      : value;
+        ? classTransformer.classToPlain(entity, this.transformOptions)
+        : value;
   }
 
   private toValidate(metadata: ArgumentMetadata): boolean {

--- a/sample/01-cats-app/src/cats/cats.controller.ts
+++ b/sample/01-cats-app/src/cats/cats.controller.ts
@@ -1,6 +1,5 @@
 import {
   Body,
-  Catch,
   Controller,
   Get,
   Param,
@@ -17,7 +16,6 @@ import { CatsService } from './cats.service';
 import { CreateCatDto } from './dto/create-cat.dto';
 import { Cat } from './interfaces/cat.interface';
 
-@Catch()
 @Controller('cats')
 @UseGuards(RolesGuard)
 @UseInterceptors(LoggingInterceptor, TransformInterceptor)


### PR DESCRIPTION
allows plainToClass to expose class properties to defined groups as per issue #1374

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
plainToClass has no facility for following rules in Expose decorators regarding groups

Issue Number: 1374


## What is the new behavior?
a new property "transformOptions" on the ValidationPipeOptions class is passed into plainToClass so that classes are transformed according to the groups provided.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information