### PR TITLE
fix(RabbitMQ Microservice): "PRECONDITION_FAILED - reply consumer already set"

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -82,6 +82,12 @@ export class ClientRMQ extends ClientProxy {
         share(),
       )
       .toPromise();
+
+    this.client.on(DISCONNECT_EVENT, (err)=> {
+      this.close();
+      this.client = null;
+    });
+
     return this.connection;
   }
 

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -74,6 +74,7 @@ export class ClientRMQ extends ClientProxy {
     }
     this.client = this.createClient();
     this.handleError(this.client);
+    this.handleDisconnectError(this.client);
 
     const connect$ = this.connect$(this.client);
     this.connection = this.mergeDisconnectEvent(this.client, connect$)
@@ -82,11 +83,6 @@ export class ClientRMQ extends ClientProxy {
         share(),
       )
       .toPromise();
-
-    this.client.on(DISCONNECT_EVENT, (err)=> {
-      this.close();
-      this.client = null;
-    });
 
     return this.connection;
   }
@@ -138,6 +134,14 @@ export class ClientRMQ extends ClientProxy {
 
   public handleError(client: any): void {
     client.addListener(ERROR_EVENT, (err: any) => this.logger.error(err));
+  }
+
+  public handleDisconnectError(client: any): void {
+    client.addListener(DISCONNECT_EVENT, (err: any) => {
+      this.close();
+      this.client = null;
+      return this.logger.error(err);
+    });
   }
 
   public handleMessage(

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -69,6 +69,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   public async start(callback?: () => void) {
     this.server = this.createClient();
     this.server.on(CONNECT_EVENT, (_: any) => {
+      if (this.channel) {
+        return;
+      }
       this.channel = this.server.createChannel({
         json: false,
         setup: (channel: any) => this.setupChannel(channel, callback),


### PR DESCRIPTION
 #3138, #2323, #2337

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3138, #2323, #2337


## What is the new behavior?
1. `server-rmq.js` - reconnect only one-off if RabbitMQ disconnects and connects again
2. `client-rmq.js` - set a new connection if RabbitMQ disconnects and connects again
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information