### PR TITLE
feature(microservices): Return correct client type in ClientProxyFactory

### DIFF
--- a/packages/microservices/client/client-proxy-factory.ts
+++ b/packages/microservices/client/client-proxy-factory.ts
@@ -14,6 +14,10 @@ export interface IClientProxyFactory {
 }
 
 export class ClientProxyFactory {
+  public static create(
+    clientOptions: { transport: Transport.GRPC } & ClientOptions,
+  ): ClientGrpcProxy;
+  public static create(clientOptions: ClientOptions): ClientProxy & Closeable;
   public static create(clientOptions: ClientOptions): ClientProxy & Closeable {
     const { transport, options } = clientOptions;
     switch (transport) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment `ClientProxyFactory.create` will always return the type `ClientProxy & Closeable`. Therefore it will not take the given `transport` option into consideration, even though we would know what type should be returned.   


```ts

const client = ClientProxyFactory.create({ transport: Transport.GRPC, options: { ... }); // The type is `ClientProxy & Closeable`

// To get the correct type you have to use this workaround
const grpcClient = (client as any) as ClientGrpc;

```
On top of that `ClientProxy & Closeable` is straight up wrong with some clients, such as the `GrpcClient`.
Calling `.connect()` from `ClientProxy & Closeable` on `ClientGrpc` would result in this error: `Error: The "connect()" method is not supported in gRPC mode.`

## What is the new behavior?
Adds overloads to the `ClientProxyFactory` for better type security.
This allows the user to not cast the client to any after creating it
using the factory.

```ts

const client = ClientProxyFactory.create({ transport: Transport.GRPC, options: { .. }) // The type is `ClientGrpcProxy`

```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The `ClientProxyFactory` is used in `@nestjs/terminus` to dynamically create a microservice client on the fly. Better type security would lead to a better code :)