### PR TITLE
Add missing isOptional() on optional field in Sample-23

### DIFF
--- a/sample/23-type-graphql/src/recipes/dto/new-recipe.input.ts
+++ b/sample/23-type-graphql/src/recipes/dto/new-recipe.input.ts
@@ -1,4 +1,4 @@
-import { Length, MaxLength } from 'class-validator';
+import { IsOptional, Length, MaxLength } from 'class-validator';
 import { Field, InputType } from 'type-graphql';
 
 @InputType()
@@ -8,6 +8,7 @@ export class NewRecipeInput {
   title: string;
 
   @Field({ nullable: true })
+  @IsOptional()
   @Length(30, 255)
   description?: string;
 


### PR DESCRIPTION
It is a simple improvement of the sample-23.

As discussed in #1616, there should be `isOptional()` decorator so GraphQL and ClassValidator validations will be in line.