### PR TITLE
fix(http): remove axios config mutation

### DIFF
--- a/packages/common/http/http.service.ts
+++ b/packages/common/http/http.service.ts
@@ -73,11 +73,7 @@ export class HttpService {
     ...args: any[]
   ) {
     return new Observable<AxiosResponse<T>>(subscriber => {
-      let config: AxiosRequestConfig = args[args.length - 1];
-      if (!config) {
-        config = {};
-        args[args.length - 1] = config;
-      }
+      const config = args[args.length - 1] ? { ...args[args.length - 1] } : {};
 
       let cancelSource: CancelTokenSource;
       if (!config.cancelToken) {

--- a/packages/common/test/http/http.service.spec.ts
+++ b/packages/common/test/http/http.service.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { HttpService } from '../../http/http.service';
+import { AxiosRequestConfig, AxiosInstance } from 'axios';
+
+describe('HttpService', () => {
+  it('should not mutate user-given axios options object', () => {
+    const http = new HttpService({ get: () => Promise.resolve() } as any);
+    const options: AxiosRequestConfig = {};
+
+    http
+      .get('/', options)
+      .toPromise()
+      .then(() => {
+        expect(options.cancelToken).to.be.undefined;
+      });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
```

## What is the current behavior?

```
const options = {}
httpService.get('/', options).toPromise().then(() => {
  // options.cancelToken is defined
})
```

## What is the new behavior?

Keep the old behavior and do not mutate the options object as it may cause side effects in userland. [Axios](https://github.com/axios/axios/blob/master/lib/core/Axios.js#L76) does clone the config object given.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```