### PR TITLE
fix(common): Single `stdout.write()` call per logging in default `Logger`

### DIFF
--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -142,29 +142,31 @@ export class Logger implements LoggerService {
       undefined,
       localeStringOptions,
     );
-    process.stdout.write(color(`[Nest] ${process.pid}   - `));
-    process.stdout.write(`${timestamp}   `);
 
-    context && process.stdout.write(yellow(`[${context}] `));
-    process.stdout.write(output);
+    const pidMessage = color(`[Nest] ${process.pid}   - `);
+    const contextMessage = context ? yellow(`[${context}] `) : '';
+    const timestampDiff = this.updateAndGetTimestampDiff(isTimeDiffEnabled);
 
-    this.printTimestamp(isTimeDiffEnabled);
-    process.stdout.write(`\n`);
+    process.stdout.write(
+      `${pidMessage}${timestamp}   ${contextMessage}${output}${timestampDiff}\n`,
+    );
   }
 
-  private static printTimestamp(isTimeDiffEnabled?: boolean) {
+  private static updateAndGetTimestampDiff(
+    isTimeDiffEnabled?: boolean,
+  ): string {
     const includeTimestamp = Logger.lastTimestamp && isTimeDiffEnabled;
-    if (includeTimestamp) {
-      process.stdout.write(yellow(` +${Date.now() - Logger.lastTimestamp}ms`));
-    }
+    const result = includeTimestamp
+      ? yellow(` +${Date.now() - Logger.lastTimestamp}ms`)
+      : '';
     Logger.lastTimestamp = Date.now();
+    return result;
   }
 
   private static printStackTrace(trace: string) {
     if (!trace) {
       return;
     }
-    process.stdout.write(trace);
-    process.stdout.write(`\n`);
+    process.stdout.write(`${trace}\n`);
   }
 }


### PR DESCRIPTION
This fixes the issue that in PM2 (at least when running in Windows) the logging lines break at the "stdout.write() border".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The default `LoggerService` multiple times calls `process.stdout.write()` per logging line. This seems to confuse the process manager [PM2](https://pm2.keymetrics.io/)'s logging system (the full logging message is split into 2 or more parts).

An example screenshot:
![image](https://user-images.githubusercontent.com/388796/68378458-7036c000-014c-11ea-9e5e-1f7065dd66e0.png)

## What is the new behavior?

I've refactored `printMessage()` so that it concatenates the logging string first and then calls `process.stdout.write()` once. Same in `printStackTrace()`. 

Note that other than this there should be no change of the behavior.

... and this fixes my issue with PM2:
![image](https://user-images.githubusercontent.com/388796/68378486-7cbb1880-014c-11ea-9de8-55e7d8ed1a26.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information