### PR TITLE
feat(common/decorators): server sent event decorator

### DIFF
--- a/packages/common/decorators/http/server-sent-event.decorator.ts
+++ b/packages/common/decorators/http/server-sent-event.decorator.ts
@@ -1,0 +1,66 @@
+import { METHOD_METADATA, PATH_METADATA, REDIRECT_METADATA, ROUTE_ARGS_METADATA } from '../../constants';
+import { RequestMethod } from '../../enums';
+import { RouteParamtypes } from '../../enums/route-paramtypes.enum';
+import { Observable, Subject } from 'rxjs';
+
+export interface SSEMessage<T> {
+  id?: string;
+  data: string;
+  event?: T
+}
+
+export function ServerSentEvent<T>(path: string, retry: number = 2000): MethodDecorator {
+  return <Type>(target, propertyKey, descriptor) => {
+
+    const oldFunction = descriptor.value;
+
+    function newFunction(req: Request, res: Response) {
+      req.socket.setKeepAlive(true);
+      req.socket.setTimeout(0);
+      const lastEventId = req.header('last-event-id');
+
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.status(200);
+      const subject = new Subject<SSEMessage<T>>();
+      res.write(`retry: ${retry}\n\n`);
+      const stopSubject = subject.subscribe((messageData) => {
+        const message = Object.entries(messageData)
+          .filter(([, value]) => ![undefined, null].includes(value))
+          .map(([key, value]) => `${key}: ${value}`)
+          .join('\n') + '\n\n';
+
+        res.write(message);
+      });
+
+      const observableFromController: Observable<any> = oldFunction.call(target.constructor, subject, lastEventId);
+
+      let unSubscribeObservableFromController;
+      if (observableFromController && observableFromController.subscribe) {
+        unSubscribeObservableFromController = observableFromController.subscribe((data) => subject.next(data));
+      }
+
+      res.on('close', () => {
+        stopSubject.unsubscribe();
+        if (unSubscribeObservableFromController) {
+          unSubscribeObservableFromController.unsubscribe();
+        }
+      });
+
+    }
+
+    descriptor.value = newFunction;
+
+    Reflect.defineMetadata(PATH_METADATA, path, descriptor.value);
+    Reflect.defineMetadata(METHOD_METADATA, RequestMethod.GET, descriptor.value);
+    const metaData = {
+      [`${RouteParamtypes.REQUEST}:0`]: { index: 0, data: undefined, pipe: [] },
+      [`${RouteParamtypes.RESPONSE}:1`]: { index: 1, data: undefined, pipe: [] }
+    };
+
+    Reflect.defineMetadata(ROUTE_ARGS_METADATA, metaData, target.constructor, propertyKey);
+    return descriptor;
+    return descriptor;
+  };
+}

--- a/packages/common/decorators/http/server-sent-event.decorator.ts
+++ b/packages/common/decorators/http/server-sent-event.decorator.ts
@@ -26,7 +26,8 @@ export function ServerSentEvent<T>(path: string, retry: number = 2000): MethodDe
       const subject = new Subject<SSEMessage<T>>();
       res.write(`retry: ${retry}\n\n`);
       const stopSubject = subject.subscribe((messageData) => {
-        const message = Object.entries(messageData)
+        const {id, event, data} = messageData;
+        const message = Object.entries({id, event, data})
           .filter(([, value]) => ![undefined, null].includes(value))
           .map(([key, value]) => `${key}: ${value}`)
           .join('\n') + '\n\n';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[*] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is not this decorator 
Issue Number: N/A


## What is the new behavior?
Add new decorator for Server-Sent Event

https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events

```
@ServerSentEvent<string>('sse', 1000)
serverSentEventController(subject: Subject<SSEMessage<string>>, lastEventID: string): Observable<SSEMessage<string>>{
     let id = 0;
     const tmp = () => setTimeout(() => {
           subject.next({ data: '' + Date.now(), id: '' + id++, event: 'Test' });
           tmp();
     }, 500);
    tmp();
// or return Observable
// return interval(1000).pipe(mapTo(Date.now()),map((val) => ({ data: val})));
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[*] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information