### PR TITLE
fix(common): `ParseIntPipe` handle number value

### DIFF
--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -20,7 +20,7 @@ export class ParseIntPipe implements PipeTransform<string> {
    */
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
     const isNumeric =
-      'string' === typeof value &&
+      ['string', 'number'].includes(typeof value) &&
       !isNaN(parseFloat(value)) &&
       isFinite(value as any);
     if (!isNumeric) {


### PR DESCRIPTION
handle `number` as `string` instead of throw an error
values may be parsed by other global pipes provided by other modules
we expect `ParseIntPipe` to return int value. it's doesn't break the logic.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information