### PR TITLE
bugfix(microservices) fix rmq client socketOptions

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -98,7 +98,7 @@ export class ClientRMQ extends ClientProxy {
 
   public createClient<T = any>(): T {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
-    return rqmPackage.connect(this.urls, socketOptions) as T;
+    return rqmPackage.connect(this.urls, { connectionOptions: socketOptions }) as T;
   }
 
   public mergeDisconnectEvent<T = any>(


### PR DESCRIPTION
socketOptions are currently being ignored when creating
a rabbitMQ client (server was fixed in #2889). This PR correctly passes
socketOptions to external libraries.

Fixes #2887

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information