### PR TITLE
feature(common): add option to allow validation of custom decorators

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -16,6 +16,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   disableErrorMessages?: boolean;
   transformOptions?: ClassTransformOptions;
   exceptionFactory?: (errors: ValidationError[]) => any;
+  validateCustomDecorators?: boolean;
 }
 
 let classValidator: any = {};
@@ -28,6 +29,7 @@ export class ValidationPipe implements PipeTransform<any> {
   protected validatorOptions: ValidatorOptions;
   protected transformOptions: ClassTransformOptions;
   protected exceptionFactory: (errors: ValidationError[]) => any;
+  protected validateCustomDecorators: boolean;
 
   constructor(@Optional() options?: ValidationPipeOptions) {
     options = options || {};
@@ -35,12 +37,14 @@ export class ValidationPipe implements PipeTransform<any> {
       transform,
       disableErrorMessages,
       transformOptions,
+      validateCustomDecorators,
       ...validatorOptions
     } = options;
     this.isTransformEnabled = !!transform;
     this.validatorOptions = validatorOptions;
     this.transformOptions = transformOptions;
     this.isDetailedOutputDisabled = disableErrorMessages;
+    this.validateCustomDecorators = validateCustomDecorators || false;
     this.exceptionFactory =
       options.exceptionFactory ||
       (errors =>
@@ -82,7 +86,7 @@ export class ValidationPipe implements PipeTransform<any> {
 
   private toValidate(metadata: ArgumentMetadata): boolean {
     const { metatype, type } = metadata;
-    if (type === 'custom') {
+    if (type === 'custom' && !this.validateCustomDecorators) {
       return false;
     }
     const types = [String, Boolean, Number, Array, Object];


### PR DESCRIPTION
No matter what the reason is to not validate custom decorators, you should be able to at least provide an option

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2010

You are required to create a new validation pipe for custom decorators. You cannot use the build in one.


## What is the new behavior?

You have the option to allow the validation of custom decorators.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information