### PR TITLE
feature(platform-socket.io): pass ack to message handler

### DIFF
--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -45,7 +45,7 @@ export class IoAdapter extends AbstractWsAdapter {
       const source$ = fromEvent(client, message).pipe(
         mergeMap((payload: any) => {
           const { data, ack } = this.mapPayload(payload);
-          return transform(callback(data)).pipe(
+          return transform(callback(data, ack)).pipe(
             filter((response: any) => !isNil(response)),
             map((response: any) => [response, ack]),
           );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using socket.io we can simply return some data from our `@SubscribeMessage()`-annoted method, causing the data to be automatically send back to the client using socket.io's acknowledgement feature.
However, in case an exception is thrown, for example by the `ValidationPipe`, that ack-feature isn't used at all, but instead a generic 'exception' message is emitted by the `BaseWsExceptionFilter`. That is totally fine for the default behavior, since we cannot force the user to use a specific response format like `{success: false, error: ...}`.

But it would be nice, if the user could use the ack-function inside an exception filter, to achieve exactly that: answer with a `{success: false, error: ...}` response or something similar. Currently that is not possible because the ack-function is not part of the `ArgumentsHost` passed to the exception filter.

## What is the new behavior?

The ack-function is now passed to the message handler. Thus, it will be available in the ArgumentsHost, too.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I know, I could also leverage interceptors for this, but I'd like to keep exception-related code inside an exception filter.