### PR TITLE
fix(microservice/kafka): properly await disconnect promises

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -80,9 +80,9 @@ export class ClientKafka extends ClientProxy {
     this.responsePatterns.push(this.getResponsePatternName(request));
   }
 
-  public close(): void {
-    this.producer && this.producer.disconnect();
-    this.consumer && this.consumer.disconnect();
+  public async close(): Promise<void> {
+    this.producer && (await this.producer.disconnect());
+    this.consumer && (await this.consumer.disconnect());
     this.producer = null;
     this.consumer = null;
     this.client = null;

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -232,14 +232,14 @@ describe('ClientKafka', () => {
   });
 
   describe('close', () => {
-    const consumer = { disconnect: sinon.spy() };
-    const producer = { disconnect: sinon.spy() };
+    const consumer = { disconnect: sinon.stub().resolves() };
+    const producer = { disconnect: sinon.stub().resolves() };
     beforeEach(() => {
       (client as any).consumer = consumer;
       (client as any).producer = producer;
     });
-    it('should close server', () => {
-      client.close();
+    it('should close server', async () => {
+      await client.close();
 
       expect(consumer.disconnect.calledOnce).to.be.true;
       expect(producer.disconnect.calledOnce).to.be.true;


### PR DESCRIPTION
`producer.disconnect()` and `consumer.disconnect()` are promises.
Since they weren't being `await`ed properly, you would have Kafka code that
would attempt to execute after teardown. By waiting for the promises, those errors
go away.

Official documentation: https://kafka.js.org/docs/getting-started

Closes #4830

[Here are tests from KafkaJS showing those methods as async](https://github.com/tulios/kafkajs/blob/c025e05725a8b1badf813ea6a5231d0b8f77647a/src/consumer/__tests__/consumeMessages.spec.js#L47-L50)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Tests with kafka do not get torn down properly

Issue Number: #4830 


## What is the new behavior?

Promises are handled properly and no code is executed after teardown.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Maybe? People will have to `await` their promises if they weren't already

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information