### PR TITLE
style(common): Added return types to Controller decorator overloads

### DIFF
--- a/packages/common/decorators/core/controller.decorator.ts
+++ b/packages/common/decorators/core/controller.decorator.ts
@@ -36,7 +36,7 @@ export interface ControllerOptions extends ScopeOptions {
  *
  * @publicApi
  */
-export function Controller();
+export function Controller(): ClassDecorator;
 
 /**
  * Decorator that marks a class as a Nest controller that can receive inbound
@@ -61,7 +61,7 @@ export function Controller();
  *
  * @publicApi
  */
-export function Controller(prefix: string);
+export function Controller(prefix: string): ClassDecorator;
 
 /**
  * Decorator that marks a class as a Nest controller that can receive inbound
@@ -91,7 +91,7 @@ export function Controller(prefix: string);
  *
  * @publicApi
  */
-export function Controller(options: ControllerOptions);
+export function Controller(options: ControllerOptions): ClassDecorator;
 
 /**
  * Decorator that marks a class as a Nest controller that can receive inbound


### PR DESCRIPTION
This results in properly generated d.ts files, from which tslint won't complain about no-unsafe-any in controllers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Applying ```@Controller()``` or ```@Controller(prefix)``` results in "no-unsafe-any" warning from tslint.

## What is the new behavior?

The warnings should be gone, now that the return type is explicitly not any.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There is an issue on tslint's side about this:
https://github.com/palantir/tslint/issues/3784

As you can see there, Angular was also affected, and they changed their decorator types to more specific ones. This PR merely does the same for Nest.