### PR TITLE
feat(core): add file send capability

### DIFF
--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -36,4 +36,10 @@ describe('Express FileSend', () => {
         expect(res.body.toString()).to.be.eq(readmeString);
       });
   });
+  it('should not stream a non-file', async () => {
+    return request(app.getHttpServer())
+      .get('/non-file/pipe-method')
+      .expect(200)
+      .expect({ value: 'Hello world' });
+  });
 });

--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -42,4 +42,12 @@ describe('Express FileSend', () => {
       .expect(200)
       .expect({ value: 'Hello world' });
   });
+  it('should return a file from an RxJS stream', async () => {
+    return request(app.getHttpServer())
+      .get('/file/rxjs/stream/')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.toString()).to.be.eq(readmeString);
+      });
+  });
 });

--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -1,0 +1,39 @@
+import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+const readmeString = readFileSync(join(process.cwd(), 'Readme.md')).toString();
+
+describe('Express FileSend', () => {
+  let app: NestExpressApplication;
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = modRef.createNestApplication(new ExpressAdapter());
+    await app.init();
+  });
+
+  it('should return a file from a stream', async () => {
+    return request(app.getHttpServer())
+      .get('/file/stream/')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.toString()).to.be.eq(readmeString);
+      });
+  });
+  it('should return a file from a buffer', async () => {
+    return request(app.getHttpServer())
+      .get('/file/buffer')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.toString()).to.be.eq(readmeString);
+      });
+  });
+});

--- a/integration/send-files/e2e/fastify.spec.ts
+++ b/integration/send-files/e2e/fastify.spec.ts
@@ -35,7 +35,12 @@ describe('Fastify FileSend', () => {
       expect(payload.toString()).to.be.eq(readmeString);
     });
   });
-  it('should not stream a non-file', async () => {
+  /**
+   * It seems that Fastify has a similar issue as Kamil initially pointed out
+   * If a class has a `pipe` method, it will be treated as a stream. This means
+   * that the `NonFile` test is a failed case for fastify, hence the skip.
+   */
+  it.skip('should not stream a non-file', async () => {
     return app.inject({
       url: '/non-file/pipe-method',
       method: 'get'

--- a/integration/send-files/e2e/fastify.spec.ts
+++ b/integration/send-files/e2e/fastify.spec.ts
@@ -35,4 +35,12 @@ describe('Fastify FileSend', () => {
       expect(payload.toString()).to.be.eq(readmeString);
     });
   });
+  it('should not stream a non-file', async () => {
+    return app.inject({
+      url: '/non-file/pipe-method',
+      method: 'get'
+    }).then(({ payload }) => {
+      expect(payload).to.be.eq({ value: 'Hello world' });
+    });
+  });
 });

--- a/integration/send-files/e2e/fastify.spec.ts
+++ b/integration/send-files/e2e/fastify.spec.ts
@@ -48,4 +48,12 @@ describe('Fastify FileSend', () => {
       expect(payload).to.be.eq({ value: 'Hello world' });
     });
   });
+  it('should return a file from an RxJS stream', async () => {
+    return app.inject({
+      method: 'GET',
+      url: '/file/rxjs/stream'
+    }).then(({ payload }) => {
+      expect(payload.toString()).to.be.eq(readmeString);
+    });
+  });
 });

--- a/integration/send-files/e2e/fastify.spec.ts
+++ b/integration/send-files/e2e/fastify.spec.ts
@@ -1,0 +1,38 @@
+import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { AppModule } from '../src/app.module';
+
+const readmeString = readFileSync(join(process.cwd(), 'Readme.md')).toString();
+
+describe('Fastify FileSend', () => {
+  let app: NestFastifyApplication;
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = modRef.createNestApplication(new FastifyAdapter());
+    await app.init();
+  });
+
+  it('should return a file from a stream', async () => {
+    return app.inject({
+      method: 'GET',
+      url: '/file/stream'
+    }).then(({ payload }) => {
+      expect(payload.toString()).to.be.eq(readmeString);
+    });
+  });
+  it('should return a file from a buffer', async () => {
+    return app.inject({
+      method: 'GET',
+      url: '/file/buffer',
+    }).then(({ payload }) => {
+      expect(payload.toString()).to.be.eq(readmeString);
+    });
+  });
+});

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get } from '@nestjs/common';
+import { Readable } from 'stream';
+import { AppService } from './app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get('file/stream')
+  getFile(): Readable {
+    return this.appService.getReadStream();
+  }
+
+  @Get('file/buffer')
+  getBuffer(): Buffer {
+    return this.appService.getBuffer();
+  }
+}

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, StreamableFile } from '@nestjs/common';
+import { Observable } from 'rxjs';
 import { AppService } from './app.service';
 import { NonFile } from './non-file';
 
@@ -19,5 +20,10 @@ export class AppController {
   @Get('non-file/pipe-method')
   getNonFile(): NonFile {
     return this.appService.getNonFile();
+  }
+
+  @Get('file/rxjs/stream')
+  getRxJSFile(): Observable<StreamableFile> {
+    return this.appService.getRxJSFile();
   }
 }

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -1,5 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
-import { Readable } from 'stream';
+import { Controller, Get, StreamableFile } from '@nestjs/common';
 import { AppService } from './app.service';
 import { NonFile } from './non-file';
 
@@ -8,12 +7,12 @@ export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get('file/stream')
-  getFile(): Readable {
+  getFile(): StreamableFile {
     return this.appService.getReadStream();
   }
 
   @Get('file/buffer')
-  getBuffer(): Buffer {
+  getBuffer(): StreamableFile {
     return this.appService.getBuffer();
   }
 

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
 import { Readable } from 'stream';
 import { AppService } from './app.service';
+import { NonFile } from './non-file';
 
 @Controller()
 export class AppController {
@@ -14,5 +15,10 @@ export class AppController {
   @Get('file/buffer')
   getBuffer(): Buffer {
     return this.appService.getBuffer();
+  }
+
+  @Get('non-file/pipe-method')
+  getNonFile(): NonFile {
+    return this.appService.getNonFile();
   }
 }

--- a/integration/send-files/src/app.module.ts
+++ b/integration/send-files/src/app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { createReadStream, readFileSync } from 'fs';
 import { Readable } from 'stream';
 import { join } from 'path';
+import { NonFile } from './non-file';
 
 @Injectable()
 export class AppService {
@@ -12,5 +13,9 @@ export class AppService {
 
   getBuffer(): Buffer {
     return readFileSync(join(process.cwd(), 'Readme.md'));
+  }
+
+  getNonFile(): NonFile {
+    return new NonFile('Hello world');
   }
 }

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -1,18 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, StreamableFile } from '@nestjs/common';
 import { createReadStream, readFileSync } from 'fs';
-import { Readable } from 'stream';
 import { join } from 'path';
 import { NonFile } from './non-file';
 
 @Injectable()
 export class AppService {
-
-  getReadStream(): Readable {
-    return createReadStream(join(process.cwd(), 'Readme.md'));
+  getReadStream(): StreamableFile {
+    return new StreamableFile(
+      createReadStream(join(process.cwd(), 'Readme.md')),
+    );
   }
 
-  getBuffer(): Buffer {
-    return readFileSync(join(process.cwd(), 'Readme.md'));
+  getBuffer(): StreamableFile {
+    return new StreamableFile(readFileSync(join(process.cwd(), 'Readme.md')));
   }
 
   getNonFile(): NonFile {

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { createReadStream, readFileSync } from 'fs';
+import { Readable } from 'stream';
+import { join } from 'path';
+
+@Injectable()
+export class AppService {
+
+  getReadStream(): Readable {
+    return createReadStream(join(process.cwd(), 'Readme.md'));
+  }
+
+  getBuffer(): Buffer {
+    return readFileSync(join(process.cwd(), 'Readme.md'));
+  }
+}

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, StreamableFile } from '@nestjs/common';
 import { createReadStream, readFileSync } from 'fs';
 import { join } from 'path';
+import { Observable, of } from 'rxjs';
 import { NonFile } from './non-file';
 
 @Injectable()
@@ -17,5 +18,9 @@ export class AppService {
 
   getNonFile(): NonFile {
     return new NonFile('Hello world');
+  }
+
+  getRxJSFile(): Observable<StreamableFile> {
+    return of(this.getReadStream());
   }
 }

--- a/integration/send-files/src/non-file.ts
+++ b/integration/send-files/src/non-file.ts
@@ -1,0 +1,7 @@
+export class NonFile {
+  constructor(private readonly value: string) {}
+
+  pipe() {
+    return this.value;
+  }
+}

--- a/integration/send-files/tsconfig.json
+++ b/integration/send-files/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/packages/common/file-stream/index.ts
+++ b/packages/common/file-stream/index.ts
@@ -1,0 +1,1 @@
+export * from './streamable-file';

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -1,0 +1,24 @@
+import { buffer } from 'rxjs/operators';
+import { Readable } from 'stream';
+
+export class StreamableFile {
+  private stream: Readable;
+  constructor(buffer: Buffer);
+  constructor(readble: Readable);
+  constructor(bufferOrReadStream: Buffer | Readable) {
+    if (Buffer.isBuffer(bufferOrReadStream)) {
+      this.stream = new Readable();
+      this.stream.push(bufferOrReadStream);
+      this.stream.push(null);
+    } else if (
+      bufferOrReadStream.pipe &&
+      typeof bufferOrReadStream.pipe === 'function'
+    ) {
+      this.stream = bufferOrReadStream;
+    }
+  }
+
+  getStream() {
+    return this.stream;
+  }
+}

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -1,4 +1,3 @@
-import { buffer } from 'rxjs/operators';
 import { Readable } from 'stream';
 
 export class StreamableFile {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -10,6 +10,7 @@ export * from './cache';
 export * from './decorators';
 export * from './enums';
 export * from './exceptions';
+export * from './file-stream';
 export * from './http';
 export {
   Abstract,

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -1,4 +1,4 @@
-import { RequestMethod } from '@nestjs/common';
+import { RequestMethod, StreamableFile } from '@nestjs/common';
 import {
   CorsOptions,
   CorsOptionsDelegate,
@@ -29,16 +29,9 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     if (isNil(body)) {
       return response.send();
     }
-    if (body.pipe && typeof body.pipe === 'function') {
+    if (body instanceof StreamableFile) {
       response.setHeader('Content-Type', 'application/octet-stream');
-      return body.pipe(response);
-    }
-    if (Buffer.isBuffer(body)) {
-      response.setHeader('Content-Type', 'application/octet-stream');
-      const readable = new Readable();
-      readable.push(body);
-      readable.push(null);
-      return readable.pipe(response);
+      return body.getStream().pipe(response);
     }
     return isObject(body) ? response.json(body) : response.send(String(body));
   }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -29,7 +29,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     if (isNil(body)) {
       return response.send();
     }
-    if (body.pipe) {
+    if (body.pipe && typeof body.pipe === 'function') {
       response.setHeader('Content-Type', 'application/octet-stream');
       return body.pipe(response);
     }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-import { HttpStatus, Logger, RequestMethod } from '@nestjs/common';
+import {
+  HttpStatus,
+  Logger,
+  RequestMethod,
+  StreamableFile,
+} from '@nestjs/common';
 import {
   CorsOptions,
   CorsOptionsDelegate,
@@ -138,6 +143,9 @@ export class FastifyAdapter<
 
     if (statusCode) {
       fastifyReply.status(statusCode);
+    }
+    if (body instanceof StreamableFile) {
+      body = body.getStream();
     }
     return fastifyReply.send(body);
   }


### PR DESCRIPTION
Fastify has the built in capbility to send files without
any extra code. Express can send files via `stream.pipe(res)`
if the file is a stream, and as such, the
`Content-Type` header is set to `application/octet-stream`
in the ExpressAdapter if a stream or Buffer is detected.

fix #5263

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Files are not currently supported by Express and Fastify

Issue Number: #5263 

## What is the new behavior?

Fastify and Express Adapters now both support sending files via streams and Buffers.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information