### PR TITLE
fix(core): allow setting log level after app creation

### DIFF
--- a/packages/common/interfaces/nest-application-context.interface.ts
+++ b/packages/common/interfaces/nest-application-context.interface.ts
@@ -1,5 +1,5 @@
 import { ShutdownSignal } from '../enums/shutdown-signal.enum';
-import { LoggerService } from '../services/logger.service';
+import { LoggerService, LogLevel } from '../services/logger.service';
 import { Abstract } from './abstract.interface';
 import { Type } from './type.interface';
 
@@ -53,7 +53,7 @@ export interface INestApplicationContext {
    * Sets custom logger service
    * @returns {void}
    */
-  useLogger(logger: LoggerService): void;
+  useLogger(logger: LoggerService | LogLevel[] | false): void;
 
   /**
    * Enables the usage of shutdown hooks. Will call the

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -2,6 +2,7 @@ import {
   INestApplicationContext,
   Logger,
   LoggerService,
+  LogLevel,
   ShutdownSignal,
 } from '@nestjs/common';
 import { Abstract, Scope } from '@nestjs/common/interfaces';
@@ -119,7 +120,7 @@ export class NestApplicationContext implements INestApplicationContext {
     this.unsubscribeFromProcessSignals();
   }
 
-  public useLogger(logger: LoggerService) {
+  public useLogger(logger: LoggerService | LogLevel[] | false) {
     Logger.overrideLogger(logger);
   }
 


### PR DESCRIPTION
So far, the types only allowed to set the log level within the application options, and not when calling app.useLogger(), although internally they call the same method.
closes @nestjs/nest#5484

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5484


## What is the new behavior?
Fixed types.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```