### PR TITLE
fix(microservices): RMQ json [de]serialization

### DIFF
--- a/integration/microservices/e2e/custom-transport-adapter-rmq.spec.ts
+++ b/integration/microservices/e2e/custom-transport-adapter-rmq.spec.ts
@@ -1,0 +1,66 @@
+import { INestApplication } from '@nestjs/common';
+import { Transport } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as request from 'supertest';
+import { RMQCustomTransportAdapterController } from '../src/rmq-custon-transport-adapter/rmq-custom-transport-adapter.controller';
+import { customTransportAdapter } from '../src/rmq-custon-transport-adapter/custom-transport-adapter'
+
+describe('custom TransportAdapter', () => {
+  let server;
+  let app: INestApplication;
+  let encryptSpy: sinon.SinonSpy;
+  let decryptSpy: sinon.SinonSpy;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [RMQCustomTransportAdapterController],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpAdapter().getInstance();
+
+    encryptSpy = sinon.spy(customTransportAdapter, 'encrypt');
+    decryptSpy = sinon.spy(customTransportAdapter, 'decrypt');
+
+    app.connectMicroservice({
+      transport: Transport.RMQ,
+      options: {
+        urls: [`amqp://0.0.0.0:5672`],
+        queue: 'custom-transport-test',
+        queueOptions: { durable: false },
+        socketOptions: { noDelay: true },
+        transportAdapter: customTransportAdapter,
+      },
+    });
+    await app.startAllMicroservicesAsync();
+    await app.init();
+  });
+
+  it(`/POST (message)`, async () => {
+    await request(server)
+      .post('/?command=greet')
+      .send({ recipient: 'World' })
+      .expect(200, { message: 'Hello World!' });
+    expect(encryptSpy.callCount).to.equal(2);
+    expect(decryptSpy.callCount).to.equal(2);
+  });
+
+  it('/POST (event)', async () => {
+    expect(RMQCustomTransportAdapterController.greetingsSent).to.equal(0);
+    await request(server)
+      .post(`/greeting`)
+      .send()
+      .expect(201);
+    expect(RMQCustomTransportAdapterController.greetingsSent).to.equal(1);
+  })
+
+  afterEach(async () => {
+
+    encryptSpy.restore();
+    decryptSpy.restore();
+
+    await app.close();
+  });
+});

--- a/integration/microservices/src/rmq-custon-transport-adapter/custom-transport-adapter.ts
+++ b/integration/microservices/src/rmq-custon-transport-adapter/custom-transport-adapter.ts
@@ -1,0 +1,32 @@
+import * as crypto from 'crypto';
+import { TransportAdapter } from '@nestjs/microservices/interfaces';
+
+const algorithm = 'aes-256-cbc';
+const key = crypto.randomBytes(32);
+const iv = crypto.randomBytes(16);
+
+class CustomTransportAdapter implements TransportAdapter<Buffer> {
+
+  encrypt(message: string): Buffer {
+    let cipher = crypto.createCipheriv(algorithm, Buffer.from(key), iv);
+    let encrypted = cipher.update(message);
+    return Buffer.concat([encrypted, cipher.final()]);
+  }
+
+  decrypt(message: Buffer) {
+    let decipher = crypto.createDecipheriv(algorithm, Buffer.from(key), iv);
+    let decrypted = decipher.update(message);
+    decrypted = Buffer.concat([decrypted, decipher.final()]);
+    return decrypted.toString();
+  }
+
+  encode(value: {}) {
+    return this.encrypt(JSON.stringify(value));
+  }
+
+  decode(body: Buffer) {
+    return JSON.parse(this.decrypt(body));
+  }
+}
+
+export const customTransportAdapter = new CustomTransportAdapter();

--- a/integration/microservices/src/rmq-custon-transport-adapter/rmq-custom-transport-adapter.controller.ts
+++ b/integration/microservices/src/rmq-custon-transport-adapter/rmq-custom-transport-adapter.controller.ts
@@ -1,0 +1,46 @@
+import { Controller, Post, HttpCode, Query, Body } from "@nestjs/common";
+import { ClientRMQ, MessagePattern, EventPattern } from "@nestjs/microservices";
+import { customTransportAdapter } from './custom-transport-adapter'
+
+@Controller()
+export class RMQCustomTransportAdapterController {
+  private client: ClientRMQ;
+  static greetingsSent = 0;
+
+  constructor() {
+    this.client = new ClientRMQ({
+      urls: [`amqp://localhost:5672`],
+      queue: 'custom-transport-test',
+      queueOptions: { durable: false },
+      socketOptions: { noDelay: true },
+      transportAdapter: customTransportAdapter
+    })
+  }
+
+  @Post()
+  @HttpCode(200)
+  call(@Query('command') cmd: string, @Body() data: {}) {
+    return this.client.send({ cmd }, data);
+  }
+
+  @MessagePattern({ cmd: 'greet' })
+  greet(data: { recipient: string }) {
+    return { message: `Hello ${data.recipient}!` };
+  }
+
+  @Post(`greeting`)
+  @HttpCode(201)
+  emitGreetingSent() {
+    return this.client.emit('greeting_sent', {
+      data: {
+        message: 'greeting_sent event happened'
+      }
+    });
+  }
+
+  @EventPattern('greeting_sent')
+  handleGreetingSent() {
+    RMQCustomTransportAdapterController.greetingsSent += 1;
+    return { greetingsCount: RMQCustomTransportAdapterController.greetingsSent };
+  }
+}

--- a/packages/microservices/interfaces/index.ts
+++ b/packages/microservices/interfaces/index.ts
@@ -10,3 +10,4 @@ export * from './pattern-metadata.interface';
 export * from './pattern.interface';
 export * from './request-context.interface';
 export * from './serializer.interface';
+export * from './transport-adapter.interface';

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -10,6 +10,7 @@ import { Server } from '../server/server';
 import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
+import { TransportAdapter } from './transport-adapter.interface';
 
 export type MicroserviceOptions =
   | GrpcOptions
@@ -125,6 +126,7 @@ export interface RmqOptions {
     noAck?: boolean;
     serializer?: Serializer;
     deserializer?: Deserializer;
+    transportAdapter?: TransportAdapter<Buffer, any>;
   };
 }
 

--- a/packages/microservices/interfaces/transport-adapter.interface.ts
+++ b/packages/microservices/interfaces/transport-adapter.interface.ts
@@ -1,0 +1,4 @@
+export interface TransportAdapter<TransportFormat, AppFormat = {}> {
+  encode(value: AppFormat, options?: any): TransportFormat;
+  decode(body: TransportFormat, options?: any): AppFormat;
+}

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -70,9 +70,7 @@ describe('ServerRMQ', () => {
 
   describe('handleMessage', () => {
     const createMessage = payload => ({
-      content: {
-        toString: () => JSON.stringify(payload),
-      },
+      content: Buffer.from(JSON.stringify(payload)),
       properties: { correlationId: 1 },
     });
     const pattern = 'test';


### PR DESCRIPTION
Adds a `TransportAdapter` (only to RMQ microservice server + client) to
be singularly responsible for transport-level [de]serialization. This
allows custom parsing/formatting of raw messages (as opposed to `nest`
read/write packets) to be defined on the `RmqOptions` object.

Closes #4407.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information