### PR TITLE
Allow Custom Types Not to be validated in default ValidationPipe

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -20,6 +20,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (errors: ValidationError[]) => any;
   validateCustomDecorators?: boolean;
+  customTypesToNotValidate: any[],
 }
 
 let classValidator: any = {};
@@ -34,6 +35,7 @@ export class ValidationPipe implements PipeTransform<any> {
   protected errorHttpStatusCode: ErrorHttpStatusCode;
   protected exceptionFactory: (errors: ValidationError[]) => any;
   protected validateCustomDecorators: boolean;
+  protected customTypesToNotValidate: any[];
 
   constructor(@Optional() options?: ValidationPipeOptions) {
     options = options || {};
@@ -43,6 +45,7 @@ export class ValidationPipe implements PipeTransform<any> {
       errorHttpStatusCode,
       transformOptions,
       validateCustomDecorators,
+      customTypesToNotValidate,
       ...validatorOptions
     } = options;
 
@@ -51,6 +54,10 @@ export class ValidationPipe implements PipeTransform<any> {
     this.transformOptions = transformOptions;
     this.isDetailedOutputDisabled = disableErrorMessages;
     this.validateCustomDecorators = validateCustomDecorators || false;
+    this.customTypesToNotValidate = 
+      Array.isArray(customTypesToNotValidate) && customTypesToNotValidate.length 
+      ? customTypesToNotValidate
+      : [];
     this.errorHttpStatusCode = errorHttpStatusCode || HttpStatus.BAD_REQUEST;
     this.exceptionFactory =
       options.exceptionFactory || this.createExceptionFactory();
@@ -130,7 +137,7 @@ export class ValidationPipe implements PipeTransform<any> {
     if (type === 'custom' && !this.validateCustomDecorators) {
       return false;
     }
-    const types = [String, Boolean, Number, Array, Object];
+    const types = [String, Boolean, Number, Array, Object, ...this.customTypesToNotValidate];
     return !types.some(t => metatype === t) && !isNil(metatype);
   }
 

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -20,7 +20,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (errors: ValidationError[]) => any;
   validateCustomDecorators?: boolean;
-  customTypesToNotValidate: any[],
+  customTypesToNotValidate: any[];
 }
 
 let classValidator: any = {};

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -20,7 +20,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (errors: ValidationError[]) => any;
   validateCustomDecorators?: boolean;
-  customTypesToNotValidate: any[];
+  customTypesToNotValidate?: any[];
 }
 
 let classValidator: any = {};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I want to enable `validateCustomDecorators`. This means that the return type of the decorator can be a Class Transformer entity as well. But in some cases, I'd not like those entities to be validated. 

For eg:

1. I have this custom decorator called `EditedRequest()` which basically just adds the `id` present in the request params to the request body.

```ts
export const EditRequest = createParamDecorator(
  (data: string[] = ['id'], req: Request): InputInterface => {
    const requestParamsToReturn = {};

    data.forEach(dataString =>
      Object.assign(requestParamsToReturn, {
        [dataString]: req.params[dataString],
      }),
    );

    return { ...req.body, ...requestParamsToReturn };
  },
);
```

The return type of this in case of a user entity is let's say `EditUserDto`.

2. I have another custom decorator called `EntityBeingQueried()` which basically goes looks for the id present in the request params within the database for let's say a user entity.

```ts
export const EntityBeingQueried = createParamDecorator(
  (data, req): ModelEntity => {
    return req.entityBeingQueried;
  },
);
```

How I add entityBeingQueried to the request is using the NestMiddleware like this

```ts
export class UserMiddleware implements NestMiddleware {
  constructor(private readonly userRepository: UsersRepository) {}

  async use(req: Request, res: Response, next: any) {
    const { id } = req.params;

    if (id && validateMongoId(id, true, `'Cannot ${req.method} ${req.url}'`)) {
      await this.userRepository.findOneById(id).then(user => {
        (req as any).entityBeingQueried = user;
      });
    }

    next();
  }
}
```

Now, in my `UserController`, my update function looks like this:

```ts
async update(
  @LoggedInUser() loggedInUser: UserEntity,
  @EntityBeingQueried() queriedUser: UserEntity,
  @EditRequest() inputs: EditUserDto,
): Promise<SuccessResponseEntity> {
  // more code...
}
```

Note that the return type of `entityBeingQueried` is `UserEntity` and not `EditUserDto`. So from the above request, I don't want to validate `UserEntity` but I do want to validate `EditUserDto`.

Currently, there is no provision to allow this.

Issue Number: N/A


## What is the new behavior?

You can now add custom validations not to be validated when customDecoratorValidations is enabled.

This means that in case you don't want a custom type to be validated by the default validation pipe, you can now add it using the `customTypesToNotValidate` parameter of the class constructor.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I will update the docs & tests when you feel this pull request makes sense.