### PR TITLE
feat(core): add full route path metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1649,6 +1649,7 @@
         "@types/accepts": "^1.3.5",
         "@types/body-parser": "1.17.1",
         "@types/cors": "^2.8.4",
+        "@types/express": "4.17.1",
         "accepts": "^1.3.5",
         "apollo-server-core": "^2.9.7",
         "apollo-server-types": "^0.2.5",
@@ -1660,6 +1661,18 @@
         "parseurl": "^1.3.2",
         "subscriptions-transport-ws": "^0.9.16",
         "type-is": "^1.6.16"
+      },
+      "dependencies": {
+        "@types/express": {
+          "version": "4.17.1",
+          "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+          "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+          "requires": {
+            "@types/body-parser": "*",
+            "@types/express-serve-static-core": "*",
+            "@types/serve-static": "*"
+          }
+        }
       }
     },
     "apollo-server-plugin-base": {

--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -8,6 +8,7 @@ export const METADATA = {
 export const SHARED_MODULE_METADATA = '__module:shared__';
 export const GLOBAL_MODULE_METADATA = '__module:global__';
 export const PATH_METADATA = 'path';
+export const FULL_PATH_METADATA = 'full_path';
 export const PARAMTYPES_METADATA = 'design:paramtypes';
 export const SELF_DECLARED_DEPS_METADATA = 'self:paramtypes';
 export const OPTIONAL_DEPS_METADATA = 'optional:paramtypes';

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -184,30 +184,22 @@ export class RouterExplorer {
       str[str.length - 1] === '/' ? str.slice(0, str.length - 1) : str;
 
     const isRequestScoped = !instanceWrapper.isDependencyTreeStatic();
-    const module = this.container.getModuleByKey(moduleKey);
+    const proxy = isRequestScoped
+      ? this.createRequestScopedHandler(
+          instanceWrapper,
+          requestMethod,
+          this.container.getModuleByKey(moduleKey),
+          moduleKey,
+          methodName,
+        )
+      : this.createCallbackProxy(
+          instance,
+          targetCallback,
+          methodName,
+          moduleKey,
+          requestMethod,
+        );
 
-    if (isRequestScoped) {
-      const handler = this.createRequestScopedHandler(
-        instanceWrapper,
-        requestMethod,
-        module,
-        moduleKey,
-        methodName,
-      );
-
-      paths.forEach(path => {
-        const fullPath = stripSlash(basePath) + path;
-        routerMethod(stripSlash(fullPath) || '/', handler);
-      });
-      return;
-    }
-    const proxy = this.createCallbackProxy(
-      instance,
-      targetCallback,
-      methodName,
-      moduleKey,
-      requestMethod,
-    );
     paths.forEach(path => {
       const fullPath = stripSlash(basePath) + path;
       routerMethod(stripSlash(fullPath) || '/', proxy);

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -1,5 +1,9 @@
 import { HttpServer } from '@nestjs/common';
-import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import {
+  METHOD_METADATA,
+  PATH_METADATA,
+  FULL_PATH_METADATA,
+} from '@nestjs/common/constants';
 import { RequestMethod } from '@nestjs/common/enums/request-method.enum';
 import { Controller } from '@nestjs/common/interfaces/controllers/controller.interface';
 import { Type } from '@nestjs/common/interfaces/type.interface';
@@ -199,11 +203,14 @@ export class RouterExplorer {
           moduleKey,
           requestMethod,
         );
-
+    const routerPaths: string[] = [];
     paths.forEach(path => {
       const fullPath = stripSlash(basePath) + path;
-      routerMethod(stripSlash(fullPath) || '/', proxy);
+      const routerPath = stripSlash(fullPath) || '/';
+      routerPaths.push(routerPath);
+      routerMethod(routerPath, proxy);
     });
+    Reflect.defineMetadata(FULL_PATH_METADATA, routerPaths, targetCallback);
   }
 
   private createCallbackProxy(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
With current behaviour it is difficult to determine the full route path for a Controller route handler ( global/module/controller/method ) 

Issue Number: N/A


## What is the new behavior?

The code that adds this full path to the actual implementation ( express / fastify ) now adds metadata to the Controller route handler which can then be used by guards and interceptors.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If desired, the ApplicationConfig could have setAddFullPathMetadata getAddFullPathMetadata to conditionally apply the full path metadata.
I will update the documentation if the pull request is accepted.