### PR TITLE
test(@nestjs/core): Check lifecycle hook order

### DIFF
--- a/integration/hooks/e2e/lifecycle-hook-order.spec.ts
+++ b/integration/hooks/e2e/lifecycle-hook-order.spec.ts
@@ -1,0 +1,43 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as Sinon from 'sinon';
+import {
+  Injectable,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+  OnModuleDestroy,
+  OnModuleInit,
+} from '@nestjs/common';
+
+@Injectable()
+class TestInjectable
+  implements
+    OnApplicationBootstrap,
+    OnModuleInit,
+    OnModuleDestroy,
+    OnApplicationShutdown {
+  onApplicationBootstrap = Sinon.spy();
+  onApplicationShutdown = Sinon.spy();
+  onModuleDestroy = Sinon.spy();
+  onModuleInit = Sinon.spy();
+}
+
+describe('Lifecycle Hook Order', () => {
+  it('should call the lifecycle hooks in the correct order', async () => {
+    const module = await Test.createTestingModule({
+      providers: [TestInjectable],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init();
+    await app.close();
+
+    const instance = module.get(TestInjectable);
+    Sinon.assert.callOrder(
+      instance.onModuleInit,
+      instance.onApplicationBootstrap,
+      instance.onModuleDestroy,
+      instance.onApplicationShutdown,
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The order of the lifecycle events is not backed by any test


## What is the new behavior?
Added e2e test which checks which hook gets called in which order.

`OnModuleInit -> OnApplicationBootstrap -> OnModuleClose -> OnApplicationShutdown`.

If this is not the expected behavior, we would have to change the order.

Related pr: [docs.nestjs.com#267](https://github.com/nestjs/docs.nestjs.com/pull/267)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information