### PR TITLE
fix(common): standardizes http exceptions output

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -66,7 +66,7 @@ export class HttpException extends Error {
     statusCode?: number,
   ) {
     if (!message) {
-      return { statusCode, error };
+      return { statusCode, message: error };
     }
     return isObject(message) && !Array.isArray(message)
       ? message

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -34,7 +34,7 @@ describe('HttpException', () => {
   it('should return an object even when the message is undefined', () => {
     expect(new BadRequestException().message).to.be.eql({
       statusCode: 400,
-      error: 'Bad Request',
+      message: 'Bad Request',
     });
   });
 
@@ -45,11 +45,11 @@ describe('HttpException', () => {
 
   it('should return a response', () => {
     expect(new BadRequestException().getResponse()).to.be.eql({
-      error: 'Bad Request',
+      message: 'Bad Request',
       statusCode: 400,
     });
     expect(new NotFoundException().getResponse()).to.be.eql({
-      error: 'Not Found',
+      message: 'Not Found',
       statusCode: 404,
     });
   });
@@ -105,7 +105,7 @@ describe('HttpException', () => {
         const status = 500;
         const error = 'error';
         expect(HttpException.createBody(null, error, status)).to.be.eql({
-          error,
+          message: error,
           statusCode: status,
         });
       });


### PR DESCRIPTION
Originally, the default output of `HTTPException` is `{statusCode,
message}`, but the default output for another specific exception
(e.g., `BadRequestException`) is `{statusCode, error}`. These changes
make them behave consistently.

Closes #3454
Closes #4044

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
All exceptions by default now return `{statusCode, message}`.

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default output of HTTPException is `{statusCode, message}`, but the default output for another specific exception (e.g., BadRequestException) is `{statusCode, error}`.

Issue Number: #4044 


## What is the new behavior?
All exceptions by default now return `{statusCode, message}`.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The default exceptions output changed.

## Other information
If this is merged before #4043, the documentation strings in #4043 must be updated.
If this is merged after #4043, this PR should be updated to fix those documentation strings.