### PR TITLE
re-add NestGateway to exports

### DIFF
--- a/packages/websockets/interfaces/index.ts
+++ b/packages/websockets/interfaces/index.ts
@@ -3,3 +3,4 @@ export * from './hooks';
 export * from './observable-socket-server.interface';
 export * from './web-socket-server.interface';
 export * from './ws-response.interface';
+export * from './nest-gateway.interface';


### PR DESCRIPTION
NestGateway was removed from exports (mistakenly?) when hooks were moved to their own folder. Re adds so the interface may be imported.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

https://github.com/nestjs/nest/commit/7c2143f8890e6e3b1bf70b7ebb2137c1a0029409#diff-3c6661c4add03f173da677144a00b96eL2 removed the export, it seems to be mistakenly removed because the interface itself still exists.

## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information