### PR TITLE
feat(core): Update routers logging to include basePath and remove trailing slash

### DIFF
--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -143,6 +143,9 @@ export class RouterExplorer {
     };
   }
 
+  private static stripEndSlash = (str: string) =>
+    str[str.length - 1] === '/' ? str.slice(0, str.length - 1) : str;
+
   public applyPathsToRouterProxy<T extends HttpServer>(
     router: T,
     routePaths: RoutePathProperties[],
@@ -161,9 +164,12 @@ export class RouterExplorer {
         basePath,
         host,
       );
-      path.forEach(p =>
-        this.logger.log(ROUTE_MAPPED_MESSAGE(p, requestMethod)),
-      );
+      path.forEach(p => {
+        const pathStr =
+          RouterExplorer.stripEndSlash(basePath) +
+          RouterExplorer.stripEndSlash(p);
+        this.logger.log(ROUTE_MAPPED_MESSAGE(pathStr, requestMethod));
+      });
     });
   }
 
@@ -186,9 +192,6 @@ export class RouterExplorer {
       .get(router, requestMethod)
       .bind(router);
 
-    const stripSlash = (str: string) =>
-      str[str.length - 1] === '/' ? str.slice(0, str.length - 1) : str;
-
     const isRequestScoped = !instanceWrapper.isDependencyTreeStatic();
     const proxy = isRequestScoped
       ? this.createRequestScopedHandler(
@@ -208,8 +211,8 @@ export class RouterExplorer {
 
     const hostHandler = this.applyHostFilter(host, proxy);
     paths.forEach(path => {
-      const fullPath = stripSlash(basePath) + path;
-      routerMethod(stripSlash(fullPath) || '/', hostHandler);
+      const fullPath = RouterExplorer.stripEndSlash(basePath) + path;
+      routerMethod(RouterExplorer.stripEndSlash(fullPath) || '/', hostHandler);
     });
   }
 

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -50,6 +50,9 @@ export class RoutesResolver implements Resolver {
     });
   }
 
+  private static stripEndSlash = (str: string) =>
+    str[str.length - 1] === '/' ? str.slice(0, str.length - 1) : str;
+
   public registerRouters(
     routes: Map<string, InstanceWrapper<Controller>>,
     moduleName: string,
@@ -65,7 +68,12 @@ export class RoutesResolver implements Resolver {
         basePath,
       );
       const controllerName = metatype.name;
-      this.logger.log(CONTROLLER_MAPPING_MESSAGE(controllerName, path));
+      this.logger.log(
+        CONTROLLER_MAPPING_MESSAGE(
+          controllerName,
+          RoutesResolver.stripEndSlash(path),
+        ),
+      );
       this.routerBuilder.explore(
         instanceWrapper,
         moduleName,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Part 1:
Currently the logging does not prepend the basePath to the RouterExplorer on the Nest application startup, ex:

```
[RoutesResolver] TestController {/test}:
[RouterExplorer] Mapped {/, GET} route
```
Here the TestController has a basePath of `/test`, with a single `@Get()` inside. When the RouterExplorer is logged, it looks likes you could get the TestController's `@Get()` from directly calling the root get, and not on `/test`

Part 2:
If you defined a controllers as follows:
```
@Controller('test')
```
and one:
```
@Controller('test2/')
```
They would be logged without and with the slash

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
With the changes, the logging for when starting the Nest application, would correctly show the full path for controller actions, and controllers RoutesResolver will have removed trailing slashes, to be consistent between defined routes/controllers. Ex:
```
@Controller('test')
@Controller('/test')
@Controller('test/')
@Controller('/test/')
```
Would all be logged as:
```
[RoutesResolver] TestController {/test}
```

Routes inside nested controllers `@Controller('test')`:
```
@Get('getCats')
@Get('/getCats')
@Get('getCats/')
@Get('/getCats/')
```
Would all be logged as:
```
[RouterExplorer] Mapped {/test/getCats, GET} route
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information