### PR TITLE
fix(core): fix hooks being called when registered as alias

### DIFF
--- a/packages/core/hooks/before-app-shutdown.hook.ts
+++ b/packages/core/hooks/before-app-shutdown.hook.ts
@@ -50,7 +50,7 @@ export async function callBeforeAppShutdownHook(
   module: Module,
   signal?: string,
 ): Promise<void> {
-  const providers = [...module.providers];
+  const providers = [...module.getNonAliasProviders()];
   const [_, { instance: moduleClassInstance }] = providers.shift();
   const instances = [...module.controllers, ...providers];
 

--- a/packages/core/hooks/on-app-bootstrap.hook.ts
+++ b/packages/core/hooks/on-app-bootstrap.hook.ts
@@ -39,7 +39,7 @@ function callOperator(instances: InstanceWrapper[]): Promise<any>[] {
  * @param module The module which will be initialized
  */
 export async function callModuleBootstrapHook(module: Module): Promise<any> {
-  const providers = [...module.providers];
+  const providers = [...module.getNonAliasProviders()];
   // Module (class) instance is the first element of the providers array
   // Lifecycle hook has to be called once all classes are properly initialized
   const [_, { instance: moduleClassInstance }] = providers.shift();

--- a/packages/core/hooks/on-app-shutdown.hook.ts
+++ b/packages/core/hooks/on-app-shutdown.hook.ts
@@ -47,7 +47,7 @@ export async function callAppShutdownHook(
   module: Module,
   signal?: string,
 ): Promise<any> {
-  const providers = [...module.providers];
+  const providers = [...module.getNonAliasProviders()];
   // Module (class) instance is the first element of the providers array
   // Lifecycle hook has to be called once all classes are properly initialized
   const [_, { instance: moduleClassInstance }] = providers.shift();

--- a/packages/core/hooks/on-module-destroy.hook.ts
+++ b/packages/core/hooks/on-module-destroy.hook.ts
@@ -39,7 +39,7 @@ function callOperator(instances: InstanceWrapper[]): Promise<any>[] {
  * @param module The module which will be initialized
  */
 export async function callModuleDestroyHook(module: Module): Promise<any> {
-  const providers = [...module.providers];
+  const providers = [...module.getNonAliasProviders()];
   // Module (class) instance is the first element of the providers array
   // Lifecycle hook has to be called once all classes are properly destroyed
   const [_, { instance: moduleClassInstance }] = providers.shift();

--- a/packages/core/hooks/on-module-init.hook.ts
+++ b/packages/core/hooks/on-module-init.hook.ts
@@ -35,7 +35,7 @@ function callOperator(instances: InstanceWrapper[]): Promise<any>[] {
  * @param module The module which will be initialized
  */
 export async function callModuleInitHook(module: Module): Promise<void> {
-  const providers = [...module.providers];
+  const providers = [...module.getNonAliasProviders()];
   // Module (class) instance is the first element of the providers array
   // Lifecycle hook has to be called once all classes are properly initialized
   const [_, { instance: moduleClassInstance }] = providers.shift();

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -42,6 +42,8 @@ export class InstanceWrapper<T = any> {
   public inject?: (string | symbol | Function | Type<any>)[];
   public forwardRef?: boolean;
 
+  public isAlias: Boolean = false;
+
   private readonly values = new WeakMap<ContextId, InstancePerContext<T>>();
   private readonly [INSTANCE_METADATA_SYMBOL]: InstanceMetadataStore = {};
   private readonly [INSTANCE_ID_SYMBOL]: string;

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -345,6 +345,7 @@ export class Module {
         isResolved: false,
         inject: [useExisting],
         host: this,
+        isAlias: true,
       }),
     );
   }
@@ -453,6 +454,18 @@ export class Module {
 
   public getProviderByKey<T = any>(name: string | symbol): InstanceWrapper<T> {
     return this._providers.get(name) as InstanceWrapper<T>;
+  }
+
+  public getNonAliasProviders(): Map<string, InstanceWrapper<Injectable>> {
+    const result = new Map<string, InstanceWrapper<Injectable>>();
+
+    this._providers.forEach((wrapper, key) => {
+      if (!wrapper.isAlias) {
+        result.set(key, wrapper);
+      }
+    });
+
+    return result;
   }
 
   public createModuleReferenceType(): any {

--- a/packages/core/test/injector/module.spec.ts
+++ b/packages/core/test/injector/module.spec.ts
@@ -262,6 +262,7 @@ describe('Module', () => {
             instance: null,
             inject: [provider.useExisting as any],
             isResolved: false,
+            isAlias: true,
           }),
         ),
       ).to.be.true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3182 


## What is the new behavior?
Hook methods will not be called for providers that are registered as aliases (using the new `isAlias` flag).


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information