### PR TITLE
[feature] use preHandler instead of use inside fastify adapter

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -25,9 +25,9 @@ class TestController {
 class TestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
-      .apply((req, res, next) => res.end(SCOPED_VALUE))
+      .apply((req, res, next) => res.send(SCOPED_VALUE))
       .forRoutes(TestController)
-      .apply((req, res, next) => res.end(RETURN_VALUE))
+      .apply((req, res, next) => res.send(RETURN_VALUE))
       .forRoutes('*');
   }
 }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -130,19 +130,19 @@ export class FastifyAdapter extends AbstractHttpAdapter {
       const re = pathToRegexp(path);
       const normalizedPath = path === '/*' ? '' : path;
 
-      this.instance.use(normalizedPath, (req, res, next) => {
-        const queryParamsIndex = req.originalUrl.indexOf('?');
+      this.instance.addHook('preHandler', (req, res, next) => {
+        const queryParamsIndex = req.raw.originalUrl.indexOf('?');
         const pathname =
           queryParamsIndex >= 0
-            ? req.originalUrl.slice(0, queryParamsIndex)
-            : req.originalUrl;
+            ? req.raw.originalUrl.slice(0, queryParamsIndex)
+            : req.raw.originalUrl;
 
         if (!re.exec(pathname + '/') && normalizedPath) {
           return next();
         }
         if (
           requestMethod === RequestMethod.ALL ||
-          req.method === RequestMethod[requestMethod]
+          req.raw.method === RequestMethod[requestMethod]
         ) {
           return callback(req, res, next);
         }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2791 


## What is the new behavior?
The new behavior is that now nestjs will provide [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md) and [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) to the middleware and it's running it in a later state in the [`lifecycle`](https://github.com/fastify/fastify/blob/master/docs/Lifecycle.md) so that you can use the parsed request body etc.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
Right now all the developers that have been implementing the middleware with the fastify adapter have been using the `http.Request` and `http.Response` [nodejs http](https://nodejs.org/api/http.html) so they should change their logic to fit the new [`Reply`](https://github.com/fastify/fastify/blob/master/docs/Reply.md) and [`Request`](https://github.com/fastify/fastify/blob/master/docs/Request.md). The easiest way to fix their logic within the made middleware is:

### before:
```typescript
res.end('body')
```
### after:
```typescript
res.send('body')
// OR
res.raw.end('body')
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information