### PR TITLE
feat(@nestjs/core): support transient-scope provider and request-scop…

### DIFF
--- a/integration/scopes/e2e/nest-application-context-get-scope-provider.spec.ts
+++ b/integration/scopes/e2e/nest-application-context-get-scope-provider.spec.ts
@@ -1,0 +1,69 @@
+import { INestApplication, Scope } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+
+class Meta {
+  static COUNTER = 0;
+  constructor() {
+    Meta.COUNTER++;
+  }
+}
+
+describe('NestApplicationContext get scope provider', () => {
+  let server;
+  let app: INestApplication;
+
+  before(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: 'META',
+          useClass: Meta,
+        },
+        {
+          provide: 'META_REQUEST',
+          useClass: Meta,
+          scope: Scope.REQUEST,
+        },
+        {
+          provide: 'META_TRANSIENT',
+          useClass: Meta,
+          scope: Scope.TRANSIENT,
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  it(`should create provider for scope default `, async () => {
+    app.get('META');
+    expect(Meta.COUNTER).to.be.eql(1);
+    app.get('META');
+    expect(Meta.COUNTER).to.be.eql(1);
+    await app.resolve('META');
+    expect(Meta.COUNTER).to.be.eql(1);
+    await app.resolve('META');
+    expect(Meta.COUNTER).to.be.eql(1);
+  });
+
+  it(`should create provider for scope request `, async () => {
+    await app.resolve('META_REQUEST');
+    expect(Meta.COUNTER).to.be.eql(2);
+    await app.resolve('META_REQUEST');
+    expect(Meta.COUNTER).to.be.eql(3);
+  });
+
+  it(`should create provider for scope transient `, async () => {
+    await app.resolve('META_TRANSIENT');
+    expect(Meta.COUNTER).to.be.eql(4);
+    await app.resolve('META_TRANSIENT');
+    expect(Meta.COUNTER).to.be.eql(5);
+  });
+
+  after(async () => {
+    await app.close();
+  });
+});

--- a/packages/common/interfaces/nest-application-context.interface.ts
+++ b/packages/common/interfaces/nest-application-context.interface.ts
@@ -12,12 +12,23 @@ export interface INestApplicationContext {
 
   /**
    * Retrieves an instance of either injectable or controller available anywhere, otherwise, throws exception.
+   * It use for singleton providers.
    * @returns {TResult}
    */
   get<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Abstract<TInput> | string | symbol,
     options?: { strict: boolean },
   ): TResult;
+
+  /**
+   * Retrieves an instance of either injectable or controller available anywhere, otherwise, throws exception.
+   * It use for transient and request-scoped providers.
+   * @returns {Promise<TResult>}
+   */
+  resolve<TInput = any, TResult = TInput>(
+    typeOrToken: Type<TInput> | Abstract<TInput> | string | symbol,
+    options?: { strict: boolean },
+  ): Promise<TResult>;
 
   /**
    * Terminates the application

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -142,14 +142,16 @@ export class InstanceWrapper<T = any> {
     return this[INSTANCE_METADATA_SYMBOL].dependencies;
   }
 
-  public addPropertiesMetadata(key: string, wrapper: InstanceWrapper) {
+  public addPropertiesMetadata(key?: string, wrapper?: InstanceWrapper) {
     if (!this[INSTANCE_METADATA_SYMBOL].properties) {
       this[INSTANCE_METADATA_SYMBOL].properties = [];
     }
-    this[INSTANCE_METADATA_SYMBOL].properties.push({
-      key,
-      wrapper,
-    });
+    if (key && wrapper) {
+      this[INSTANCE_METADATA_SYMBOL].properties.push({
+        key,
+        wrapper,
+      });
+    }
   }
 
   public getPropertiesMetadata(): PropertyMetadata[] {

--- a/packages/core/injector/module-ref.ts
+++ b/packages/core/injector/module-ref.ts
@@ -18,11 +18,16 @@ export abstract class ModuleRef {
     options?: { strict: boolean },
   ): TResult;
 
+  public abstract async resolve<TInput = any, TResult = TInput>(
+    typeOrToken: Type<TInput> | string | symbol,
+    options?: { strict: boolean },
+  ): Promise<TResult>;
+
   public abstract create<T = any>(type: Type<T>): Promise<T>;
 
   protected find<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | string | symbol,
-  ): TResult {
+  ): Promise<TResult> | TResult {
     return this.containerScanner.find<TInput, TResult>(typeOrToken);
   }
 
@@ -63,7 +68,7 @@ export abstract class ModuleRef {
   protected findInstanceByPrototypeOrToken<TInput = any, TResult = TInput>(
     metatypeOrToken: Type<TInput> | string | symbol,
     contextModule: Partial<Module>,
-  ): TResult {
+  ): Promise<TResult> | TResult {
     return this.containerScanner.findInstanceByPrototypeOrToken<
       TInput,
       TResult

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -437,6 +437,19 @@ export class Module {
         options: { strict: boolean } = { strict: true },
       ): TResult {
         if (!(options && options.strict)) {
+          return this.find<TInput, TResult>(typeOrToken) as TResult;
+        }
+        return this.findInstanceByPrototypeOrToken<TInput, TResult>(
+          typeOrToken,
+          self,
+        ) as TResult;
+      }
+
+      public async resolve<TInput = any, TResult = TInput>(
+        typeOrToken: Type<TInput> | string | symbol,
+        options: { strict: boolean } = { strict: true },
+      ): Promise<TResult> {
+        if (!(options && options.strict)) {
           return this.find<TInput, TResult>(typeOrToken);
         }
         return this.findInstanceByPrototypeOrToken<TInput, TResult>(

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -56,6 +56,19 @@ export class NestApplicationContext implements INestApplicationContext {
     options: { strict: boolean } = { strict: false },
   ): TResult {
     if (!(options && options.strict)) {
+      return this.find<TInput, TResult>(typeOrToken) as TResult;
+    }
+    return this.findInstanceByPrototypeOrToken<TInput, TResult>(
+      typeOrToken,
+      this.contextModule,
+    ) as TResult;
+  }
+
+  public async resolve<TInput = any, TResult = TInput>(
+    typeOrToken: Type<TInput> | Abstract<TInput> | string | symbol,
+    options: { strict: boolean } = { strict: false },
+  ): Promise<TResult> {
+    if (!(options && options.strict)) {
       return this.find<TInput, TResult>(typeOrToken);
     }
     return this.findInstanceByPrototypeOrToken<TInput, TResult>(
@@ -191,14 +204,14 @@ export class NestApplicationContext implements INestApplicationContext {
 
   protected find<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Abstract<TInput> | string | symbol,
-  ): TResult {
+  ): Promise<TResult> | TResult {
     return this.containerScanner.find<TInput, TResult>(typeOrToken);
   }
 
   protected findInstanceByPrototypeOrToken<TInput = any, TResult = TInput>(
     metatypeOrToken: Type<TInput> | Abstract<TInput> | string | symbol,
     contextModule: Partial<Module>,
-  ): TResult {
+  ): Promise<TResult> | TResult {
     return this.containerScanner.findInstanceByPrototypeOrToken<
       TInput,
       TResult

--- a/packages/core/test/injector/module.spec.ts
+++ b/packages/core/test/injector/module.spec.ts
@@ -403,6 +403,11 @@ describe('Module', () => {
         expect(() => moduleRef.get('fail')).to.throws(UnknownElementException);
       });
     });
+    describe('resolve', () => {
+      it('should throw exception if not exists', () => {
+        expect(moduleRef.resolve('fail')).to.eventually.be.rejectedWith(UnknownElementException);
+      });
+    });
   });
   describe('validateExportedProvider', () => {
     const token = 'token';


### PR DESCRIPTION
…e provider with `NestApplicationContext`. #2049

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 2049


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
before
```
@Module({
  providers: [
    {
      scope: Scope.TRANSIENT,
      provide: 'TRANSIENT_PROVIDER',
      useFactory: () => {
        return 'TRANSIENT_PROVIDER_VALUE';
      }
    },
  ]
})
export class AppModule {}

async function bootstrap() {
  const app = await NestFactory.createApplicationContext(AppModule);
  // Returns `null`
  app.get('TRANSIENT_PROVIDER')}
}
```
after
```
@Module({
  providers: [
    {
      scope: Scope.TRANSIENT,
      provide: 'TRANSIENT_PROVIDER',
      useFactory: () => {
        return 'TRANSIENT_PROVIDER_VALUE';
      }
    },
  ]
})
export class AppModule {}

async function bootstrap() {
  const app = await NestFactory.createApplicationContext(AppModule);
  // Returns `TRANSIENT_PROVIDER_VALUE`, the same as support with `Scope.REQUEST`
  // Note: The`get` mothed return `Promise<any>`, it`s is a breaking change
  await app.get('TRANSIENT_PROVIDER')}
}
```
## Other information