### PR TITLE
Fix: Delete disuse period

### DIFF
--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -89,7 +89,7 @@ export const INVALID_MODULE_MESSAGE = (
 ) =>
   `Nest cannot create the module instance. Often, this is because of a circular dependency between modules. Use forwardRef() to avoid it.
 
-(Read more: https://docs.nestjs.com/fundamentals/circular-dependency.)
+(Read more: https://docs.nestjs.com/fundamentals/circular-dependency)
 Scope [${scope}]
 `;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

If `INVALID_MODULE_MESSAGE` is displayed, the editor will display the following:

<img width="679" alt="Screen Shot 2019-10-18 at 10 51 21" src="https://user-images.githubusercontent.com/33852683/67086151-1db45480-f1db-11e9-92fb-ef1ea98a6aad.png">

If developers click on a link in the code editor, the wrong link with a period show in browsers.
 
## What is the new behavior?

If developers click on a link in the code editor, the correct link with a period show in browsers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I use VSCode.