### PR TITLE
feature(microservices) add serializer for RMQ messages

### DIFF
--- a/packages/common/interfaces/microservices/microservice-configuration.interface.ts
+++ b/packages/common/interfaces/microservices/microservice-configuration.interface.ts
@@ -91,5 +91,7 @@ export interface RmqOptions {
     isGlobalPrefetchCount?: boolean;
     queueOptions?: any;
     socketOptions?: any;
+    serialize?: (packet: any) => any;
+    deserialize?: (packet: any) => any;
   };
 }

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -175,18 +175,14 @@ export class ClientRMQ extends ClientProxy {
   }
 
   protected dispatchEvent(packet: ReadPacket): Promise<any> {
-    let buffer;
-
     if (this.options.deserialize) {
-      buffer = Buffer.from(JSON.stringify(this.options.deserialize(packet)));
-    } else {
-      buffer = Buffer.from(JSON.stringify(packet));
+      packet = this.options.deserialize(packet);
     }
 
     return new Promise((resolve, reject) =>
       this.channel.sendToQueue(
         this.queue,
-        buffer,
+        Buffer.from(JSON.stringify(packet)),
         {},
         err => (err ? reject(err) : resolve()),
       ),

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -175,10 +175,18 @@ export class ClientRMQ extends ClientProxy {
   }
 
   protected dispatchEvent(packet: ReadPacket): Promise<any> {
+    let buffer;
+
+    if (this.options.deserialize) {
+      buffer = Buffer.from(JSON.stringify(this.options.deserialize(packet)));
+    } else {
+      buffer = Buffer.from(JSON.stringify(packet));
+    }
+
     return new Promise((resolve, reject) =>
       this.channel.sendToQueue(
         this.queue,
-        Buffer.from(JSON.stringify(packet)),
+        buffer,
         {},
         err => (err ? reject(err) : resolve()),
       ),

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -96,5 +96,7 @@ export interface RmqOptions {
     queueOptions?: any;
     socketOptions?: any;
     noAck?: boolean;
+    serialize?: (packet: any) => any;
+    deserialize?: (packet: any) => any;
   };
 }

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -86,7 +86,12 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
 
   public async handleMessage(message: any): Promise<void> {
     const { content, properties } = message;
-    const packet = JSON.parse(content.toString());
+    let packet = JSON.parse(content.toString());
+
+    if (this.options.serialize) {
+      packet = this.options.serialize(packet);
+    }
+
     const pattern = isString(packet.pattern)
       ? packet.pattern
       : JSON.stringify(packet.pattern);
@@ -119,6 +124,10 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     replyTo: any,
     correlationId: string,
   ): void {
+    if (this.options.deserialize) {
+      message = this.options.deserialize(message);
+    }
+
     const buffer = Buffer.from(JSON.stringify(message));
     this.channel.sendToQueue(replyTo, buffer, { correlationId });
   }


### PR DESCRIPTION
Add optional serializer for RMQ messages, to convert non-compatibly-shaped messages into compatibly-shaped messages.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Non-compatibly-shape messages (e.g. no `data` property) results in `undefined` data when using `@EventPattern`.

Issue Number: #2455 


## What is the new behavior?
A serializer can be added on `app.connectMicroservice()`, which uses ad hoc logic for converting message shape to be compatibly-shaped.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information