### PR TITLE
Fix/grpc multi package client getService error

### DIFF
--- a/integration/microservices/e2e/sum-grpc.spec.ts
+++ b/integration/microservices/e2e/sum-grpc.spec.ts
@@ -25,8 +25,11 @@ describe('GRPC transport', () => {
     app.connectMicroservice({
       transport: Transport.GRPC,
       options: {
-        package: 'math',
-        protoPath: join(__dirname, '../src/grpc/math.proto'),
+        package: ['math', 'math2'],
+        protoPath: [
+          join(__dirname, '../src/grpc/math.proto'),
+          join(__dirname, '../src/grpc/math2.proto'),
+        ],
       },
     });
     // Start gRPC microservice
@@ -47,7 +50,19 @@ describe('GRPC transport', () => {
 
   it(`GRPC Sending and Receiving HTTP POST`, () => {
     return request(server)
-      .post('/')
+      .post('/sum')
+      .send([1, 2, 3, 4, 5])
+      .expect(200, { result: 15 });
+  });
+
+  it(`GRPC Sending and Receiving HTTP POST (multiple proto)`, async () => {
+    await request(server)
+      .post('/multi/sum')
+      .send([1, 2, 3, 4, 5])
+      .expect(200, { result: 15 });
+
+    await request(server)
+      .post('/multi/sum2')
       .send([1, 2, 3, 4, 5])
       .expect(200, { result: 15 });
   });

--- a/integration/microservices/src/grpc/grpc.controller.ts
+++ b/integration/microservices/src/grpc/grpc.controller.ts
@@ -31,9 +31,9 @@ export class GrpcController {
       ],
     },
   })
-  client2: ClientGrpc;
+  clientMulti: ClientGrpc;
 
-  @Post()
+  @Post('sum')
   @HttpCode(200)
   call(@Body() data: number[]): Observable<number> {
     const svc = this.client.getService<any>('Math');
@@ -77,10 +77,17 @@ export class GrpcController {
     });
   }
 
-  @Post()
+  @Post('multi/sum')
   @HttpCode(200)
-  call2(@Body() data: number[]): Observable<number> {
-    const svc = this.client2.getService<any>('Math2');
+  callMultiSum(@Body() data: number[]): Observable<number> {
+    const svc = this.clientMulti.getService<any>('Math');
     return svc.sum({ data });
+  }
+
+  @Post('multi/sum2')
+  @HttpCode(200)
+  callMultiSum2(@Body() data: number[]): Observable<number> {
+    const svc = this.clientMulti.getService<any>('Math2');
+    return svc.sum2({ data });
   }
 }

--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -89,16 +89,10 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
     }
 
     const keepaliveOptions = this.getKeepaliveOptions();
-    const options: Record<string, unknown> = isObject(this.options)
-      ? {
-          ...this.options,
-          ...maxMessageLengthOptions,
-          ...keepaliveOptions,
-          loader: '',
-        }
-      : {
-          ...maxMessageLengthOptions,
-        };
+    const options: Record<string, string | number> = {
+      ...maxMessageLengthOptions,
+      ...keepaliveOptions,
+    };
 
     const credentials =
       options.credentials || grpcPackage.credentials.createInsecure();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Calling `getService` of `ClientGrpcProxy` with multiple packages shows error  _'Channel third argument (options) must be an object with string keys and integer or string values'_. 

Which is caused by passing `ClientGrpcProxy`'s options (`GrpcOptions['options']` format) to node-grpc client's constructor. 

References:
https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/ext/channel.cc#L226
https://github.com/grpc/grpc-node/blob/master/packages/grpc-native-core/src/client.js#L413

Issue Number: N/A


## What is the new behavior?

As the options are transformed and kept in `maxMessageLengthOptions` and `keepaliveOptions`, this PR sends only `maxMessageLengthOptions` and `keepaliveOptions` to node-grpc Client's constructor.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information