### PR TITLE
fix(microservices): handle rmq queue deletion

### DIFF
--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -1,4 +1,8 @@
-import { isString, isUndefined } from '@nestjs/common/utils/shared.utils';
+import {
+  isNil,
+  isString,
+  isUndefined,
+} from '@nestjs/common/utils/shared.utils';
 import { Observable } from 'rxjs';
 import {
   CONNECT_EVENT,
@@ -111,6 +115,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     message: Record<string, any>,
     channel: any,
   ): Promise<void> {
+    if (isNil(message)) {
+      return;
+    }
     const { content, properties } = message;
     const rawMessage = JSON.parse(content.toString());
     const packet = this.deserializer.deserialize(rawMessage);


### PR DESCRIPTION
A null message is passed to callback when RabbitMQ queue is deleted.

Fixes #5683

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
An exception is thrown and RMQ microservice is broken for the rest of the app's lifetime. See more details on the issue.

Issue Number: #5683

## What is the new behavior?

`null` message passed to callback is ignored. This part is my code fix.

Subsequently, the RMQ channel will be closed by the broker server and then rest of the existing functionality kicks in where the RMQ microservice setup is re-trigerred and it ends up in declaring the deleted queue again so microservice recovers from this failure.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information