### PR TITLE
bugfix(core) Fixed mismatching get and set types for HttpAdapterHost

### DIFF
--- a/packages/core/helpers/http-adapter-host.ts
+++ b/packages/core/helpers/http-adapter-host.ts
@@ -22,8 +22,10 @@ export class HttpAdapterHost<
    *
    * @param httpAdapter reference to the `HttpAdapter` to be set
    */
-  set httpAdapter(httpAdapter: T) {
-    this._httpAdapter = httpAdapter;
+  set httpAdapter(httpAdapter: T | undefined) {
+    if (httpAdapter) {
+      this._httpAdapter = httpAdapter;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixed mismatching get and set types for HttpAdapterHost.httpAdapter. Undefined in accepted in the setter, but ignored if provided.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3505


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information