### PR TITLE
feat(decorators) Added pipe overrides and types.

### DIFF
--- a/packages/common/decorators/http/create-route-param-metadata.decorator.ts
+++ b/packages/common/decorators/http/create-route-param-metadata.decorator.ts
@@ -5,7 +5,7 @@ import {
 } from '../../constants';
 import { PipeTransform } from '../../index';
 import { Type } from '../../interfaces';
-import { CustomParamFactory } from '../../interfaces/features/custom-route-param-factory.interface';
+import { CustomParamFactory } from '../../interfaces';
 import { isFunction, isNil } from '../../utils/shared.utils';
 import { ParamData, RouteParamsMetadata } from './route-params.decorator';
 
@@ -32,10 +32,20 @@ export type ParamDecoratorEnhancer = ParameterDecorator;
  * Defines HTTP route param decorator
  *
  * @param factory
+ * @param enhancers
+ * @param pipeList A callback that accepts a list of all pipes that would be
+ *     applied to the result, and returns
+ *     a list of pipes to actually apply to the result.
+ *     If not specified, all would be pipes are actually applied.
  */
-export function createParamDecorator(
-  factory: CustomParamFactory,
+export function createParamDecorator<
+  TFactoryData = any,
+  TFactoryRequest = any,
+  TFactoryResult = any
+>(
+  factory: CustomParamFactory<TFactoryData, TFactoryRequest, TFactoryResult>,
   enhancers: ParamDecoratorEnhancer[] = [],
+  pipeList?: (pipes?: (Type<PipeTransform> | PipeTransform)[]) => (Type<PipeTransform> | PipeTransform)[],
 ): (
   ...dataOrPipes: (Type<PipeTransform> | PipeTransform | any)[]
 ) => ParameterDecorator {
@@ -56,7 +66,9 @@ export function createParamDecorator(
 
     const hasParamData = isNil(data) || !isPipe(data);
     const paramData = hasParamData ? data : undefined;
-    const paramPipes = hasParamData ? pipes : [data, ...pipes];
+    const pipesToApply =
+      typeof pipeList !== 'undefined' ? pipeList(pipes) : pipes;
+    const paramPipes = hasParamData ? pipesToApply : [data, ...pipesToApply];
 
     Reflect.defineMetadata(
       ROUTE_ARGS_METADATA,


### PR DESCRIPTION
Added a new optional pipeList parameter, that allows decorators to opt out of the request's pipe, or override them with custom ones.

Also added generic types to the createParamDecorator function, which are passed down to the factory, allowing the caller to make the factory type safe.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [?] Tests for the changes have been added (for bug fixes / features) - I'm unable to run tests locally. See below.
- [?] Docs have been added / updated (for bug fixes / features) - Is createParamDecorator even documented anywhere?


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Whenever one uses createParamDecorator(), the result is also passed to all of the request's pipes. This isn't necesarily desired. See [this StackOverflow question of mine](https://stackoverflow.com/questions/58751743/disable-validation-in-nestjs-param-decorator) as an example.

Issue Number: N/A


## What is the new behavior?
If provided, the new callback will define the pipes to apply to the result, after taking in those that would be applied otherwise.

In my particular case, my callback would be just ```() => []```, but having a callback would also allow for more complicated cases than simply not having any pipes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I should note that for some reason, I can't install nest locally (on Windows 10; ```npm install``` fails when compiling grpc), so I can't really run or make tests locally, making it sort of impossible for me to make additional ones... But that's a separate problem. If this PR is in the right direction, I hope it could be merged even without tests, if the existing ones pass.