### PR TITLE
Return a promise to wait the end of express http server in close function of adapter

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -59,7 +59,10 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public close() {
-    return this.httpServer ? this.httpServer.close() : undefined;
+    if (!this.httpServer) {
+      return undefined;
+    }
+    return new Promise(resolve => this.httpServer.close(resolve));
   }
 
   public set(...args: any[]) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When closing a Nest Express application, the cleanup process does not wait the end of http server.

Issue Number: N/A


## What is the new behavior?

The Express Adapter return a promise for the close function (like the Fastify adapter) and the application waits that the http server cleanup all its connection.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information