### PR TITLE
fix(core): add missing optional dependencies

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,6 +25,20 @@
   },
   "peerDependencies": {
     "reflect-metadata": "^0.1.12",
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.0.0",
+    "cache-manager": "*",
+    "class-validator": "*",
+    "class-transformer": "*"
+  },
+  "peerDependenciesMeta": {
+    "cache-manager": {
+      "optional": true
+    },
+    "class-validator": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,8 +39,22 @@
     "@nestjs/common": "7.4.4"
   },
   "peerDependencies": {
+    "@nestjs/websockets": "^7.0.0",
+    "@nestjs/microservices": "^7.0.0",
+    "@nestjs/platform-express": "^7.0.0",
     "@nestjs/common": "^7.0.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/websockets": {
+      "optional": true
+    },
+    "@nestjs/microservices": {
+      "optional": true
+    },
+    "@nestjs/platform-express": {
+      "optional": true
+    }
   }
 }

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -26,8 +26,47 @@
     "@nestjs/core": "7.4.4"
   },
   "peerDependencies": {
+    "reflect-metadata": "^0.1.12",
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
-    "rxjs": "^6.0.0"
+    "@nestjs/websockets": "^7.0.0",
+    "rxjs": "^6.0.0",
+    "cache-manager": "*",
+    "grpc": "*",
+    "kafkajs": "*",
+    "mqtt": "*",
+    "nats": "*",
+    "redis": "*",
+    "amqplib": "*",
+    "amqp-connection-manager": "*"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/websockets": {
+      "optional": true
+    },
+    "cache-manager": {
+      "optional": true
+    },
+    "grpc": {
+      "optional": true
+    },
+    "kafkajs": {
+      "optional": true
+    },
+    "mqtt": {
+      "optional": true
+    },
+    "nats": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    },
+    "amqplib": {
+      "optional": true
+    },
+    "amqp-connection-manager": {
+      "optional": true
+    }
   }
 }

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -22,6 +22,16 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
-    "@nestjs/core": "^7.0.0"
+    "@nestjs/core": "^7.0.0",
+    "@nestjs/microservices": "^7.0.0",
+    "@nestjs/platform-express": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/microservices":{
+      "optional": true
+    },
+    "@nestjs/platform-express":{
+      "optional": true
+    }
   }
 }

--- a/packages/websockets/package.json
+++ b/packages/websockets/package.json
@@ -22,6 +22,7 @@
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
-    "rxjs": "^6.0.0"
+    "rxjs": "^6.0.0",
+    "reflect-metadata": "^0.1.12"
   }
 }


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`@nestjs/platform-express` is hardcoded as the default platform, and is `require`d in various places in the code base. However, it is not an explicit dependency and thus package installers (yarn/npm/pnpm) need a hint on how to properly link them in order to be resolved.

See: https://github.com/nestjs/nest/blob/09fbc83108c8429a21c4d383b62f68037d6d2204/packages/core/nest-factory.ts#L211-L218

Without this change, Nest has problems running on stricter package managers (yarn with pnp, or pnpm)

## What is the new behavior?

`@nestjs/platform-express` is added as an optional dependency. `peerDependenciesMeta` is supported by all major package managers: npm, yarn and pnpm.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

See: https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies