### PR TITLE
feat(microservices): add subscribe and from beginning to kafka options

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -120,9 +120,11 @@ export class ClientKafka extends ClientProxy {
   }
 
   public async bindTopics(): Promise<void> {
+    const consumerSubscribeOptions = this.options.subscribe || {};
     const subscribeTo = async (responsePattern: string) =>
       this.consumer.subscribe({
         topic: responsePattern,
+        ...consumerSubscribeOptions,
       });
     await Promise.all(this.responsePatterns.map(subscribeTo));
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -130,6 +130,9 @@ export interface KafkaOptions {
       eachBatchAutoResolve?: boolean;
       partitionsConsumedConcurrently?: number;
     };
+    subscribe?: {
+      fromBeginning?: boolean;
+    };
     producer?: ProducerConfig;
     send?: {
       acks?: number;

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -101,9 +101,11 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
 
   public async bindEvents(consumer: Consumer) {
     const registeredPatterns = [...this.messageHandlers.keys()];
+    const consumerSubscribeOptions = this.options.subscribe || {};
     const subscribeToPattern = async (pattern: string) =>
       consumer.subscribe({
         topic: pattern,
+        ...consumerSubscribeOptions,
       });
     await Promise.all(registeredPatterns.map(subscribeToPattern));
 

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -333,6 +333,29 @@ describe('ClientKafka', () => {
       await client.bindTopics();
 
       expect(subscribe.calledOnce).to.be.true;
+      expect(
+        subscribe.calledWith({
+          topic: replyTopic,
+        }),
+      ).to.be.true;
+      expect(run.calledOnce).to.be.true;
+    });
+
+    it('should bind topics from response patterns with options', async () => {
+      (client as any).responsePatterns = [replyTopic];
+      (client as any).consumer = kafkaClient.consumer();
+      (client as any).options.subscribe = {};
+      (client as any).options.subscribe.fromBeginning = true;
+
+      await client.bindTopics();
+
+      expect(subscribe.calledOnce).to.be.true;
+      expect(
+        subscribe.calledWith({
+          topic: replyTopic,
+          fromBeginning: true,
+        }),
+      ).to.be.true;
       expect(run.calledOnce).to.be.true;
     });
   });

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -177,6 +177,31 @@ describe('ServerKafka', () => {
       expect(run.called).to.be.true;
       expect(connect.called).to.be.true;
     });
+    it('should call subscribe with options and run on consumer when there are messageHandlers', async () => {
+      (server as any).logger = new NoopLogger();
+      (server as any).options.subscribe = {};
+      (server as any).options.subscribe.fromBeginning = true;
+      await server.listen(callback);
+
+      const pattern = 'test';
+      const handler = sinon.spy();
+      (server as any).messageHandlers = objectToMap({
+        [pattern]: handler,
+      });
+
+      await server.bindEvents((server as any).consumer);
+
+      expect(subscribe.called).to.be.true;
+      expect(
+        subscribe.calledWith({
+          topic: pattern,
+          fromBeginning: true,
+        }),
+      ).to.be.true;
+
+      expect(run.called).to.be.true;
+      expect(connect.called).to.be.true;
+    });
   });
 
   describe('getMessageHandler', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/3739


## What is the new behavior?
KafkaOptions includes support for the [kafka.js subscribe fromBeginning option](https://kafka.js.org/docs/consuming#a-name-from-beginning-a-frombeginning).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information