### PR TITLE
update types for MiddlewareConsumer

### DIFF
--- a/packages/common/interfaces/middleware/middleware-consumer.interface.ts
+++ b/packages/common/interfaces/middleware/middleware-consumer.interface.ts
@@ -16,4 +16,5 @@ export interface MiddlewareConsumer {
    * @returns {MiddlewareConfigProxy}
    */
   apply(...middleware: (Type<any> | Function)[]): MiddlewareConfigProxy;
+  apply(middleware: (Type<any> | Function)[]): MiddlewareConfigProxy;
 }


### PR DESCRIPTION
`...middleware` does not permit use of arrays, as stated in the comment above it: 
_middleware class/function or array_. 

Implementation itself appears to work correctly with both variants of usage.
Workaround is module augmentation:
`nest.d.ts`
```TS
import { Type } from '@nestjs/common/interfaces/type.interface'
import { MiddlewareConfigProxy } from '@nestjs/common/interfaces/middleware/middleware-config-proxy.interface'

declare module '@nestjs/common/interfaces/middleware/middleware-config-proxy.interface' {
	export interface MiddlewareConsumer {
		/**
		 * @param  middleware middleware class/function or array of classes/functions
		 * to be attached to the passed routes.
		 *
		 * @returns {MiddlewareConfigProxy}
		 */
		apply (...middleware: (Type<any> | Function)[]): MiddlewareConfigProxy;
		apply (middleware: (Type<any> | Function)[]): MiddlewareConfigProxy;
	}
}
```

## PR Type
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Other... Please describe: types update
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```