### PR TITLE
fix: Ack never called when no data sent

### DIFF
--- a/integration/websockets/e2e/gateway-ack.spec.ts
+++ b/integration/websockets/e2e/gateway-ack.spec.ts
@@ -28,5 +28,18 @@ describe('WebSocketGateway (ack)', () => {
     );
   });
 
+  it(`should handle message with ack & without data (http)`, async () => {
+    app = await createNestApp(AckGateway);
+    await app.listenAsync(3000);
+
+    ws = io.connect('http://localhost:8080');
+    await new Promise(resolve =>
+      ws.emit('push', data => {
+        expect(data).to.be.eql('pong');
+        resolve();
+      }),
+    );
+  });
+
   afterEach(() => app.close());
 });

--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -63,6 +63,9 @@ export class IoAdapter extends AbstractWsAdapter {
 
   public mapPayload(payload: any): { data: any; ack?: Function } {
     if (!Array.isArray(payload)) {
+      if (isFunction(payload)) {
+        return { data: undefined, ack: payload };
+      }
       return { data: payload };
     }
     const lastElement = payload[payload.length - 1];


### PR DESCRIPTION
Ack method is never called when no data sent to the event.
https://github.com/nestjs/nest/issues/5711

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
https://github.com/nestjs/nest/issues/5711

Issue Number: 5711


## What is the new behavior?
Ack method is called even if no data sent to the event.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information