### PR TITLE
fix(core): update normalize path logic to support global prefix

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -144,8 +144,8 @@ export class FastifyAdapter extends AbstractHttpAdapter {
     requestMethod: RequestMethod,
   ): (path: string, callback: Function) => any {
     return (path: string, callback: Function) => {
-      const re = pathToRegexp(path);
-      const normalizedPath = path === '/*' ? '' : path;
+      const normalizedPath = path.replace('*', '(.*)');
+      const re = pathToRegexp(normalizedPath);
 
       this.instance.use(normalizedPath, (req, res, next) => {
         const queryParamsIndex = req.originalUrl.indexOf('?');


### PR DESCRIPTION
fixes #3497

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If setGlobalPrefix has been called, 'path' in the call to createMiddlewareFactory will be equal to `/{globalPrefix}*`.  Currently checking path for equality to `/*` will never match and therefore middleware will not be setup correctly.
Issue Number: #3497


## What is the new behavior?
Rather than change `/*` to '' (empty string) replacing the wildcard with a matching regex will allow a correct regex to be generated from the path.  This will also allow the path with a global prefix to generate a correct regex.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information