### PR TITLE
feat(microservices): change nats-server to pass replyTo

### DIFF
--- a/packages/microservices/ctx-host/nats.context.ts
+++ b/packages/microservices/ctx-host/nats.context.ts
@@ -1,6 +1,6 @@
 import { BaseRpcContext } from './base-rpc.context';
 
-type NatsContextArgs = [string];
+type NatsContextArgs = [string, string];
 
 export class NatsContext extends BaseRpcContext<NatsContextArgs> {
   constructor(args: NatsContextArgs) {
@@ -12,5 +12,12 @@ export class NatsContext extends BaseRpcContext<NatsContextArgs> {
    */
   getSubject() {
     return this.args[0];
+  }
+
+  /**
+   * Returns the replyTo.
+   */
+  getReplyTo() {
+    return this.args[1];
   }
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -103,6 +103,7 @@ export interface NatsOptions {
     name?: string;
     user?: string;
     pass?: string;
+    json?: boolean;
     maxReconnectAttempts?: number;
     reconnectTimeWait?: number;
     servers?: string[];

--- a/packages/microservices/server/server-nats.ts
+++ b/packages/microservices/server/server-nats.ts
@@ -93,7 +93,7 @@ export class ServerNats extends Server implements CustomTransportStrategy {
     replyTo: string,
     callerSubject: string,
   ) {
-    const natsCtx = new NatsContext([callerSubject]);
+    const natsCtx = new NatsContext([callerSubject, replyTo]);
     const message = this.deserializer.deserialize(rawMessage, {
       channel,
       replyTo,

--- a/packages/microservices/server/server-nats.ts
+++ b/packages/microservices/server/server-nats.ts
@@ -72,9 +72,9 @@ export class ServerNats extends Server implements CustomTransportStrategy {
   public createNatsClient(): Client {
     const options = this.options || ({} as NatsOptions);
     return natsPackage.connect({
+      json: true,
       ...options,
       url: this.url,
-      json: true,
     });
   }
 

--- a/packages/microservices/test/ctx-host/nats.context.spec.ts
+++ b/packages/microservices/test/ctx-host/nats.context.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { NatsContext } from '../../ctx-host';
 
 describe('NatsContext', () => {
-  const args: [string] = ['test'];
+  const args: [string, string] = ['test', 'test2'];
   let context: NatsContext;
 
   beforeEach(() => {
@@ -11,6 +11,11 @@ describe('NatsContext', () => {
   describe('getSubject', () => {
     it('should return subject', () => {
       expect(context.getSubject()).to.be.eql(args[0]);
+    });
+  });
+  describe('getReplyTo', () => {
+    it('should return subject', () => {
+      expect(context.getReplyTo()).to.be.eql(args[1]);
     });
   });
 });

--- a/packages/microservices/test/server/server-nats.spec.ts
+++ b/packages/microservices/test/server/server-nats.spec.ts
@@ -126,12 +126,13 @@ describe('ServerNats', () => {
       });
 
       const callerSubject = 'subject';
-      const natsContext = new NatsContext([callerSubject]);
+      const replyTo = 'message-id';
+      const natsContext = new NatsContext([callerSubject, replyTo]);
       server.handleMessage(
         channel,
         { pattern: '', data, id: '2' },
         null,
-        '',
+        replyTo,
         callerSubject,
       );
       expect(handler.calledWith(data, natsContext)).to.be.true;


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When a message is received by @MessagePattern() with NATS, it is not possible to get the replyTo to send an acknowledgment.

Issue Number: N/A


## What is the new behavior?

It is now possible to use ```context.getReplyTo()``` to get the replyTo and use as needed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
This functionality is useful for sending the ack manually as describe in [NATS acks](https://docs.nats.io/nats-concepts/acks)