### PR TITLE
fix(common): Allow users to provide a cancellation token to http service

### DIFF
--- a/packages/common/http/http.service.ts
+++ b/packages/common/http/http.service.ts
@@ -3,6 +3,7 @@ import Axios, {
   AxiosRequestConfig,
   AxiosResponse,
   AxiosPromise,
+  CancelTokenSource,
 } from 'axios';
 import { Observable } from 'rxjs';
 import { Inject } from '../decorators';
@@ -72,13 +73,18 @@ export class HttpService {
     ...args: any[]
   ) {
     return new Observable<AxiosResponse<T>>(subscriber => {
-      let config = args[args.length - 1];
+      let config: AxiosRequestConfig = args[args.length - 1];
       if (!config) {
         config = {};
         args[args.length - 1] = config;
       }
-      const cancelSource = Axios.CancelToken.source();
-      config.cancelToken = cancelSource.token;
+
+      let cancelSource: CancelTokenSource;
+      if (!config.cancelToken) {
+        cancelSource = Axios.CancelToken.source();
+        config.cancelToken = cancelSource.token;
+      }
+
       axios(...args)
         .then(res => {
           subscriber.next(res);
@@ -88,7 +94,11 @@ export class HttpService {
           subscriber.error(err);
         });
       return () => {
-        if (config.responseType !== 'stream') {
+        if (config.responseType === 'stream') {
+          return;
+        }
+
+        if (cancelSource) {
           cancelSource.cancel();
         }
       };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
Fix issue https://github.com/nestjs/nest/issues/4698 where a user can't provide a cancellation token to Axios through the HTTP service
.
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: https://github.com/nestjs/nest/issues/4698
Any cancel token provided to the HTTP Service is overwritten by an internal cancel token mechanism.

## What is the new behavior?

The internal cancel token is created and used only when no cancel token is provided via the config object. When a user decides to handle the cancelation on its end, it should remain responsible for the cancelation and no other cancelation process should step in.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information