### PR TITLE
refactor(common): fix exceptions doc/var names

### DIFF
--- a/packages/common/exceptions/bad-gateway.exception.ts
+++ b/packages/common/exceptions/bad-gateway.exception.ts
@@ -16,27 +16,26 @@ export class BadGatewayException extends HttpException {
    * `throw new BadGatewayException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 502.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 502.
    * - `message`: the string `'Bad Gateway'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Bad Gateway') {
+  constructor(objectOrError?: string | object | any, message = 'Bad Gateway') {
     super(
-      HttpException.createBody(message, error, HttpStatus.BAD_GATEWAY),
+      HttpException.createBody(objectOrError, message, HttpStatus.BAD_GATEWAY),
       HttpStatus.BAD_GATEWAY,
     );
   }

--- a/packages/common/exceptions/bad-request.exception.ts
+++ b/packages/common/exceptions/bad-request.exception.ts
@@ -16,27 +16,26 @@ export class BadRequestException extends HttpException {
    * `throw new BadRequestException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 400.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 400.
    * - `message`: the string `'Bad Request'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Bad Request') {
+  constructor(objectOrError?: string | object | any, message = 'Bad Request') {
     super(
-      HttpException.createBody(message, error, HttpStatus.BAD_REQUEST),
+      HttpException.createBody(objectOrError, message, HttpStatus.BAD_REQUEST),
       HttpStatus.BAD_REQUEST,
     );
   }

--- a/packages/common/exceptions/conflict.exception.ts
+++ b/packages/common/exceptions/conflict.exception.ts
@@ -16,26 +16,26 @@ export class ConflictException extends HttpException {
    * `throw new ConflictException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 409.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 409.
    * - `message`: the string `'Conflict'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
-   */ constructor(message?: string | object | any, error = 'Conflict') {
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
+   */
+  constructor(objectOrError?: string | object | any, message = 'Conflict') {
     super(
-      HttpException.createBody(message, error, HttpStatus.CONFLICT),
+      HttpException.createBody(objectOrError, message, HttpStatus.CONFLICT),
       HttpStatus.CONFLICT,
     );
   }

--- a/packages/common/exceptions/forbidden.exception.ts
+++ b/packages/common/exceptions/forbidden.exception.ts
@@ -16,27 +16,26 @@ export class ForbiddenException extends HttpException {
    * `throw new ForbiddenException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 403.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 403.
    * - `message`: the string `'Forbidden'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Forbidden') {
+  constructor(objectOrError?: string | object | any, message = 'Forbidden') {
     super(
-      HttpException.createBody(message, error, HttpStatus.FORBIDDEN),
+      HttpException.createBody(objectOrError, message, HttpStatus.FORBIDDEN),
       HttpStatus.FORBIDDEN,
     );
   }

--- a/packages/common/exceptions/gateway-timeout.exception.ts
+++ b/packages/common/exceptions/gateway-timeout.exception.ts
@@ -16,27 +16,33 @@ export class GatewayTimeoutException extends HttpException {
    * `throw new GatewayTimeoutException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 504.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 504.
    * - `message`: the string `'Gateway Timeout'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Gateway Timeout') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Gateway Timeout',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.GATEWAY_TIMEOUT),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.GATEWAY_TIMEOUT,
+      ),
       HttpStatus.GATEWAY_TIMEOUT,
     );
   }

--- a/packages/common/exceptions/gone.exception.ts
+++ b/packages/common/exceptions/gone.exception.ts
@@ -16,27 +16,26 @@ export class GoneException extends HttpException {
    * `throw new GoneException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 410.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 410.
    * - `message`: the string `'Gone'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Gone') {
+  constructor(objectOrError?: string | object | any, message = 'Gone') {
     super(
-      HttpException.createBody(message, error, HttpStatus.GONE),
+      HttpException.createBody(objectOrError, message, HttpStatus.GONE),
       HttpStatus.GONE,
     );
   }

--- a/packages/common/exceptions/http-version-not-supported.exception.ts
+++ b/packages/common/exceptions/http-version-not-supported.exception.ts
@@ -16,32 +16,31 @@ export class HttpVersionNotSupportedException extends HttpException {
    * `throw new HttpVersionNotSupportedException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 505.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 505.
    * - `message`: the string `'HTTP Version Not Supported'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
   constructor(
-    message?: string | object | any,
-    error = 'HTTP Version Not Supported',
+    objectOrError?: string | object | any,
+    message = 'HTTP Version Not Supported',
   ) {
     super(
       HttpException.createBody(
+        objectOrError,
         message,
-        error,
         HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
       ),
       HttpStatus.HTTP_VERSION_NOT_SUPPORTED,

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -16,23 +16,23 @@ export class HttpException extends Error {
    * `throw new HttpException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
+   * The constructor arguments define the response and the HTTP response status code.
    * - The `response` argument (required) defines the JSON response body.
    * - The `status` argument (required) defines the HTTP Status Code.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: the Http Status Code.
    * - `message`: a short description of the HTTP error by default; override this
    * by supplying a string in the `response` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * To override the entire JSON response body, pass an object to the `createBody`
+   * method. Nest will serialize the object and return it as the JSON response body.
    *
    * The `status` argument is required, and should be a valid HTTP status code.
    * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
    *
    * @param response string or object describing the error condition.
-   * @param status HTTP response status code
+   * @param status HTTP response status code.
    */
   constructor(
     private readonly response: string | Record<string, any>,

--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -19,27 +19,30 @@ export class ImATeapotException extends HttpException {
    * `throw new BadGatewayException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 418.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 418.
    * - `message`: the string `"I'm a Teapot"` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = `I'm a teapot`) {
+  constructor(objectOrError?: string | object | any, message = `I'm a teapot`) {
     super(
-      HttpException.createBody(message, error, HttpStatus.I_AM_A_TEAPOT),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.I_AM_A_TEAPOT,
+      ),
       HttpStatus.I_AM_A_TEAPOT,
     );
   }

--- a/packages/common/exceptions/internal-server-error.exception.ts
+++ b/packages/common/exceptions/internal-server-error.exception.ts
@@ -16,32 +16,31 @@ export class InternalServerErrorException extends HttpException {
    * `throw new InternalServerErrorException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 500.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 500.
    * - `message`: the string `'Internal Server Error'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
   constructor(
-    message?: string | object | any,
-    error = 'Internal Server Error',
+    objectOrError?: string | object | any,
+    message = 'Internal Server Error',
   ) {
     super(
       HttpException.createBody(
+        objectOrError,
         message,
-        error,
         HttpStatus.INTERNAL_SERVER_ERROR,
       ),
       HttpStatus.INTERNAL_SERVER_ERROR,

--- a/packages/common/exceptions/method-not-allowed.exception.ts
+++ b/packages/common/exceptions/method-not-allowed.exception.ts
@@ -16,27 +16,33 @@ export class MethodNotAllowedException extends HttpException {
    * `throw new MethodNotAllowedException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 405.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 405.
    * - `message`: the string `'Method Not Allowed'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Method Not Allowed') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Method Not Allowed',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.METHOD_NOT_ALLOWED),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.METHOD_NOT_ALLOWED,
+      ),
       HttpStatus.METHOD_NOT_ALLOWED,
     );
   }

--- a/packages/common/exceptions/not-acceptable.exception.ts
+++ b/packages/common/exceptions/not-acceptable.exception.ts
@@ -16,27 +16,33 @@ export class NotAcceptableException extends HttpException {
    * `throw new NotAcceptableException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 406.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
-   * - `message`: the string `'Not Acceptable'` by default; override this by supplying
-   * a string in the `message` parameter.
+   * - `statusCode`: this will be the value 406.
+   * - `error`: the string `'Not Acceptable'` by default; override this by supplying
+   * a string in the `error` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Not Acceptable') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Not Acceptable',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.NOT_ACCEPTABLE),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.NOT_ACCEPTABLE,
+      ),
       HttpStatus.NOT_ACCEPTABLE,
     );
   }

--- a/packages/common/exceptions/not-found.exception.ts
+++ b/packages/common/exceptions/not-found.exception.ts
@@ -16,27 +16,26 @@ export class NotFoundException extends HttpException {
    * `throw new NotFoundException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 404.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 404.
    * - `message`: the string `'Not Found'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Not Found') {
+  constructor(objectOrError?: string | object | any, message = 'Not Found') {
     super(
-      HttpException.createBody(message, error, HttpStatus.NOT_FOUND),
+      HttpException.createBody(objectOrError, message, HttpStatus.NOT_FOUND),
       HttpStatus.NOT_FOUND,
     );
   }

--- a/packages/common/exceptions/not-implemented.exception.ts
+++ b/packages/common/exceptions/not-implemented.exception.ts
@@ -16,27 +16,33 @@ export class NotImplementedException extends HttpException {
    * `throw new NotImplementedException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 501.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 501.
    * - `message`: the string `'Not Implemented'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
-   *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
    * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param error a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Not Implemented') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Not Implemented',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.NOT_IMPLEMENTED),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.NOT_IMPLEMENTED,
+      ),
       HttpStatus.NOT_IMPLEMENTED,
     );
   }

--- a/packages/common/exceptions/payload-too-large.exception.ts
+++ b/packages/common/exceptions/payload-too-large.exception.ts
@@ -16,27 +16,33 @@ export class PayloadTooLargeException extends HttpException {
    * `throw new PayloadTooLargeException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 413.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 413.
    * - `message`: the string `'Payload Too Large'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Payload Too Large') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Payload Too Large',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.PAYLOAD_TOO_LARGE),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.PAYLOAD_TOO_LARGE,
+      ),
       HttpStatus.PAYLOAD_TOO_LARGE,
     );
   }

--- a/packages/common/exceptions/request-timeout.exception.ts
+++ b/packages/common/exceptions/request-timeout.exception.ts
@@ -16,27 +16,33 @@ export class RequestTimeoutException extends HttpException {
    * `throw new RequestTimeoutException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 408.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 408.
    * - `message`: the string `'Request Timeout'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Request Timeout') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Request Timeout',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.REQUEST_TIMEOUT),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.REQUEST_TIMEOUT,
+      ),
       HttpStatus.REQUEST_TIMEOUT,
     );
   }

--- a/packages/common/exceptions/service-unavailable.exception.ts
+++ b/packages/common/exceptions/service-unavailable.exception.ts
@@ -16,27 +16,33 @@ export class ServiceUnavailableException extends HttpException {
    * `throw new ServiceUnavailableException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 503.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 503.
    * - `message`: the string `'Service Unavailable'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Service Unavailable') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Service Unavailable',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.SERVICE_UNAVAILABLE),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.SERVICE_UNAVAILABLE,
+      ),
       HttpStatus.SERVICE_UNAVAILABLE,
     );
   }

--- a/packages/common/exceptions/unauthorized.exception.ts
+++ b/packages/common/exceptions/unauthorized.exception.ts
@@ -16,27 +16,26 @@ export class UnauthorizedException extends HttpException {
    * `throw new UnauthorizedException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 401.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 401.
    * - `message`: the string `'Unauthorized'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Unauthorized') {
+  constructor(objectOrError?: string | object | any, message = 'Unauthorized') {
     super(
-      HttpException.createBody(message, error, HttpStatus.UNAUTHORIZED),
+      HttpException.createBody(objectOrError, message, HttpStatus.UNAUTHORIZED),
       HttpStatus.UNAUTHORIZED,
     );
   }

--- a/packages/common/exceptions/unprocessable-entity.exception.ts
+++ b/packages/common/exceptions/unprocessable-entity.exception.ts
@@ -16,27 +16,33 @@ export class UnprocessableEntityException extends HttpException {
    * `throw new UnprocessableEntityException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 422.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 422.
    * - `message`: the string `'Unprocessable Entity'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
-  constructor(message?: string | object | any, error = 'Unprocessable Entity') {
+  constructor(
+    objectOrError?: string | object | any,
+    message = 'Unprocessable Entity',
+  ) {
     super(
-      HttpException.createBody(message, error, HttpStatus.UNPROCESSABLE_ENTITY),
+      HttpException.createBody(
+        objectOrError,
+        message,
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      ),
       HttpStatus.UNPROCESSABLE_ENTITY,
     );
   }

--- a/packages/common/exceptions/unsupported-media-type.exception.ts
+++ b/packages/common/exceptions/unsupported-media-type.exception.ts
@@ -16,32 +16,31 @@ export class UnsupportedMediaTypeException extends HttpException {
    * `throw new UnsupportedMediaTypeException()`
    *
    * @usageNotes
-   * The constructor arguments define the HTTP response.
-   * - The `message` argument defines the JSON response body.
-   * - The `error` argument defines the HTTP Status Code.
+   * The HTTP response status code will be 415.
+   * - The `objectOrError` argument defines the JSON response body or the error string.
+   * - The `message` argument contains a short description of the HTTP error.
    *
    * By default, the JSON response body contains two properties:
-   * - `statusCode`: defaults to the Http Status Code provided in the `error` argument
+   * - `statusCode`: this will be the value 415.
    * - `message`: the string `'Unsupported Media Type'` by default; override this by supplying
    * a string in the `message` parameter.
    *
-   * To override the entire JSON response body, pass an object.  Nest will serialize
-   * the object and return it as the JSON response body.
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, containing the given string. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
    *
-   * The `error` argument is required, and should be a valid HTTP status code.
-   * Best practice is to use the `HttpStatus` enum imported from `nestjs/common`.
-   *
-   * @param message string or object describing the error condition.
-   * @param error HTTP response status code
+   * @param objectOrError string or object describing the error condition.
+   * @param message a short description of the HTTP error.
    */
   constructor(
-    message?: string | object | any,
-    error = 'Unsupported Media Type',
+    objectOrError?: string | object | any,
+    message = 'Unsupported Media Type',
   ) {
     super(
       HttpException.createBody(
+        objectOrError,
         message,
-        error,
         HttpStatus.UNSUPPORTED_MEDIA_TYPE,
       ),
       HttpStatus.UNSUPPORTED_MEDIA_TYPE,


### PR DESCRIPTION
Fix incorrect documentation strings for HTTP exceptions.

Closes #4042

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: incorrect documentation
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #4042


## What is the new behavior?
Documentation strings are now correct.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
If this is merged before #4045, the documentation strings for the exceptions must be updated by #4045.
If this is merged after #4045, this PR should be updated to fix the documentation strings.