### PR TITLE
fix(test e2e): Error console jest detect open handle

### DIFF
--- a/sample/01-cats-app/e2e/cats/cats.e2e-spec.ts
+++ b/sample/01-cats-app/e2e/cats/cats.e2e-spec.ts
@@ -22,13 +22,13 @@ describe('Cats', () => {
     await app.init();
   });
 
-  it(`/GET cats`, () => {
-    return request(app.getHttpServer())
-      .get('/cats')
-      .expect(200)
-      .expect({
+  it(`/GET cats`, done => {
+    return request(app.getHttpServer()).get('/cats').expect(200).expect(
+      {
         data: catsService.findAll(),
-      });
+      },
+      done,
+    );
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Fix error when run e2e test with option  --detectOpenHandles

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When execute the command ``test:e2e`` with the option ``--detectOpenHandles``, Jest return this message in console:
```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:
```

## What is the new behavior?

According to documentation [SuperTest](https://github.com/visionmedia/supertest), we need informe in the last ``expect`` the  ``done`` function to finish the open handle.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information