### PR TITLE
feat(common/core): Added useGlobalPrefix option for Controllers

### DIFF
--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -8,6 +8,7 @@ export const METADATA = {
 export const SHARED_MODULE_METADATA = '__module:shared__';
 export const GLOBAL_MODULE_METADATA = '__module:global__';
 export const PATH_METADATA = 'path';
+export const PATH_PREFIX_METADATA = 'path:globalPrefix';
 export const PARAMTYPES_METADATA = 'design:paramtypes';
 export const SELF_DECLARED_DEPS_METADATA = 'self:paramtypes';
 export const OPTIONAL_DEPS_METADATA = 'optional:paramtypes';

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -1,5 +1,9 @@
 import { HttpServer } from '@nestjs/common';
-import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import {
+  PATH_METADATA,
+  METHOD_METADATA,
+  PATH_PREFIX_METADATA,
+} from '@nestjs/common/constants';
 import { RequestMethod } from '@nestjs/common/enums/request-method.enum';
 import { Controller } from '@nestjs/common/interfaces/controllers/controller.interface';
 import { Type } from '@nestjs/common/interfaces/type.interface';
@@ -88,7 +92,8 @@ export class RouterExplorer {
     prefix?: string,
   ): string {
     let path = Reflect.getMetadata(PATH_METADATA, metatype);
-    if (prefix) path = prefix + this.validateRoutePath(path);
+    const usePrefix = Reflect.getMetadata(PATH_PREFIX_METADATA, metatype);
+    if (prefix && usePrefix) path = prefix + this.validateRoutePath(path);
     return this.validateRoutePath(path);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #963


## What is the new behavior?

Add's a possible fix for enabling/disabling the use of global prefix path for controllers.

```ts
@Controller({
  path: 'withoutGlobal'
  useGlobalPrefix: false  // true by default
})
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I am not sure if this is a recommended fix, but I feel is better than `exclude: ` for each path (as suggested in that issue), since this is controller based and not based on request methods or the respective path values.

Please let me know your take on this and if you feel this can be one of the viable solutions, I'll update the docs. 

Also, I am not sure but there is basically no test for object param for Controller Decorator. Let me know if that is something required. 

Thanks a lot!! 😃 