### PR TITLE
fix(common): expectedType get overriden by metatype

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -70,7 +70,7 @@ export class ValidationPipe implements PipeTransform<any> {
 
   public async transform(value: any, metadata: ArgumentMetadata) {
     const metatype = this.expectedType || metadata.metatype;
-    if (!metatype || !this.toValidate(metadata)) {
+    if (!metatype || !this.toValidate({ ...metadata, metatype })) {
       return this.isTransformEnabled
         ? this.transformPrimitive(value, metadata)
         : value;

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -10,7 +10,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { HttpStatus } from '../../enums';
-import { BadRequestException, UnprocessableEntityException } from '../../exceptions';
+import { UnprocessableEntityException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ValidationPipe } from '../../pipes/validation.pipe';
 chai.use(chaiAsPromised);

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -403,7 +403,7 @@ describe('ValidationPipe', () => {
       public prop1: string;
 
       @IsBoolean()
-      public prop2: string;
+      public prop2: boolean;
 
       @IsOptional()
       @IsString()
@@ -418,9 +418,9 @@ describe('ValidationPipe', () => {
       };
 
       target = new ValidationPipe({ expectedType: TestModel });
-      const testObj = { prop1: 'value1', prop2: 1 };
+      const testObj = { prop1: 'value1', prop2: 'value2' };
 
-      await expect(target.transform(testObj, m)).rejectedWith(BadRequestException);
+      expect(await target.transform(testObj, m)).to.equal(testObj);
     });
 
     it('should validate against the expected type if presented and metatype is primitive type', async () => {
@@ -431,9 +431,9 @@ describe('ValidationPipe', () => {
       };
 
       target = new ValidationPipe({ expectedType: TestModel });
-      const testObj = { prop1: 'value1', prop2: 1 };
+      const testObj = { prop1: 'value1', prop2: 'value2' };
 
-      await expect(target.transform(testObj, m)).rejectedWith(BadRequestException);
+      expect(await target.transform(testObj, m)).to.equal(testObj);
     });
   });
 });

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -10,7 +10,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { HttpStatus } from '../../enums';
-import { UnprocessableEntityException } from '../../exceptions';
+import { BadRequestException, UnprocessableEntityException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ValidationPipe } from '../../pipes/validation.pipe';
 chai.use(chaiAsPromised);
@@ -418,9 +418,22 @@ describe('ValidationPipe', () => {
       };
 
       target = new ValidationPipe({ expectedType: TestModel });
-      const testObj = { prop1: 'value1', prop2: 'value2' };
+      const testObj = { prop1: 'value1', prop2: 1 };
 
-      expect(await target.transform(testObj, m)).to.equal(testObj);
+      await expect(target.transform(testObj, m)).rejectedWith(BadRequestException);
+    });
+
+    it('should validate against the expected type if presented and metatype is primitive type', async () => {
+      const m: ArgumentMetadata = {
+        type: 'body',
+        metatype: String,
+        data: '',
+      };
+
+      target = new ValidationPipe({ expectedType: TestModel });
+      const testObj = { prop1: 'value1', prop2: 1 };
+
+      await expect(target.transform(testObj, m)).rejectedWith(BadRequestException);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `expectedType`  ignored and we use `metatype` instead.

Issue Number: N/A


## What is the new behavior?
Send the correct value to the `toValidate` method.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
n/a