### PR TITLE
bugfix(grpc) Handle null value in proto definition

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -227,7 +227,7 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
       const nameExtended = this.parseDeepServiceName(name, key);
       const deepDefinition = grpcDefinition[key];
 
-      const isServiceDefined = !isUndefined(deepDefinition.service);
+      const isServiceDefined = deepDefinition && !isUndefined(deepDefinition.service);
       const isServiceBoolean = isServiceDefined
         ? deepDefinition.service !== false
         : false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The proto definition produced by @grpc/proto-loader may have null value field, which will cause error.

```
syntax = "proto3";

message ProtoMessage {
    string param = 0x1;
}
```
The above message will generate following proto definition, which has null value field `options`.
```
{
  ProtoMessage: {
    format: 'Protocol Buffer 3 DescriptorProto',
    type: {
      field: [{
        name: 'param',
        extendee: '',
        number: 1,
        label: 'LABEL_OPTIONAL',
        type: 'TYPE_STRING',
        typeName: '',
        defaultValue: '',
        options: null, // <-- null value here
        oneofIndex: 0,
        jsonName: ''
      }],
      nestedType: [],
      enumType: [],
      extensionRange: [],
      extension: [],
      oneofDecl: [],
      reservedRange: [],
      reservedName: [],
      name: 'ProtoMessage',
      options: null
    }
  }
}
```
## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information