### PR TITLE
feat(common) add expected type option to validation pipe

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -6,6 +6,7 @@ import { ArgumentMetadata, ValidationError } from '../index';
 import { ClassTransformOptions } from '../interfaces/external/class-transform-options.interface';
 import { ValidatorOptions } from '../interfaces/external/validator-options.interface';
 import { PipeTransform } from '../interfaces/features/pipe-transform.interface';
+import { Type } from '../interfaces/type.interface';
 import {
   ErrorHttpStatusCode,
   HttpErrorByCode,
@@ -20,6 +21,7 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (errors: ValidationError[]) => any;
   validateCustomDecorators?: boolean;
+  expectedType?: Type<any>;
 }
 
 let classValidator: any = {};
@@ -32,6 +34,7 @@ export class ValidationPipe implements PipeTransform<any> {
   protected validatorOptions: ValidatorOptions;
   protected transformOptions: ClassTransformOptions;
   protected errorHttpStatusCode: ErrorHttpStatusCode;
+  protected expectedType: Type<any>;
   protected exceptionFactory: (errors: ValidationError[]) => any;
   protected validateCustomDecorators: boolean;
 
@@ -41,6 +44,7 @@ export class ValidationPipe implements PipeTransform<any> {
       transform,
       disableErrorMessages,
       errorHttpStatusCode,
+      expectedType,
       transformOptions,
       validateCustomDecorators,
       ...validatorOptions
@@ -52,6 +56,7 @@ export class ValidationPipe implements PipeTransform<any> {
     this.isDetailedOutputDisabled = disableErrorMessages;
     this.validateCustomDecorators = validateCustomDecorators || false;
     this.errorHttpStatusCode = errorHttpStatusCode || HttpStatus.BAD_REQUEST;
+    this.expectedType = expectedType;
     this.exceptionFactory =
       options.exceptionFactory || this.createExceptionFactory();
 
@@ -64,7 +69,7 @@ export class ValidationPipe implements PipeTransform<any> {
   }
 
   public async transform(value: any, metadata: ArgumentMetadata) {
-    const { metatype } = metadata;
+    const metatype = this.expectedType || metadata.metatype;
     if (!metatype || !this.toValidate(metadata)) {
       return this.isTransformEnabled
         ? this.transformPrimitive(value, metadata)

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -396,4 +396,31 @@ describe('ValidationPipe', () => {
       });
     });
   });
+
+  describe('option: "expectedType"', () => {
+    class TestModel2 {
+      @IsString()
+      public prop1: string;
+
+      @IsBoolean()
+      public prop2: string;
+
+      @IsOptional()
+      @IsString()
+      public optionalProp: string;
+    }
+
+    it('should validate against the expected type if presented', async () => {
+      const m: ArgumentMetadata = {
+        type: 'body',
+        metatype: TestModel2,
+        data: '',
+      };
+
+      target = new ValidationPipe({ expectedType: TestModel });
+      const testObj = { prop1: 'value1', prop2: 'value2' };
+
+      expect(await target.transform(testObj, m)).to.equal(testObj);
+    });
+  });
 });


### PR DESCRIPTION
It's possible to have multiple pipes for a single parameter, so the argument type won't necessary will be same as the original type and we need to explicitly set the type for the validation pipe
see discussion:
https://discord.com/channels/520622812742811698/520649487924985885/732209853854122055

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
We can't do custom transformation and use the built-in ValidationPipe.
see discussion:
https://discord.com/channels/520622812742811698/520649487924985885/732209853854122055

Issue Number: N/A


## What is the new behavior?
We can add `expectedType` option to make the ValidationPipe to validate against this type:
```
new ValidationPipe({ expectedType: TestModel })
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is my first PR 🎉 