### PR TITLE
feat(core): Add abortOnError option in NestApplicationContextOptions

### DIFF
--- a/packages/common/interfaces/nest-application-context-options.interface.ts
+++ b/packages/common/interfaces/nest-application-context-options.interface.ts
@@ -8,4 +8,11 @@ export class NestApplicationContextOptions {
    * Specifies the logger to use.  Pass `false` to turn off logging.
    */
   logger?: LoggerService | LogLevel[] | boolean;
+
+  /**
+   * Whether to abort the process on Error. By default the process is exited.
+   * Pass `false` to override default behaviour. If `false` is passed nest will not exit
+   * the application on an exception and instead, will throw the exception.
+   */
+  abortOnError?: boolean | null;
 }

--- a/packages/common/interfaces/nest-application-context-options.interface.ts
+++ b/packages/common/interfaces/nest-application-context-options.interface.ts
@@ -14,5 +14,5 @@ export class NestApplicationContextOptions {
    * Pass `false` to override the default behavior. If `false` is passed, Nest will not exit
    * the application and instead will rethrow the exception.
    */
-  abortOnError?: boolean | null;
+  abortOnError?: boolean | undefined;
 }

--- a/packages/common/interfaces/nest-application-context-options.interface.ts
+++ b/packages/common/interfaces/nest-application-context-options.interface.ts
@@ -10,9 +10,9 @@ export class NestApplicationContextOptions {
   logger?: LoggerService | LogLevel[] | boolean;
 
   /**
-   * Whether to abort the process on Error. By default the process is exited.
-   * Pass `false` to override default behaviour. If `false` is passed nest will not exit
-   * the application on an exception and instead, will throw the exception.
+   * Whether to abort the process on Error. By default, the process is exited.
+   * Pass `false` to override the default behavior. If `false` is passed, Nest will not exit
+   * the application and instead will rethrow the exception.
    */
   abortOnError?: boolean | null;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/nestjs/nest/issues/5162

Issue Number: 5162


## What is the new behavior?
An abortOnError flag is added in nestApplicationContext. By default the process is aborted, but if abortOnError is set to false,
error is rethrown instead of calling process.abort() or process.exit(1)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information