### PR TITLE
bugfix(common) allow classes as data parameter in createParamDecorato…

### DIFF
--- a/packages/common/decorators/http/create-route-param-metadata.decorator.ts
+++ b/packages/common/decorators/http/create-route-param-metadata.decorator.ts
@@ -48,7 +48,8 @@ export function createParamDecorator(
 
     const isPipe = (pipe: any) =>
       pipe &&
-      ((isFunction(pipe) && pipe.prototype) || isFunction(pipe.transform));
+      ((isFunction(pipe) && pipe.prototype && isFunction(pipe.prototype.transform)) ||
+        isFunction(pipe.transform));
 
     const hasParamData = isNil(data) || !isPipe(data);
     const paramData = hasParamData ? data : undefined;

--- a/packages/common/test/decorators/create-param-decorator.spec.ts
+++ b/packages/common/test/decorators/create-param-decorator.spec.ts
@@ -88,5 +88,24 @@ describe('createParamDecorator', () => {
         });
       });
     });
+
+    describe('when class type passed as data', () => {
+      class Data { }
+      class Test {
+        public test(
+          @Decorator(Data) prop,
+        ) { }
+      }
+
+      it('should return class type as data parameter', () => {
+        const metadata = Reflect.getMetadata(
+          ROUTE_ARGS_METADATA,
+          Test,
+          'test',
+        );
+        const key = Object.keys(metadata)[0];
+        expect(metadata[key].data).to.equal(Data);
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When we pass class type as data parameter to createParamDecorator function, it will be recognized as Pipe and data will be null in the factory. :disappointed: 

## What is the new behavior?
We can pass classes as data parameter :smiley: 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```