### PR TITLE
add void return type to nest-module.interface.ts

### DIFF
--- a/packages/common/interfaces/modules/nest-module.interface.ts
+++ b/packages/common/interfaces/modules/nest-module.interface.ts
@@ -1,5 +1,5 @@
 import { MiddlewareConsumer } from '../middleware/middleware-consumer.interface';
 
 export interface NestModule {
-  configure(consumer: MiddlewareConsumer);
+  configure(consumer: MiddlewareConsumer): void;
 }


### PR DESCRIPTION
There seems to be only one usage of `configure`, [here](https://github.com/nestjs/nest/blob/32d2172461dd996cc8d6c447e26968315bc41f18/packages/core/middleware/middleware-module.ts#L94), and it doesn't return anything.


## PR Type

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ x ] Other... Please describe: types update
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[ x ] No
```