### PR TITLE
fix(@nestjs/core): Display Symbol in UnknownDependencyException

### DIFF
--- a/packages/core/errors/exceptions/unknown-dependencies.exception.ts
+++ b/packages/core/errors/exceptions/unknown-dependencies.exception.ts
@@ -5,7 +5,7 @@ import { Module } from '../../injector/module';
 
 export class UnknownDependenciesException extends RuntimeException {
   constructor(
-    type: string,
+    type: string | symbol,
     unknownDependencyContext: InjectorDependencyContext,
     module?: Module,
   ) {

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -21,7 +21,13 @@ const getInstanceName = (instance: any) =>
  * @param dependency The dependency whichs name should get displayed
  */
 const getDependencyName = (dependency: InjectorDependency) =>
-  getInstanceName(dependency) || dependency || '+';
+  // Use class name
+  getInstanceName(dependency) ||
+  // Use injection token
+  dependency && dependency.toString() ||
+  // Don't know, don't care
+  '+';
+
 /**
  * Returns the name of the module
  * Tries to get the class name. As fallback it returns 'current'.
@@ -31,15 +37,15 @@ const getModuleName = (module: Module) =>
   (module && getInstanceName(module.metatype)) || 'current';
 
 export const UNKNOWN_DEPENDENCIES_MESSAGE = (
-  type: string,
+  type: string | symbol,
   unknownDependencyContext: InjectorDependencyContext,
   module: Module,
 ) => {
   const { index, dependencies, key } = unknownDependencyContext;
-  let message = `Nest can't resolve dependencies of the ${type}`;
+  let message = `Nest can't resolve dependencies of the ${type.toString()}`;
 
   if (isNil(index)) {
-    message += `. Please make sure that the "${key}" property is available in the current context.`;
+    message += `. Please make sure that the "${key.toString()}" property is available in the current context.`;
     return message;
   }
   const dependenciesName = (dependencies || []).map(getDependencyName);

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -24,7 +24,7 @@ import { Module } from './module';
 /**
  * The type of an injectable dependency
  */
-export type InjectorDependency = Type<any> | Function | string;
+export type InjectorDependency = Type<any> | Function | string | symbol;
 
 /**
  * The property-based dependency
@@ -44,7 +44,7 @@ export interface InjectorDependencyContext {
   /**
    * The name of the property key (property-based injection)
    */
-  key?: string;
+  key?: string | symbol;
   /**
    * The name of the function or injection token
    */

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -46,4 +46,14 @@ describe('UnknownDependenciesMessage', () => {
     myModule.metatype = myMetaType;
     expect(new UnknownDependenciesException('CatService', { index, dependencies: ['', 'MY_TOKEN'] }, myModule as Module).message).to.equal(expectedResult);
   });
+  it('should display the symbol name of the provider', () => {
+    const expectedResult = 'Nest can\'t resolve dependencies of the Symbol(CatProvider) (?). ' +
+      'Please make sure that the argument at index [0] is available in the current context.';
+    expect(new UnknownDependenciesException(Symbol('CatProvider'), { index, dependencies: [''] }).message).to.equal(expectedResult);
+  });
+  it('should display the symbol dependency of the provider', () => {
+    const expectedResult = 'Nest can\'t resolve dependencies of the CatProvider (?, Symbol(DogProvider)). ' +
+      'Please make sure that the argument at index [0] is available in the current context.';
+    expect(new UnknownDependenciesException('CatProvider', { index, dependencies: ['', Symbol('DogProvider')] }).message).to.equal(expectedResult);
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using a `Symbol` as provide it won't print the `UnknownDependencyException` message correctly

e.g.
```
[Nest] 31114   - 2019-2-13 17:08:35   [ExceptionHandler] Cannot convert a Symbol value to a string +1ms
TypeError: Cannot convert a Symbol value to a string
    at Object.exports.UNKNOWN_DEPENDENCIES_MESSAGE (/home/user/project/node_modules/@nestjs/core/errors/messages.js:25:61)
```
Issue Number: #1551

## What is the new behavior?
Will print the error like this:

```
Nest can't resolve dependencies of the Symbol(CatProvider) (?). Please make sure that the argument at index [0] is available in the ApplicationModule context.
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information