### PR TITLE
feat(core): add a feature to disable routes log

### DIFF
--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -40,7 +40,8 @@ const {
 /**
  * @publicApi
  */
-export class NestApplication extends NestApplicationContext
+export class NestApplication
+  extends NestApplicationContext
   implements INestApplication {
   private readonly logger = new Logger(NestApplication.name, true);
   private readonly middlewareModule = new MiddlewareModule();
@@ -54,6 +55,7 @@ export class NestApplication extends NestApplicationContext
   private readonly microservices: any[] = [];
   private httpServer: any;
   private isListening = false;
+  private isDisableRouterLog = false;
 
   constructor(
     container: NestContainer,
@@ -164,7 +166,11 @@ export class NestApplication extends NestApplicationContext
 
     const prefix = this.config.getGlobalPrefix();
     const basePath = validatePath(prefix);
-    this.routesResolver.resolve(this.httpAdapter, basePath);
+    this.routesResolver.resolve(
+      this.httpAdapter,
+      basePath,
+      this.isDisableRouterLog,
+    );
   }
 
   public async registerRouterHooks() {
@@ -225,6 +231,10 @@ export class NestApplication extends NestApplicationContext
 
   public enableCors(options?: CorsOptions): void {
     this.httpAdapter.enableCors(options);
+  }
+
+  public disableRouterLog() {
+    this.isDisableRouterLog = true;
   }
 
   public async listen(

--- a/packages/core/router/interfaces/resolver.interface.ts
+++ b/packages/core/router/interfaces/resolver.interface.ts
@@ -1,5 +1,5 @@
 export interface Resolver {
-  resolve(instance: any, basePath: string): void;
+  resolve(instance: any, basePath: string, isDisableRouterLog?: boolean): void;
   registerNotFoundHandler(): void;
   registerExceptionHandler(): void;
 }

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -74,6 +74,7 @@ export class RouterExplorer {
     applicationRef: T,
     basePath: string,
     host: string,
+    isDisableRouterLog?: boolean,
   ) {
     const { instance } = instanceWrapper;
     const routerPaths = this.scanForPaths(instance);
@@ -84,6 +85,7 @@ export class RouterExplorer {
       module,
       basePath,
       host,
+      isDisableRouterLog,
     );
   }
 
@@ -151,6 +153,7 @@ export class RouterExplorer {
     moduleKey: string,
     basePath: string,
     host: string,
+    isDisableRouterLog?: boolean,
   ) {
     (routePaths || []).forEach(pathProperties => {
       const { path, requestMethod } = pathProperties;
@@ -162,10 +165,14 @@ export class RouterExplorer {
         basePath,
         host,
       );
-      path.forEach(item => {
-        const pathStr = this.stripEndSlash(basePath) + this.stripEndSlash(item);
-        this.logger.log(ROUTE_MAPPED_MESSAGE(pathStr, requestMethod));
-      });
+
+      if (isDisableRouterLog) {
+        path.forEach(item => {
+          const pathStr =
+            this.stripEndSlash(basePath) + this.stripEndSlash(item);
+          this.logger.log(ROUTE_MAPPED_MESSAGE(pathStr, requestMethod));
+        });
+      }
     });
   }
 

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -41,12 +41,22 @@ export class RoutesResolver implements Resolver {
     );
   }
 
-  public resolve<T extends HttpServer>(applicationRef: T, basePath: string) {
+  public resolve<T extends HttpServer>(
+    applicationRef: T,
+    basePath: string,
+    isDisableRouterLog?: boolean,
+  ) {
     const modules = this.container.getModules();
     modules.forEach(({ controllers, metatype }, moduleName) => {
       let path = metatype ? this.getModulePathMetadata(metatype) : undefined;
       path = path ? basePath + path : basePath;
-      this.registerRouters(controllers, moduleName, path, applicationRef);
+      this.registerRouters(
+        controllers,
+        moduleName,
+        path,
+        applicationRef,
+        isDisableRouterLog,
+      );
     });
   }
 
@@ -55,6 +65,7 @@ export class RoutesResolver implements Resolver {
     moduleName: string,
     basePath: string,
     applicationRef: HttpServer,
+    isDisableRouterLog?: boolean,
   ) {
     routes.forEach(instanceWrapper => {
       const { metatype } = instanceWrapper;
@@ -65,18 +76,23 @@ export class RoutesResolver implements Resolver {
         basePath,
       );
       const controllerName = metatype.name;
-      this.logger.log(
-        CONTROLLER_MAPPING_MESSAGE(
-          controllerName,
-          this.routerExplorer.stripEndSlash(path),
-        ),
-      );
+
+      if (isDisableRouterLog) {
+        this.logger.log(
+          CONTROLLER_MAPPING_MESSAGE(
+            controllerName,
+            this.routerExplorer.stripEndSlash(path),
+          ),
+        );
+      }
+
       this.routerExplorer.explore(
         instanceWrapper,
         moduleName,
         applicationRef,
         path,
         host,
+        isDisableRouterLog,
       );
     });
   }

--- a/packages/core/test/router/router-explorer.spec.ts
+++ b/packages/core/test/router/router-explorer.spec.ts
@@ -128,6 +128,33 @@ describe('RouterExplorer', () => {
     });
   });
 
+  describe('applyPathsToRouterProxyWithDisableLogger', () => {
+    it('should method return expected object which represent single route', () => {
+      const bindStub = sinon.stub(
+        routerBuilder,
+        'applyCallbackToRouter' as any,
+      );
+      const paths = [
+        { path: [''], requestMethod: RequestMethod.GET },
+        { path: ['test'], requestMethod: RequestMethod.GET },
+        { path: ['foo', 'bar'], requestMethod: RequestMethod.GET },
+      ];
+
+      routerBuilder.applyPathsToRouterProxy(
+        null,
+        paths as any,
+        null,
+        '',
+        '',
+        '',
+        true,
+      );
+
+      expect(bindStub.calledWith(null, paths[0], null)).to.be.true;
+      expect(bindStub.callCount).to.be.eql(paths.length);
+    });
+  });
+
   describe('extractRouterPath', () => {
     it('should return expected path', () => {
       expect(routerBuilder.extractRouterPath(TestRoute)).to.be.eql('/global');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
Create a new function in the app so that it can disable the router logger when app runs the first time.
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
App displays all route definitions, which is quite time consuming if a project has thousands of routes.
Issue Number: N/A


## What is the new behavior?
To disable log route at startup use the following function
```ts
app.disableRouterLog();
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```