### PR TITLE
feat(Multer): Add any file interceptor

### DIFF
--- a/packages/platform-express/multer/interceptors/any-files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/any-files.interceptor.ts
@@ -1,0 +1,60 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Inject,
+  mixin,
+  NestInterceptor,
+  Optional,
+  Type,
+} from '@nestjs/common';
+import * as multer from 'multer';
+import { Observable } from 'rxjs';
+import { MULTER_MODULE_OPTIONS } from '../files.constants';
+import { MulterModuleOptions } from '../interfaces';
+import { MulterOptions } from '../interfaces/multer-options.interface';
+import { transformException } from '../multer/multer.utils';
+
+type MulterInstance = any;
+
+export function AnyFilesInterceptor(
+  localOptions?: MulterOptions,
+): Type<NestInterceptor> {
+  class MixinInterceptor implements NestInterceptor {
+    protected multer: MulterInstance;
+
+    constructor(
+      @Optional()
+      @Inject(MULTER_MODULE_OPTIONS)
+      options: MulterModuleOptions = {},
+    ) {
+      this.multer = (multer as any)({
+        ...options,
+        ...localOptions,
+      });
+    }
+
+    async intercept(
+      context: ExecutionContext,
+      next: CallHandler,
+    ): Promise<Observable<any>> {
+      const ctx = context.switchToHttp();
+
+      await new Promise((resolve, reject) =>
+        this.multer.any()(
+          ctx.getRequest(),
+          ctx.getResponse(),
+          (err: any) => {
+            if (err) {
+              const error = transformException(err);
+              return reject(error);
+            }
+            resolve();
+          },
+        ),
+      );
+      return next.handle();
+    }
+  }
+  const Interceptor = mixin(MixinInterceptor);
+  return Interceptor as Type<NestInterceptor>;
+}

--- a/packages/platform-express/test/multer/interceptors/any-files.interceptor.spec.ts
+++ b/packages/platform-express/test/multer/interceptors/any-files.interceptor.spec.ts
@@ -1,0 +1,46 @@
+import { CallHandler } from '@nestjs/common';
+import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import { expect } from 'chai';
+import { of } from 'rxjs';
+import * as sinon from 'sinon';
+import { AnyFilesInterceptor } from '../../../multer/interceptors/any-files.interceptor';
+
+describe('FilesInterceptor', () => {
+  it('should return metatype with expected structure', async () => {
+    const targetClass = AnyFilesInterceptor();
+    expect(targetClass.prototype.intercept).to.not.be.undefined;
+  });
+  describe('intercept', () => {
+    let handler: CallHandler;
+    beforeEach(() => {
+      handler = {
+        handle: () => of('test'),
+      };
+    });
+    it('should call any() with expected params', async () => {
+      const target = new (AnyFilesInterceptor())();
+
+      const callback = (req, res, next) => next();
+      const arraySpy = sinon
+        .stub((target as any).multer, 'any')
+        .returns(callback);
+
+      await target.intercept(new ExecutionContextHost([]), handler);
+
+      expect(arraySpy.called).to.be.true;
+      expect(arraySpy.calledWith()).to.be.true;
+    });
+    it('should transform exception', async () => {
+      const target = new (AnyFilesInterceptor())();
+      const err = {};
+      const callback = (req, res, next) => next(err);
+
+      (target as any).multer = {
+        any: () => callback,
+      };
+      (target.intercept(new ExecutionContextHost([]), handler) as any).catch(
+        error => expect(error).to.not.be.undefined,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If you receive a multipart request with random names of your files (e.g. uuid) you cannot gather all of them. But Multer allows it with [any](https://github.com/expressjs/multer#any).

Issue Number: N/A


## What is the new behavior?

An interceptor for the multer [any](https://github.com/expressjs/multer#any) is now available.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information