### PR TITLE
fix(test): stricten unit test file pattern

### DIFF
--- a/sample/01-cats-app/package.json
+++ b/sample/01-cats-app/package.json
@@ -57,7 +57,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/sample/09-babel-example/package.json
+++ b/sample/09-babel-example/package.json
@@ -42,7 +42,7 @@
       "json"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.js$",
+    "testRegex": ".*\\.spec\\.js$",
     "coverageDirectory": "../coverage"
   }
 }

--- a/sample/19-auth-jwt/package.json
+++ b/sample/19-auth-jwt/package.json
@@ -61,7 +61,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/sample/25-dynamic-modules/package.json
+++ b/sample/25-dynamic-modules/package.json
@@ -57,7 +57,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/sample/26-queues/package.json
+++ b/sample/26-queues/package.json
@@ -60,7 +60,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },

--- a/sample/27-scheduling/package.json
+++ b/sample/27-scheduling/package.json
@@ -59,7 +59,7 @@
       "ts"
     ],
     "rootDir": "src",
-    "testRegex": ".spec.ts$",
+    "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The unit test file pattern includes any files containing `test` and the `ts` suffix, since `testRegex: .spec.ts` a regex and not a glob pattern.

Issue Number: #5293 


## What is the new behavior?
The test file pattern strictly follows the .spec.ts file suffix. This rules out .e2e-spec.ts files from unit tests. The change has been applied to all sample projects with unit tests.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information