### PR TITLE
fix(): use class reference as injection token

### DIFF
--- a/packages/common/decorators/core/inject.decorator.ts
+++ b/packages/common/decorators/core/inject.decorator.ts
@@ -2,7 +2,7 @@ import {
   PROPERTY_DEPS_METADATA,
   SELF_DECLARED_DEPS_METADATA,
 } from '../../constants';
-import { isFunction, isUndefined } from '../../utils/shared.utils';
+import { isUndefined } from '../../utils/shared.utils';
 
 /**
  * Decorator that marks a constructor parameter as a target for
@@ -35,9 +35,7 @@ import { isFunction, isUndefined } from '../../utils/shared.utils';
  */
 export function Inject<T = any>(token?: T) {
   return (target: object, key: string | symbol, index?: number) => {
-    token = token || Reflect.getMetadata('design:type', target, key);
-    const type =
-      token && isFunction(token) ? ((token as any) as Function).name : token;
+    const type = token || Reflect.getMetadata('design:type', target, key);
 
     if (!isUndefined(index)) {
       let dependencies =

--- a/packages/common/test/decorators/inject.decorator.spec.ts
+++ b/packages/common/test/decorators/inject.decorator.spec.ts
@@ -16,7 +16,7 @@ describe('@Inject', () => {
     const metadata = Reflect.getMetadata(SELF_DECLARED_DEPS_METADATA, Test);
 
     const expectedMetadata = [
-      { index: 2, param: opaqueToken.name },
+      { index: 2, param: opaqueToken },
       { index: 1, param: 'test2' },
       { index: 0, param: 'test' },
     ];

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -9,7 +9,6 @@ import { Controller } from '@nestjs/common/interfaces/controllers/controller.int
 import { Injectable } from '@nestjs/common/interfaces/injectable.interface';
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import {
-  isFunction,
   isNil,
   isObject,
   isString,
@@ -54,9 +53,9 @@ export interface InjectorDependencyContext {
    */
   key?: string | symbol;
   /**
-   * The name of the function or injection token
+   * The function itself, the name of the function, or injection token.
    */
-  name?: string | symbol;
+  name?: Function | string | symbol;
   /**
    * The index of the dependency which gets injected
    * from the dependencies array
@@ -322,7 +321,7 @@ export class Injector {
     const token = this.resolveParamToken(wrapper, param);
     return this.resolveComponentInstance<T>(
       moduleRef,
-      isFunction(token) ? (token as Type<any>).name : token,
+      token,
       dependencyContext,
       wrapper,
       contextId,
@@ -412,7 +411,7 @@ export class Injector {
   }
 
   public async lookupComponent<T = any>(
-    providers: Map<string | symbol, InstanceWrapper>,
+    providers: Map<Function | string | symbol, InstanceWrapper>,
     moduleRef: Module,
     dependencyContext: InjectorDependencyContext,
     wrapper: InstanceWrapper<T>,
@@ -557,7 +556,7 @@ export class Injector {
         try {
           const dependencyContext = {
             key: item.key,
-            name: item.name as string,
+            name: item.name as Function | string | symbol,
           };
           if (this.isInquirer(item.name, parentInquirer)) {
             return parentInquirer && parentInquirer.instance;

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -44,20 +44,20 @@ describe('Injector', () => {
         isResolved: false,
       });
       depOne = new InstanceWrapper({
-        name: 'DependencyOne',
+        name: DependencyOne,
         metatype: DependencyOne,
         instance: Object.create(DependencyOne.prototype),
         isResolved: false,
       });
       depTwo = new InstanceWrapper({
-        name: 'DependencyTwo',
+        name: DependencyTwo,
         metatype: DependencyTwo,
         instance: Object.create(DependencyOne.prototype),
         isResolved: false,
       });
       moduleDeps.providers.set('MainTest', mainTest);
-      moduleDeps.providers.set('DependencyOne', depOne);
-      moduleDeps.providers.set('DependencyTwo', depTwo);
+      moduleDeps.providers.set(DependencyOne, depOne);
+      moduleDeps.providers.set(DependencyTwo, depTwo);
       moduleDeps.providers.set('MainTestResolved', {
         ...mainTest,
         isResolved: true,
@@ -616,6 +616,7 @@ describe('Injector', () => {
       });
     });
   });
+
   describe('applyProperties', () => {
     describe('when instance is not an object', () => {
       it('should return undefined', () => {


### PR DESCRIPTION
For class providers use a class reference instead of a class name as an injection token to address dependency injection conflicts when two classes share the same name.

resolve #5591

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5591


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Not sure
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A