### PR TITLE
Fix: The noAck option is not taken into account (rmq microservice)

### DIFF
--- a/packages/common/interfaces/microservices/microservice-configuration.interface.ts
+++ b/packages/common/interfaces/microservices/microservice-configuration.interface.ts
@@ -108,6 +108,7 @@ export interface RmqOptions {
     isGlobalPrefetchCount?: boolean;
     queueOptions?: any;
     socketOptions?: any;
+    noAck?: boolean;
     serializer?: Serializer;
     deserializer?: Deserializer;
   };

--- a/packages/microservices/ctx-host/rmq.context.ts
+++ b/packages/microservices/ctx-host/rmq.context.ts
@@ -15,7 +15,7 @@ export class RmqContext extends BaseRpcContext<RmqContextArgs> {
   }
 
   /**
-   * Returns the reference to the original MQTT channel.
+   * Returns the reference to the original RMQ channel.
    */
   getChannelRef() {
     return this.args[1];

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -86,7 +86,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
 
   public async setupChannel(channel: any, callback: Function) {
     const noAck =
-      this.getOptionsProp(this.options, 'noAck') || RQM_DEFAULT_NOACK;
+      this.options && this.options.noAck === false
+        ? false
+        : this.getOptionsProp(this.options, 'noAck') || RQM_DEFAULT_NOACK;
 
     await channel.assertQueue(this.queue, this.queueOptions);
     await channel.prefetch(this.prefetchCount, this.isGlobalPrefetchCount);

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { NO_MESSAGE_HANDLER } from '../../constants';
+import { NO_MESSAGE_HANDLER, RQM_DEFAULT_NOACK } from '../../constants';
 import { BaseRpcContext } from '../../ctx-host/base-rpc.context';
 import { ServerRMQ } from '../../server/server-rmq';
 // tslint:disable:no-string-literal
@@ -140,9 +140,26 @@ describe('ServerRMQ', () => {
       expect(channel.prefetch.calledWith(prefetchCount, isGlobalPrefetchCount))
         .to.be.true;
     });
-    it('should call "consumeChannel" method', async () => {
+    it('should call "consumeChannel" method with default noAck', async () => {
       await server.setupChannel(channel, () => null);
       expect(channel.consume.called).to.be.true;
+      expect(channel.consume.args[0][2]).to.contain({
+        noAck: RQM_DEFAULT_NOACK,
+      });
+    });
+    it('should call "consumeChannel" method with noAck equal to true', async () => {
+      const noAck = true;
+      (server as any)['options']['noAck'] = noAck;
+      await server.setupChannel(channel, () => null);
+      expect(channel.consume.called).to.be.true;
+      expect(channel.consume.args[0][2]).to.contain({ noAck });
+    });
+    it('should call "consumeChannel" method with noAck equal to false', async () => {
+      const noAck = false;
+      (server as any)['options']['noAck'] = noAck;
+      await server.setupChannel(channel, () => null);
+      expect(channel.consume.called).to.be.true;
+      expect(channel.consume.args[0][2]).to.contain({ noAck });
     });
     it('should call "resolve" function', async () => {
       const resolve = sinon.spy();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
- the `noAck` option was not possible when creating a microservice:
```
  app.connectMicroservice({
    transport: Transport.RMQ,
    options: {
      urls: [process.env.APP_RABBITMQ_URL],
      queue: process.env.APP_RABBITMQ_JOB_QUEUE,
      noAck: false,
    },
  });
```

```
Types of property 'options' are incompatible.
  Type '{ urls: string[]; queue: string; noAck: boolean; }' is not assignable to type '{ urls?: string[]; queue?: string; prefetchCount?: number; isGlobalPrefetchCount?: boolean; queueOptions?: any; socketOptions?: any; serializer?: Serializer<any, any>; deserializer?: Deserializer<any, any>; }'.
    Object literal may only specify known properties, and 'noAck' does not exist in type '{ urls?: string[]; queue?: string; prefetchCount?: number; isGlobalPrefetchCount?: boolean; queueOptions?: any; socketOptions?: any; serializer?: Serializer<any, any>; deserializer?: Deserializer<any, any>; }'.
```
- the `noAck` option was always enabled, even with noAck = false. 


## What is the new behavior?
- The `RmqOptions` interface on package common in now the same as the one on microservice
- The `noAck` can be defined to false and is taken into account

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Feel free to contact me regarding this PR on discord ('Alex')