### PR TITLE
Fix "Channel options must be an object with (...) string values"

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -65,9 +65,12 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
     if (!this.grpcClient[name]) {
       throw new InvalidGrpcServiceException();
     }
+    const credentials =
+      options.credentials || grpcPackage.credentials.createInsecure();
+    delete options.credentials;
     const grpcClient = new this.grpcClient[name](
       this.url,
-      options.credentials || grpcPackage.credentials.createInsecure(),
+      credentials,
       options,
     );
     const protoMethods = Object.keys(this.grpcClient[name].prototype);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?


Passing down credentials options into grpc-client lead to crash of the server.

![image](https://user-images.githubusercontent.com/13785185/59965759-ae6f7200-9512-11e9-805e-b5b64514c1a0.png)


Issue Number: no issue


## What is the new behavior?

Everything works well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Reproduction here: https://github.com/tychota/grpc-docker-envoy

Try to do: `make`

- works with patch-packages hotfix: https://github.com/tychota/grpc-docker-envoy/commit/69ad72ab4d3f0887a9c831270d2caa856d2f5138#diff-5713bb8c26392aacc0319825d4344daa
- does not works without