### PR TITLE
fix(common): http service should not cancel when response type is stream

### DIFF
--- a/packages/common/http/http.service.ts
+++ b/packages/common/http/http.service.ts
@@ -88,7 +88,9 @@ export class HttpService {
           subscriber.error(err);
         });
       return () => {
-        cancelSource.cancel();
+        if (config.responseType !== 'stream') {
+          cancelSource.cancel();
+        }
       };
     });
   }


### PR DESCRIPTION
when response type stream is set, the node stream is ended early as `subscriber.complete()` -> `cancelSource.cancel()` is called in sequence.
The better approach to fix this is to wrap the stream with an observable, but that'll be a lot of code.
So a simpler approach is to ignore request cancellation on stream response type.

fixes #4014

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[*] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[*] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information