### PR TITLE
feat(core): add support to default  serializer options

### DIFF
--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { Inject, Injectable } from '../decorators/core';
+import { Inject, Injectable, Optional } from '../decorators/core';
 import { ClassTransformOptions } from '../interfaces/external/class-transform-options.interface';
 import { loadPackage } from '../utils/load-package.util';
 import { isObject } from '../utils/shared.utils';
@@ -20,7 +20,9 @@ const REFLECTOR = 'Reflector';
 
 @Injectable()
 export class ClassSerializerInterceptor implements NestInterceptor {
-  constructor(@Inject(REFLECTOR) protected readonly reflector: any, protected readonly defaultOptions: ClassTransformOptions = {}) {
+  constructor(
+    @Inject(REFLECTOR) protected readonly reflector: any,
+    @Optional() protected readonly defaultOptions: ClassTransformOptions = {}) {
     classTransformer = loadPackage(
       'class-transformer',
       'ClassSerializerInterceptor',

--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -20,7 +20,7 @@ const REFLECTOR = 'Reflector';
 
 @Injectable()
 export class ClassSerializerInterceptor implements NestInterceptor {
-  constructor(@Inject(REFLECTOR) protected readonly reflector: any) {
+  constructor(@Inject(REFLECTOR) protected readonly reflector: any, protected readonly defaultOptions: ClassTransformOptions = {}) {
     classTransformer = loadPackage(
       'class-transformer',
       'ClassSerializerInterceptor',
@@ -30,7 +30,11 @@ export class ClassSerializerInterceptor implements NestInterceptor {
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
-    const options = this.getContextOptions(context);
+    const contextOptions = this.getContextOptions(context);
+    const options = {
+      ...this.defaultOptions,
+      ...contextOptions
+    }
     return next
       .handle()
       .pipe(


### PR DESCRIPTION
Enable pass `ClassTransformOptions` when use `ClassSerializerInterceptor` as GlobalInterceptors.

```
const reflector = app.get<Reflector>(Reflector);

app.useGlobalInterceptors(
  new ClassSerializerInterceptor(reflector, {
    excludeExtraneousValues: true,
    enableImplicitConversion: true
  })
);
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information