### PR TITLE
feat(@nestjs/core): Add Transient Inquirer Injection

### DIFF
--- a/integration/scopes/e2e/inject-inquirer.spec.ts
+++ b/integration/scopes/e2e/inject-inquirer.spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication, Logger } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import * as sinon from 'sinon';
+import { HelloModule } from '../src/inject-inquirer/hello.module';
+
+describe('Inject Inquirer', () => {
+  let logger;
+
+  let server;
+  let app: INestApplication;
+
+  before(async () => {
+    logger = { log: sinon.spy() };
+
+    const module = await Test.createTestingModule({
+      imports: [HelloModule],
+    })
+      .overrideProvider(Logger)
+      .useValue(logger)
+      .compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  beforeEach(() => {
+    logger.log.reset();
+  });
+
+  it(`should allow the injection of the inquirer in a Transient Scope`, async () => {
+    await request(server).get('/hello/transient');
+
+    expect(
+      logger.log.calledWith({
+        message: 'Hello transient!',
+        feature: 'transient',
+      }),
+    ).to.be.true;
+  });
+
+  it(`should allow the injection of the inquirer in a Request Scope`, async () => {
+    await request(server).get('/hello/request');
+
+    expect(
+      logger.log.calledWith({
+        message: 'Hello request!',
+        requestId: sinon.match.string,
+        feature: 'request',
+      }),
+    ).to.be.true;
+
+    const requestId = logger.log.getCall(0).args[0].requestId;
+
+    expect(
+      logger.log.calledWith({
+        message: 'Goodbye request!',
+        requestId,
+        feature: 'request',
+      }),
+    );
+  });
+
+  after(async () => {
+    await app.close();
+  });
+});

--- a/integration/scopes/src/inject-inquirer/hello-request/hello-request.service.ts
+++ b/integration/scopes/src/inject-inquirer/hello-request/hello-request.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { RequestLogger } from './request-logger.service';
+
+@Injectable()
+export class HelloRequestService {
+  static logger = { feature: 'request' };
+
+  constructor(private readonly logger: RequestLogger) {}
+
+  greeting() {
+    this.logger.log('Hello request!');
+  }
+
+  farewell() {
+    this.logger.log('Goodbye request!');
+  }
+}

--- a/integration/scopes/src/inject-inquirer/hello-request/request-logger.service.ts
+++ b/integration/scopes/src/inject-inquirer/hello-request/request-logger.service.ts
@@ -1,0 +1,26 @@
+import { Inject, Logger, Injectable, Scope } from '@nestjs/common';
+import { REQUEST, INQUIRER } from '@nestjs/core';
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class RequestLogger {
+  config: object;
+
+  constructor(
+    @Inject(INQUIRER) { constructor },
+    @Inject(REQUEST) private readonly request,
+    private readonly logger: Logger,
+  ) {
+    this.config = (constructor && constructor.logger) || {};
+  }
+
+  get requestId() {
+    if (!this.request.id) {
+      this.request.id = `${Date.now()}.${Math.floor(Math.random() * 1000000)}`;
+    }
+    return this.request.id;
+  }
+
+  log(message: string) {
+    this.logger.log({ message, requestId: this.requestId, ...this.config });
+  }
+}

--- a/integration/scopes/src/inject-inquirer/hello-transient/hello-transient.service.ts
+++ b/integration/scopes/src/inject-inquirer/hello-transient/hello-transient.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { TransientLogger } from './transient-logger.service';
+
+@Injectable()
+export class HelloTransientService {
+  static logger = { feature: 'transient' };
+
+  constructor(private readonly logger: TransientLogger) {}
+
+  greeting() {
+    this.logger.log('Hello transient!');
+  }
+}

--- a/integration/scopes/src/inject-inquirer/hello-transient/transient-logger.service.ts
+++ b/integration/scopes/src/inject-inquirer/hello-transient/transient-logger.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Logger, Injectable, Scope } from '@nestjs/common';
+import { INQUIRER } from '@nestjs/core';
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class TransientLogger {
+  config: object;
+
+  constructor(
+    @Inject(INQUIRER) { constructor },
+    private readonly logger: Logger,
+  ) {
+    this.config = (constructor && constructor.logger) || {};
+  }
+
+  log(message: string) {
+    this.logger.log({ message, ...this.config });
+  }
+}

--- a/integration/scopes/src/inject-inquirer/hello.controller.ts
+++ b/integration/scopes/src/inject-inquirer/hello.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get } from '@nestjs/common';
+import { HelloRequestService } from './hello-request/hello-request.service';
+import { HelloTransientService } from './hello-transient/hello-transient.service';
+
+@Controller('hello')
+export class HelloController {
+  constructor(
+    private readonly helloTransientService: HelloTransientService,
+    private readonly helloRequestService: HelloRequestService,
+  ) {}
+
+  @Get('transient')
+  greetingTransient() {
+    this.helloTransientService.greeting();
+  }
+
+  @Get('request')
+  greetingRequest() {
+    this.helloRequestService.greeting();
+    this.helloRequestService.farewell();
+  }
+}

--- a/integration/scopes/src/inject-inquirer/hello.module.ts
+++ b/integration/scopes/src/inject-inquirer/hello.module.ts
@@ -1,0 +1,18 @@
+import { Module, Logger } from '@nestjs/common';
+import { HelloController } from './hello.controller';
+import { HelloRequestService } from './hello-request/hello-request.service';
+import { HelloTransientService } from './hello-transient/hello-transient.service';
+import { RequestLogger } from './hello-request/request-logger.service';
+import { TransientLogger } from './hello-transient/transient-logger.service';
+
+@Module({
+  controllers: [HelloController],
+  providers: [
+    HelloRequestService,
+    HelloTransientService,
+    RequestLogger,
+    TransientLogger,
+    Logger,
+  ],
+})
+export class HelloModule {}

--- a/packages/core/injector/index.ts
+++ b/packages/core/injector/index.ts
@@ -1,3 +1,4 @@
 export * from './container';
 export * from './module-ref';
 export * from './modules-container';
+export * from './inquirer';

--- a/packages/core/injector/inquirer/index.ts
+++ b/packages/core/injector/inquirer/index.ts
@@ -1,0 +1,1 @@
+export * from './inquirer-constants';

--- a/packages/core/injector/inquirer/inquirer-constants.ts
+++ b/packages/core/injector/inquirer/inquirer-constants.ts
@@ -1,0 +1,1 @@
+export const INQUIRER = Symbol('INQUIRER');

--- a/packages/core/injector/inquirer/inquirer-providers.ts
+++ b/packages/core/injector/inquirer/inquirer-providers.ts
@@ -1,0 +1,9 @@
+import { Provider, Scope } from '@nestjs/common';
+import { INQUIRER } from './inquirer-constants';
+
+const noop = () => {};
+export const inquirerProvider: Provider = {
+  provide: INQUIRER,
+  scope: Scope.TRANSIENT,
+  useFactory: noop,
+};

--- a/packages/core/injector/internal-core-module.ts
+++ b/packages/core/injector/internal-core-module.ts
@@ -2,11 +2,12 @@ import { DynamicModule, Global, Module } from '@nestjs/common';
 import { ValueProvider } from '@nestjs/common/interfaces';
 import { requestProvider } from './../router/request/request-providers';
 import { Reflector } from './../services';
+import { inquirerProvider } from './inquirer/inquirer-providers';
 
 @Global()
 @Module({
-  providers: [Reflector, requestProvider],
-  exports: [Reflector, requestProvider],
+  providers: [Reflector, requestProvider, inquirerProvider],
+  exports: [Reflector, requestProvider, inquirerProvider],
 })
 export class InternalCoreModule {
   static register(providers: ValueProvider[]): DynamicModule {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In a transient injectable, the current instance is bound to the context in which it is instanciated.
However, there is no way I am aware of to configure the behaviour of the injected injectable at the intanciation level

## What is the new behavior?
This PR introduce a way to achieve this intention by adding a new provider in the InternalCoreModule.
The injection of the `INQUIRER` symbol token results in the inquirer to be injected into our transient injectable.
```ts
@Inject(INQUIRER) inquirer
```
An example with a concrete business use-case is available in the PR

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The way we implemented the feature may not be ideal given the architecture of the injection mechanism, so @millehorde and myself are willing to take all measures you consider appropriated