### PR TITLE
Add socketOptions to RMQ connection for client and server

### DIFF
--- a/integration/microservices/e2e/sum-rmq.spec.ts
+++ b/integration/microservices/e2e/sum-rmq.spec.ts
@@ -22,6 +22,7 @@ describe('RabbitMQ transport', () => {
         urls: [`amqp://localhost:5672`],
         queue: 'test',
         queueOptions: { durable: false },
+        socketOptions: { noDelay: true },
       },
     });
     await app.startAllMicroservicesAsync();

--- a/integration/microservices/src/rmq/rmq-broadcast.controller.ts
+++ b/integration/microservices/src/rmq/rmq-broadcast.controller.ts
@@ -19,6 +19,7 @@ export class RMQBroadcastController {
         urls: [`amqp://localhost:5672`],
         queue: 'test_broadcast',
         queueOptions: { durable: false },
+        socketOptions: { noDelay: true },
       },
     });
   }

--- a/integration/microservices/src/rmq/rmq.controller.ts
+++ b/integration/microservices/src/rmq/rmq.controller.ts
@@ -19,6 +19,7 @@ export class RMQController {
         urls: [`amqp://localhost:5672`],
         queue: 'test',
         queueOptions: { durable: false },
+        socketOptions: { noDelay: true },
       },
     });
   }

--- a/packages/common/interfaces/microservices/microservice-configuration.interface.ts
+++ b/packages/common/interfaces/microservices/microservice-configuration.interface.ts
@@ -91,5 +91,6 @@ export interface RmqOptions {
     prefetchCount?: number;
     isGlobalPrefetchCount?: boolean;
     queueOptions?: any;
+    socketOptions?: any;
   };
 }

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -12,6 +12,7 @@ import {
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
+  RQM_DEFAULT_SOCKET_OPTIONS,
   RQM_DEFAULT_URL,
 } from './../constants';
 import { WritePacket } from './../interfaces';
@@ -29,6 +30,7 @@ export class ClientRMQ extends ClientProxy {
   protected prefetchCount: number;
   protected isGlobalPrefetchCount: boolean;
   protected queueOptions: any;
+  protected socketOptions: any;
   protected replyQueue: string;
   protected responseEmitter: EventEmitter;
 
@@ -49,6 +51,9 @@ export class ClientRMQ extends ClientProxy {
     this.queueOptions =
       this.getOptionsProp<RmqOptions>(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
+    this.socketOptions =
+      this.getOptionsProp<RmqOptions>(this.options, 'socketOptions') ||
+      RQM_DEFAULT_SOCKET_OPTIONS;
 
     loadPackage('amqplib', ClientRMQ.name);
     rqmPackage = loadPackage('amqp-connection-manager', ClientRMQ.name);
@@ -93,7 +98,7 @@ export class ClientRMQ extends ClientProxy {
   }
 
   public createClient<T = any>(): T {
-    return rqmPackage.connect(this.urls) as T;
+    return rqmPackage.connect(this.urls, this.socketOptions) as T;
   }
 
   public mergeDisconnectEvent<T = any>(

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -12,7 +12,6 @@ import {
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
-  RQM_DEFAULT_SOCKET_OPTIONS,
   RQM_DEFAULT_URL,
 } from './../constants';
 import { WritePacket } from './../interfaces';
@@ -30,7 +29,6 @@ export class ClientRMQ extends ClientProxy {
   protected prefetchCount: number;
   protected isGlobalPrefetchCount: boolean;
   protected queueOptions: any;
-  protected socketOptions: any;
   protected replyQueue: string;
   protected responseEmitter: EventEmitter;
 
@@ -51,9 +49,6 @@ export class ClientRMQ extends ClientProxy {
     this.queueOptions =
       this.getOptionsProp<RmqOptions>(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
-    this.socketOptions =
-      this.getOptionsProp<RmqOptions>(this.options, 'socketOptions') ||
-      RQM_DEFAULT_SOCKET_OPTIONS;
 
     loadPackage('amqplib', ClientRMQ.name);
     rqmPackage = loadPackage('amqp-connection-manager', ClientRMQ.name);
@@ -98,6 +93,7 @@ export class ClientRMQ extends ClientProxy {
   }
 
   public createClient<T = any>(): T {
+    const socketOptions = this.getOptionsProp<RmqOptions>(this.options, 'socketOptions');
     return rqmPackage.connect(this.urls, this.socketOptions) as T;
   }
 

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -94,7 +94,7 @@ export class ClientRMQ extends ClientProxy {
 
   public createClient<T = any>(): T {
     const socketOptions = this.getOptionsProp<RmqOptions>(this.options, 'socketOptions');
-    return rqmPackage.connect(this.urls, this.socketOptions) as T;
+    return rqmPackage.connect(this.urls, socketOptions) as T;
   }
 
   public mergeDisconnectEvent<T = any>(

--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -25,7 +25,6 @@ export const RQM_DEFAULT_QUEUE = 'default';
 export const RQM_DEFAULT_PREFETCH_COUNT = 0;
 export const RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT = false;
 export const RQM_DEFAULT_QUEUE_OPTIONS = {};
-export const RQM_DEFAULT_SOCKET_OPTIONS = {};
 
 export const GRPC_DEFAULT_PROTO_LOADER = '@grpc/proto-loader';
 export const GRPC_DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH = 4 * 1024 * 1024;

--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -25,6 +25,7 @@ export const RQM_DEFAULT_QUEUE = 'default';
 export const RQM_DEFAULT_PREFETCH_COUNT = 0;
 export const RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT = false;
 export const RQM_DEFAULT_QUEUE_OPTIONS = {};
+export const RQM_DEFAULT_SOCKET_OPTIONS = {};
 
 export const GRPC_DEFAULT_PROTO_LOADER = '@grpc/proto-loader';
 export const GRPC_DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH = 4 * 1024 * 1024;

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -95,5 +95,6 @@ export interface RmqOptions {
     prefetchCount?: number;
     isGlobalPrefetchCount?: boolean;
     queueOptions?: any;
+    socketOptions?: any;
   };
 }

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -9,7 +9,6 @@ import {
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
-  RQM_DEFAULT_SOCKET_OPTIONS,
   RQM_DEFAULT_URL,
 } from '../constants';
 import { CustomTransportStrategy, RmqOptions } from '../interfaces';
@@ -25,7 +24,6 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   private readonly queue: string;
   private readonly prefetchCount: number;
   private readonly queueOptions: any;
-  private readonly socketOptions: any;
   private readonly isGlobalPrefetchCount: boolean;
 
   constructor(private readonly options: MicroserviceOptions) {
@@ -45,9 +43,6 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     this.queueOptions =
       this.getOptionsProp<RmqOptions>(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
-    this.socketOptions =
-      this.getOptionsProp<RmqOptions>(this.options, 'socketOptions') ||
-      RQM_DEFAULT_SOCKET_OPTIONS;
 
     loadPackage('amqplib', ServerRMQ.name);
     rqmPackage = loadPackage('amqp-connection-manager', ServerRMQ.name);
@@ -76,7 +71,8 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   }
 
   public createClient<T = any>(): T {
-    return rqmPackage.connect(this.urls, this.socketOptions);
+    const socketOptions = this.getOptionsProp<RmqOptions>(this.options, 'socketOptions');
+    return rqmPackage.connect(this.urls, socketOptions);
   }
 
   public async setupChannel(channel: any, callback: Function) {

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -25,6 +25,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   private readonly queue: string;
   private readonly prefetchCount: number;
   private readonly queueOptions: any;
+  private readonly socketOptions: any;
   private readonly isGlobalPrefetchCount: boolean;
 
   constructor(private readonly options: MicroserviceOptions) {

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -9,6 +9,7 @@ import {
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
+  RQM_DEFAULT_SOCKET_OPTIONS,
   RQM_DEFAULT_URL,
 } from '../constants';
 import { CustomTransportStrategy, RmqOptions } from '../interfaces';
@@ -43,6 +44,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     this.queueOptions =
       this.getOptionsProp<RmqOptions>(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
+    this.socketOptions =
+      this.getOptionsProp<RmqOptions>(this.options, 'socketOptions') ||
+      RQM_DEFAULT_SOCKET_OPTIONS;
 
     loadPackage('amqplib', ServerRMQ.name);
     rqmPackage = loadPackage('amqp-connection-manager', ServerRMQ.name);
@@ -71,7 +75,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   }
 
   public createClient<T = any>(): T {
-    return rqmPackage.connect(this.urls);
+    return rqmPackage.connect(this.urls, this.socketOptions);
   }
 
   public async setupChannel(channel: any, callback: Function) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) - https://github.com/nestjs/docs.nestjs.com/pull/244

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

You cannot specify the socket (connection) options detailed in https://www.squaremobius.net/amqp.node/channel_api.html#connect

Issue Number: N/A

## What is the new behavior?

You will now be able to specify the socket options (i.e. adding noDelay)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I came across this not being possible when I was looking at tuning our system, so decided to add it!