### PR TITLE
feat(core): Add beforeApplicationShutdown hook

### DIFF
--- a/integration/hooks/e2e/before-app-shutdown.spec.ts
+++ b/integration/hooks/e2e/before-app-shutdown.spec.ts
@@ -1,0 +1,55 @@
+import { Injectable, BeforeApplicationShutdown } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as Sinon from 'sinon';
+
+@Injectable()
+class TestInjectable implements BeforeApplicationShutdown {
+  beforeApplicationShutdown = Sinon.spy();
+}
+
+describe('BeforeApplicationShutdown', () => {
+  it('should call `beforeApplicationShutdown` when application closes', async () => {
+    const module = await Test.createTestingModule({
+      providers: [TestInjectable],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.close();
+    const instance = module.get(TestInjectable);
+    expect(instance.beforeApplicationShutdown.called).to.be.true;
+  });
+
+  it('should not stop the server once beforeApplicationShutdown has been called', async () => {
+    let resolve;
+    const promise = new Promise(r => (resolve = r));
+    const module = await Test.createTestingModule({
+      providers: [
+        {
+          provide: 'Test',
+          useValue: {
+            beforeApplicationShutdown: () => promise,
+          },
+        },
+      ],
+    }).compile();
+    Sinon.stub(module, 'dispose' as any);
+    const app = module.createNestApplication();
+
+    app.close();
+
+    expect(((module as any).dispose as Sinon.SinonSpy).called, 'dispose')
+      .to.be.false;
+
+    resolve();
+
+    setTimeout(
+      () =>
+        expect(
+          ((module as any).dispose as Sinon.SinonSpy).called,
+          'dispose',
+        ).to.be.true,
+      0,
+    );
+  });
+});

--- a/integration/hooks/e2e/enable-shutdown-hook.spec.ts
+++ b/integration/hooks/e2e/enable-shutdown-hook.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { spawnSync } from 'child_process';
+import { join } from 'path';
+
+describe('enableShutdownHooks', () => {
+  it('should call the correct hooks if any shutdown signal gets invoked', done => {
+    const result = spawnSync('ts-node', [
+      join(__dirname, '../src/enable-shutdown-hooks-main.ts'),
+      'SIGHUP',
+    ]);
+    const calls = result.stdout
+      .toString()
+      .split('\n')
+      .map((call: string) => call.trim());
+    expect(calls[0]).to.equal('beforeApplicationShutdown SIGHUP');
+    expect(calls[1]).to.equal('onApplicationShutdown SIGHUP');
+    done();
+  }).timeout(5000);
+
+  it('should call the correct hooks if a specific shutdown signal gets invoked', done => {
+    const result = spawnSync('ts-node', [
+      join(__dirname, '../src/enable-shutdown-hooks-main.ts'),
+      'SIGINT',
+      'SIGINT',
+    ]);
+    const calls = result.stdout
+      .toString()
+      .split('\n')
+      .map((call: string) => call.trim());
+    expect(calls[0]).to.equal('beforeApplicationShutdown SIGINT');
+    expect(calls[1]).to.equal('onApplicationShutdown SIGINT');
+    done();
+  }).timeout(5000);
+
+  it('should ignore system signals which are not specified', done => {
+    const result = spawnSync('ts-node', [
+      join(__dirname, '../src/enable-shutdown-hooks-main.ts'),
+      'SIGINT',
+      'SIGHUP',
+    ]);
+    expect(result.stdout.toString().trim()).to.be.eq('');
+    done();
+  }).timeout(5000);
+
+  it('should ignore system signals if "enableShutdownHooks" was not called', done => {
+    const result = spawnSync('ts-node', [
+      join(__dirname, '../src/enable-shutdown-hooks-main.ts'),
+      'SIGINT',
+      'NONE',
+    ]);
+    expect(result.stdout.toString().trim()).to.be.eq('');
+    done();
+  }).timeout(5000);
+});

--- a/integration/hooks/e2e/lifecycle-hook-order.spec.ts
+++ b/integration/hooks/e2e/lifecycle-hook-order.spec.ts
@@ -1,5 +1,4 @@
 import { Test } from '@nestjs/testing';
-import { expect } from 'chai';
 import * as Sinon from 'sinon';
 import {
   Injectable,
@@ -7,6 +6,7 @@ import {
   OnApplicationShutdown,
   OnModuleDestroy,
   OnModuleInit,
+  BeforeApplicationShutdown,
 } from '@nestjs/common';
 
 @Injectable()
@@ -15,8 +15,10 @@ class TestInjectable
     OnApplicationBootstrap,
     OnModuleInit,
     OnModuleDestroy,
-    OnApplicationShutdown {
+    OnApplicationShutdown,
+    BeforeApplicationShutdown {
   onApplicationBootstrap = Sinon.spy();
+  beforeApplicationShutdown = Sinon.spy();
   onApplicationShutdown = Sinon.spy();
   onModuleDestroy = Sinon.spy();
   onModuleInit = Sinon.spy();
@@ -37,6 +39,7 @@ describe('Lifecycle Hook Order', () => {
       instance.onModuleInit,
       instance.onApplicationBootstrap,
       instance.onModuleDestroy,
+      instance.beforeApplicationShutdown,
       instance.onApplicationShutdown,
     );
   });

--- a/integration/hooks/e2e/on-app-shutdown.spec.ts
+++ b/integration/hooks/e2e/on-app-shutdown.spec.ts
@@ -1,8 +1,6 @@
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
-import { spawnSync } from 'child_process';
-import { join } from 'path';
 import * as Sinon from 'sinon';
 
 @Injectable()
@@ -21,43 +19,4 @@ describe('OnApplicationShutdown', () => {
     const instance = module.get(TestInjectable);
     expect(instance.onApplicationShutdown.called).to.be.true;
   });
-
-  it('should call onApplicationShutdown if any shutdown signal gets invoked', done => {
-    const result = spawnSync('ts-node', [
-      join(__dirname, '../src/main.ts'),
-      'SIGHUP',
-    ]);
-    expect(result.stdout.toString().trim() === 'Signal SIGHUP').to.be.true;
-    done();
-  }).timeout(5000);
-
-  it('should call onApplicationShutdown if a specific shutdown signal gets invoked', done => {
-    const result = spawnSync('ts-node', [
-      join(__dirname, '../src/main.ts'),
-      'SIGINT',
-      'SIGINT',
-    ]);
-    expect(result.stdout.toString().trim()).to.be.eq('Signal SIGINT');
-    done();
-  }).timeout(5000);
-
-  it('should ignore system signals which are not specified', done => {
-    const result = spawnSync('ts-node', [
-      join(__dirname, '../src/main.ts'),
-      'SIGINT',
-      'SIGHUP',
-    ]);
-    expect(result.stdout.toString().trim()).to.be.eq('');
-    done();
-  }).timeout(5000);
-
-  it('should ignore system signals if "enableShutdownHooks" was not called', done => {
-    const result = spawnSync('ts-node', [
-      join(__dirname, '../src/main.ts'),
-      'SIGINT',
-      'NONE',
-    ]);
-    expect(result.stdout.toString().trim()).to.be.eq('');
-    done();
-  }).timeout(5000);
 });

--- a/integration/hooks/src/enable-shutdown-hooks-main.ts
+++ b/integration/hooks/src/enable-shutdown-hooks-main.ts
@@ -1,12 +1,16 @@
-import { Injectable, OnApplicationShutdown, Module } from '@nestjs/common';
+import { Injectable, OnApplicationShutdown, BeforeApplicationShutdown, Module } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 const SIGNAL = process.argv[2];
 const SIGNAL_TO_LISTEN = process.argv[3];
 
 @Injectable()
-class TestInjectable implements OnApplicationShutdown {
+class TestInjectable implements OnApplicationShutdown, BeforeApplicationShutdown {
+  beforeApplicationShutdown(signal: string) {
+    console.log('beforeApplicationShutdown ' + signal);
+  }
+
   onApplicationShutdown(signal: string) {
-    console.log('Signal ' + signal);
+    console.log('onApplicationShutdown ' + signal);
   }
 }
 

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -15,6 +15,7 @@ export {
   Abstract,
   ArgumentMetadata,
   ArgumentsHost,
+  BeforeApplicationShutdown,
   CallHandler,
   CanActivate,
   DynamicModule,

--- a/packages/common/interfaces/before-application-shutdown.interface.ts
+++ b/packages/common/interfaces/before-application-shutdown.interface.ts
@@ -1,0 +1,3 @@
+export interface BeforeApplicationShutdown {
+  beforeApplicationShutdown(signal?: string): any;
+}

--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -27,6 +27,7 @@ export * from './nest-application.interface';
 export * from './nest-microservice.interface';
 export * from './on-application-bootstrap.interface';
 export * from './on-application-shutdown.interface';
+export * from './before-application-shutdown.interface';
 export * from './request-mapping-metadata.interface';
 export * from './scope-options.interface';
 export * from './type.interface';

--- a/packages/core/constants.ts
+++ b/packages/core/constants.ts
@@ -3,6 +3,7 @@ export const MESSAGES = {
   APPLICATION_READY: `Nest application successfully started`,
   MICROSERVICE_READY: `Nest microservice successfully started`,
   UNKNOWN_EXCEPTION_MESSAGE: 'Internal server error',
+  ERROR_DURING_SHUTDOWN: 'Error happened during shutdown',
 };
 
 export const APP_INTERCEPTOR = 'APP_INTERCEPTOR';

--- a/packages/core/hooks/before-app-shutdown.hook.ts
+++ b/packages/core/hooks/before-app-shutdown.hook.ts
@@ -1,0 +1,67 @@
+import { Module } from '../injector/module';
+import { isNil } from '@nestjs/common/utils/shared.utils';
+import iterate from 'iterare';
+import { BeforeApplicationShutdown } from '@nestjs/common';
+import { InstanceWrapper } from '../injector/instance-wrapper';
+import {
+  getNonTransientInstances,
+  getTransientInstances,
+} from '../injector/transient-instances';
+
+/**
+ * Checks if the given instance has the `beforeApplicationShutdown` function
+ *
+ * @param instance The instance which should be checked
+ */
+function hasBeforeApplicationShutdownHook(
+  instance: unknown,
+): instance is BeforeApplicationShutdown {
+  return !isNil(
+    (instance as BeforeApplicationShutdown).beforeApplicationShutdown,
+  );
+}
+
+/**
+ * Calls the given instances
+ */
+function callOperator(
+  instances: InstanceWrapper[],
+  signal?: string,
+): Promise<any>[] {
+  return iterate(instances)
+    .filter(instance => !isNil(instance))
+    .filter(hasBeforeApplicationShutdownHook)
+    .map(async instance =>
+      ((instance as any) as BeforeApplicationShutdown).beforeApplicationShutdown(
+        signal,
+      ),
+    )
+    .toArray();
+}
+
+/**
+ * Calls the `beforeApplicationShutdown` function on the module and its children
+ * (providers / controllers).
+ *
+ * @param module The module which will be initialized
+ * @param signal The signal which caused the shutdown
+ */
+export async function callBeforeAppShutdownHook(
+  module: Module,
+  signal?: string,
+): Promise<void> {
+  const providers = [...module.providers];
+  const [_, { instance: moduleClassInstance }] = providers.shift();
+  const instances = [...module.controllers, ...providers];
+
+  const nonTransientInstances = getNonTransientInstances(instances);
+  await Promise.all(callOperator(nonTransientInstances, signal));
+  const transientInstances = getTransientInstances(instances);
+  await Promise.all(callOperator(transientInstances, signal));
+
+  if (moduleClassInstance && hasBeforeApplicationShutdownHook(moduleClassInstance)) {
+    await (moduleClassInstance as BeforeApplicationShutdown).beforeApplicationShutdown(
+      signal,
+    );
+  }
+}

--- a/packages/core/hooks/index.ts
+++ b/packages/core/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './on-app-bootstrap.hook';
 export * from './on-app-shutdown.hook';
 export * from './on-module-destroy.hook';
 export * from './on-module-init.hook';
+export * from './before-app-shutdown.hook';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment only `OnApplicationShutdown` exists, which gets called once the server stops taking any requests.

## What is the new behavior?
`BeforeApplicationShutdown` gets called once an e.g. system signal got sent to the process, but the app still **accepts any requests**, as long as all `BeforeApplicationShutdown`-Promises have been resolved.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

The shutdown order

```
- OnModuleDestroy: Use to clean up an injectable (unsubscribe Observables, etc.)
- BeforeApplicationShutdown: Gracefully shutdown all the services, but still send unavailable response codes
- OnApplicationShutdown: Shutdown all pending services
```

Being able to still process requests, even if a system signal has been sent, is crucial in Kubernetes.
`@nestjs/terminus` can be further improved once this PR gets merged. As soon as `beforeApplicationShutdown` gets called, Terminus will send unhealthy responses, notifying Kubernetes to switch out the Pod.

I will update the docs once this PR has been merged :)