### PR TITLE
feat(microservices): implement server grpc max metadata size option

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -64,6 +64,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
     if (!clientRef) {
       throw new InvalidGrpcServiceException();
     }
+
     const maxSendMessageLengthKey = 'grpc.max_send_message_length';
     const maxReceiveMessageLengthKey = 'grpc.max_receive_message_length';
     const maxMessageLengthOptions = {
@@ -78,6 +79,14 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
         GRPC_DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH,
       ),
     };
+    const maxMetadataSize = this.getOptionsProp(
+      this.options,
+      'maxMetadataSize',
+      -1,
+    );
+    if (maxMetadataSize > 0) {
+      maxMessageLengthOptions['grpc.max_metadata_size'] = maxMetadataSize;
+    }
 
     const keepaliveOptions = this.getKeepaliveOptions();
     const options: Record<string, unknown> = isObject(this.options)

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -32,6 +32,7 @@ export interface GrpcOptions {
     url?: string;
     maxSendMessageLength?: number;
     maxReceiveMessageLength?: number;
+    maxMetadataSize?: number;
     keepalive?: {
       keepaliveTimeMs?: number;
       keepaliveTimeoutMs?: number;

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -240,7 +240,9 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
       call.on('data', (m: any) => req.next(m));
       call.on('error', (e: any) => {
         // Check if error means that stream ended on other end
-        const isCancelledError = String(e).toLowerCase().indexOf('cancelled');
+        const isCancelledError = String(e)
+          .toLowerCase()
+          .indexOf('cancelled');
 
         if (isCancelledError) {
           call.end();
@@ -323,7 +325,7 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
   }
 
   public createClient(): any {
-    const server = new grpcPackage.Server({
+    const grpcOptions = {
       'grpc.max_send_message_length': this.getOptionsProp(
         this.options,
         'maxSendMessageLength',
@@ -334,7 +336,16 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         'maxReceiveMessageLength',
         GRPC_DEFAULT_MAX_RECEIVE_MESSAGE_LENGTH,
       ),
-    });
+    };
+    const maxMetadataSize = this.getOptionsProp(
+      this.options,
+      'maxMetadataSize',
+      -1,
+    );
+    if (maxMetadataSize > 0) {
+      grpcOptions['grpc.max_metadata_size'] = maxMetadataSize;
+    }
+    const server = new grpcPackage.Server(grpcOptions);
     const credentials = this.getOptionsProp(this.options, 'credentials');
     server.bind(
       this.url,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is currently no way to change the default maximum metadata size for gRPC and it will always be set at the default (4KB).

Issue Number: #4237


## What is the new behavior?
A new `maxMetadataSize` is added on `GrpcOptions` to override the default of 4KB.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information