### PR TITLE
Microservices: Order of pattern fields

### DIFF
--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -18,6 +18,8 @@ import {
   WritePacket,
 } from '../interfaces';
 
+import * as Utils from '../utils';
+
 export abstract class ClientProxy {
   public abstract connect(): Promise<any>;
   public abstract close(): any;
@@ -101,6 +103,6 @@ export abstract class ClientProxy {
   }
 
   protected normalizePattern<T = any>(pattern: T): string {
-    return (isString(pattern) ? pattern : JSON.stringify(pattern)) as string;
+    return Utils.MsvcUtil.transformPatternToRoute(pattern);
   }
 }

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -25,6 +25,7 @@ export abstract class ClientProxy {
   public abstract close(): any;
 
   protected routingMap = new Map<string, Function>();
+  protected readonly msvcUtil = Utils.MsvcUtil;
 
   public send<TResult = any, TInput = any>(
     pattern: any,
@@ -103,6 +104,6 @@ export abstract class ClientProxy {
   }
 
   protected normalizePattern<T = any>(pattern: T): string {
-    return Utils.MsvcUtil.transformPatternToRoute(pattern);
+    return this.msvcUtil.transformPatternToRoute(pattern);
   }
 }

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -18,6 +18,8 @@ import {
   WritePacket,
 } from '../interfaces';
 
+import * as Interfaces from '../interfaces';
+
 import * as Utils from '../utils';
 
 export abstract class ClientProxy {
@@ -103,7 +105,7 @@ export abstract class ClientProxy {
     return (obj && obj[prop]) || defaultValue;
   }
 
-  protected normalizePattern<T = any>(pattern: T): string {
+  protected normalizePattern(pattern: Interfaces.MsPattern): string {
     return this.msvcUtil.transformPatternToRoute(pattern);
   }
 }

--- a/packages/microservices/interfaces/index.ts
+++ b/packages/microservices/interfaces/index.ts
@@ -7,3 +7,4 @@ export * from './microservice-configuration.interface';
 export * from './packet.interface';
 export * from './pattern-metadata.interface';
 export * from './request-context.interface';
+export * from './pattern.interface';

--- a/packages/microservices/interfaces/pattern.interface.ts
+++ b/packages/microservices/interfaces/pattern.interface.ts
@@ -1,0 +1,8 @@
+
+export type MsFundamentalPattern = string | number;
+
+export interface MsObjectPattern {
+  [key: string]: MsFundamentalPattern | MsObjectPattern;
+}
+
+export type MsPattern = MsObjectPattern | MsFundamentalPattern;

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -18,6 +18,8 @@ import {
 } from '../interfaces';
 import { NO_EVENT_HANDLER } from './../constants';
 
+import * as Interfaces from '../interfaces';
+
 import * as Utils from '../utils';
 
 export abstract class Server {
@@ -111,7 +113,7 @@ export abstract class Server {
    * @returns string
    */
   private getRouteFromPattern(pattern: string): string {
-    let validPattern: any;
+    let validPattern: Interfaces.MsPattern;
 
     try {
       // Gets the pattern in JSON format

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -18,6 +18,8 @@ import {
 } from '../interfaces';
 import { NO_EVENT_HANDLER } from './../constants';
 
+import * as Utils from '../utils';
+
 export abstract class Server {
   protected readonly messageHandlers = new Map<string, MessageHandler>();
   protected readonly logger = new Logger(Server.name);
@@ -28,8 +30,9 @@ export abstract class Server {
     isEventHandler = false,
   ) {
     const key = isString(pattern) ? pattern : JSON.stringify(pattern);
+    const route = this.getRouteFromPattern(key);
     callback.isEventHandler = isEventHandler;
-    this.messageHandlers.set(key, callback);
+    this.messageHandlers.set(route, callback);
   }
 
   public getHandlers(): Map<string, MessageHandler> {
@@ -37,8 +40,9 @@ export abstract class Server {
   }
 
   public getHandlerByPattern(pattern: string): MessageHandler | null {
-    return this.messageHandlers.has(pattern)
-      ? this.messageHandlers.get(pattern)
+    const route = this.getRouteFromPattern(pattern);
+    return this.messageHandlers.has(route)
+      ? this.messageHandlers.get(route)
       : null;
   }
 
@@ -98,5 +102,26 @@ export abstract class Server {
 
   private isObservable(input: unknown): input is Observable<any> {
     return input && isFunction((input as Observable<any>).subscribe);
+  }
+
+  /**
+   * Transforms the server Pattern to valid type and returns a route for him.
+   *
+   * @param  {string} pattern - server pattern
+   * @returns string
+   */
+  private getRouteFromPattern(pattern: string): string {
+    let validPattern: any;
+
+    try {
+      // Gets the pattern in JSON format
+      validPattern = JSON.parse(pattern);
+    } catch (error) {
+      // Uses a fundamental object (`pattern` variable without any conversion)
+      validPattern = pattern;
+    }
+
+    // Transform the Pattern to Route
+    return Utils.MsvcUtil.transformPatternToRoute(validPattern);
   }
 }

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -30,8 +30,7 @@ export abstract class Server {
     callback: MessageHandler,
     isEventHandler = false,
   ) {
-    const key = isString(pattern) ? pattern : JSON.stringify(pattern);
-    const route = this.getRouteFromPattern(key);
+    const route = this.msvcUtil.transformPatternToRoute(pattern);
     callback.isEventHandler = isEventHandler;
     this.messageHandlers.set(route, callback);
   }

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -23,6 +23,7 @@ import * as Utils from '../utils';
 export abstract class Server {
   protected readonly messageHandlers = new Map<string, MessageHandler>();
   protected readonly logger = new Logger(Server.name);
+  protected readonly msvcUtil = Utils.MsvcUtil;
 
   public addHandler(
     pattern: any,
@@ -122,6 +123,6 @@ export abstract class Server {
     }
 
     // Transform the Pattern to Route
-    return Utils.MsvcUtil.transformPatternToRoute(validPattern);
+    return this.msvcUtil.transformPatternToRoute(validPattern);
   }
 }

--- a/packages/microservices/test/client/client-proxy.spec.ts
+++ b/packages/microservices/test/client/client-proxy.spec.ts
@@ -172,4 +172,27 @@ describe('ClientProxy', () => {
       expect(err$).to.be.instanceOf(Observable);
     });
   });
+
+  describe('normalizePattern', () => {
+    describe(`when gets 'string' pattern`, () => {
+      it(`should call 'transformPatternToRoute' with 'string' argument`, () => {
+        const inputPattern = 'hello';
+
+        const sandbox = sinon.createSandbox();
+        sandbox
+          .stub((client as any), 'msvcUtil')
+          .value({ transformPatternToRoute() {} });
+        const msvcUtilTransformPatternToRouteStub = sinon
+          .spy((client as any).msvcUtil, 'transformPatternToRoute');
+
+        (client as any).normalizePattern(inputPattern);
+
+        expect(msvcUtilTransformPatternToRouteStub.args[0][0])
+          .to.be.equal(inputPattern);
+
+        msvcUtilTransformPatternToRouteStub.restore();
+        sandbox.restore();
+      });
+    });
+  });
 });

--- a/packages/microservices/test/utils/msvc.util.spec.ts
+++ b/packages/microservices/test/utils/msvc.util.spec.ts
@@ -4,106 +4,116 @@ import { MsvcUtil } from '../../utils/msvc.util';
 describe('MsvcUtil', () => {
 
   describe('transformPatternToRoute', () => {
-    it(`use 'string' value`, () => {
-      const testPattern1 = `pattern1`;
-      const testPattern2 = 'PaTteRn2';
-      const testPattern3 = '3PaTteRn';
+    describe(`gets 'string' value`, () => {
+      it(`should return the same string`, () => {
+        const testPattern1 = `pattern1`;
+        const testPattern2 = 'PaTteRn2';
+        const testPattern3 = '3PaTteRn';
 
-      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+        const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+        const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+        const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
 
-      expect(testData1).to.be.equal(testPattern1);
-      expect(testData2).to.be.equal(testPattern2);
-      expect(testData3).to.be.equal(testPattern3);
+        expect(testData1).to.be.equal(testPattern1);
+        expect(testData2).to.be.equal(testPattern2);
+        expect(testData3).to.be.equal(testPattern3);
+      });
     });
 
-    it(`use 'JSON' value without nested JSON (1 level)`, () => {
-      const testPattern1 = {
-        controller: 'app',
-        use: 'getHello'
-      };
-      const testPattern2 = {
-        use: 'getHello',
-        controller: 'app'
-      };
-      const testPattern3 = {
-        service: 'one',
-        use: 'getHello',
-        controller: 'app'
-      };
+    describe(`gets 'JSON' value`, () => {
+      describe(`without nested JSON (1 level)`, () => {
+        it(`should return correct route`, () => {
+          const testPattern1 = {
+            controller: 'app',
+            use: 'getHello'
+          };
+          const testPattern2 = {
+            use: 'getHello',
+            controller: 'app'
+          };
+          const testPattern3 = {
+            service: 'one',
+            use: 'getHello',
+            controller: 'app'
+          };
 
-      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
 
-      expect(testData1).to.be.equal(`{controller:app/use:getHello}`);
-      expect(testData2).to.be.equal(`{controller:app/use:getHello}`);
-      expect(testData3).to.be.equal(`{controller:app/service:one/use:getHello}`);
+          expect(testData1).to.be.equal(`{controller:app/use:getHello}`);
+          expect(testData2).to.be.equal(`{controller:app/use:getHello}`);
+          expect(testData3).to.be.equal(`{controller:app/service:one/use:getHello}`);
+        });
+      });
+      describe(`use 'JSON' value with nested JSON (2 levels)`, () => {
+        it(`should return correct route`, () => {
+          const testPattern1 = {
+            controller: 'app',
+            use: { p1: 'path1', p2: 'path2' }
+          };
+          const testPattern2 = {
+            use: { p1: 'path1', p2: 'path2' },
+            controller: 'app'
+          };
+          const testPattern3 = {
+            service: 'one',
+            use: { p1: 'path1', p2: 'path2' },
+            controller: 'app'
+          };
+
+          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+          expect(testData1).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
+          expect(testData2).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
+          expect(testData3).to.be.equal(`{controller:app/service:one/use:{p1:path1/p2:path2}}`);
+        });
+      });
+      describe(`use 'JSON' value with nested JSON (3 levels)`, () => {
+        it(`should return correct route`, () => {
+          const testPattern1 = {
+            controller: 'app',
+            use: { p1: 'path1', p2: { pp1: 'ppath1' } }
+          };
+          const testPattern2 = {
+            use: { p1: 'path1' },
+            controller: { p2: 'path2' },
+          };
+          const testPattern3 = {
+            service: 'one',
+            use: { p1: 'path1', p2: { pp1: 'ppath1' } },
+            controller: { p1: { pp1: 'ppath1' } }
+          };
+
+          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+          expect(testData1)
+            .to.be.equal(`{controller:app/use:{p1:path1/p2:{pp1:ppath1}}}`);
+          expect(testData2)
+            .to.be.equal(`{controller:{p2:path2}/use:{p1:path1}}`);
+          expect(testData3)
+            .to.be.equal(`{controller:{p1:{pp1:ppath1}}/service:one/use:{p1:path1/p2:{pp1:ppath1}}}`);
+        });
+      });
     });
 
-    it(`use 'JSON' value with nested JSON (2 levels)`, () => {
-      const testPattern1 = {
-        controller: 'app',
-        use: { p1: 'path1', p2: 'path2' }
-      };
-      const testPattern2 = {
-        use: { p1: 'path1', p2: 'path2' },
-        controller: 'app'
-      };
-      const testPattern3 = {
-        service: 'one',
-        use: { p1: 'path1', p2: 'path2' },
-        controller: 'app'
-      };
+    describe(`gets value with incorrect type (no string/JSON)`, () => {
+      it(`should throw error`, () => {
+        const testPattern1 = 150;
+        const testPattern2 = null;
+        const testPattern3 = undefined;
+        const testPattern4 = Symbol(213);
+        const errMsg = `The pattern must be of type 'string' or 'object'!`;
 
-      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
-
-      expect(testData1).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
-      expect(testData2).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
-      expect(testData3).to.be.equal(`{controller:app/service:one/use:{p1:path1/p2:path2}}`);
-    });
-
-    it(`use 'JSON' value with nested JSON (3 levels)`, () => {
-      const testPattern1 = {
-        controller: 'app',
-        use: { p1: 'path1', p2: { pp1: 'ppath1' } }
-      };
-      const testPattern2 = {
-        use: { p1: 'path1' },
-        controller: { p2: 'path2' },
-      };
-      const testPattern3 = {
-        service: 'one',
-        use: { p1: 'path1', p2: { pp1: 'ppath1' } },
-        controller: { p1: { pp1: 'ppath1' } }
-      };
-
-      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
-
-      expect(testData1)
-        .to.be.equal(`{controller:app/use:{p1:path1/p2:{pp1:ppath1}}}`);
-      expect(testData2)
-        .to.be.equal(`{controller:{p2:path2}/use:{p1:path1}}`);
-      expect(testData3)
-        .to.be.equal(`{controller:{p1:{pp1:ppath1}}/service:one/use:{p1:path1/p2:{pp1:ppath1}}}`);
-    });
-
-    it(`throw error if pattern has an incorrect type (no string/JSON)`, () => {
-      const testPattern1 = 150;
-      const testPattern2 = null;
-      const testPattern3 = undefined;
-      const testPattern4 = Symbol(213);
-      const errMsg = `The pattern must be of type 'string' or 'object'!`;
-
-      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern1)).to.throw(errMsg);
-      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern2)).to.throw(errMsg);
-      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern3)).to.throw(errMsg);
-      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern4)).to.throw(errMsg);
+        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern1)).to.throw(errMsg);
+        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern2)).to.throw(errMsg);
+        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern3)).to.throw(errMsg);
+        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern4)).to.throw(errMsg);
+      });
     });
   });
 });

--- a/packages/microservices/test/utils/msvc.util.spec.ts
+++ b/packages/microservices/test/utils/msvc.util.spec.ts
@@ -1,9 +1,30 @@
+import * as Interfaces from './../../interfaces';
 import { expect } from 'chai';
 import { MsvcUtil } from '../../utils/msvc.util';
+
+function equalTest<R>(testPatterns: Interfaces.MsPattern[], expectedResults: R[]) {
+  testPatterns.forEach((testPattern: Interfaces.MsPattern, index: number) => {
+    const testData = MsvcUtil.transformPatternToRoute(testPattern);
+    expect(testData).to.be.equal(expectedResults[index]);
+  });
+}
 
 describe('MsvcUtil', () => {
 
   describe('transformPatternToRoute', () => {
+    describe(`when gets 'number' value`, () => {
+      it(`should return the 'number' what is wrapped in a string`, () => {
+        const testPatterns = [
+          1, 150, 12345,
+        ];
+        const expectedResults = [
+          `1`, `150`, `12345`,
+        ];
+
+        equalTest(testPatterns, expectedResults);
+      });
+    });
+
     describe(`gets 'string' value`, () => {
       it(`should return the same string`, () => {
         const testPattern1 = `pattern1`;
@@ -101,18 +122,18 @@ describe('MsvcUtil', () => {
       });
     });
 
-    describe(`gets value with incorrect type (no string/JSON)`, () => {
+    describe(`when gets value with incorrect type (no string/number/JSON)`, () => {
       it(`should throw error`, () => {
-        const testPattern1 = 150;
-        const testPattern2 = null;
-        const testPattern3 = undefined;
-        const testPattern4 = Symbol(213);
+        const testPatterns = [
+          null,
+          undefined,
+          Symbol(213),
+        ];
         const errMsg = `The pattern must be of type 'string' or 'object'!`;
 
-        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern1)).to.throw(errMsg);
-        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern2)).to.throw(errMsg);
-        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern3)).to.throw(errMsg);
-        expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern4)).to.throw(errMsg);
+        testPatterns.forEach((testPattern: any) => {
+          expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern)).to.throw(errMsg);
+        });
       });
     });
   });

--- a/packages/microservices/test/utils/msvc.util.spec.ts
+++ b/packages/microservices/test/utils/msvc.util.spec.ts
@@ -25,99 +25,97 @@ describe('MsvcUtil', () => {
       });
     });
 
-    describe(`gets 'string' value`, () => {
+    describe(`when gets 'string' value`, () => {
       it(`should return the same string`, () => {
-        const testPattern1 = `pattern1`;
-        const testPattern2 = 'PaTteRn2';
-        const testPattern3 = '3PaTteRn';
+        const testPatterns = [
+          `pattern1`, 'PaTteRn2', '3PaTteRn',
+        ];
 
-        const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-        const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-        const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
-
-        expect(testData1).to.be.equal(testPattern1);
-        expect(testData2).to.be.equal(testPattern2);
-        expect(testData3).to.be.equal(testPattern3);
+        equalTest(testPatterns, testPatterns);
       });
     });
 
-    describe(`gets 'JSON' value`, () => {
+    describe(`when gets 'JSON' value`, () => {
       describe(`without nested JSON (1 level)`, () => {
         it(`should return correct route`, () => {
-          const testPattern1 = {
-            controller: 'app',
-            use: 'getHello'
-          };
-          const testPattern2 = {
-            use: 'getHello',
-            controller: 'app'
-          };
-          const testPattern3 = {
-            service: 'one',
-            use: 'getHello',
-            controller: 'app'
-          };
+          const testPatterns = [
+            {
+              controller: 'app',
+              use: 'getHello',
+            },
+            {
+              use: 'getHello',
+              controller: 'app',
+            },
+            {
+              service: 'one',
+              use: 'getHello',
+              controller: 'app',
+              id: 150,
+            },
+          ];
 
-          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+          const expectedResults = [
+            `{controller:app/use:getHello}`,
+            `{controller:app/use:getHello}`,
+            `{controller:app/id:150/service:one/use:getHello}`,
+          ];
 
-          expect(testData1).to.be.equal(`{controller:app/use:getHello}`);
-          expect(testData2).to.be.equal(`{controller:app/use:getHello}`);
-          expect(testData3).to.be.equal(`{controller:app/service:one/use:getHello}`);
+          equalTest(testPatterns, expectedResults);
         });
       });
-      describe(`use 'JSON' value with nested JSON (2 levels)`, () => {
+      describe(`with nested JSON (2 levels)`, () => {
         it(`should return correct route`, () => {
-          const testPattern1 = {
-            controller: 'app',
-            use: { p1: 'path1', p2: 'path2' }
-          };
-          const testPattern2 = {
-            use: { p1: 'path1', p2: 'path2' },
-            controller: 'app'
-          };
-          const testPattern3 = {
-            service: 'one',
-            use: { p1: 'path1', p2: 'path2' },
-            controller: 'app'
-          };
+          const testPatterns = [
+            {
+              controller: 'app',
+              use: { p1: 'path1', p2: 'path2' },
+            },
+            {
+              use: { p1: 'path1', p2: 'path2' },
+              controller: 'app',
+            },
+            {
+              service: 'one',
+              use: { p1: 'path1', p2: 'path2', id: 160 },
+              controller: 'app',
+            },
+          ];
 
-          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+          const expectedResults = [
+            `{controller:app/use:{p1:path1/p2:path2}}`,
+            `{controller:app/use:{p1:path1/p2:path2}}`,
+            `{controller:app/service:one/use:{id:160/p1:path1/p2:path2}}`,
+          ];
 
-          expect(testData1).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
-          expect(testData2).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
-          expect(testData3).to.be.equal(`{controller:app/service:one/use:{p1:path1/p2:path2}}`);
+          equalTest(testPatterns, expectedResults);
         });
       });
-      describe(`use 'JSON' value with nested JSON (3 levels)`, () => {
+      describe(`with nested JSON (3 levels)`, () => {
         it(`should return correct route`, () => {
-          const testPattern1 = {
-            controller: 'app',
-            use: { p1: 'path1', p2: { pp1: 'ppath1' } }
-          };
-          const testPattern2 = {
-            use: { p1: 'path1' },
-            controller: { p2: 'path2' },
-          };
-          const testPattern3 = {
-            service: 'one',
-            use: { p1: 'path1', p2: { pp1: 'ppath1' } },
-            controller: { p1: { pp1: 'ppath1' } }
-          };
+          const testPatterns = [
+            {
+              controller: 'app',
+              use: { p1: 'path1', p2: { pp1: 'ppath1' } },
+            },
+            {
+              use: { p1: 'path1' },
+              controller: { p2: 'path2' },
+            },
+            {
+              service: 'one',
+              use: { p1: 'path1', p2: { pp1: 'ppath1' } },
+              controller: { p1: { pp1: 'ppath1', id: 180 } },
+            },
+          ];
 
-          const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
-          const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
-          const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+          const expectedResults = [
+            `{controller:app/use:{p1:path1/p2:{pp1:ppath1}}}`,
+            `{controller:{p2:path2}/use:{p1:path1}}`,
+            `{controller:{p1:{id:180/pp1:ppath1}}/service:one/use:{p1:path1/p2:{pp1:ppath1}}}`,
+          ];
 
-          expect(testData1)
-            .to.be.equal(`{controller:app/use:{p1:path1/p2:{pp1:ppath1}}}`);
-          expect(testData2)
-            .to.be.equal(`{controller:{p2:path2}/use:{p1:path1}}`);
-          expect(testData3)
-            .to.be.equal(`{controller:{p1:{pp1:ppath1}}/service:one/use:{p1:path1/p2:{pp1:ppath1}}}`);
+          equalTest(testPatterns, expectedResults);
         });
       });
     });

--- a/packages/microservices/test/utils/msvc.util.spec.ts
+++ b/packages/microservices/test/utils/msvc.util.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from 'chai';
+import { MsvcUtil } from '../../utils/msvc.util';
+
+describe('MsvcUtil', () => {
+
+  describe('transformPatternToRoute', () => {
+    it(`use 'string' value`, () => {
+      const testPattern1 = `pattern1`;
+      const testPattern2 = 'PaTteRn2';
+      const testPattern3 = '3PaTteRn';
+
+      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+      expect(testData1).to.be.equal(testPattern1);
+      expect(testData2).to.be.equal(testPattern2);
+      expect(testData3).to.be.equal(testPattern3);
+    });
+
+    it(`use 'JSON' value without nested JSON (1 level)`, () => {
+      const testPattern1 = {
+        controller: 'app',
+        use: 'getHello'
+      };
+      const testPattern2 = {
+        use: 'getHello',
+        controller: 'app'
+      };
+      const testPattern3 = {
+        service: 'one',
+        use: 'getHello',
+        controller: 'app'
+      };
+
+      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+      expect(testData1).to.be.equal(`{controller:app/use:getHello}`);
+      expect(testData2).to.be.equal(`{controller:app/use:getHello}`);
+      expect(testData3).to.be.equal(`{controller:app/service:one/use:getHello}`);
+    });
+
+    it(`use 'JSON' value with nested JSON (2 levels)`, () => {
+      const testPattern1 = {
+        controller: 'app',
+        use: { p1: 'path1', p2: 'path2' }
+      };
+      const testPattern2 = {
+        use: { p1: 'path1', p2: 'path2' },
+        controller: 'app'
+      };
+      const testPattern3 = {
+        service: 'one',
+        use: { p1: 'path1', p2: 'path2' },
+        controller: 'app'
+      };
+
+      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+      expect(testData1).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
+      expect(testData2).to.be.equal(`{controller:app/use:{p1:path1/p2:path2}}`);
+      expect(testData3).to.be.equal(`{controller:app/service:one/use:{p1:path1/p2:path2}}`);
+    });
+
+    it(`use 'JSON' value with nested JSON (3 levels)`, () => {
+      const testPattern1 = {
+        controller: 'app',
+        use: { p1: 'path1', p2: { pp1: 'ppath1' } }
+      };
+      const testPattern2 = {
+        use: { p1: 'path1' },
+        controller: { p2: 'path2' },
+      };
+      const testPattern3 = {
+        service: 'one',
+        use: { p1: 'path1', p2: { pp1: 'ppath1' } },
+        controller: { p1: { pp1: 'ppath1' } }
+      };
+
+      const testData1 = MsvcUtil.transformPatternToRoute(testPattern1);
+      const testData2 = MsvcUtil.transformPatternToRoute(testPattern2);
+      const testData3 = MsvcUtil.transformPatternToRoute(testPattern3);
+
+      expect(testData1)
+        .to.be.equal(`{controller:app/use:{p1:path1/p2:{pp1:ppath1}}}`);
+      expect(testData2)
+        .to.be.equal(`{controller:{p2:path2}/use:{p1:path1}}`);
+      expect(testData3)
+        .to.be.equal(`{controller:{p1:{pp1:ppath1}}/service:one/use:{p1:path1/p2:{pp1:ppath1}}}`);
+    });
+
+    it(`throw error if pattern has an incorrect type (no string/JSON)`, () => {
+      const testPattern1 = 150;
+      const testPattern2 = null;
+      const testPattern3 = undefined;
+      const testPattern4 = Symbol(213);
+      const errMsg = `The pattern must be of type 'string' or 'object'!`;
+
+      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern1)).to.throw(errMsg);
+      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern2)).to.throw(errMsg);
+      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern3)).to.throw(errMsg);
+      expect(MsvcUtil.transformPatternToRoute.bind(null, testPattern4)).to.throw(errMsg);
+    });
+  });
+});

--- a/packages/microservices/utils/index.ts
+++ b/packages/microservices/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './msvc.util';

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -33,7 +33,7 @@ export class MsvcUtil {
             `${key}:${MsvcUtil.transformPatternToRoute(pattern[key])}`);
 
         // Creates and returns the Route
-        const sortedPattern = sortedPatternParams.join('/');
-        return sortedPattern;
+        const route = sortedPatternParams.join('/');
+        return `{${route}}`;
     }
 }

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -30,7 +30,7 @@ export class MsvcUtil {
 
         // Creates the array of Pattern params from sorted keys and their corresponding values
         const sortedPatternParams = sortedKeys.map((key) =>
-            `${key}:${pattern[key]}`);
+            `${key}:${MsvcUtil.transformPatternToRoute(pattern[key])}`);
 
         // Creates and returns the Route
         const sortedPattern = sortedPatternParams.join('/');

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -2,38 +2,38 @@ import { isString, isObject } from '@nestjs/common/utils/shared.utils';
 
 export class MsvcUtil {
 
-    /**
-     * Transforms the Pattern to Route.
-     * 1. If Pattern is a `string`, it will be returned as it is.
-     * 2. If Pattern is a `JSON` object, it will be transformed to Route. For that end,
-     * the function will sort properties of `JSON` Object and creates `route` string
-     * according to the following template:
-     * <key1>:<value1>/<key2>:<value2>/.../<keyN>:<valueN>
-     *
-     * @param  {any} pattern - client pattern
-     * @returns string
-     */
-    public static transformPatternToRoute(pattern: any): string {
-        // Returns the pattern according to the 1st
-        if (isString(pattern)) {
-            return pattern;
-        }
-
-        // Throws the error if the pattern has an incorrect type
-        if (!isObject(pattern)) {
-            throw new Error(`The pattern must be of type 'string' or 'object'!`);
-        }
-
-        // Gets keys of the JSON Pattern and sorts them
-        const sortedKeys = Object.keys(pattern)
-            .sort((a, b) => ('' + a).localeCompare(b));
-
-        // Creates the array of Pattern params from sorted keys and their corresponding values
-        const sortedPatternParams = sortedKeys.map((key) =>
-            `${key}:${MsvcUtil.transformPatternToRoute(pattern[key])}`);
-
-        // Creates and returns the Route
-        const route = sortedPatternParams.join('/');
-        return `{${route}}`;
+  /**
+   * Transforms the Pattern to Route.
+   * 1. If Pattern is a `string`, it will be returned as it is.
+   * 2. If Pattern is a `JSON` object, it will be transformed to Route. For that end,
+   * the function will sort properties of `JSON` Object and creates `route` string
+   * according to the following template:
+   * <key1>:<value1>/<key2>:<value2>/.../<keyN>:<valueN>
+   *
+   * @param  {any} pattern - client pattern
+   * @returns string
+   */
+  public static transformPatternToRoute(pattern: any): string {
+    // Returns the pattern according to the 1st
+    if (isString(pattern)) {
+      return pattern;
     }
+
+    // Throws the error if the pattern has an incorrect type
+    if (!isObject(pattern)) {
+      throw new Error(`The pattern must be of type 'string' or 'object'!`);
+    }
+
+    // Gets keys of the JSON Pattern and sorts them
+    const sortedKeys = Object.keys(pattern)
+      .sort((a, b) => ('' + a).localeCompare(b));
+
+    // Creates the array of Pattern params from sorted keys and their corresponding values
+    const sortedPatternParams = sortedKeys.map((key) =>
+      `${key}:${MsvcUtil.transformPatternToRoute(pattern[key])}`);
+
+    // Creates and returns the Route
+    const route = sortedPatternParams.join('/');
+    return `{${route}}`;
+  }
 }

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -10,10 +10,10 @@ export class MsvcUtil {
    * according to the following template:
    * <key1>:<value1>/<key2>:<value2>/.../<keyN>:<valueN>
    *
-   * @param  {any} pattern - client pattern
+   * @param  {Interfaces.MsPattern} pattern - client pattern
    * @returns string
    */
-  public static transformPatternToRoute(pattern: any): string {
+  public static transformPatternToRoute(pattern: Interfaces.MsPattern): string {
     // Returns the pattern according to the 1st
     if (isString(pattern)) {
       return pattern;

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -1,11 +1,13 @@
 import { isString, isObject } from '@nestjs/common/utils/shared.utils';
+import * as Interfaces from '../interfaces';
 
 export class MsvcUtil {
 
   /**
    * Transforms the Pattern to Route.
    * 1. If Pattern is a `string`, it will be returned as it is.
-   * 2. If Pattern is a `JSON` object, it will be transformed to Route. For that end,
+   * 2. If Pattern is a `number`, it will be converted to `string`.
+   * 3. If Pattern is a `JSON` object, it will be transformed to Route. For that end,
    * the function will sort properties of `JSON` Object and creates `route` string
    * according to the following template:
    * <key1>:<value1>/<key2>:<value2>/.../<keyN>:<valueN>
@@ -14,9 +16,9 @@ export class MsvcUtil {
    * @returns string
    */
   public static transformPatternToRoute(pattern: Interfaces.MsPattern): string {
-    // Returns the pattern according to the 1st
-    if (isString(pattern)) {
-      return pattern;
+    // Returns the pattern according to the 1st and the 2nd points
+    if (isString(pattern) || typeof pattern === 'number') {
+      return `${pattern}`;
     }
 
     // Throws the error if the pattern has an incorrect type

--- a/packages/microservices/utils/msvc.util.ts
+++ b/packages/microservices/utils/msvc.util.ts
@@ -1,0 +1,39 @@
+import { isString, isObject } from '@nestjs/common/utils/shared.utils';
+
+export class MsvcUtil {
+
+    /**
+     * Transforms the Pattern to Route.
+     * 1. If Pattern is a `string`, it will be returned as it is.
+     * 2. If Pattern is a `JSON` object, it will be transformed to Route. For that end,
+     * the function will sort properties of `JSON` Object and creates `route` string
+     * according to the following template:
+     * <key1>:<value1>/<key2>:<value2>/.../<keyN>:<valueN>
+     *
+     * @param  {any} pattern - client pattern
+     * @returns string
+     */
+    public static transformPatternToRoute(pattern: any): string {
+        // Returns the pattern according to the 1st
+        if (isString(pattern)) {
+            return pattern;
+        }
+
+        // Throws the error if the pattern has an incorrect type
+        if (!isObject(pattern)) {
+            throw new Error(`The pattern must be of type 'string' or 'object'!`);
+        }
+
+        // Gets keys of the JSON Pattern and sorts them
+        const sortedKeys = Object.keys(pattern)
+            .sort((a, b) => ('' + a).localeCompare(b));
+
+        // Creates the array of Pattern params from sorted keys and their corresponding values
+        const sortedPatternParams = sortedKeys.map((key) =>
+            `${key}:${pattern[key]}`);
+
+        // Creates and returns the Route
+        const sortedPattern = sortedPatternParams.join('/');
+        return sortedPattern;
+    }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When we `send`/`emit` request according to some `object` pattern, pattern doesn’t sort pattern’s fields . Pattern:
```
{ controller: `main`, service: `users`, use: `addUser` }
```
doesn’t equal:
```
{ service: `users`, controller: `main`, use: `addUser` }
```
Thus, if we try to catch a pattern using `MessagePattern` or `EventPattern`, nest will not call a required handler.

## What is the new behavior?
I added simple middle-logic, that parses a patterns, sorts fields and creates a new pattern (route). 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```
## Other information