### PR TITLE
Added seconds to logger timestamp

### DIFF
--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -111,6 +111,7 @@ export class Logger implements LoggerService {
       year: 'numeric',
       hour: 'numeric',
       minute: 'numeric',
+      second: 'numeric',
       day: '2-digit',
       month: '2-digit',
     };


### PR DESCRIPTION
At the moment only hours and minutes are logged in the default Logger implementation.

This pull request add seconds to default logger format.

Note that I don't want to override the whole logger service. It's pretty nice, I just want another timestamp format

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
The logger now shows seconds

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information