### PR TITLE
feature(core): allow for multiple view dirs in Express

### DIFF
--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -38,7 +38,7 @@ export interface HttpServer {
   setErrorHandler?(handler: Function);
   setNotFoundHandler?(handler: Function);
   useStaticAssets?(...args: any[]): this;
-  setBaseViewsDir?(path: string): this;
+  setBaseViewsDir?(path: string | string[]): this;
   setViewEngine?(engineOrOptions: any): this;
   createMiddlewareFactory(
     method: RequestMethod,

--- a/packages/common/interfaces/nest-express-application.interface.ts
+++ b/packages/common/interfaces/nest-express-application.interface.ts
@@ -43,12 +43,12 @@ export interface INestExpressApplication {
   useStaticAssets(path: string, options?: ServeStaticOptions): this;
 
   /**
-   * Sets a base directory for templates (views).
+   * Sets one or multiple base directories for templates (views).
    * Example `app.setBaseViewsDir('views')`
    *
    * @returns {this}
    */
-  setBaseViewsDir(path: string): this;
+  setBaseViewsDir(path: string | string[]): this;
 
   /**
    * Sets a view engine for templates (views).

--- a/packages/core/adapters/express-adapter.ts
+++ b/packages/core/adapters/express-adapter.ts
@@ -126,7 +126,7 @@ export class ExpressAdapter implements HttpServer {
     return this.use(express.static(path, options));
   }
 
-  setBaseViewsDir(path: string) {
+  setBaseViewsDir(path: string | string[]) {
     return this.set('views', path);
   }
 

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -363,7 +363,7 @@ export class NestApplication extends NestApplicationContext
     return this;
   }
 
-  public setBaseViewsDir(path: string): this {
+  public setBaseViewsDir(path: string | string[]): this {
     this.httpAdapter.setBaseViewsDir && this.httpAdapter.setBaseViewsDir(path);
     return this;
   }


### PR DESCRIPTION
In Express, you can set a string or an array of string as
base view paths. The views are looked up in the order they occur in
the array. The ExpressAdapter only allowed for a single string, now it
accepts an array of strings as well.

closes #1513

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
Since this was just a typing issue, I'm not sure if this has to be tested. There was no unit test for it and since it is an express library feature it does not need to be integration tested IMO.
- [x] Docs have been added / updated (for bug fixes / features)
code docs only though

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1513 


## What is the new behavior?
The ExpressAdapter accepts multiple view directories.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information