### PR TITLE
feat(common): add graphql to context type enum

### DIFF
--- a/packages/common/interfaces/features/arguments-host.interface.ts
+++ b/packages/common/interfaces/features/arguments-host.interface.ts
@@ -1,4 +1,4 @@
-export type ContextType = 'http' | 'ws' | 'rpc';
+export type ContextType = 'http' | 'ws' | 'rpc' | 'graphql';
 
 /**
  * Methods to obtain request and response objects.


### PR DESCRIPTION
The `@nestjs/graphql` module uses `graphql` as the context type. So adding it to `ContextType` enum will let other packages/modules to interact with graphql in a more documented way.

No breaking changes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information