### PR TITLE
feat(core): add code excerpt in unknown dependency message

### DIFF
--- a/packages/core/errors/code-excerpt.ts
+++ b/packages/core/errors/code-excerpt.ts
@@ -1,0 +1,104 @@
+import * as clc from 'cli-color';
+
+import { InjectorDependencyContext } from '../injector/injector';
+import {
+  createInstanceNameAsCodeFactory,
+  getIndent,
+  getInstanceName,
+} from './utils';
+import { InstanceWrapper } from '../injector/instance-wrapper';
+
+const getNameInConstructor = createInstanceNameAsCodeFactory(
+  i => `@Inject('${i}')`,
+  i => `@Inject(${i})`,
+);
+
+const getNameInExpression = createInstanceNameAsCodeFactory(i => `'${i}'`);
+
+function getErrorArrow(offset: number, arrowLength: number, message: string) {
+  let code = '';
+  // Arrow
+  code += getIndent(offset, ' ');
+  code += clc.red.bold(getIndent(arrowLength, '^'));
+
+  // Inline error message
+  code += `  ${clc.red.bold(message)}\n`;
+
+  return code;
+}
+
+function toCodeBlock(code: string): string {
+  return code
+    .split('\n')
+    .map(line => `${clc.blue('|')} ${line}`)
+    .join('\n');
+}
+
+function dependenciesToCode(dependencies: string[], errorIndex: number) {
+  return dependencies
+    .map((name, index) => {
+      if (index === errorIndex) {
+        return `    ${clc.red.bold(name.toString())},
+    ${getErrorArrow(
+      0,
+      name.toString().length + 1,
+      'not available in current context',
+    )}`;
+      } else {
+        return `    ${name.toString()},`;
+      }
+    })
+    .join('\n');
+}
+
+export function getClassCodeExcerpt(
+  instanceWrapper: InstanceWrapper,
+  dependencyContext: InjectorDependencyContext,
+) {
+  const { dependencies, index } = dependencyContext;
+  const code = `${clc.cyan('class')} ${clc.green(
+    getInstanceName(instanceWrapper),
+  )} {
+  ${clc.cyan('constructor')}(
+${dependenciesToCode(dependencies.map(getNameInConstructor), index)}
+  ) { }
+`;
+
+  return clc.white(toCodeBlock(code));
+}
+
+export function getUseFactoryCodeExcerpt(
+  instanceWrapper: InstanceWrapper,
+  dependencyContext: InjectorDependencyContext,
+): string {
+  const { dependencies, index } = dependencyContext;
+
+  const code = `{
+  provide: ${getNameInExpression(instanceWrapper.metatype)},
+  inject: [
+${dependenciesToCode(dependencies.map(getNameInExpression), index)}
+  ]
+}`;
+
+  return clc.white(toCodeBlock(code));
+}
+
+export function getPropertyCodeExcerpt(
+  instanceWrapper: InstanceWrapper,
+  dependencyContext: InjectorDependencyContext,
+): string {
+  const { key, name } = dependencyContext;
+  const injectExpression = `${getNameInConstructor(name)} ${key.toString()};`;
+  const code = `${clc.cyan('class')} ${clc.green(
+    getInstanceName(instanceWrapper),
+  )} {
+  ${clc.red.bold(injectExpression)}
+  ${getErrorArrow(
+    0,
+    injectExpression.length,
+    'not available in current context',
+  )}
+}`;
+
+  return clc.white(toCodeBlock(code));
+}

--- a/packages/core/errors/exceptions/undefined-dependency.exception.ts
+++ b/packages/core/errors/exceptions/undefined-dependency.exception.ts
@@ -1,16 +1,17 @@
-import { InjectorDependencyContext } from '../../injector/injector';
 import { UNKNOWN_DEPENDENCIES_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
+import { InstanceWrapper } from '../../injector/instance-wrapper';
+import { InjectorDependencyContext } from '../../injector/injector';
 import { Module } from '../../injector/module';
 
 export class UndefinedDependencyException extends RuntimeException {
   constructor(
-    type: string,
-    undefinedDependencyContext: InjectorDependencyContext,
+    instanceWrapper: InstanceWrapper,
+    dependencyContext: InjectorDependencyContext,
     module?: Module,
   ) {
     super(
-      UNKNOWN_DEPENDENCIES_MESSAGE(type, undefinedDependencyContext, module),
+      UNKNOWN_DEPENDENCIES_MESSAGE(instanceWrapper, dependencyContext, module),
     );
   }
 }

--- a/packages/core/errors/exceptions/unknown-dependencies.exception.ts
+++ b/packages/core/errors/exceptions/unknown-dependencies.exception.ts
@@ -1,14 +1,17 @@
-import { InjectorDependencyContext } from '../../injector/injector';
 import { UNKNOWN_DEPENDENCIES_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
+import { InstanceWrapper } from '../../injector/instance-wrapper';
+import { InjectorDependencyContext } from '../../injector/injector';
 import { Module } from '../../injector/module';
 
 export class UnknownDependenciesException extends RuntimeException {
   constructor(
-    type: string | symbol,
-    unknownDependencyContext: InjectorDependencyContext,
+    instanceWrapper: InstanceWrapper,
+    dependencyContext: InjectorDependencyContext,
     module?: Module,
   ) {
-    super(UNKNOWN_DEPENDENCIES_MESSAGE(type, unknownDependencyContext, module));
+    super(
+      UNKNOWN_DEPENDENCIES_MESSAGE(instanceWrapper, dependencyContext, module),
+    );
   }
 }

--- a/packages/core/errors/utils.ts
+++ b/packages/core/errors/utils.ts
@@ -1,0 +1,60 @@
+import { Type } from '@nestjs/common';
+import {
+  isSymbol,
+  isString,
+  isObject,
+  isFunction,
+} from '@nestjs/common/utils/shared.utils';
+
+import { Module } from '../injector/module';
+
+type ClassInstance = Function | Type<any> | { name: string };
+type Instance = ClassInstance | string | symbol;
+
+/**
+ * Returns the name of the instance,
+ * Tries to get the class name, otherwise the string value
+ * (= injection token)
+ *
+ * @param dependency The dependency whichs name should get displayed
+ */
+export const getInstanceName = (instance: Instance | null): string =>
+  // use class name
+  (instance as ClassInstance)?.name?.toString() ||
+  // use injection token (symbol)
+  (isSymbol(instance) && instance.toString()) ||
+  // use injection token (string)
+  (isString(instance) && instance);
+
+type InstanceTransformerFn = (instance: string) => string;
+/**
+ * Returns the instance as displayed in the code.
+ *
+ * @param dependency The dependency which should get displayed as code
+ */
+export function createInstanceNameAsCodeFactory(
+  asStringFn: InstanceTransformerFn,
+  asSymbolFn: InstanceTransformerFn = i => i,
+  asClassFn: InstanceTransformerFn = i => i,
+) {
+  return (instance: Instance | null) => {
+    console.log(instance);
+    return (
+      ((instance as ClassInstance)?.name &&
+        asClassFn((instance as ClassInstance).name)) ||
+      (isSymbol(instance) && asSymbolFn(instance.toString())) ||
+      (isString(instance) && asStringFn(instance))
+    );
+  };
+}
+
+/**
+ * Returns the name of the module
+ * Tries to get the class name. As fallback it returns 'current'.
+ * @param module The module which should get displayed
+ */
+export const getModuleName = (module: Module): string =>
+  module && getInstanceName(module.metatype);
+
+export const getIndent = (amount: number, seperator = ' ') =>
+  new Array(amount).join(seperator);

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -314,7 +314,7 @@ export class Injector {
   ) {
     if (isUndefined(param)) {
       throw new UndefinedDependencyException(
-        wrapper.name,
+        wrapper,
         dependencyContext,
         moduleRef,
       );
@@ -421,9 +421,9 @@ export class Injector {
     keyOrIndex?: string | number,
   ): Promise<InstanceWrapper<T>> {
     const { name } = dependencyContext;
-    if (wrapper && wrapper.name === name) {
+    if (wrapper?.name === name) {
       throw new UnknownDependenciesException(
-        wrapper.name,
+        wrapper,
         dependencyContext,
         moduleRef,
       );
@@ -462,7 +462,7 @@ export class Injector {
     );
     if (isNil(instanceWrapper)) {
       throw new UnknownDependenciesException(
-        wrapper.name,
+        wrapper,
         dependencyContext,
         moduleRef,
       );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```


## What is the new behavior?
Introduces a proof of concept of showing a code excerpt to improve the understanding of the error message.


Example error message:
![Error message](https://user-images.githubusercontent.com/9899423/79083620-ba415480-7d2f-11ea-8fec-28b746610ab9.png)

*Note: The 2x appearing `DogService`s is the correct outcome -- there are indeed two DogService* 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other

This PR is meant to discuss whether we should go in the direction of showing code excerpts in general (wherever appropriate).

Pros:

- More straight-forward to understand. 

Cons:

- Because of JavaScript - a very limited amount of information in most cases.
- It can get quite iffy since this is usually something that is supported by the compiler. 