### PR TITLE
fix(platform-fastify): adds missing chaining API types for LightMyRequest inject()

### DIFF
--- a/integration/hello-world/e2e/fastify-adapter.spec.ts
+++ b/integration/hello-world/e2e/fastify-adapter.spec.ts
@@ -63,6 +63,14 @@ describe('Hello world (fastify adapter)', () => {
       });
   });
 
+  it(`/GET inject with LightMyRequest chaining API`, () => {
+    return app
+      .inject()
+      .get('/hello')
+      .end()
+      .then(({ payload }) => expect(payload).to.be.eql('Hello world!'));
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -191,7 +191,7 @@ export class FastifyAdapter<
   }
 
   public inject(opts?: InjectOptions | string) {
-    return (opts) ? this.instance.inject(opts) : this.instance.inject();
+    return this.instance.inject(opts);
   }
 
   public async close() {

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -190,8 +190,8 @@ export class FastifyAdapter<
     return this.instance.register(plugin, opts);
   }
 
-  public async inject(opts: InjectOptions | string) {
-    return await this.instance.inject(opts);
+  public inject(opts?: InjectOptions | string) {
+    return (opts) ? this.instance.inject(opts) : this.instance.inject();
   }
 
   public async close() {

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -7,6 +7,7 @@ import {
 import {
   InjectOptions,
   Response as LightMyRequestResponse,
+  Chain as LightMyRequestChain,
 } from 'light-my-request';
 import { FastifyStaticOptions, PointOfViewOptions } from './external';
 
@@ -42,6 +43,7 @@ export interface NestFastifyApplication extends INestApplication {
    * A wrapper function around native `fastify.inject()` method.
    * @returns {void}
    */
+  inject(): LightMyRequestChain;
   inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
 
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
If we currently use inject() from LightMyRequest to test the application we need to call it like this:
```
const response = await app.inject({ method: 'POST', url: '/login', payload: loginPayload });
```
If we try to use the chaining API we are getting TypeScript errors like `TS2554: Expected 1 arguments, but got 0.` because of missing types.

## What is the new behavior?
With the chaining API (https://github.com/fastify/light-my-request#method-chaining) we can also call it in a fluent style like this:
```
const response = await app.inject().post('/login').payload(loginPayload).end()
```
Types for this were missing, this PR adds the missing types to be able to use the chaining API. It also allows a usage which is more in line with other testing libraries like e.g. supertest.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information