### PR TITLE
Fix: Ensure prototype of nest errors is actually Error

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -21,6 +21,8 @@ export class HttpException extends Error {
   ) {
     super();
     this.message = response;
+
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 
   public getResponse(): string | object {


### PR DESCRIPTION
This is due to Errors being the only class you cannot directly extend and retain functionality

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Actually ensures the errors are of javascript "Error"

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently errors in nest do not honor what regular errors allow you to do which are inherently serializable. This information is lost due to not correctly inheriting from Error.

## What is the new behavior?

Have the HttpException inherit from the Error class and set the prototype correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

This should not be a breaking change unless people specifically relied on the serialization to be `[object Object]`.