### PR TITLE
fix(common): support info level type

### DIFF
--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -6,7 +6,7 @@ import { isObject } from '../utils/shared.utils';
 declare const process: any;
 const yellow = clc.xterm(3);
 
-export type LogLevel = 'log' | 'error' | 'warn' | 'debug' | 'verbose';
+export type LogLevel = 'log' | 'info' | 'error' | 'warn' | 'debug' | 'verbose';
 
 export interface LoggerService {
   log(message: any, context?: string);
@@ -20,6 +20,7 @@ export interface LoggerService {
 export class Logger implements LoggerService {
   private static logLevels: LogLevel[] = [
     'log',
+    'info',
     'error',
     'warn',
     'debug',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Nest built-in logger does not support `info` level.

```typescript
NestFactory.create(AppModule, {
   logger: ['info'],  // Type '"info"' is not assignable to type 'LogLevel'.
});
```

Issue Number: #2813


## What is the new behavior?

Support `info` level logging.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information