### PR TITLE
feat(common): add support for conditional cache ttl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3651,6 +3651,7 @@
           "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-7.3.0.tgz",
           "integrity": "sha512-BUKSoz7AFSKPcYTZODbICW2mOthAN4vc5juD6FL1lD/dLwZ0WvrC3zqBM3/X6f5gHxq3yaz+HmanHGaWm0ddbQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "@dsherret/to-absolute-glob": "^2.0.2",
             "@ts-morph/common": "~0.5.2",
@@ -3894,6 +3895,7 @@
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.5.2.tgz",
       "integrity": "sha512-eLmfYV6u6gUgHrB9QV9lpuWg3cD60mhXdv0jvM5exWR/Cor8HG+GziFIj2hPEWHJknqzuU4meZd8DTqIzZfDRQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@dsherret/to-absolute-glob": "^2.0.2",
         "fast-glob": "^3.2.2",
@@ -3907,7 +3909,8 @@
           "version": "3.9.7",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
           "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/common/cache/decorators/cache-ttl.decorator.ts
+++ b/packages/common/cache/decorators/cache-ttl.decorator.ts
@@ -1,5 +1,6 @@
 import { SetMetadata } from '../../decorators';
 import { CACHE_TTL_METADATA } from '../cache.constants';
+import { ExecutionContext } from '../../interfaces/features/execution-context.interface';
 
 /**
  * Decorator that sets the cache ttl setting the duration for cache expiration.
@@ -12,4 +13,6 @@ import { CACHE_TTL_METADATA } from '../cache.constants';
  *
  * @publicApi
  */
-export const CacheTTL = (ttl: number) => SetMetadata(CACHE_TTL_METADATA, ttl);
+type CacheTTLHandler<T> = (ctx: T) => Promise<number> | number;
+export const CacheTTL = (ttl: number | CacheTTLHandler<ExecutionContext>) =>
+  SetMetadata(CACHE_TTL_METADATA, ttl);

--- a/packages/common/cache/index.ts
+++ b/packages/common/cache/index.ts
@@ -1,4 +1,4 @@
-export { CACHE_MANAGER } from './cache.constants';
+export * from './cache.constants';
 export * from './cache.module';
 export * from './decorators';
 export * from './interceptors';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
In the current implementation of `@CacheTTL`, the input value is a fixed number and constant tokens of cache module are all private except `CACHE_MANAGER` so we can not set our desired value as metadata

Issue Number: #5335


## What is the new behavior?
1 - `@CacheTTL` decorator accept `number` or `CacheTTLHandler` as argument
```typescript
type CacheTTLHandler<T> = (ctx: T) => Promise<number> | number;
export const CacheTTL = (ttl: number | CacheTTLHandler<ExecutionContext>) =>
  SetMetadata(CACHE_TTL_METADATA, ttl);
```
2 - export all constant tokens of cache module to create the ability to customization
```typescript
export * from './cache.constants';
```
for example for more complex scenarios now we can create an interceptor that change the cache ttl value
```typescript
intercept(ctx: ExecutionContext, next: CallHandler) {
    const body = ...;
    if (!body.term) {
      Reflect.defineMetadata(CACHE_TTL_METADATA /** (solved) cache constant in @nest/common as public api */, 2000, ctx.getHandler());
    } // else will be default
    return super.intercept(ctx, next);
}
```
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
