### PR TITLE
fix(common): change cache ttl decorator to set 0 value ttl

### DIFF
--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -7,6 +7,7 @@ import {
   HttpServer,
   NestInterceptor,
 } from '../../interfaces';
+import { isNil } from '../../utils/shared.utils';
 import {
   CACHE_KEY_METADATA,
   CACHE_MANAGER,
@@ -51,7 +52,7 @@ export class CacheInterceptor implements NestInterceptor {
       return next.handle().pipe(
         tap(response => {
           const args =
-            ttl || ttl === 0 ? [key, response, { ttl }] : [key, response];
+            isNil(ttl) ? [key, response] : [key, response, { ttl }];
           this.cacheManager.set(...args);
         }),
       );

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -50,7 +50,8 @@ export class CacheInterceptor implements NestInterceptor {
 
       return next.handle().pipe(
         tap(response => {
-          const args = ttl ? [key, response, { ttl }] : [key, response];
+          const args =
+            ttl || ttl === 0 ? [key, response, { ttl }] : [key, response];
           this.cacheManager.set(...args);
         }),
       );


### PR DESCRIPTION
@CacheTTL(0) now sets 0 TTL on underlying cache manager. This is equivalent to a non-expiring cache key.

fixes #4447

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The CacheTTL decorator has a check for a defined TTL that returns falsey if the value is 0. This prevents the underlying cache manager accepting a TTL value of 0 which sets a non-expiring cache/no TTL.

Issue Number: #4447 

## What is the new behavior?
A TTL of 0 is now accepted as valid and sets the underlying cache manager TTL to 0.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information