### PR TITLE
fix(application): makes get-url work in callback

### DIFF
--- a/integration/nest-application/get-url/e2e/express.spec.ts
+++ b/integration/nest-application/get-url/e2e/express.spec.ts
@@ -37,6 +37,13 @@ describe('Get URL (Express Application)', () => {
     expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
     await app.close();
   });
+  it('should return 127.0.0.1 even in a callback', () => {
+    const app = testModule.createNestApplication(new ExpressAdapter(express()));
+    return app.listen(port, async () => {
+      expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
+      await app.close();
+    });
+  });
   it('should throw an error for calling getUrl before listen', async () => {
     const app = testModule.createNestApplication(new ExpressAdapter(express()));
     try {

--- a/integration/nest-application/get-url/e2e/fastify.spec.ts
+++ b/integration/nest-application/get-url/e2e/fastify.spec.ts
@@ -30,6 +30,13 @@ describe('Get URL (Fastify Application)', () => {
     expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
     await app.close();
   });
+  it('should return 127.0.0.1 even in a callback', () => {
+    const app = testModule.createNestApplication(new FastifyAdapter());
+    return app.listen(port, async () => {
+      expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
+      await app.close();
+    });
+  });
   it('should throw an error for calling getUrl before listen', async () => {
     const app = testModule.createNestApplication(new FastifyAdapter());
     try {

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -239,8 +239,8 @@ export class NestApplication
   ): Promise<any>;
   public async listen(port: number | string, ...args: any[]): Promise<any> {
     !this.isInitialized && (await this.init());
-    this.httpAdapter.listen(port, ...args);
     this.isListening = true;
+    this.httpAdapter.listen(port, ...args);
     return this.httpServer;
   }
 


### PR DESCRIPTION
`app.getUrl()` was throwing an error when `this.isListening`
was set to false. The value was set _after_ `this.httpServer.listen`
was called, now it is set _before_ to ensure that the `app.getUrl()`
can be called in the callback of `listen`. A regression test has
been added for this, and all tests related to the change are passing.

fix: #5798

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the callback of `app.listen()`, `await app.getUrl()` cannot be called.

Issue Number: #5798 


## What is the new behavior?

In the callback of `app.listen()`, `await app.getUrl()` can be called

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information