### PR TITLE
fix(platform): added prefix to adapters

### DIFF
--- a/integration/hello-world/e2e/express-multiple.spec.ts
+++ b/integration/hello-world/e2e/express-multiple.spec.ts
@@ -20,7 +20,7 @@ describe('Hello world (express instance with multiple applications)', () => {
     const adapter = new ExpressAdapter(express());
 
     apps = [
-      module1.createNestApplication(adapter),
+      module1.createNestApplication(adapter).setGlobalPrefix('app1'),
       module2.createNestApplication(adapter).setGlobalPrefix('/app2'),
     ];
     await Promise.all(apps.map(app => app.init()));
@@ -28,9 +28,9 @@ describe('Hello world (express instance with multiple applications)', () => {
     server = adapter.getInstance();
   });
 
-  it(`/GET`, () => {
+  it(`/GET (app1)`, () => {
     return request(server)
-      .get('/hello')
+      .get('/app1/hello')
       .expect(200)
       .expect('Hello world!');
   });
@@ -42,9 +42,9 @@ describe('Hello world (express instance with multiple applications)', () => {
       .expect('Hello world!');
   });
 
-  it(`/GET (Promise/async)`, () => {
+  it(`/GET (app1 Promise/async)`, () => {
     return request(server)
-      .get('/hello/async')
+      .get('/app1/hello/async')
       .expect(200)
       .expect('Hello world!');
   });
@@ -56,9 +56,9 @@ describe('Hello world (express instance with multiple applications)', () => {
       .expect('Hello world!');
   });
 
-  it(`/GET (Observable stream)`, () => {
+  it(`/GET (app1 Observable stream)`, () => {
     return request(server)
-      .get('/hello/stream')
+      .get('/app1/hello/stream')
       .expect(200)
       .expect('Hello world!');
   });
@@ -68,6 +68,28 @@ describe('Hello world (express instance with multiple applications)', () => {
       .get('/app2/hello/stream')
       .expect(200)
       .expect('Hello world!');
+  });
+
+  it(`/GET (app1 NotFound)`, () => {
+    return request(server)
+      .get('/app1/cats')
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Cannot GET /cats',
+      });
+  });
+
+  it(`/GET (app2 NotFound)`, () => {
+    return request(server)
+      .get('/app2/cats')
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Cannot GET /cats',
+      });
   });
 
   afterEach(async () => {

--- a/integration/hello-world/e2e/express-multiple.spec.ts
+++ b/integration/hello-world/e2e/express-multiple.spec.ts
@@ -16,12 +16,16 @@ describe('Hello world (express instance with multiple applications)', () => {
     const module2 = await Test.createTestingModule({
       imports: [ApplicationModule],
     }).compile();
+    const module3 = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
 
     const adapter = new ExpressAdapter(express());
 
     apps = [
       module1.createNestApplication(adapter).setGlobalPrefix('app1'),
       module2.createNestApplication(adapter).setGlobalPrefix('/app2'),
+      module3.createNestApplication(adapter),
     ];
     await Promise.all(apps.map(app => app.init()));
 
@@ -89,6 +93,17 @@ describe('Hello world (express instance with multiple applications)', () => {
         statusCode: 404,
         error: 'Not Found',
         message: 'Cannot GET /cats',
+      });
+  });
+
+  it(`/GET (app3 NotFound)`, () => {
+    return request(server)
+      .get('/app3/cats')
+      .expect(404)
+      .expect({
+        statusCode: 404,
+        error: 'Not Found',
+        message: 'Cannot GET /app3/cats',
       });
   });
 

--- a/integration/hello-world/e2e/fastify-multiple.spec.ts
+++ b/integration/hello-world/e2e/fastify-multiple.spec.ts
@@ -15,6 +15,9 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
     const module2 = await Test.createTestingModule({
       imports: [ApplicationModule],
     }).compile();
+    const module3 = await Test.createTestingModule({
+      imports: [ApplicationModule],
+    }).compile();
 
     adapter = new FastifyAdapter();
 
@@ -25,6 +28,7 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
           bodyParser: false,
         })
         .setGlobalPrefix('/app2'),
+      module3.createNestApplication<NestFastifyApplication>(adapter),
     ];
     await Promise.all(apps.map(app => app.init()));
   });
@@ -112,6 +116,23 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
             statusCode: 404,
             error: 'Not Found',
             message: 'Cannot GET /app2/cats',
+          }));
+        },
+      );
+  });
+
+  it(`/GET (app3 NotFound)`, () => {
+    return adapter
+      .inject({
+        method: 'GET',
+        url: '/app3/cats',
+      })
+      .then(
+        ({ payload }) => {
+         expect(payload).to.be.eql(JSON.stringify({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Cannot GET /app3/cats',
           }));
         },
       );

--- a/integration/hello-world/e2e/fastify-multiple.spec.ts
+++ b/integration/hello-world/e2e/fastify-multiple.spec.ts
@@ -1,8 +1,7 @@
-/* Temporarily disabled due to various regressions
-
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
+import { fail } from 'assert';
 import { ApplicationModule } from '../src/app.module';
 
 describe('Hello world (fastify adapter with multiple applications)', () => {
@@ -20,7 +19,7 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
     adapter = new FastifyAdapter();
 
     apps = [
-      module1.createNestApplication<NestFastifyApplication>(adapter),
+      module1.createNestApplication<NestFastifyApplication>(adapter).setGlobalPrefix('app1'),
       module2
         .createNestApplication<NestFastifyApplication>(adapter, {
           bodyParser: false,
@@ -30,11 +29,11 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
     await Promise.all(apps.map(app => app.init()));
   });
 
-  it(`/GET`, () => {
+  it(`/GET (app1)`, () => {
     return adapter
       .inject({
         method: 'GET',
-        url: '/hello',
+        url: '/app1/hello',
       })
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
@@ -48,11 +47,11 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
 
-  it(`/GET (Promise/async)`, () => {
+  it(`/GET (app1 Promise/async)`, () => {
     return adapter
       .inject({
         method: 'GET',
-        url: '/hello/async',
+        url: '/app1/hello/async',
       })
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
@@ -66,11 +65,11 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
 
-  it(`/GET (Observable stream)`, () => {
+  it(`/GET (app1 Observable stream)`, () => {
     return adapter
       .inject({
         method: 'GET',
-        url: '/hello/stream',
+        url: '/app1/hello/stream',
       })
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
@@ -84,8 +83,42 @@ describe('Hello world (fastify adapter with multiple applications)', () => {
       .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
   });
 
+  it(`/GET (app1 NotFound)`, () => {
+    return adapter
+      .inject({
+        method: 'GET',
+        url: '/app1/cats',
+      })
+      .then(
+        ({ payload }) => {
+          expect(payload).to.be.eql(JSON.stringify({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Cannot GET /app1/cats',
+          }));
+        },
+      );
+  });
+
+  it(`/GET (app2 NotFound)`, () => {
+    return adapter
+      .inject({
+        method: 'GET',
+        url: '/app2/cats',
+      })
+      .then(
+        ({ payload }) => {
+         expect(payload).to.be.eql(JSON.stringify({
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Cannot GET /app2/cats',
+          }));
+        },
+      );
+  });
+
   afterEach(async () => {
     await Promise.all(apps.map(app => app.close()));
     await adapter.close();
   });
-});*/
+});

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -59,8 +59,8 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   getRequestMethod?(request: TRequest): string;
   getRequestUrl?(request: TResponse): string;
   getInstance(): any;
-  registerParserMiddleware(): any;
-  enableCors(options: CorsOptions): any;
+  registerParserMiddleware(prefix?: string): any;
+  enableCors(options: CorsOptions, prefix?: string): any;
   getHttpServer(): any;
   initHttpServer(options: NestApplicationOptions): void;
   close(): any;

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -92,6 +92,7 @@ export abstract class AbstractHttpAdapter<
   abstract redirect(response, statusCode: number, url: string);
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
+  abstract setRootNotFoundHandler(handler: Function);
   abstract setHeader(response, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string);
   abstract enableCors(options: CorsOptions, prefix?: string);
@@ -99,4 +100,7 @@ export abstract class AbstractHttpAdapter<
     requestMethod: RequestMethod,
   ): (path: string, callback: Function) => any;
   abstract getType(): string;
+  abstract addNestInstanceBaseUrl(baseUrl?: string): void;
+  abstract getNotFoundCallback(baseUrl?: string);
+  abstract getRootNotFoundCallback();
 }

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -140,7 +140,8 @@ export class NestApplication extends NestApplicationContext
 
     const useBodyParser =
       this.appOptions && this.appOptions.bodyParser !== false;
-    useBodyParser && this.registerParserMiddleware();
+    useBodyParser &&
+      this.registerParserMiddleware(this.config.getGlobalPrefix());
 
     await this.registerModules();
     await this.registerRouter();
@@ -153,8 +154,8 @@ export class NestApplication extends NestApplicationContext
     return this;
   }
 
-  public registerParserMiddleware() {
-    this.httpAdapter.registerParserMiddleware();
+  public registerParserMiddleware(prefix?: string) {
+    this.httpAdapter.registerParserMiddleware(prefix);
   }
 
   public async registerRouter() {
@@ -216,7 +217,7 @@ export class NestApplication extends NestApplicationContext
   }
 
   public enableCors(options?: CorsOptions): void {
-    this.httpAdapter.enableCors(options);
+    this.httpAdapter.enableCors(options, this.config.getGlobalPrefix());
   }
 
   public async listen(

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -78,15 +78,25 @@ export class RoutesResolver implements Resolver {
 
   public registerNotFoundHandler() {
     const applicationRef = this.container.getHttpAdapterRef();
-    const callback = <TRequest, TResponse>(req: TRequest, res: TResponse) => {
-      const method = applicationRef.getRequestMethod(req);
-      const url = applicationRef.getRequestUrl(req);
-      throw new NotFoundException(`Cannot ${method} ${url}`);
-    };
+    applicationRef.addNestInstanceBaseUrl(this.config.getGlobalPrefix());
+
+    const callback = applicationRef.getNotFoundCallback(
+      this.config.getGlobalPrefix(),
+    );
     const handler = this.routerExceptionsFilter.create({}, callback, undefined);
     const proxy = this.routerProxy.createProxy(callback, handler);
     applicationRef.setNotFoundHandler &&
       applicationRef.setNotFoundHandler(proxy, this.config.getGlobalPrefix());
+
+    const rootCallback = applicationRef.getRootNotFoundCallback();
+    const rootHandler = this.routerExceptionsFilter.create(
+      {},
+      rootCallback,
+      undefined,
+    );
+    const rootProxy = this.routerProxy.createProxy(rootCallback, rootHandler);
+    applicationRef.setRootNotFoundHandler &&
+      applicationRef.setRootNotFoundHandler(rootProxy);
   }
 
   public registerExceptionHandler() {

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -251,6 +251,28 @@ describe('RoutesResolver', () => {
 
   describe('registerNotFoundHandler', () => {
     it('should register not found handler', () => {
+      let applicationRef = {
+        addNestInstanceBaseUrl: (baseUrl: string) => {
+          return;
+        },
+        getNotFoundCallback: (baseUrl?: string) => {
+          return (req, res, next) => {
+            next();
+          };
+        },
+        getRootNotFoundCallback: () => {
+          return (req, res, next) => {
+            next();
+          };
+        },
+        setNotFoundHandler: sinon.spy(),
+        setRootNotFoundHandler: sinon.spy(),
+      };
+
+      sinon
+        .stub((routesResolver as any).container, 'getHttpAdapterRef')
+        .callsFake(() => applicationRef);
+
       routesResolver.registerNotFoundHandler();
 
       expect(applicationRef.setNotFoundHandler.called).to.be.true;

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -1,5 +1,6 @@
 import { RequestMethod } from '@nestjs/common';
 import { AbstractHttpAdapter } from '../../adapters';
+import { Func } from 'mocha';
 
 export class NoopHttpAdapter extends AbstractHttpAdapter {
   constructor(instance: any) {
@@ -18,6 +19,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   redirect(response: any, statusCode: number, url: string) {}
   setErrorHandler(handler: Function, prefix = '/'): any {}
   setNotFoundHandler(handler: Function, prefix = '/'): any {}
+  setRootNotFoundHandler(handler: Function): any {}
   setHeader(response: any, name: string, value: string): any {}
   registerParserMiddleware(prefix?: string): any {}
   enableCors(options: any, prefix?: string): any {}
@@ -25,4 +27,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   getType() {
     return '';
   }
+  addNestInstanceBaseUrl(baseUrl?: string): void {}
+  getNotFoundCallback(baseUrl?: string) {}
+  getRootNotFoundCallback() {}
 }

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -19,8 +19,8 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   setErrorHandler(handler: Function, prefix = '/'): any {}
   setNotFoundHandler(handler: Function, prefix = '/'): any {}
   setHeader(response: any, name: string, value: string): any {}
-  registerParserMiddleware(): any {}
-  enableCors(options: any): any {}
+  registerParserMiddleware(prefix?: string): any {}
+  enableCors(options: any, prefix?: string): any {}
   createMiddlewareFactory(requestMethod: RequestMethod): any {}
   getType() {
     return '';

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -70,14 +70,30 @@ export class FastifyAdapter<TInstance = any> extends AbstractHttpAdapter {
     handler: Parameters<fastify.FastifyInstance['setErrorHandler']>[0],
     prefix?: string,
   ) {
-    return this.instance.setErrorHandler(handler);
+    if (!prefix) {
+      return this.instance.setErrorHandler(handler);
+    }
+    return this.registerWithPrefix(
+      async (instance: fastify.FastifyInstance): Promise<void> => {
+        instance.setErrorHandler(handler);
+      },
+      prefix.charAt(0) !== '/' ? '/' + prefix : prefix,
+    );
   }
 
   public setNotFoundHandler(
     handler: Parameters<fastify.FastifyInstance['setNotFoundHandler']>[0],
     prefix?: string,
   ) {
-    return this.instance.setNotFoundHandler(handler);
+    if (!prefix) {
+      return this.instance.setNotFoundHandler(handler);
+    }
+    return this.registerWithPrefix(
+      async (instance: fastify.FastifyInstance): Promise<void> => {
+        instance.setNotFoundHandler(handler);
+      },
+      prefix.charAt(0) !== '/' ? '/' + prefix : prefix,
+    );
   }
 
   public getHttpServer<TServer = any>(): TServer {
@@ -142,12 +158,30 @@ export class FastifyAdapter<TInstance = any> extends AbstractHttpAdapter {
     return request.raw.url;
   }
 
-  public enableCors(options: CorsOptions) {
-    this.register(cors, options);
+  public enableCors(options: CorsOptions, prefix?: string) {
+    if (!prefix) {
+      this.register(cors, options);
+      return;
+    }
+    this.registerWithPrefix(
+      async (instance: fastify.FastifyInstance): Promise<void> => {
+        instance.register(cors, (options as unknown) as {});
+      },
+      prefix.charAt(0) !== '/' ? '/' + prefix : prefix,
+    );
   }
 
-  public registerParserMiddleware() {
-    this.register(formBody);
+  public registerParserMiddleware(prefix?: string) {
+    if (!prefix) {
+      this.register(formBody);
+      return;
+    }
+    this.registerWithPrefix(
+      async (instance: fastify.FastifyInstance): Promise<void> => {
+        instance.register(formBody);
+      },
+      prefix.charAt(0) !== '/' ? '/' + prefix : prefix,
+    );
   }
 
   public createMiddlewareFactory(


### PR DESCRIPTION
fixes https://github.com/nestjs/nest/issues/4114

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When launching multiple NestApplication instances for a single adapter and using `setGlobalPrefix` for each, the router of the instance that executed the `init` method later cannot be used.

### example
```
  const server = express();
  const adapter = new ExpressAdapter(server);
  const adminApp = await NestFactory.create(AppModule, adapter);
  const apiApp = await NestFactory.create(AppModule, adapter);

  adminApp.setGlobalPrefix('admin');
  apiApp.setGlobalPrefix('api');

  await adminApp.init();
  await apiApp.init();

  server.listen(3000, () => console.log('Listening at 3000'));
```

### result
```
$ curl localhost:3000/admin
admin
$ curl localhost:3000/api
{"statusCode":404,"error":"Not Found","message":"Cannot GET /api"}
```

Issue Number: https://github.com/nestjs/nest/issues/4114


## What is the new behavior?

When setting middreware to the adapter, set the prefix registered with `setGlobalPrefix`.

With the above measures, the middleware is set for each instance, and the router is set appropriately.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If we do not use `setGlobalPrefix`, if we set with '/' added, if we set without '/', everything works normally.
This has been adapted to maintain compatibility.


## Other information