### PR TITLE
feat(core): Redirection of 3xx Exceptions

### DIFF
--- a/packages/common/exceptions/found.exception.ts
+++ b/packages/common/exceptions/found.exception.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { RedirectionException } from './redirection.exception';
+
+/**
+ * Defines an HTTP exception for *Found* (formerly *MovedTemporarily*) type redirection errors.
+ *
+ * @see [Base Exceptions](https://docs.nestjs.com/exception-filters#base-exceptions)
+ *
+ * @publicApi
+ */
+export class FoundException extends RedirectionException {
+  /**
+   * Instantiate a `FoundException` Exception.
+   *
+   * @example
+   * `throw new FoundException(location)`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 302.
+   * - The `location` argument indicates where the user should be redirected to.
+   *
+   * @param location string indicating the url to redirect the user to.
+   */
+  constructor(location: string) {
+    super('Found', location, HttpStatus.FOUND);
+  }
+}

--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -17,3 +17,8 @@ export * from './bad-gateway.exception';
 export * from './service-unavailable.exception';
 export * from './gateway-timeout.exception';
 export * from './im-a-teapot.exception';
+export * from './redirection.exception';
+export * from './found.exception';
+export * from './moved-permanently.exception';
+export * from './see-other.exception';
+export * from './temporary-redirect.exception';

--- a/packages/common/exceptions/moved-permanently.exception.ts
+++ b/packages/common/exceptions/moved-permanently.exception.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { RedirectionException } from './redirection.exception';
+
+/**
+ * Defines an HTTP exception for *Moved Permanently* type redirection errors.
+ *
+ * @see [Base Exceptions](https://docs.nestjs.com/exception-filters#base-exceptions)
+ *
+ * @publicApi
+ */
+export class MovedPermanentlyException extends RedirectionException {
+  /**
+   * Instantiate a `MovedPermanentlyException` Exception.
+   *
+   * @example
+   * `throw new MovedPermanentlyException(location)`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 301.
+   * - The `location` argument indicates where the user should be redirected to.
+   *
+   * @param location string indicating the url to redirect the user to.
+   */
+  constructor(location: string) {
+    super('Moved Permanently', location, HttpStatus.MOVED_PERMANENTLY);
+  }
+}

--- a/packages/common/exceptions/redirection.exception.ts
+++ b/packages/common/exceptions/redirection.exception.ts
@@ -1,0 +1,33 @@
+import { HttpException } from './http.exception';
+
+/**
+ * Defines an HTTP exception for *Redirection* type errors which should result in
+ * the client being redirected to a different location (URI).
+ *
+ * @see [Base Exceptions](https://docs.nestjs.com/exception-filters#base-exceptions)
+ *
+ * @publicApi
+ */
+export class RedirectionException extends HttpException {
+  /**
+   * Instantiate a `RedirectionException` Exception.
+   *
+   * @example
+   * `throw new RedirectionException(location)`
+   *
+   * @usageNotes
+   * The constructor arguments define the location and the HTTP response status code.
+   * - The `location` argument (required) defines the URI to redirect the client to.
+   * - The `status` argument defines the HTTP Status Code.  It should be a 3xx code.
+   *
+   * @param location string indicating the url to redirect the user to.
+   * @param status HTTP response status code.  It should be a 3xx status code.
+   */
+  constructor(response: string, private location: string, status = 302) {
+    super(response, status);
+  }
+
+  public getLocation(): string {
+    return this.location;
+  }
+}

--- a/packages/common/exceptions/see-other.exception.ts
+++ b/packages/common/exceptions/see-other.exception.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { RedirectionException } from './redirection.exception';
+
+/**
+ * Defines an HTTP exception for *See Other* type redirection errors.
+ *
+ * @see [Base Exceptions](https://docs.nestjs.com/exception-filters#base-exceptions)
+ *
+ * @publicApi
+ */
+export class SeeOtherException extends RedirectionException {
+  /**
+   * Instantiate a `SeeOtherException` Exception.
+   *
+   * @example
+   * `throw new SeeOtherException(location)`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 303.
+   * - The `location` argument indicates where the user should be redirected to.
+   *
+   * @param location string indicating the url to redirect the user to.
+   */
+  constructor(location: string) {
+    super('See Other', location, HttpStatus.SEE_OTHER);
+  }
+}

--- a/packages/common/exceptions/temporary-redirect.exception.ts
+++ b/packages/common/exceptions/temporary-redirect.exception.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { RedirectionException } from './redirection.exception';
+
+/**
+ * Defines an HTTP exception for *Temporary Redirect* type redirection errors.
+ *
+ * @see [Base Exceptions](https://docs.nestjs.com/exception-filters#base-exceptions)
+ *
+ * @publicApi
+ */
+export class TemporaryRedirectException extends RedirectionException {
+  /**
+   * Instantiate a `TemporaryRedirectException` Exception.
+   *
+   * @example
+   * `throw new TemporaryRedirectException(location)`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 307.
+   * - The `location` argument indicates where the user should be redirected to.
+   *
+   * @param location string indicating the url to redirect the user to.
+   */
+  constructor(location: string) {
+    super('Temporary Redirect', location, HttpStatus.TEMPORARY_REDIRECT);
+  }
+}


### PR DESCRIPTION
Add the ability to throw 3xx exceptions that send a redirect response to the client.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Not sure where to add or update docs for the feature.  I noticed another project for the main nest website and I'll be happy to add instruction and examples there if this PR is merged.

## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When an HttpException is thrown, the `BaseExceptionFilter` will set the status code and write a JSON object to the response stream.

Issue Number: N/A


## What is the new behavior?
If a Redirection (3xx) exception is thrown, then the `BaseExceptionFilter` will perform a standard response redirect instead of writing the exception message to the response stream.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
This feature was added primarily to handle the case when an AuthGuard should result in a redirect.  Specifically this was encountered when using an AuthGuard for the Facebook strategy where browser authentication and authorization is performed using redirects and callbacks.  In the event that a person cancels the Facebook prompt to grant permission, then the `handleRequest` method in the AuthGuard can perform a redirect back to a web application's login screen (or elsewhere) like is in the following example:

```
import { Injectable, FoundException } from '@nestjs/common';
import { AuthGuard } from '@nestjs/passport';
import { ConfigService } from '@nestjs/config';

@Injectable()
export class FacebookAuthGuard extends AuthGuard('facebook') {
  constructor(private configService: ConfigService) {
    super({
      authType: 'rerequest',
    });
  }

  handleRequest(err: Error, user: any, info: any): any {
    const authCompletedUrl = this.configService.get(
      'FACEBOOK_AUTH_COMPLETED_URL',
    );

    if (err) {
      throw new FoundException(
        `${authCompletedUrl}?status=1&message=${encodeURIComponent(
          info?.message ?? err.message,
        )}`,
      );
    } else if (!user) {
      throw new FoundException(
        `${authCompletedUrl}?status=2&message=${encodeURIComponent(
          info?.message ?? '',
        )}`,
      );
    }

    return user;
  }
}
```

Initially I had tried to just call `context.getResponse().redirect(...)` from within the `handleRequest` funciton.  Although it worked and redirected as desired, it also resulted in the following error being written to the console:

```
(node:12238) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:526:11)
    at ServerResponse.header (/home/skennedy/visualstudio/nest-redirection/node_modules/express/lib/response.js:771:10)
    at ServerResponse.send (/home/skennedy/visualstudio/nest-redirection/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/home/skennedy/visualstudio/nest-redirection/node_modules/express/lib/response.js:267:15)
    at ExpressAdapter.reply (/home/skennedy/visualstudio/nest-redirection/node_modules/@nestjs/platform-express/adapters/express-adapter.js:23:57)
    at ExceptionsHandler.handleUnknownError (/home/skennedy/visualstudio/nest-redirection/node_modules/@nestjs/core/exceptions/base-exception-filter.js:35:24)
    at ExceptionsHandler.catch (/home/skennedy/visualstudio/nest-redirection/node_modules/@nestjs/core/exceptions/base-exception-filter.js:16:25)
    at ExceptionsHandler.next (/home/skennedy/visualstudio/nest-redirection/node_modules/@nestjs/core/exceptions/exceptions-handler.js:15:20)
    at /home/skennedy/visualstudio/nest-redirection/node_modules/@nestjs/core/router/router-proxy.js:12:35
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:12238) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:12238) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I worked around the error by creating a custom `RedirectingException` class and a custom `RedirectingExceptionFilter` by following the documentation at https://docs.nestjs.com/exception-filters which worked perfectly and gave no console errors, so I thought it would be a good feature to add to the core nest solution.