### PR TITLE
feat(core): add support to controller path alias

### DIFF
--- a/packages/common/decorators/core/controller.decorator.ts
+++ b/packages/common/decorators/core/controller.decorator.ts
@@ -18,7 +18,7 @@ export interface ControllerOptions extends ScopeOptions {
    *
    * @see [Routing](https://docs.nestjs.com/controllers#routing)
    */
-  path?: string;
+  path?: string | string[];
 
   /**
    * Specifies an optional HTTP Request host filter.  When configured, methods
@@ -65,7 +65,7 @@ export function Controller(): ClassDecorator;
  * It defines a class that provides a context for one or more message or event
  * handlers.
  *
- * @param {string} prefix string that defines a `route path prefix`.  The prefix
+ * @param {string, Array} prefix string that defines a `route path prefix`.  The prefix
  * is pre-pended to the path specified in any request decorator in the class.
  *
  * @see [Routing](https://docs.nestjs.com/controllers#routing)
@@ -74,7 +74,7 @@ export function Controller(): ClassDecorator;
  *
  * @publicApi
  */
-export function Controller(prefix: string): ClassDecorator;
+export function Controller(prefix: string | string[]): ClassDecorator;
 
 /**
  * Decorator that marks a class as a Nest controller that can receive inbound
@@ -137,12 +137,13 @@ export function Controller(options: ControllerOptions): ClassDecorator;
  * @publicApi
  */
 export function Controller(
-  prefixOrOptions?: string | ControllerOptions,
+  prefixOrOptions?: string | string[] | ControllerOptions,
 ): ClassDecorator {
   const defaultPath = '/';
+
   const [path, host, scopeOptions] = isUndefined(prefixOrOptions)
     ? [defaultPath, undefined, undefined]
-    : isString(prefixOrOptions)
+    : isString(prefixOrOptions) || Array.isArray(prefixOrOptions)
     ? [prefixOrOptions, undefined, undefined]
     : [
         prefixOrOptions.path || defaultPath,

--- a/packages/common/test/utils/shared.utils.spec.ts
+++ b/packages/common/test/utils/shared.utils.spec.ts
@@ -5,7 +5,7 @@ import {
   isObject,
   isString,
   isConstructor,
-  validatePath,
+  addLeadingSlash,
   isNil,
   isEmpty,
   isPlainObject,
@@ -81,17 +81,17 @@ describe('Shared utils', () => {
       expect(isConstructor('nope')).to.be.false;
     });
   });
-  describe('validatePath', () => {
+  describe('addLeadingSlash', () => {
     it('should returns validated path ("add / if not exists")', () => {
-      expect(validatePath('nope')).to.be.eql('/nope');
+      expect(addLeadingSlash('nope')).to.be.eql('/nope');
     });
     it('should returns same path', () => {
-      expect(validatePath('/nope')).to.be.eql('/nope');
+      expect(addLeadingSlash('/nope')).to.be.eql('/nope');
     });
     it('should returns empty path', () => {
-      expect(validatePath('')).to.be.eql('');
-      expect(validatePath(null)).to.be.eql('');
-      expect(validatePath(undefined)).to.be.eql('');
+      expect(addLeadingSlash('')).to.be.eql('');
+      expect(addLeadingSlash(null)).to.be.eql('');
+      expect(addLeadingSlash(undefined)).to.be.eql('');
     });
   });
   describe('isNil', () => {

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -24,7 +24,7 @@ export const isPlainObject = (fn: any): fn is object => {
   );
 };
 
-export const validatePath = (path?: string): string =>
+export const addLeadingSlash = (path?: string): string =>
   path ? (path.charAt(0) !== '/' ? '/' + path : path) : '';
 
 export const isFunction = (fn: any): boolean => typeof fn === 'function';

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -6,7 +6,10 @@ import {
 } from '@nestjs/common/interfaces/middleware/middleware-configuration.interface';
 import { NestMiddleware } from '@nestjs/common/interfaces/middleware/nest-middleware.interface';
 import { NestModule } from '@nestjs/common/interfaces/modules/nest-module.interface';
-import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
+import {
+  addLeadingSlash,
+  isUndefined,
+} from '@nestjs/common/utils/shared.utils';
 import { ApplicationConfig } from '../application-config';
 import { InvalidMiddlewareException } from '../errors/exceptions/invalid-middleware.exception';
 import { RuntimeException } from '../errors/exceptions/runtime.exception';
@@ -265,7 +268,7 @@ export class MiddlewareModule {
     ) => void,
   ) {
     const prefix = this.config.getGlobalPrefix();
-    const basePath = validatePath(prefix);
+    const basePath = addLeadingSlash(prefix);
     if (basePath && path === '/*') {
       // strip slash when a wildcard is being used
       // and global prefix has been set

--- a/packages/core/middleware/routes-mapper.ts
+++ b/packages/core/middleware/routes-mapper.ts
@@ -2,10 +2,11 @@ import { RequestMethod } from '@nestjs/common';
 import { PATH_METADATA } from '@nestjs/common/constants';
 import { RouteInfo, Type } from '@nestjs/common/interfaces';
 import {
+  addLeadingSlash,
   isString,
   isUndefined,
-  validatePath,
 } from '@nestjs/common/utils/shared.utils';
+
 import { NestContainer } from '../injector/container';
 import { MetadataScanner } from '../metadata-scanner';
 import { RouterExplorer } from '../router/router-explorer';
@@ -64,11 +65,11 @@ export class RoutesMapper {
   }
 
   private validateGlobalPath(path: string): string {
-    const prefix = validatePath(path);
+    const prefix = addLeadingSlash(path);
     return prefix === '/' ? '' : prefix;
   }
 
   private validateRoutePath(path: string): string {
-    return validatePath(path);
+    return addLeadingSlash(path);
   }
 }

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -1,3 +1,6 @@
+import { iterate } from 'iterare';
+import { platform } from 'os';
+
 import {
   CanActivate,
   ExceptionFilter,
@@ -13,9 +16,8 @@ import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.int
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
-import { isObject, validatePath } from '@nestjs/common/utils/shared.utils';
-import { iterate } from 'iterare';
-import { platform } from 'os';
+import { addLeadingSlash, isObject } from '@nestjs/common/utils/shared.utils';
+
 import { AbstractHttpAdapter } from './adapters';
 import { ApplicationConfig } from './application-config';
 import { MESSAGES } from './constants';
@@ -164,7 +166,7 @@ export class NestApplication
     await this.registerMiddleware(this.httpAdapter);
 
     const prefix = this.config.getGlobalPrefix();
-    const basePath = validatePath(prefix);
+    const basePath = addLeadingSlash(prefix);
     this.routesResolver.resolve(this.httpAdapter, basePath);
   }
 

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -60,24 +60,27 @@ export class RoutesResolver implements Resolver {
       const { metatype } = instanceWrapper;
 
       const host = this.getHostMetadata(metatype);
-      const path = this.routerExplorer.extractRouterPath(
+      const paths = this.routerExplorer.extractRouterPath(
         metatype as Type<any>,
         basePath,
       );
       const controllerName = metatype.name;
-      this.logger.log(
-        CONTROLLER_MAPPING_MESSAGE(
-          controllerName,
-          this.routerExplorer.stripEndSlash(path),
-        ),
-      );
-      this.routerExplorer.explore(
-        instanceWrapper,
-        moduleName,
-        applicationRef,
-        path,
-        host,
-      );
+
+      paths.forEach(path => {
+        this.logger.log(
+          CONTROLLER_MAPPING_MESSAGE(
+            controllerName,
+            this.routerExplorer.stripEndSlash(path),
+          ),
+        );
+        this.routerExplorer.explore(
+          instanceWrapper,
+          moduleName,
+          applicationRef,
+          path,
+          host,
+        );
+      });
     });
   }
 

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -88,7 +88,7 @@ describe('RoutesResolver', () => {
 
       sinon
         .stub((routesResolver as any).routerExplorer, 'extractRouterPath')
-        .callsFake(() => '');
+        .callsFake(() => ['']);
       routesResolver.registerRouters(routes, moduleName, '', appInstance);
 
       expect(exploreSpy.called).to.be.true;
@@ -114,7 +114,7 @@ describe('RoutesResolver', () => {
 
       sinon
         .stub((routesResolver as any).routerExplorer, 'extractRouterPath')
-        .callsFake(() => '');
+        .callsFake(() => ['']);
       routesResolver.registerRouters(routes, moduleName, '', appInstance);
 
       expect(exploreSpy.called).to.be.true;

--- a/packages/websockets/socket-server-provider.ts
+++ b/packages/websockets/socket-server-provider.ts
@@ -1,6 +1,8 @@
-import { validatePath } from '@nestjs/common/utils/shared.utils';
-import { ApplicationConfig } from '@nestjs/core/application-config';
 import { isString } from 'util';
+
+import { addLeadingSlash } from '@nestjs/common/utils/shared.utils';
+import { ApplicationConfig } from '@nestjs/core/application-config';
+
 import { GatewayMetadata } from './interfaces/gateway-metadata.interface';
 import { SocketEventsHost } from './interfaces/socket-events-host.interface';
 import { SocketEventsHostFactory } from './socket-events-host-factory';
@@ -74,6 +76,6 @@ export class SocketServerProvider {
     if (!isString(namespace)) {
       return namespace;
     }
-    return validatePath(namespace);
+    return addLeadingSlash(namespace);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The controller decorator doesn't support multi-path.

Issue Number: #5193

## What is the new behavior?
The `prefix` parameter or the `path` parameter of `ControllerOptions` both support multi-value now.
```typescript
Controller(prefix: string | string[])

interface ControllerOptions extends ScopeOptions {
    path?: string | string[];
    host?: string;
}

Controller({ path, host }: ControllerOptions)
```

The output log should look like the following one after provided the path alias to the controller:
```
@Controller(['v1/foos', 'external/foos'])

~~~

[RoutesResolver] FooController {/v1/foos}:
[RouterExplorer] Mapped {/v1/foos, GET} route
[RouterExplorer] Mapped {/v1/foos, POST} route
[RoutesResolver] FooController {external/foos}:
[RouterExplorer] Mapped {/external/foos, GET} route
[RouterExplorer] Mapped {/external/foos, POST} route
```

^ This is different from what I described in the issue since I tend to not deal with the logger message parts too much. Otherwise, there would be a lot of changes in `messages.ts` to achieve the complex format.

## Does this PR introduce a breaking change?
This PR shouldn't impact any existing usage.

```
[ ] Yes
[x] No
```

## Other information
I added the test cases as well but I'm not sure some of them are necessary or not.
I appreciate the reviewer's help very much.