### PR TITLE
feature(common) Add CacheTTL decorator. Cache decorators priority over global defaults.

### DIFF
--- a/packages/common/cache/cache.constants.ts
+++ b/packages/common/cache/cache.constants.ts
@@ -1,3 +1,4 @@
 export const CACHE_MANAGER = 'CACHE_MANAGER';
 export const CACHE_MODULE_OPTIONS = 'CACHE_MODULE_OPTIONS';
 export const CACHE_KEY_METADATA = 'cache_module:cache_key';
+export const CACHE_TTL_METADATA = 5;

--- a/packages/common/cache/decorators/cache-ttl.decorator.ts
+++ b/packages/common/cache/decorators/cache-ttl.decorator.ts
@@ -2,11 +2,9 @@ import { SetMetadata } from '../../decorators';
 import { CACHE_TTL_METADATA } from '../cache.constants';
 
 /**
- * Decorator that sets the cache ttl setting the duration for cache expiration for
- * Web sockets or Microservice based apps.
+ * Decorator that sets the cache ttl setting the duration for cache expiration.
  *
- * For example:
- * `@CacheTTL(5)`
+ * For example: `@CacheTTL(5)`
  *
  * @param ttl number set the cache expiration time
  *

--- a/packages/common/cache/decorators/cache-ttl.decorator.ts
+++ b/packages/common/cache/decorators/cache-ttl.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '../../decorators';
+import { CACHE_TTL_METADATA } from '../cache.constants';
+
+/**
+ * Decorator that sets the cache ttl setting the duration for cache expiration for
+ * Web sockets or Microservice based apps.
+ *
+ * For example:
+ * `@CacheTTL(5)`
+ *
+ * @param ttl number set the cache expiration time
+ *
+ * @see [Caching](https://docs.nestjs.com/techniques/caching)
+ *
+ * @publicApi
+ */
+export const CacheTTL = (ttl: number) => SetMetadata(CACHE_TTL_METADATA, ttl);

--- a/packages/common/cache/decorators/index.ts
+++ b/packages/common/cache/decorators/index.ts
@@ -1,1 +1,2 @@
 export * from './cache-key.decorator';
+export * from './cache-ttl.decorator';

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -62,6 +62,7 @@ export class CacheInterceptor implements NestInterceptor {
     if (!isHttpApp || cacheMetadata) {
       return cacheMetadata;
     }
+
     const request = context.getArgByIndex(0);
     if (httpAdapter.getRequestMethod(request) !== 'GET') {
       return undefined;

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -47,7 +47,7 @@ export class CacheInterceptor implements NestInterceptor {
         .handle()
         .pipe(tap(response => {
           const args = ttl ? [key, response, {ttl}] : [key, response];
-          this.cacheManager.set.apply(this, args);
+          this.cacheManager.set.apply(this.cacheManager, args);
         }));
     } catch {
       return next.handle();

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -49,7 +49,6 @@ export class CacheInterceptor implements NestInterceptor {
           const args = ttl ? [key, response, {ttl}] : [key, response];
           this.cacheManager.set.apply(this, args);
         }));
-
     } catch {
       return next.handle();
     }
@@ -58,12 +57,11 @@ export class CacheInterceptor implements NestInterceptor {
   trackBy(context: ExecutionContext): string | undefined {
     const httpAdapter = this.httpAdapterHost.httpAdapter;
     const isHttpApp = httpAdapter && !!httpAdapter.getRequestMethod;
-    // Note: Priority should be given to decorators over globals
-    const cacheMetadata = this.reflector.get(CACHE_KEY_METADATA, context.getHandler()) || null;
-    if (cacheMetadata) {
+    const cacheMetadata = this.reflector.get(CACHE_KEY_METADATA, context.getHandler());
+
+    if (!isHttpApp || cacheMetadata) {
       return cacheMetadata;
     }
-
     const request = context.getArgByIndex(0);
     if (httpAdapter.getRequestMethod(request) !== 'GET') {
       return undefined;

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -1,0 +1,171 @@
+{
+  "name": "@nestjs/common",
+  "version": "6.6.7",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "axios": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.51",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+      "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
+      "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.51"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    }
+  }
+}

--- a/packages/common/test/decorators/cache.decorator.spec.ts
+++ b/packages/common/test/decorators/cache.decorator.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { CacheKey, CacheInterceptor, CacheTTL } from '../../cache';
+import { CACHE_KEY_METADATA, CACHE_TTL_METADATA } from '../../cache/cache.constants';
+import { UseInterceptors, Controller } from '../../decorators';
+
+describe('@Cache', () => {
+  class Metadata {
+    @Controller()
+    @CacheKey('/a_different_cache_key')
+    @CacheTTL(99999)
+    @UseInterceptors(CacheInterceptor)
+    public static testAll() {}
+    @Controller()
+    @UseInterceptors(CacheInterceptor)
+    @CacheKey('/a_different_cache_key')
+    public static testKey() {}
+    @Controller()
+    @UseInterceptors(CacheInterceptor)
+    @CacheTTL(99999)
+    public static testTTL() {}
+  }
+
+  it('should override global defaults for CacheKey and CacheTTL', () => {
+    expect(Reflect.getMetadata(CACHE_KEY_METADATA, Metadata.testAll)).to.be.eql('/a_different_cache_key') &&
+    expect(Reflect.getMetadata(CACHE_TTL_METADATA, Metadata.testAll)).to.be.greaterThan(9999);
+  });
+
+  it('should override only the TTL', () => {
+    expect(Reflect.getMetadata(CACHE_TTL_METADATA, Metadata.testTTL)).to.be.greaterThan(9999);
+  });
+
+  it('should override only the Key', () => {
+    expect(Reflect.getMetadata(CACHE_KEY_METADATA, Metadata.testKey)).to.be.eql('/a_different_cache_key');
+  });
+});

--- a/packages/common/test/decorators/cache.decorator.spec.ts
+++ b/packages/common/test/decorators/cache.decorator.spec.ts
@@ -1,35 +1,36 @@
 import { expect } from 'chai';
 import { CacheKey, CacheInterceptor, CacheTTL } from '../../cache';
 import { CACHE_KEY_METADATA, CACHE_TTL_METADATA } from '../../cache/cache.constants';
-import { UseInterceptors, Controller } from '../../decorators';
+import { UseInterceptors } from '../../decorators';
+import { Controller } from '../../decorators/core/controller.decorator';
 
 describe('@Cache', () => {
-  class Metadata {
-    @Controller()
-    @CacheKey('/a_different_cache_key')
-    @CacheTTL(99999)
-    @UseInterceptors(CacheInterceptor)
-    public static testAll() {}
-    @Controller()
-    @UseInterceptors(CacheInterceptor)
-    @CacheKey('/a_different_cache_key')
-    public static testKey() {}
-    @Controller()
-    @UseInterceptors(CacheInterceptor)
-    @CacheTTL(99999)
-    public static testTTL() {}
-  }
+  @Controller('test')
+  @CacheKey('/a_different_cache_key')
+  @CacheTTL(99999)
+  @UseInterceptors(CacheInterceptor)
+  class TestAll {}
+
+  @Controller()
+  @UseInterceptors(CacheInterceptor)
+  @CacheKey('/a_different_cache_key')
+  class TestKey {}
+
+  @Controller()
+  @UseInterceptors(CacheInterceptor)
+  @CacheTTL(99999)
+  class TestTTL {}
 
   it('should override global defaults for CacheKey and CacheTTL', () => {
-    expect(Reflect.getMetadata(CACHE_KEY_METADATA, Metadata.testAll)).to.be.eql('/a_different_cache_key') &&
-    expect(Reflect.getMetadata(CACHE_TTL_METADATA, Metadata.testAll)).to.be.greaterThan(9999);
+    expect(Reflect.getMetadata(CACHE_KEY_METADATA, TestAll)).to.be.eql('/a_different_cache_key') &&
+    expect(Reflect.getMetadata(CACHE_TTL_METADATA, TestAll)).to.be.greaterThan(9999);
   });
 
   it('should override only the TTL', () => {
-    expect(Reflect.getMetadata(CACHE_TTL_METADATA, Metadata.testTTL)).to.be.greaterThan(9999);
+    expect(Reflect.getMetadata(CACHE_TTL_METADATA, TestTTL)).to.be.greaterThan(9999);
   });
 
   it('should override only the Key', () => {
-    expect(Reflect.getMetadata(CACHE_KEY_METADATA, Metadata.testKey)).to.be.eql('/a_different_cache_key');
+    expect(Reflect.getMetadata(CACHE_KEY_METADATA, TestKey)).to.be.eql('/a_different_cache_key');
   });
 });


### PR DESCRIPTION
- [✓] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [✓] Tests for the changes have been added (for bug fixes / features)
- [   ] Docs have been added / updated (for bug fixes / features)

## PR Type
The `CacheTTL` decorator has been added to controller methods for adding additional cache features. This allows the user to set the Cache TTL before it's set in it's cache store.

Additionally, `@CacheKey()` and `@CacheTTL()` decorator usage with `@CacheInterceptor()` take priority over global Cache configuration defaults. This allows for sensible Global Caching defaults, with controller specific cache overrides.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[✓] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, when Global Cache is enabled, controller specific CacheKey settings are ignored. This forces the user to annotate all of their cached methods, or globally cache all, making customization tedious and repetitive, and potentially dangerous.

Furthermore, TTL override hasn't been possible before on a controller routing.

Issue Number: N/A

## What is the new behavior?
The new behavior allows the user to override CacheTTL when globals are set, or not.

When `@CacheKey()` or `@CacheTTL()` is provided on a cash intercepted route (`@UseInterceptor()`), it will take priority over default cache setting.

## Does this PR introduce a breaking change?
```
[ ] Yes
[✓] No
```

## Other information

Open to making modifications as necessary. I built this to solve a problem in my own application, hopefully it helps others. I think this is a very simple cache improvement that should have no side-effects, performance implications or otherwise.