### PR TITLE
refactor(common): change names of createBody arguments

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -67,14 +67,15 @@ export class HttpException extends Error {
 
   public static createBody(
     objectOrError: object | string,
-    message?: string,
+    description?: string,
     statusCode?: number,
   ) {
     if (!objectOrError) {
-      return { statusCode, message };
+      return { statusCode, message: description };
     }
     return isObject(objectOrError) && !Array.isArray(objectOrError)
       ? objectOrError
-      : { statusCode, message: objectOrError, error: message };
+      : { statusCode, message: objectOrError, error: description };
   }
 }
+


### PR DESCRIPTION
#5098 People relying on the message being the error and the error being the message will
see that behavior changing and this may cause some issues in their error handling. PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, while using the `createBody` static method from the `HttpException`, if the `objecOrtError` argument is not an object, then the returned object uses the `objectOrError` value in order to fill the `message` property value, and the `message` value for the `error` property value.

This feels very strange, as the signature of the method seems to not match the returned object. This behavior expands to all the Exceptions that rely on the `HttpException` class.

## What is the new behavior?
The changes provide consistency and modify the `createBody` static method to assign the correct signature arguments to its properties in the returned object.

## Does this PR introduce a breaking change?
- [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

People relying on the message being the error and the error being the message will
see that behavior changing and this may cause some issues in their error handling.

## Other information