### PR TITLE
Added missing options to for NATS client to use jwt

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -114,6 +114,9 @@ export interface NatsOptions {
     queue?: string;
     serializer?: Serializer;
     deserializer?: Deserializer;
+    userJWT?: string;
+    nonceSigner?: any;
+    userCreds?: any;
   };
 }
 


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the jwt feature of NATS microservice can be used only on responder part (configured through main.ts) although the nestjs nats docs says oterwise.

Issue Number: #4356 


## What is the new behavior?
By adding missing options the client (requester) can use jwt too.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Tracking [StackOverflow issue](https://stackoverflow.com/questions/64898076/jwt-auth-for-nats-in-nestjs)