### PR TITLE
feat(cache-manager): extend cache-store interface

### DIFF
--- a/packages/common/cache/interfaces/cache-manager.interface.ts
+++ b/packages/common/cache/interfaces/cache-manager.interface.ts
@@ -15,7 +15,7 @@ export interface CacheStore {
    * @param key cache key
    * @param value cache value
    */
-  set<T>(key: string, value: T): Promise<void> | void;
+  set<T>(key: string, value: T, options?: CacheStoreSetOptions<T>): Promise<void> | void;
   /**
    * Retrieve a key/value pair from the cache.
    *
@@ -28,6 +28,14 @@ export interface CacheStore {
    * @param key cache key
    */
   del(key: string): void | Promise<void>;
+}
+
+export interface CacheStoreSetOptions<T> {
+  /**
+   * Time to live - amount of time in seconds that a response is cached before it
+   * is deleted. Defaults based on your cache manager settings.
+   */
+  ttl?: ((value: T) => number) | number;
 }
 
 /**


### PR DESCRIPTION
- introducing the options with time to live for the set function in cache-manager

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features) -> interface extension - no tests needed
- [x] Docs have been added / updated (for bug fixes / features) - interface extension is documented


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no possibility to set a custom time to live on **set** if I use the types.

Issue Number: N/A


## What is the new behavior?
Possible to use TTL for set function on cache store type

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information