### PR TITLE
feature(core): Add multi option for custom providers

### DIFF
--- a/integration/injector/e2e/multi-provider.spec.ts
+++ b/integration/injector/e2e/multi-provider.spec.ts
@@ -1,0 +1,45 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { MultiProviderUseValueModule } from '../src/multi-provider/multi-provider-use-value.module';
+import { MultiProviderUseFactoryModule } from '../src/multi-provider/multi-provider-use-factory.module';
+import { MultiProviderUseClassModule } from '../src/multi-provider/multi-provider-use-class.module';
+import { MultiProviderMixedModule } from '../src/multi-provider/multi-provider-mixed.module';
+import { MixedMultiProviderException } from '@nestjs/core/errors/exceptions/mixed-multi-provider.exception';
+
+describe('MultiProvider', () => {
+  it(`should return an array of values when using the "multi" option and "useValue"`, async () => {
+    const builder = Test.createTestingModule({
+      imports: [MultiProviderUseValueModule],
+    });
+    const app = await builder.compile();
+    expect(app.get('TEST')).to.deep.eq(['a', 'b']);
+  });
+
+  it(`should return an array of values when using the "multi" option and "useFactory"`, async () => {
+    const builder = Test.createTestingModule({
+      imports: [MultiProviderUseFactoryModule],
+    });
+    const app = await builder.compile();
+    expect(app.get('TEST')).to.deep.eq(['a', 'b']);
+  });
+
+  it(`should return an array of values when using the "multi" option and "useClass"`, async () => {
+    const builder = Test.createTestingModule({
+      imports: [MultiProviderUseClassModule],
+    });
+    const app = await builder.compile();
+    expect(app.get('TEST')[0].test()).to.deep.eq('a');
+    expect(app.get('TEST')[1].test()).to.deep.eq('b');
+  });
+
+  it(`should throw an error if "mutli" value is mixed with the same token`, async () => {
+    try {
+      const builder = Test.createTestingModule({
+        imports: [MultiProviderMixedModule],
+      });
+      await builder.compile();
+    } catch (err) {
+      expect(err).to.be.instanceof(MixedMultiProviderException);
+    }
+  });
+});

--- a/integration/injector/src/multi-provider/multi-provider-mixed.module.ts
+++ b/integration/injector/src/multi-provider/multi-provider-mixed.module.ts
@@ -1,0 +1,17 @@
+import { Module, Inject } from '@nestjs/common';
+
+@Module({
+  providers: [
+
+    {
+      provide: 'TEST',
+      useValue: 'a',
+      multi: true,
+    },
+    {
+      provide: 'TEST',
+      useValue: 'b',
+      multi: false,
+    }],
+})
+export class MultiProviderMixedModule { }

--- a/integration/injector/src/multi-provider/multi-provider-use-class.module.ts
+++ b/integration/injector/src/multi-provider/multi-provider-use-class.module.ts
@@ -1,0 +1,32 @@
+import { Module, Inject } from '@nestjs/common';
+
+class Test1 {
+  test() {
+    return 'a';
+  }
+}
+class Test2 {
+  constructor(@Inject('B_VALUE') private b: string) { }
+  test() {
+    return this.b;
+  }
+}
+
+@Module({
+  providers: [
+    {
+      provide: 'B_VALUE',
+      useValue: 'b',
+    },
+    {
+      provide: 'TEST',
+      useClass: Test1,
+      multi: true,
+    },
+    {
+      provide: 'TEST',
+      useClass: Test2,
+      multi: true,
+    }],
+})
+export class MultiProviderUseClassModule { }

--- a/integration/injector/src/multi-provider/multi-provider-use-factory.module.ts
+++ b/integration/injector/src/multi-provider/multi-provider-use-factory.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [{
+    provide: 'TEST',
+    useFactory: () => 'a',
+    multi: true,
+  },
+  {
+    provide: 'B_VALUE',
+    useValue: 'b',
+  },
+  {
+    provide: 'TEST',
+    useFactory: (b) => b,
+    inject: ['B_VALUE'],
+    multi: true,
+  }],
+})
+export class MultiProviderUseFactoryModule { }

--- a/integration/injector/src/multi-provider/multi-provider-use-value.module.ts
+++ b/integration/injector/src/multi-provider/multi-provider-use-value.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+
+@Module({
+  providers: [{
+    provide: 'TEST',
+    useValue: 'a',
+    multi: true,
+  },
+  {
+    provide: 'TEST',
+    useValue: 'b',
+    multi: true,
+  }],
+})
+export class MultiProviderUseValueModule { }

--- a/packages/common/interfaces/modules/provider.interface.ts
+++ b/packages/common/interfaces/modules/provider.interface.ts
@@ -11,6 +11,11 @@ export interface ClassProvider {
   provide: any;
   useClass: Type<any>;
   scope?: Scope;
+  /**
+   * If true, then injector returns an array of instances. This is useful to allow multiple
+   * providers spread across many files to provide configuration information to a common token.
+   */
+  multi?: boolean | undefined;
 }
 
 export interface ValueProvider {
@@ -28,4 +33,9 @@ export interface FactoryProvider {
   useFactory: (...args: any[]) => any;
   inject?: Array<Type<any> | string | any>;
   scope?: Scope;
+  /**
+   * If true, then injector returns an array of instances. This is useful to allow multiple
+   * providers spread across many files to provide configuration information to a common token.
+   */
+  multi?: boolean | undefined;
 }

--- a/packages/common/interfaces/modules/provider.interface.ts
+++ b/packages/common/interfaces/modules/provider.interface.ts
@@ -16,6 +16,11 @@ export interface ClassProvider {
 export interface ValueProvider {
   provide: any;
   useValue: any;
+  /**
+   * If true, then injector returns an array of instances. This is useful to allow multiple
+   * providers spread across many files to provide configuration information to a common token.
+   */
+  multi?: boolean | undefined;
 }
 
 export interface FactoryProvider {

--- a/packages/core/errors/exceptions/mixed-multi-provider.exception.ts
+++ b/packages/core/errors/exceptions/mixed-multi-provider.exception.ts
@@ -1,0 +1,31 @@
+import { MIXED_MULTI_PROVIDER_MESSAGE } from '../messages';
+import { RuntimeException } from './runtime.exception';
+
+/**
+ * Errors which should get thrown when the user
+ * mixes up the `multi` option of a provider
+ *
+ * ```typescript
+ * // Will throw an exception
+ * @Module({
+ *   providers: [
+ *     {
+ *       useValue: 'eng',
+ *       provide: 'LANG',
+ *       multi: true,
+ *     },
+ *     {
+ *       useValue: 'de',
+ *       provide: 'LANG',
+ *       // Not allowed, because inconsistent value for `multi`
+ *       multi: false,
+ *     },
+ *   ],
+ * })
+ * ```
+ */
+export class MixedMultiProviderException extends RuntimeException {
+  constructor(name: string) {
+    super(MIXED_MULTI_PROVIDER_MESSAGE(name));
+  }
+}

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -53,6 +53,10 @@ export const UNKNOWN_DEPENDENCIES_MESSAGE = (
   return message;
 };
 
+export const MIXED_MULTI_PROVIDER_MESSAGE = (
+  name: string
+) => `Mixed multi-provider for ${name}.`;
+
 export const INVALID_MIDDLEWARE_MESSAGE = (
   text: TemplateStringsArray,
   name: string,

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -34,6 +34,7 @@ export class InstanceWrapper<T = any> {
   public readonly inject?: (string | symbol | Function | Type<any>)[];
   public readonly async?: boolean;
   public readonly host?: Module;
+  public readonly multi?: boolean | undefined;
   public readonly scope?: Scope = Scope.DEFAULT;
   public forwardRef?: boolean;
 

--- a/packages/core/test/injector/module.spec.ts
+++ b/packages/core/test/injector/module.spec.ts
@@ -187,9 +187,53 @@ describe('Module', () => {
             instance: value,
             isResolved: true,
             async: false,
+            multi: undefined,
           }),
         ),
       ).to.be.true;
+    });
+
+    it('should store multi provider', () => {
+      module.addCustomValue({...provider, multi: true, useValue: 'a'} as any, (module as any)._providers);
+      expect(
+        setSpy.calledWith(
+          name,
+          new InstanceWrapper({
+            host: module,
+            name,
+            scope: Scope.DEFAULT,
+            metatype: null,
+            instance: ['a'],
+            isResolved: true,
+            async: false,
+            multi: true,
+          }),
+        ),
+      ).to.be.true;
+
+      module.addCustomValue({...provider, multi: true, useValue: 'b'} as any, (module as any)._providers);
+      expect(
+        setSpy.calledWith(
+          name,
+          new InstanceWrapper({
+            host: module,
+            name,
+            scope: Scope.DEFAULT,
+            metatype: null,
+            instance: ['a', 'b'],
+            isResolved: true,
+            async: false,
+            multi: true,
+          }),
+        ),
+      ).to.be.true;
+    });
+
+    it('should throw an exception if mixed multi provider', () => {
+      module.addCustomValue({...provider, multi: true, useValue: 'a'} as any, (module as any)._providers);
+      expect(() =>
+        module.addCustomValue({...provider, multi: false, useValue: 'a'} as any, (module as any)._providers)
+      ).to.throws(RuntimeException);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No `multi` provider option 

Issue Number: #770 


## What is the new behavior?

Support the `multi` option for providers

```ts
@Module({
  providers: [{
    provide: 'TEST',
    useValue: 'a',
    multi: true,
  },
  {
    provide: 'TEST',
    useValue: 'b',
    multi: true,
  }],
})
export class ApplicationModule { }

async function bootstrap() {
  const app = await NestFactory.createApplicationContext(ApplicationModule);
  console.log(app.get('TEST')); // ['a', 'b']
}
bootstrap();

```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I am looking forward to implementing a [`APP_INITIALIZER`](https://angular.io/api/core/APP_INITIALIZER) token for NestJS which could help with #1438 