### PR TITLE
fix(microservices): enable grpc option value to accept 0

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -125,7 +125,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
       this.options.keepalive,
     )) {
       const key = keepaliveKeys[optionKey];
-      if (!key) {
+      if (key === undefined) {
         continue;
       }
       keepaliveOptions[key] = optionValue;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
currently the logic ignore if value grpc option is `0`

Issue Number: #4816


## What is the new behavior?
grpc option should be able accept `0` value


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information