### PR TITLE
Feat/microservice deserialize error

### DIFF
--- a/integration/microservices/e2e/sum-rpc.spec.ts
+++ b/integration/microservices/e2e/sum-rpc.spec.ts
@@ -105,6 +105,22 @@ describe('RPC transport', () => {
       });
   });
 
+  it('/POST (custom client)', () => {
+    return request(server)
+      .post('/error?client=custom')
+      .send({})
+      .expect(200)
+      .expect('true');
+  });
+
+  it('/POST (standard client)', () => {
+    return request(server)
+      .post('/error?client=standard')
+      .send({})
+      .expect(200)
+      .expect('false');
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/integration/microservices/src/app.module.ts
+++ b/integration/microservices/src/app.module.ts
@@ -5,7 +5,15 @@ import {
   Transport,
   ClientsModuleOptionsFactory,
   ClientOptions,
+  ClientTCP,
+  RpcException,
 } from '@nestjs/microservices';
+
+class ErrorHandlingProxy extends ClientTCP {
+  serializeError(err) {
+    return new RpcException(err);
+  }
+}
 
 @Injectable()
 class ConfigService {
@@ -51,7 +59,14 @@ class ClientOptionService implements ClientsModuleOptionsFactory {
         name: 'USE_CLASS_CLIENT',
         useClass: ClientOptionService,
         inject: [ConfigService],
-      },
+      }, {
+        imports: [ConfigModule],
+        inject: [ConfigService],
+        name: 'CUSTOM_PROXY_CLIENT',
+        useFactory: (config: ConfigService) => ({
+          customClass: ErrorHandlingProxy
+        })
+      }
     ]),
   ],
   controllers: [AppController],

--- a/packages/microservices/client/client-proxy-factory.ts
+++ b/packages/microservices/client/client-proxy-factory.ts
@@ -1,6 +1,7 @@
 import { Transport } from '../enums/transport.enum';
 import {
   ClientOptions,
+  CustomClientOptions,
   TcpClientOptions,
 } from '../interfaces/client-metadata.interface';
 import { Closeable } from '../interfaces/closeable.interface';
@@ -30,7 +31,16 @@ export class ClientProxyFactory {
     clientOptions: { transport: Transport.GRPC } & ClientOptions,
   ): ClientGrpcProxy;
   public static create(clientOptions: ClientOptions): ClientProxy & Closeable;
-  public static create(clientOptions: ClientOptions): ClientProxy & Closeable {
+  public static create(
+    clientOptions: CustomClientOptions,
+  ): ClientProxy & Closeable;
+  public static create(
+    clientOptions: ClientOptions | CustomClientOptions,
+  ): ClientProxy & Closeable {
+    if (this.isCustomOptions(clientOptions)) {
+      const { customClass, options } = clientOptions;
+      return new customClass(options);
+    }
     const { transport, options } = clientOptions;
     switch (transport) {
       case Transport.REDIS:
@@ -48,5 +58,11 @@ export class ClientProxyFactory {
       default:
         return new ClientTCP(options as TcpClientOptions['options']);
     }
+  }
+
+  private static isCustomOptions(
+    options: ClientOptions | CustomClientOptions,
+  ): options is CustomClientOptions {
+    return !!(options as CustomClientOptions).customClass;
   }
 }

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -84,15 +84,23 @@ export abstract class ClientProxy {
   ): (packet: WritePacket) => void {
     return ({ err, response, isDisposed }: WritePacket) => {
       if (err) {
-        return observer.error(err);
+        return observer.error(this.serializeError(err));
       } else if (response !== undefined && isDisposed) {
-        observer.next(response);
+        observer.next(this.serializeResponse(response));
         return observer.complete();
       } else if (isDisposed) {
         return observer.complete();
       }
-      observer.next(response);
+      observer.next(this.serializeResponse(response));
     };
+  }
+
+  protected serializeError(err: any): any {
+    return err;
+  }
+
+  protected serializeResponse(response: any): any {
+    return response;
   }
 
   protected assignPacketId(packet: ReadPacket): ReadPacket & PacketId {

--- a/packages/microservices/interfaces/client-metadata.interface.ts
+++ b/packages/microservices/interfaces/client-metadata.interface.ts
@@ -1,3 +1,5 @@
+import { Type } from '@nestjs/common';
+import { ClientProxy } from '../client';
 import { Transport } from '../enums/transport.enum';
 import { Deserializer } from './deserializer.interface';
 import {
@@ -18,6 +20,11 @@ export type ClientOptions =
   | KafkaOptions
   | TcpClientOptions
   | RmqOptions;
+
+export interface CustomClientOptions {
+  customClass: Type<ClientProxy>;
+  options?: Record<string, any>;
+}
 
 export interface TcpClientOptions {
   transport: Transport.TCP;

--- a/packages/microservices/module/interfaces/clients-module.interface.ts
+++ b/packages/microservices/module/interfaces/clients-module.interface.ts
@@ -1,21 +1,23 @@
-import { ClientOptions } from '../../interfaces';
+import { ClientOptions, CustomClientOptions } from '../../interfaces';
 import { Type, Provider, ModuleMetadata } from '@nestjs/common/interfaces';
 
-export type ClientProviderOptions = ClientOptions & {
+export type ClientProvider = ClientOptions | CustomClientOptions;
+
+export type ClientProviderOptions = ClientProvider & {
   name: string | symbol;
 };
 
 export type ClientsModuleOptions = Array<ClientProviderOptions>;
 
 export interface ClientsModuleOptionsFactory {
-  createClientOptions(): Promise<ClientOptions> | ClientOptions;
+  createClientOptions(): Promise<ClientProvider> | ClientProvider;
 }
 
 export interface ClientsProviderAsyncOptions
   extends Pick<ModuleMetadata, 'imports'> {
   useExisting?: Type<ClientsModuleOptionsFactory>;
   useClass?: Type<ClientsModuleOptionsFactory>;
-  useFactory?: (...args: any[]) => Promise<ClientOptions> | ClientOptions;
+  useFactory?: (...args: any[]) => Promise<ClientProvider> | ClientProvider;
   inject?: any[];
   extraProviders?: Provider[];
   name: string | symbol;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, it isn't possible to use a customized `ClientProxy` class with the `ClientsModule`. This means that all errors coming back into the server are not able to be serialized, except for manually doing so on each call, which is cumbersome and a huge overhead.
Issue Number: Fix #5694 


## What is the new behavior?

There is a new option that can be passed to `ClientsModule.register/Async()` where a `customClass` can be passed in and used instead of one of the standard Nest classes. This `customClass` should `extends ClientProxy` at the very least, but it should more likely `extends Client<Transport>` instead, to get a better hold on what the class should do. There's also two new methods `serializeError` and `serializeData` that are `protected` so they can be overwritten by child classes. This will allow for a better DX by being able to implement custom serialization logic once.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information