### PR TITLE
feature(microservices): Add persistent property to RmqOptions

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -33,6 +33,7 @@ export const RQM_DEFAULT_PREFETCH_COUNT = 0;
 export const RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT = false;
 export const RQM_DEFAULT_QUEUE_OPTIONS = {};
 export const RQM_DEFAULT_NOACK = true;
+export const RQM_DEFAULT_PERSISTENT = false;
 export const GRPC_DEFAULT_PROTO_LOADER = '@grpc/proto-loader';
 
 export const NO_MESSAGE_HANDLER = `There is no matching message handler defined in the remote service.`;

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -129,6 +129,7 @@ export interface RmqOptions {
     serializer?: Serializer;
     deserializer?: Deserializer;
     replyQueue?: string;
+    persistent?: boolean;
   };
 }
 


### PR DESCRIPTION
Add the persistent property to RmqOptions so messages do not get lost should the RabbitMQ broker restart.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently when publishing or sending a message to a RabbitMQ queue the messages are not persistent, so when the RabbitMQ broker is restarted the unprocessed messages in the queue are lost.

## What is the new behavior?

A property is available within the `RmqOptions` to allow the persistence to be toggled.  The default value is set to false which is the current working behaviour to prevent a breaking change.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```