### PR TITLE
bugfix(core): fix missing await in NestApplication.close()

### DIFF
--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -222,7 +222,7 @@ export class NestApplication extends NestApplicationContext
 
   public async close(): Promise<any> {
     this.socketModule && (await this.socketModule.close());
-    this.httpAdapter && this.httpAdapter.close();
+    this.httpAdapter && (await this.httpAdapter.close());
 
     await Promise.all(
       iterate(this.microservices).map(async microservice => {


### PR DESCRIPTION
NestApplication.close() was not always closing the port after promise resolve, because of the missing `await` in implementation. This commit fixes the problem.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`NestApplication.close()` is not always closing the port after promise resolve, because of the missing `await` in implementation.
This causes sequential application create-close cycles in E2E tests to fail with "Address already in use" error, because currently `await app.close()` does not guarantee that the port will really be closed once the function resumes.

Issue Number: N/A


## What is the new behavior?
`NestApplication.close()` always closes the port, opened with `NestApplication.listen()`, once the returned promise resolves.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Unfortunately, I was not able to compile master and run the tests; I've got the following compilation errors in master:

```
packages/core/injector/module.ts(170,24): error TS2339: Property 'name' does not exist on type 'never'.
packages/core/injector/module.ts(177,38): error TS2339: Property 'name' does not exist on type 'never'.
```

Once these problems are fixed, we should merge master to this branch, and hopefully the tests will pass.