### PR TITLE
fix(microservices): Changed visibility of Kafka variables for extension

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -43,13 +43,13 @@ export class ClientKafka extends ClientProxy {
   protected client: Kafka = null;
   protected consumer: Consumer = null;
   protected producer: Producer = null;
-  protected readonly logger = new Logger(ClientKafka.name);
-  protected readonly responsePatterns: string[] = [];
+  protected logger = new Logger(ClientKafka.name);
+  protected responsePatterns: string[] = [];
   protected consumerAssignments: { [key: string]: number[] } = {};
 
-  private readonly brokers: string[];
-  private readonly clientId: string;
-  private readonly groupId: string;
+  protected brokers: string[];
+  protected clientId: string;
+  protected groupId: string;
 
   constructor(protected readonly options: KafkaOptions['options']) {
     super();

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -33,13 +33,14 @@ let kafkaPackage: any = {};
 export class ServerKafka extends Server implements CustomTransportStrategy {
   public readonly transportId = Transport.KAFKA;
 
-  protected readonly logger = new Logger(ServerKafka.name);
+  protected logger = new Logger(ServerKafka.name);
   protected client: Kafka = null;
   protected consumer: Consumer = null;
   protected producer: Producer = null;
-  private readonly brokers: string[];
-  private readonly clientId: string;
-  private readonly groupId: string;
+
+  protected brokers: string[];
+  protected clientId: string;
+  protected groupId: string;
 
   constructor(private readonly options: KafkaOptions['options']) {
     super();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/5126


## What is the new behavior?
The `brokers`, `clientId`, and `groupId` can now be extended from the `ClientKafka` and `ServerKafka` microservice classes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information