### PR TITLE
feature(redirect decorator) add redirect decorator

### DIFF
--- a/packages/common/decorators/http/index.ts
+++ b/packages/common/decorators/http/index.ts
@@ -4,3 +4,4 @@ export * from './http-code.decorator';
 export * from './create-route-param-metadata.decorator';
 export * from './render.decorator';
 export * from './header.decorator';
+export * from './redirect.decorator';

--- a/packages/common/decorators/http/redirect.decorator.ts
+++ b/packages/common/decorators/http/redirect.decorator.ts
@@ -3,9 +3,13 @@ import { REDIRECT_METADATA } from '../../constants';
 /**
  * Redirects request.
  */
-export function Redirect(url: string): MethodDecorator {
+export function Redirect(url: string, statusCode?: number): MethodDecorator {
   return (target: object, key, descriptor) => {
-    Reflect.defineMetadata(REDIRECT_METADATA, url, descriptor.value);
+    Reflect.defineMetadata(
+      REDIRECT_METADATA,
+      { statusCode, url },
+      descriptor.value,
+    );
     return descriptor;
   };
 }

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -45,6 +45,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   reply(response: any, body: any, statusCode?: number): any;
   status(response: any, statusCode: number): any;
   render(response: any, view: string, options: any): any;
+  redirect(response: any, statusCode: number, url: string): any;
   setHeader(response: any, name: string, value: string): any;
   setErrorHandler?(handler: Function): any;
   setNotFoundHandler?(handler: Function): any;

--- a/packages/common/test/decorators/redirect.decorator.spec.ts
+++ b/packages/common/test/decorators/redirect.decorator.spec.ts
@@ -1,17 +1,24 @@
 import { expect } from 'chai';
 import { Redirect } from '../../decorators/http/redirect.decorator';
 import { REDIRECT_METADATA } from '../../constants';
+import { HttpStatus } from '@nestjs/common';
 
 describe('@Redirect', () => {
   const url = 'http://test.com';
+  const statusCode = HttpStatus.FOUND;
 
   class Test {
-    @Redirect(url)
+    @Redirect(url, statusCode)
     public static test() {}
   }
 
-  it('should enhance method with expected template string', () => {
+  it('should enhance method with expected redirect url string', () => {
     const metadata = Reflect.getMetadata(REDIRECT_METADATA, Test.test);
-    expect(metadata).to.be.eql(url);
+    expect(metadata.url).to.be.eql(url);
+  });
+
+  it('should enhance method with expected response code', () => {
+    const metadata = Reflect.getMetadata(REDIRECT_METADATA, Test.test);
+    expect(metadata.statusCode).to.be.eql(statusCode);
   });
 });

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -85,6 +85,7 @@ export abstract class AbstractHttpAdapter<
   abstract status(response, statusCode: number);
   abstract reply(response, body: any, statusCode?: number);
   abstract render(response, view: string, options: any);
+  abstract redirect(response, statusCode: number, url: string);
   abstract setErrorHandler(handler: Function);
   abstract setNotFoundHandler(handler: Function);
   abstract setHeader(response, name: string, value: string);

--- a/packages/core/helpers/handler-metadata-storage.ts
+++ b/packages/core/helpers/handler-metadata-storage.ts
@@ -2,6 +2,7 @@ import { Controller } from '@nestjs/common/interfaces';
 import * as hash from 'object-hash';
 import { ContextId } from './../injector/instance-wrapper';
 import { ParamProperties } from './context-utils';
+import { RedirectResponse } from '../router/router-response-controller';
 
 export const HANDLER_METADATA_SYMBOL = Symbol.for('handler_metadata:cache');
 
@@ -11,6 +12,7 @@ export interface HandlerMetadata {
   httpStatusCode: number;
   responseHeaders: any[];
   hasCustomHeaders: boolean;
+  httpRedirectResponse: RedirectResponse;
   getParamsMetadata: (
     moduleKey: string,
     contextId?: ContextId,

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -14,6 +14,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   reply(response: any, body: any): any {}
   status(response: any, statusCode: number): any {}
   render(response: any, view: string, options: any): any {}
+  redirect(response: any, statusCode: number, url: string) {}
   setErrorHandler(handler: Function): any {}
   setNotFoundHandler(handler: Function): any {}
   setHeader(response: any, name: string, value: string): any {}

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -36,6 +36,10 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return response.render(view, options);
   }
 
+  public redirect(response: any, statusCode: number, url: string) {
+    return response.redirect(statusCode, url);
+  }
+
   public setErrorHandler(handler: Function) {
     return this.use(handler);
   }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -1,4 +1,4 @@
-import { RequestMethod } from '@nestjs/common';
+import { RequestMethod, HttpStatus } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
@@ -47,6 +47,11 @@ export class FastifyAdapter extends AbstractHttpAdapter {
 
   public render(response: any, view: string, options: any) {
     return response.view(view, options);
+  }
+
+  public redirect(response: any, statusCode: number, url: string) {
+    const code = statusCode ? statusCode : HttpStatus.FOUND;
+    return response.status(code).redirect(url);
   }
 
   public setErrorHandler(handler: Function) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

No docs yet

## PR Type
What kind of change does this PR introduce?

Exposes `@Redirect()` decorator

```typescript
@Redirect(url: string, statusCode?: number)
```
Redirects to the specified `url`
If no `statusCode`, sends `TEMPORARY_REDIRECT` (307)

Method can return an object like 
`{
   statusCode: 302,
   url: 'http://nestjs.com'
}`

which will override the decorator parameters.
```

```
<!-- Please check the one that applies to this PR using "x". -->

[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Need help with two failing unit tests:
```
1) RouterExecutionContext createHandleResponseFn when "renderTemplate" is defined should call "res.render()" with expected args:
2) RouterExecutionContext createHandleResponseFn when "renderTemplate" is undefined should not call "res.render()":
```

