### PR TITLE
Bugfix: Make errors serializable by default

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -31,7 +31,7 @@ export class HttpException extends Error {
     return this.status;
   }
 
-  private getError(target) {
+  private getErrorString(target) {
     if(typeof target === 'string') {
       return target;
     }
@@ -40,7 +40,7 @@ export class HttpException extends Error {
   }
 
   public toString(): string {
-    const message = this.getError(this.message);
+    const message = this.getErrorString(this.message);
 
     return `Error: ${message}`;
   }

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -32,7 +32,7 @@ export class HttpException extends Error {
   }
 
   private getErrorString(target) {
-    if(typeof target === 'string') {
+    if (typeof target === 'string') {
       return target;
     }
 

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -31,7 +31,7 @@ export class HttpException extends Error {
     return this.status;
   }
 
-  private getErrorString(target: string | object) {
+  private getErrorString(target: string | object): string{
     if (typeof target === 'string') {
       return target;
     }

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -30,4 +30,18 @@ export class HttpException extends Error {
   public getStatus(): number {
     return this.status;
   }
+
+  private getError(target) {
+    if(typeof target === 'string') {
+      return target;
+    }
+
+    return JSON.stringify(target);
+  }
+
+  public toString(): string {
+    const message = this.getError(this.message);
+
+    return `Error: ${message}`;
+  }
 }

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -31,7 +31,7 @@ export class HttpException extends Error {
     return this.status;
   }
 
-  private getErrorString(target) {
+  private getErrorString(target: string | object) {
     if (typeof target === 'string') {
       return target;
     }

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -44,4 +44,27 @@ describe('HttpException', () => {
       statusCode: 404,
     });
   });
+
+  it('Should inherit from error', () => {
+    const error = new HttpException('', 400);
+    expect(error instanceof Error).to.be.true;
+  });
+
+  it('Should be serializable', () => {
+    const message = 'Some Error';
+    const error = new HttpException(message, 400);
+    expect(`${error}`).to.be.eql(`Error: ${message}`);
+  });
+
+  it('Should serialize objects', () => {
+    const obj = { foo: 'bar' };
+    const error = new HttpException(obj, 400);
+    expect(`${error}`).to.be.eql(`Error: ${JSON.stringify(obj)}`);
+    expect(`${error}`.includes('[object Object]')).to.not.be.true;
+  });
+
+  it('Should serialize sub errors', () => {
+    const error = new NotFoundException();
+    expect(`${error}`.includes('Not Found')).to.be.true;
+  });
 });

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -45,26 +45,28 @@ describe('HttpException', () => {
     });
   });
 
-  it('Should inherit from error', () => {
+  it('should inherit from error', () => {
     const error = new HttpException('', 400);
     expect(error instanceof Error).to.be.true;
   });
 
-  it('Should be serializable', () => {
+  it('should be serializable', () => {
     const message = 'Some Error';
     const error = new HttpException(message, 400);
     expect(`${error}`).to.be.eql(`Error: ${message}`);
   });
 
-  it('Should serialize objects', () => {
-    const obj = { foo: 'bar' };
-    const error = new HttpException(obj, 400);
-    expect(`${error}`).to.be.eql(`Error: ${JSON.stringify(obj)}`);
-    expect(`${error}`.includes('[object Object]')).to.not.be.true;
-  });
+  describe('when "message" is an object', () => {
+    it('should serialize an object', () => {
+      const obj = { foo: 'bar' };
+      const error = new HttpException(obj, 400);
+      expect(`${error}`).to.be.eql(`Error: ${JSON.stringify(obj)}`);
+      expect(`${error}`.includes('[object Object]')).to.not.be.true;
+    });
 
-  it('Should serialize sub errors', () => {
-    const error = new NotFoundException();
-    expect(`${error}`.includes('Not Found')).to.be.true;
+    it('should serialize sub errors', () => {
+      const error = new NotFoundException();
+      expect(`${error}`.includes('Not Found')).to.be.true;
+    });
   });
 });

--- a/packages/microservices/exceptions/rpc-exception.ts
+++ b/packages/microservices/exceptions/rpc-exception.ts
@@ -8,4 +8,18 @@ export class RpcException extends Error {
   public getError(): string | object {
     return this.error;
   }
+
+  private getErrorString(target) {
+    if(typeof target === 'string') {
+      return target;
+    }
+
+    return JSON.stringify(target);
+  }
+
+  public toString(): string {
+    const message = this.getErrorString(this.message);
+
+    return `Error: ${message}`;
+  }
 }

--- a/packages/microservices/exceptions/rpc-exception.ts
+++ b/packages/microservices/exceptions/rpc-exception.ts
@@ -9,7 +9,7 @@ export class RpcException extends Error {
     return this.error;
   }
 
-  private getErrorString(target) {
+  private getErrorString(target: string | object): string {
     if (typeof target === 'string') {
       return target;
     }

--- a/packages/microservices/exceptions/rpc-exception.ts
+++ b/packages/microservices/exceptions/rpc-exception.ts
@@ -10,7 +10,7 @@ export class RpcException extends Error {
   }
 
   private getErrorString(target) {
-    if(typeof target === 'string') {
+    if (typeof target === 'string') {
       return target;
     }
 

--- a/packages/microservices/test/exceptions/rpc-exception.spec.ts
+++ b/packages/microservices/test/exceptions/rpc-exception.spec.ts
@@ -11,4 +11,10 @@ describe('RpcException', () => {
   it('should returns error message or object', () => {
     expect(instance.getError()).to.be.eql(error);
   });
+
+  it('Should serialize', () => {
+    expect(`${instance}`.includes(error)).to.be.true;
+    const obj = {foo: 'bar'};
+    expect(`${new RpcException(obj)}`.includes(JSON.stringify(obj))).to.be.true;
+  });
 });

--- a/packages/microservices/test/exceptions/rpc-exception.spec.ts
+++ b/packages/microservices/test/exceptions/rpc-exception.spec.ts
@@ -12,7 +12,7 @@ describe('RpcException', () => {
     expect(instance.getError()).to.be.eql(error);
   });
 
-  it('Should serialize', () => {
+  it('should serialize', () => {
     expect(`${instance}`.includes(error)).to.be.true;
     const obj = {foo: 'bar'};
     expect(`${new RpcException(obj)}`.includes(JSON.stringify(obj))).to.be.true;

--- a/packages/websockets/errors/ws-exception.ts
+++ b/packages/websockets/errors/ws-exception.ts
@@ -11,7 +11,7 @@ export class WsException extends Error {
   }
 
   private getErrorString(target) {
-    if(typeof target === 'string') {
+    if (typeof target === 'string') {
       return target;
     }
 

--- a/packages/websockets/errors/ws-exception.ts
+++ b/packages/websockets/errors/ws-exception.ts
@@ -9,4 +9,18 @@ export class WsException extends Error {
   public getError(): string | object {
     return this.error;
   }
+
+  private getErrorString(target) {
+    if(typeof target === 'string') {
+      return target;
+    }
+
+    return JSON.stringify(target);
+  }
+
+  public toString(): string {
+    const message = this.getErrorString(this.message);
+
+    return `Error: ${message}`;
+  }
 }

--- a/packages/websockets/errors/ws-exception.ts
+++ b/packages/websockets/errors/ws-exception.ts
@@ -10,7 +10,7 @@ export class WsException extends Error {
     return this.error;
   }
 
-  private getErrorString(target) {
+  private getErrorString(target: string | object): string {
     if (typeof target === 'string') {
       return target;
     }

--- a/packages/websockets/test/exceptions/ws-exception.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exception.spec.ts
@@ -11,4 +11,10 @@ describe('WsException', () => {
   it('should returns error message or object', () => {
     expect(instance.getError()).to.be.eql(error);
   });
+
+  it('Should serialize', () => {
+    expect(`${instance}`.includes(error)).to.be.true;
+    const obj = {foo: 'bar'};
+    expect(`${new WsException(obj)}`.includes(JSON.stringify(obj))).to.be.true;
+  });
 });

--- a/packages/websockets/test/exceptions/ws-exception.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exception.spec.ts
@@ -12,7 +12,7 @@ describe('WsException', () => {
     expect(instance.getError()).to.be.eql(error);
   });
 
-  it('Should serialize', () => {
+  it('should serialize', () => {
     expect(`${instance}`.includes(error)).to.be.true;
     const obj = {foo: 'bar'};
     expect(`${new WsException(obj)}`.includes(JSON.stringify(obj))).to.be.true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ X ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ X ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When trying to print the error it resolves to 'Error: [object Object]' which is unhelpful and means that the error objects are not serializable.


## What is the new behavior?

This adds a toString() function to HttpException that will serialize only when the message is an object. It does not modify anything other than serialization of the error (which there was none)

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X ] No
```

The only potential breaking change is if some library somewhere expects the error to return [object Object] which would be an invalid use of this error.