### PR TITLE
feat(core): exclude route from global prefix

### DIFF
--- a/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
+++ b/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
@@ -15,7 +15,7 @@ describe('Global prefix', () => {
       app = module.createNestApplication();
     });
 
-    it.only(`should use the global prefix`, async () => {
+    it(`should use the global prefix`, async () => {
       app.setGlobalPrefix('/api/v1')
 
       server = app.getHttpServer();
@@ -30,7 +30,7 @@ describe('Global prefix', () => {
         .expect(200)
     });
 
-    it.only(`should exclude the path as string`, async () => {
+    it(`should exclude the path as string`, async () => {
       app.setGlobalPrefix('/api/v1', {exclude: ['/test']})
 
       server = app.getHttpServer();
@@ -51,7 +51,7 @@ describe('Global prefix', () => {
         .expect(404)
     });
 
-    it.only(`should exclude the path as RouteInfo`, async () => {
+    it(`should exclude the path as RouteInfo`, async () => {
       app.setGlobalPrefix('/api/v1', {exclude: [{path: '/health', method: RequestMethod.GET}]})
 
       server = app.getHttpServer();
@@ -66,7 +66,26 @@ describe('Global prefix', () => {
         .expect(404)
     });
 
-    it.only(`should exclude the path as a mix of string and RouteInfo`, async () => {
+    it(`should only exclude the GET RequestMethod`, async () => {
+      app.setGlobalPrefix('/api/v1', {exclude: [{path: '/test', method: RequestMethod.GET}]})
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/test')
+        .expect(200)
+
+      await request(server)
+        .post('/test')
+        .expect(404)
+
+      await request(server)
+        .post('/api/v1/test')
+        .expect(201)
+    });
+
+    it(`should exclude the path as a mix of string and RouteInfo`, async () => {
       app.setGlobalPrefix('/api/v1', {exclude: ["test", {path: '/health', method: RequestMethod.GET}]})
 
       server = app.getHttpServer();
@@ -81,7 +100,7 @@ describe('Global prefix', () => {
         .expect(200)
     });
 
-    it.only(`should exclude the path with route param`, async () => {
+    it(`should exclude the path with route param`, async () => {
       app.setGlobalPrefix('/api/v1', {exclude: ['/hello/:name']})
 
       server = app.getHttpServer();

--- a/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
+++ b/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
@@ -1,0 +1,98 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../src/app.module';
+import * as request from 'supertest';
+import { RequestMethod } from '@nestjs/common/enums/request-method.enum'
+describe('Global prefix', () => {
+    let server;
+    let app: INestApplication;
+  
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+  
+      app = module.createNestApplication();
+    });
+
+    it.only(`should use the global prefix`, async () => {
+      app.setGlobalPrefix('/api/v1')
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/health')
+        .expect(404)
+
+      await request(server)
+        .get('/api/v1/health')
+        .expect(200)
+    });
+
+    it.only(`should exclude the path as string`, async () => {
+      app.setGlobalPrefix('/api/v1', {exclude: ['/test']})
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/test')
+        .expect(200)
+      await request(server)
+        .post('/test')
+        .expect(201)
+
+      await request(server)
+        .get('/api/v1/test')
+        .expect(404)
+      await request(server)
+        .post('/api/v1/test')
+        .expect(404)
+    });
+
+    it.only(`should exclude the path as RouteInfo`, async () => {
+      app.setGlobalPrefix('/api/v1', {exclude: [{path: '/health', method: RequestMethod.GET}]})
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/health')
+        .expect(200)
+
+      await request(server)
+        .get('/api/v1/health')
+        .expect(404)
+    });
+
+    it.only(`should exclude the path as a mix of string and RouteInfo`, async () => {
+      app.setGlobalPrefix('/api/v1', {exclude: ["test", {path: '/health', method: RequestMethod.GET}]})
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/health')
+        .expect(200)
+
+      await request(server)
+        .get('/test')
+        .expect(200)
+    });
+
+    it.only(`should exclude the path with route param`, async () => {
+      app.setGlobalPrefix('/api/v1', {exclude: ['/hello/:name']})
+
+      server = app.getHttpServer();
+      await app.init();
+
+      await request(server)
+        .get('/hello/foo')
+        .expect(200)
+    });
+  
+    afterEach(async () => {
+      await app.close();
+    });
+});

--- a/integration/nest-application/global-prefix/src/app.controller.ts
+++ b/integration/nest-application/global-prefix/src/app.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Post } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+
+  @Get('hello/:name')
+  getHello(): string {
+    return 'hello';
+  }
+
+  @Get('health')
+  getHealth(): string {
+    return 'up';
+  }
+
+  @Get('test')
+  getTest(): string {
+    return 'test';
+  }
+
+  @Post('test')
+  postTest(): string {
+    return 'test';
+  }
+}

--- a/integration/nest-application/global-prefix/src/app.module.ts
+++ b/integration/nest-application/global-prefix/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/integration/nest-application/global-prefix/tsconfig.json
+++ b/integration/nest-application/global-prefix/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/common/interfaces/global-prefix-options.interface.ts
+++ b/packages/common/interfaces/global-prefix-options.interface.ts
@@ -1,0 +1,8 @@
+import { RouteInfo } from './middleware';
+
+/**
+ * @publicApi
+ */
+export interface GlobalPrefixOptions {
+  exclude?: Array<string | RouteInfo>;
+}

--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -25,3 +25,4 @@ export * from './nest-microservice.interface';
 export * from './scope-options.interface';
 export * from './type.interface';
 export * from './websockets/web-socket-adapter.interface';
+export * from './global-prefix-options.interface';

--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -10,6 +10,7 @@ import {
 } from './index';
 import { INestApplicationContext } from './nest-application-context.interface';
 import { WebSocketAdapter } from './websockets/web-socket-adapter.interface';
+import { GlobalPrefixOptions } from './global-prefix-options.interface';
 
 /**
  * Interface defining the core NestApplication object.
@@ -67,9 +68,13 @@ export interface INestApplication extends INestApplicationContext {
    * Registers a prefix for every HTTP route path.
    *
    * @param  {string} prefix The prefix for every HTTP route path (for example `/v1/api`)
+   * @param  {NestApplicationGlobalPrefixOptions} globalPrefixOptions GlobalPrefix options object
    * @returns {void}
    */
-  setGlobalPrefix(prefix: string): this;
+  setGlobalPrefix(
+    prefix: string,
+    globalPrefixOptions?: GlobalPrefixOptions,
+  ): this;
 
   /**
    * Setup Ws Adapter which will be used inside Gateways.

--- a/packages/core/application-config.ts
+++ b/packages/core/application-config.ts
@@ -6,9 +6,11 @@ import {
   WebSocketAdapter,
 } from '@nestjs/common';
 import { InstanceWrapper } from './injector/instance-wrapper';
+import { GlobalPrefixOptions } from '@nestjs/common/interfaces';
 
 export class ApplicationConfig {
   private globalPrefix = '';
+  private globalPrefixOptions: GlobalPrefixOptions = {};
   private globalPipes: PipeTransform[] = [];
   private globalFilters: ExceptionFilter[] = [];
   private globalInterceptors: NestInterceptor[] = [];
@@ -30,6 +32,14 @@ export class ApplicationConfig {
 
   public getGlobalPrefix() {
     return this.globalPrefix;
+  }
+
+  public setGlobalPrefixOptions(options: GlobalPrefixOptions) {
+    this.globalPrefixOptions = options;
+  }
+
+  public getGlobalPrefixOptions(): GlobalPrefixOptions {
+    return this.globalPrefixOptions;
   }
 
   public setIoAdapter(ioAdapter: WebSocketAdapter) {

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -10,6 +10,7 @@ import {
   WebSocketAdapter,
 } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
+import { GlobalPrefixOptions } from '@nestjs/common/interfaces/global-prefix-options.interface';
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
@@ -279,8 +280,14 @@ export class NestApplication extends NestApplicationContext
     });
   }
 
-  public setGlobalPrefix(prefix: string): this {
+  public setGlobalPrefix(
+    prefix: string,
+    globalPrefixOptions?: GlobalPrefixOptions,
+  ): this {
     this.config.setGlobalPrefix(prefix);
+    if (globalPrefixOptions) {
+      this.config.setGlobalPrefixOptions(globalPrefixOptions);
+    }
     return this;
   }
 

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -252,7 +252,6 @@ export class RouterExplorer {
         return false;
       }
       if (
-        route.method &&
         route.method !== RequestMethod.ALL &&
         route.method !== requestMethod
       ) {

--- a/packages/core/test/application-config.spec.ts
+++ b/packages/core/test/application-config.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
 import { ApplicationConfig } from '../application-config';
+import { GlobalPrefixOptions } from '@nestjs/common/interfaces';
+import { RequestMethod } from '@nestjs/common';
 
 describe('ApplicationConfig', () => {
   let appConfig: ApplicationConfig;
@@ -14,8 +16,19 @@ describe('ApplicationConfig', () => {
 
       expect(appConfig.getGlobalPrefix()).to.be.eql(path);
     });
+    it('should set global path options', () => {
+      const options: GlobalPrefixOptions = {
+        exclude: [{ path: 'health', method: RequestMethod.GET }],
+      };
+      appConfig.setGlobalPrefixOptions(options);
+
+      expect(appConfig.getGlobalPrefixOptions()).to.be.eql(options);
+    });
     it('should has empty string as a global path by default', () => {
       expect(appConfig.getGlobalPrefix()).to.be.eql('');
+    });
+    it('should has empty string as a global path option by default', () => {
+      expect(appConfig.getGlobalPrefixOptions()).to.be.eql({});
     });
   });
   describe('IOAdapter', () => {

--- a/packages/core/test/router/router-explorer.spec.ts
+++ b/packages/core/test/router/router-explorer.spec.ts
@@ -35,14 +35,16 @@ describe('RouterExplorer', () => {
   let routerBuilder: RouterExplorer;
   let injector: Injector;
   let exceptionsFilter: RouterExceptionFilters;
+  let applicationConfig: ApplicationConfig;
 
   beforeEach(() => {
     const container = new NestContainer();
 
+    applicationConfig = new ApplicationConfig();
     injector = new Injector();
     exceptionsFilter = new RouterExceptionFilters(
       container,
-      new ApplicationConfig(),
+      applicationConfig,
       null,
     );
     routerBuilder = new RouterExplorer(
@@ -51,6 +53,7 @@ describe('RouterExplorer', () => {
       injector,
       null,
       exceptionsFilter,
+      applicationConfig,
     );
   });
 
@@ -125,6 +128,23 @@ describe('RouterExplorer', () => {
 
       expect(bindStub.calledWith(null, paths[0], null)).to.be.true;
       expect(bindStub.callCount).to.be.eql(paths.length);
+    });
+  });
+
+  describe('removeGlobalPrefixFromPath', () => {
+    it('should remove global prefix from path', () => {
+      sinon
+        .stub(applicationConfig, 'getGlobalPrefix')
+        .returns('/some/prefixed');
+      console.log(applicationConfig.getGlobalPrefix());
+
+      expect(
+        routerBuilder.removeGlobalPrefixFromPath('/some/prefixed/cats'),
+      ).be.eql('/cats');
+    });
+    it('should not change path when there is no GlobalPrefix', () => {
+      sinon.stub(applicationConfig, 'getGlobalPrefix').returns('');
+      expect(routerBuilder.removeGlobalPrefixFromPath('/cats')).be.eql('/cats');
     });
   });
 


### PR DESCRIPTION
New global prefix option to exclude some routes as a string or a RouteInfo

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
You can specify a global route prefix but you can't exclude some routes
```ts
app.setGlobalPrefix('v1');
```
Issue Number: #963 


## What is the new behavior?
It add a new option object for the global prefix. You can exclude routes based on the path and the request method
```ts
app.setGlobalPrefix('v1', { exclude: [
  { path: '/health', method: RequestMethod.GET }
]});
```
You can also specify route as a string (it apply on every request method) or a mix of the 2 like so:
```ts
app.setGlobalPrefix('v1', { exclude: [
  'cats',
  { path: '/health', method: RequestMethod.GET }
]});
```

This is my first contribution to this awesome framework and there are probably things that need to be improved or moved so please give me some feedback.

I followed the syntax proposed in the issue (back in 2018) and I tried to follow the [middleware route exclude](https://docs.nestjs.com/middleware#excluding-routes) code. 

I would like to add support for wildcard parameters (like `'cats/(.*)'`) the same way it's done for the middleware but maybe it's better to do it step by step and create another PR ?

I can also write the doc for this if you want

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Have a great day