### PR TITLE
fix(samples):  catsProvider's useFactory param type

### DIFF
--- a/sample/14-mongoose-base/src/cats/cats.providers.ts
+++ b/sample/14-mongoose-base/src/cats/cats.providers.ts
@@ -1,10 +1,10 @@
-import { Connection } from 'mongoose';
+import { Mongoose } from 'mongoose';
 import { CatSchema } from './schemas/cat.schema';
 
 export const catsProviders = [
   {
     provide: 'CAT_MODEL',
-    useFactory: (connection: Connection) => connection.model('Cat', CatSchema),
+    useFactory: (mongoose: Mongoose) => mongoose.model('Cat', CatSchema),
     inject: ['DATABASE_CONNECTION'],
   },
 ];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
In sample 14-mongoose-base, useFactory function is declared to receive a parameter of type Connection, however the actual parameter type received is of type Mongoose. This is the type provided by databaseProviders.
This wrong code also apears in the docs: https://docs.nestjs.com/recipes/mongodb#model-injection

Issue Number: 4543

## What is the new behavior?
useFactory declares the correct parameter of type Mongoose.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information