### PR TITLE
bugfix: Updated the location of the 'PreservePath' boolean within the…

### DIFF
--- a/packages/platform-express/multer/interfaces/multer-options.interface.ts
+++ b/packages/platform-express/multer/interfaces/multer-options.interface.ts
@@ -24,9 +24,11 @@ export interface MulterOptions {
     parts?: number;
     /** For multipart forms, the max number of header key=> value pairs to parse Default: 2000(same as node's http). */
     headerPairs?: number;
-    /** Keep the full path of files instead of just the base name (Default: false) */
-    preservePath?: boolean;
   };
+
+  /** Keep the full path of files instead of just the base name (Default: false) */
+  preservePath?: boolean;
+
   fileFilter?(
     req: any,
     file: {


### PR DESCRIPTION
… MulterOptions interface

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current [MulterOptions interface](https://github.com/nestjs/nest/blob/master/packages/platform-express/multer/interfaces/multer-options.interface.ts) contains the `preservePath` boolean as part of the `limits` object however according to the [Multer documentation](https://github.com/expressjs/multer#multeropts), as well as [Express documentation](https://github.com/expressjs/multer#multeropts), this option is independent.

Issue Number: N/A


## What is the new behavior?
The location of the `preserveOptions` boolean has been moved outside of the `limits` object in the `MulterOptions` interface. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information