### PR TITLE
fix(core): Do not call onModuleInit if is null

### DIFF
--- a/integration/hooks/e2e/on-app-boostrap.spec.ts
+++ b/integration/hooks/e2e/on-app-boostrap.spec.ts
@@ -19,4 +19,26 @@ describe('OnApplicationBootstrap', () => {
     const instance = module.get(TestInjectable);
     expect(instance.onApplicationBootstrap.called).to.be.true;
   });
+
+  it('should not throw an error when onApplicationBootstrap is null', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onApplicationBootstrap: null } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
+
+  it('should not throw an error when onApplicationBootstrap is undefined', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onApplicationBootstrap: undefined } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
 });

--- a/integration/hooks/e2e/on-module-destroy.spec.ts
+++ b/integration/hooks/e2e/on-module-destroy.spec.ts
@@ -19,4 +19,26 @@ describe('OnModuleDestroy', () => {
     const instance = module.get(TestInjectable);
     expect(instance.onModuleDestroy.called).to.be.true;
   });
+
+  it('should not throw an error when onModuleDestroy is null', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onModuleDestroy: null } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
+
+  it('should not throw an error when onModuleDestroy is undefined', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onModuleDestroy: undefined } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
 });

--- a/integration/hooks/e2e/on-module-init.spec.ts
+++ b/integration/hooks/e2e/on-module-init.spec.ts
@@ -19,4 +19,26 @@ describe('OnModuleInit', () => {
     const instance = module.get(TestInjectable);
     expect(instance.onModuleInit.called).to.be.true;
   });
+
+  it('should not throw an error when onModuleInit is null', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onModuleInit: null } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
+
+  it('should not throw an error when onModuleInit is undefined', async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        { provide: 'TEST', useValue: { onModuleInit: undefined } }
+      ],
+    }).compile();
+
+    const app = module.createNestApplication();
+    await app.init().then((obj) => expect(obj).to.not.be.undefined);
+  });
 });

--- a/packages/core/hooks/on-app-bootstrap.hook.ts
+++ b/packages/core/hooks/on-app-bootstrap.hook.ts
@@ -1,5 +1,5 @@
 import { OnApplicationBootstrap } from '@nestjs/common';
-import { isNil, isUndefined } from '@nestjs/common/utils/shared.utils';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import iterate from 'iterare';
 import { InstanceWrapper } from '../injector/instance-wrapper';
 import { Module } from '../injector/module';
@@ -16,7 +16,7 @@ import {
 function hasOnAppBootstrapHook(
   instance: unknown,
 ): instance is OnApplicationBootstrap {
-  return !isUndefined(
+  return !isNil(
     (instance as OnApplicationBootstrap).onApplicationBootstrap,
   );
 }

--- a/packages/core/hooks/on-app-shutdown.hook.ts
+++ b/packages/core/hooks/on-app-shutdown.hook.ts
@@ -1,5 +1,5 @@
 import { OnApplicationShutdown } from '@nestjs/common';
-import { isNil, isUndefined } from '@nestjs/common/utils/shared.utils';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import iterate from 'iterare';
 import { InstanceWrapper } from '../injector/instance-wrapper';
 import { Module } from '../injector/module';
@@ -16,7 +16,7 @@ import {
 function hasOnAppBootstrapHook(
   instance: unknown,
 ): instance is OnApplicationShutdown {
-  return !isUndefined(
+  return !isNil(
     (instance as OnApplicationShutdown).onApplicationShutdown,
   );
 }

--- a/packages/core/hooks/on-module-destroy.hook.ts
+++ b/packages/core/hooks/on-module-destroy.hook.ts
@@ -1,5 +1,5 @@
 import { OnModuleDestroy } from '@nestjs/common';
-import { isNil, isUndefined } from '@nestjs/common/utils/shared.utils';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import iterate from 'iterare';
 import { InstanceWrapper } from '../injector/instance-wrapper';
 import { Module } from '../injector/module';
@@ -16,7 +16,7 @@ import {
 function hasOnModuleDestroyHook(
   instance: unknown,
 ): instance is OnModuleDestroy {
-  return !isUndefined((instance as OnModuleDestroy).onModuleDestroy);
+  return !isNil((instance as OnModuleDestroy).onModuleDestroy);
 }
 
 /**

--- a/packages/core/hooks/on-module-init.hook.ts
+++ b/packages/core/hooks/on-module-init.hook.ts
@@ -1,5 +1,5 @@
 import { OnModuleInit } from '@nestjs/common';
-import { isNil, isUndefined } from '@nestjs/common/utils/shared.utils';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import iterate from 'iterare';
 import { InstanceWrapper } from '../injector/instance-wrapper';
 import { Module } from '../injector/module';
@@ -14,7 +14,7 @@ import {
  * @param instance The instance which should be checked
  */
 function hasOnModuleInitHook(instance: unknown): instance is OnModuleInit {
-  return !isUndefined((instance as OnModuleInit).onModuleInit);
+  return !isNil((instance as OnModuleInit).onModuleInit);
 }
 
 /**


### PR DESCRIPTION
Fixes #1252

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
See issue
 
Issue Number: #1252 


## What is the new behavior?
It does not call `onModuleInit`, `onApplicationBootstrap`, `onApplicationShutdown` or `onModuleDestroy` if it is of type `null`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information