### PR TITLE
sample(12): Example of how to use @ResolveField

### DIFF
--- a/integration/graphql-schema-first/src/cats/cats.service.ts
+++ b/integration/graphql-schema-first/src/cats/cats.service.ts
@@ -4,7 +4,7 @@ import { Cat } from './interfaces/cat.interface';
 @Injectable()
 export class CatsService {
   static COUNTER = 0;
-  private readonly cats: Cat[] = [{ id: 1, name: 'Cat', age: 5 }];
+  private readonly cats: Cat[] = [{ id: 1, ownerId: 1, name: 'Cat', age: 5 }];
 
   constructor() {
     CatsService.COUNTER++;

--- a/integration/graphql-schema-first/src/owners/owners.module.ts
+++ b/integration/graphql-schema-first/src/owners/owners.module.ts
@@ -1,0 +1,14 @@
+import { DynamicModule, Module } from '@nestjs/common';
+import { OwnersService } from "./owners.service";
+
+@Module({
+  providers: [OwnersService],
+})
+export class OwnersModule {
+  static enableRequestScope(): DynamicModule {
+    return {
+      module: OwnersModule,
+      providers: [OwnersService],
+    };
+  }
+}

--- a/integration/graphql-schema-first/src/owners/owners.module.ts
+++ b/integration/graphql-schema-first/src/owners/owners.module.ts
@@ -1,14 +1,7 @@
-import { DynamicModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { OwnersService } from "./owners.service";
 
 @Module({
   providers: [OwnersService],
 })
-export class OwnersModule {
-  static enableRequestScope(): DynamicModule {
-    return {
-      module: OwnersModule,
-      providers: [OwnersService],
-    };
-  }
-}
+export class OwnersModule {}

--- a/integration/graphql-schema-first/src/owners/owners.service.ts
+++ b/integration/graphql-schema-first/src/owners/owners.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { Owner } from "../../../../sample/12-graphql-schema-first/src/graphql.schema";
+
+@Injectable()
+export class OwnersService {
+  private readonly owners: Owner[] = [{ id: 1, name: 'Jon', age: 5 }];
+
+  findOneById(id: number): Owner {
+    return this.owners.find(owner => owner.id === id);
+  }
+}

--- a/sample/12-graphql-schema-first/src/cats/cats.graphql
+++ b/sample/12-graphql-schema-first/src/cats/cats.graphql
@@ -11,10 +11,18 @@ type Subscription {
   catCreated: Cat
 }
 
+type Owner {
+  id: Int!
+  name: String!
+  age: Int
+  cats: [Cat!]!
+}
+
 type Cat {
   id: Int
   name: String
   age: Int
+  owner: Owner!
 }
 
 input CreateCatInput {

--- a/sample/12-graphql-schema-first/src/cats/cats.resolvers.ts
+++ b/sample/12-graphql-schema-first/src/cats/cats.resolvers.ts
@@ -1,7 +1,7 @@
 import { ParseIntPipe, UseGuards } from '@nestjs/common';
-import { Args, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
+import {Args, Mutation, Parent, Query, ResolveField, Resolver, Subscription} from '@nestjs/graphql';
 import { PubSub } from 'graphql-subscriptions';
-import { Cat } from '../graphql.schema';
+import {Cat, Owner} from '../graphql.schema';
 import { CatsGuard } from './cats.guard';
 import { CatsService } from './cats.service';
 import { CreateCatDto } from './dto/create-cat.dto';
@@ -36,5 +36,10 @@ export class CatsResolvers {
   @Subscription('catCreated')
   catCreated() {
     return pubSub.asyncIterator('catCreated');
+  }
+
+  @ResolveField()
+  async owner(@Parent() cat: Cat): Promise<Owner>{
+    return this.catsService.findOwnerById(cat.ownerId);
   }
 }

--- a/sample/12-graphql-schema-first/src/cats/cats.resolvers.ts
+++ b/sample/12-graphql-schema-first/src/cats/cats.resolvers.ts
@@ -1,16 +1,20 @@
 import { ParseIntPipe, UseGuards } from '@nestjs/common';
-import {Args, Mutation, Parent, Query, ResolveField, Resolver, Subscription} from '@nestjs/graphql';
+import { Args, Mutation, Parent, Query, ResolveField, Resolver, Subscription } from '@nestjs/graphql';
 import { PubSub } from 'graphql-subscriptions';
-import {Cat, Owner} from '../graphql.schema';
+import { Cat, Owner } from '../graphql.schema';
 import { CatsGuard } from './cats.guard';
 import { CatsService } from './cats.service';
 import { CreateCatDto } from './dto/create-cat.dto';
+import { OwnersService } from "../../../../integration/graphql-schema-first/src/owners/owners.service";
 
 const pubSub = new PubSub();
 
 @Resolver('Cat')
 export class CatsResolvers {
-  constructor(private readonly catsService: CatsService) {}
+  constructor(
+    private readonly ownersService: OwnersService,
+    private readonly catsService: CatsService
+  ) {}
 
   @Query()
   @UseGuards(CatsGuard)
@@ -40,6 +44,6 @@ export class CatsResolvers {
 
   @ResolveField()
   async owner(@Parent() cat: Cat): Promise<Owner>{
-    return this.catsService.findOwnerById(cat.ownerId);
+    return this.ownersService.findOneById(cat.ownerId);
   }
 }

--- a/sample/12-graphql-schema-first/src/cats/cats.service.ts
+++ b/sample/12-graphql-schema-first/src/cats/cats.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { Cat } from '../graphql.schema';
+import {Cat, Owner} from '../graphql.schema';
 
 @Injectable()
 export class CatsService {
-  private readonly cats: Cat[] = [{ id: 1, name: 'Cat', age: 5 }];
+  private readonly cats: Cat[] = [{ id: 1, name: 'Cat', age: 5, ownerId: 1 }];
+  private readonly owners: Owner[] = [{ id: 1, name: 'Jon', age: 5 }];
 
   create(cat: Cat): Cat {
     cat.id = this.cats.length + 1;
@@ -17,5 +18,9 @@ export class CatsService {
 
   findOneById(id: number): Cat {
     return this.cats.find(cat => cat.id === id);
+  }
+
+  findOwnerById(id: number): Owner {
+    return this.owners.find(owner => owner.id === id);
   }
 }

--- a/sample/12-graphql-schema-first/src/cats/cats.service.ts
+++ b/sample/12-graphql-schema-first/src/cats/cats.service.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import {Cat, Owner} from '../graphql.schema';
+import { Cat } from '../graphql.schema';
 
 @Injectable()
 export class CatsService {
   private readonly cats: Cat[] = [{ id: 1, name: 'Cat', age: 5, ownerId: 1 }];
-  private readonly owners: Owner[] = [{ id: 1, name: 'Jon', age: 5 }];
 
   create(cat: Cat): Cat {
     cat.id = this.cats.length + 1;
@@ -18,9 +17,5 @@ export class CatsService {
 
   findOneById(id: number): Cat {
     return this.cats.find(cat => cat.id === id);
-  }
-
-  findOwnerById(id: number): Owner {
-    return this.owners.find(owner => owner.id === id);
   }
 }

--- a/sample/12-graphql-schema-first/src/graphql.schema.ts
+++ b/sample/12-graphql-schema-first/src/graphql.schema.ts
@@ -15,6 +15,12 @@ export abstract class Cat {
   age?: number;
 }
 
+export abstract class Owner {
+  id?: number;
+  name?: string;
+  age?: number;
+}
+
 export abstract class IMutation {
   abstract createCat(createCatInput?: CreateCatInput): Cat | Promise<Cat>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update (formatting, local variables)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build related changes
 - [ ] CI related changes
 - [X] Other... Please describe: Updates sample code

## What is the current behavior?
There is no demo of `@ResolveField` in the `graphql-schema-first` sample

Issue Number: N/A


## What is the new behavior?
Adds a demo of `@ResolveField`

## Does this PR introduce a breaking change?
 - [ ] Yes
 - [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I love that you've added a GQL schema-first sample!  Huge help to understanding how we can jump right in to NestJS with a little structure.  One challenge my team has  been facing is figuring out the right way to translate information from the data-layer (TypeORM) to the transport-layer (the resolver).  

In the sample you've provided, it looks like the data-layer and the transport-layer are 1-to-1 (the GQL types perfectly match the data-set) so there's no need to solve this problem there.  I would love to see how you would implement an association.  The main structure I would love to see solved is where a foreign-key lives in the data-layer but does not exist in the transport-layer.

This PR gets us most of the way, but there is a step missing to satisfy the typing, and that's what I'm hoping to get some guidance on.  I'm wondering if we should create some kind of DTO and have `CatResolvers.findOneById` return the DTO instead of the GQL type, or if there's a better way to handle this 🤔 

The example here adds an associated `Owner` with a FK on the cat data to link the two.  We would like to add `Cat.owner` without adding `ownerId` to the GQL type.