### PR TITLE
bugfix(common) Stripping proto properties works with null values

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -94,6 +94,7 @@ export class ValidationPipe implements PipeTransform<any> {
   }
 
   private stripProtoKeys(value: Record<string, any>) {
+    if (isNil(value)) { return; }
     delete value.__proto__;
     const keys = Object.keys(value);
     keys

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -26,6 +26,10 @@ class TestModel {
   @IsString() public prop1: string;
 
   @IsString() public prop2: string;
+
+  @IsOptional()
+  @IsString()
+  public optionalProp: string;
 }
 
 describe('ValidationPipe', () => {
@@ -46,8 +50,29 @@ describe('ValidationPipe', () => {
       beforeEach(() => {
         target = new ValidationPipe();
       });
-      it('should return the value unchanged', async () => {
+      it('should return the value unchanged if optional value is not defined', async () => {
         const testObj = { prop1: 'value1', prop2: 'value2' };
+        expect(await target.transform(testObj, {} as any)).to.equal(testObj);
+        expect(
+          await target.transform(testObj, metadata as any),
+        ).to.not.be.instanceOf(TestModel);
+      });
+      it('should return the value unchanged if optional value is set undefined', async () => {
+        const testObj = { prop1: 'value1', prop2: 'value2', optionalProp: undefined };
+        expect(await target.transform(testObj, {} as any)).to.equal(testObj);
+        expect(
+          await target.transform(testObj, metadata as any),
+        ).to.not.be.instanceOf(TestModel);
+      });
+      it('should return the value unchanged if optional value is null', async () => {
+        const testObj = { prop1: 'value1', prop2: 'value2', optionalProp: null };
+        expect(await target.transform(testObj, {} as any)).to.equal(testObj);
+        expect(
+          await target.transform(testObj, metadata as any),
+        ).to.not.be.instanceOf(TestModel);
+      });
+      it('should return the value unchanged if optional value is set', async () => {
+        const testObj = { prop1: 'value1', prop2: 'value2', optionalProp: 'optional value' };
         expect(await target.transform(testObj, {} as any)).to.equal(testObj);
         expect(
           await target.transform(testObj, metadata as any),
@@ -134,6 +159,48 @@ describe('ValidationPipe', () => {
           expect(
             await target.transform(testObj, metadata),
           ).to.not.have.property('prop3');
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.have.property('optionalProp');
+        });
+        it('should return a plain object without extra properties if optional prop is defined', async () => {
+          target = new ValidationPipe({ transform: false, whitelist: true });
+          const testObj = { prop1: 'value1', prop2: 'value2', prop3: 'value3', optionalProp: 'optional value' };
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.be.instanceOf(TestModel);
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.have.property('prop3');
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.have.property('optionalProp');
+        });
+        it('should return a plain object without extra properties if optional prop is undefined', async () => {
+          target = new ValidationPipe({ transform: false, whitelist: true });
+          const testObj = { prop1: 'value1', prop2: 'value2', prop3: 'value3', optionalProp: undefined };
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.be.instanceOf(TestModel);
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.have.property('prop3');
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.have.property('optionalProp');
+        });
+        it('should return a plain object without extra properties if optional prop is null', async () => {
+          target = new ValidationPipe({ transform: false, whitelist: true });
+          const testObj = { prop1: 'value1', prop2: 'value2', prop3: 'value3', optionalProp: null };
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.be.instanceOf(TestModel);
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.not.have.property('prop3');
+          expect(
+            await target.transform(testObj, metadata),
+          ).to.have.property('optionalProp');
         });
       });
       describe('when validation rejects', () => {


### PR DESCRIPTION
If an optional property has an allowed null value it is now considered when stripping proto props.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2238


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
