### PR TITLE
fix(common): return nil values before throw statement is encountered

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -77,6 +77,11 @@ export class ValidationPipe implements PipeTransform<any> {
       this.transformOptions,
     );
 
+    if (isNil) {
+      // if the value was originally undefined or null, revert it back
+      return originalValue;
+    }
+
     const originalEntity = entity;
     const isCtorNotEqual = entity.constructor !== metatype;
 
@@ -100,10 +105,6 @@ export class ValidationPipe implements PipeTransform<any> {
     }
     if (this.isTransformEnabled) {
       return entity;
-    }
-    if (isNil) {
-      // if the value was originally undefined or null, revert it back
-      return originalValue;
     }
     return Object.keys(this.validatorOptions).length > 0
       ? classTransformer.classToPlain(entity, this.transformOptions)

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -275,5 +275,23 @@ describe('ValidationPipe', () => {
         });
       });
     });
+    describe('when value is null', () => {
+      it('should return null', async () => {
+        target = new ValidationPipe();
+
+        const result = await target.transform(null, metadata);
+
+        expect(result).to.be.null;
+      });
+    });
+    describe('when value is undefined', () => {
+      it('should return undefined', async () => {
+        target = new ValidationPipe();
+
+        const result = await target.transform(undefined, metadata);
+
+        expect(result).to.be.undefined;
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) - not applicable


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`ValidationPipe` throws an error due to the provided value being nil, before it has a change to return the nil value

Issue Number: #3930 


## What is the new behaviour?

`ValidationPipe` now returns nil values before it has a chance to throw errors due to the value being nil

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```