### PR TITLE
feat(core): expose app.locals to express adapter

### DIFF
--- a/integration/nest-application/app-locals/e2e/express.spec.ts
+++ b/integration/nest-application/app-locals/e2e/express.spec.ts
@@ -1,0 +1,38 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test, TestingModule } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('App-level globals (Express Application)', () => {
+  let moduleFixture: TestingModule;
+  let app: NestExpressApplication;
+
+  beforeEach(async () => {
+    moduleFixture = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  });
+
+  beforeEach(() => {
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+  });
+
+  it('should get "title" from "app.locals"', async () => {
+    app.setLocal('title', 'My Website');
+    await app.init();
+    const response = await request(app.getHttpServer()).get('/').expect(200);
+    expect(response.body.title).to.equal('My Website');
+  });
+
+  it('should get "email" from "app.locals"', async () => {
+    app.setLocal('email', 'admin@example.com');
+    await app.listen(4444);
+    const response = await request(app.getHttpServer()).get('/').expect(200);
+    expect(response.body.email).to.equal('admin@example.com');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/integration/nest-application/app-locals/src/app.controller.ts
+++ b/integration/nest-application/app-locals/src/app.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import { Request } from 'express';
+
+@Controller()
+export class AppController {
+  @Get()
+  getGlobals(@Req() req: Request) {
+    return req.app.locals;
+  }
+}

--- a/integration/nest-application/app-locals/src/app.module.ts
+++ b/integration/nest-application/app-locals/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/integration/nest-application/app-locals/tsconfig.json
+++ b/integration/nest-application/app-locals/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -142,6 +142,11 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       .forEach(parserKey => this.use(parserMiddleware[parserKey]));
   }
 
+  public setLocal(key: string, value: any) {
+    this.instance.locals[key] = value;
+    return this;
+  }
+
   public getType(): string {
     return 'express';
   }

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -75,4 +75,16 @@ export interface NestExpressApplication extends INestApplication {
    * @returns {this}
    */
   setViewEngine(engine: string): this;
+
+  /**
+   * Sets app-level globals for view templates
+   *
+   * @example
+   * app.setLocal('title', 'My Site')
+   *
+   * @see https://expressjs.com/en/4x/api.html#app.locals
+   *
+   * @returns {this}
+   */
+  setLocal(key: string, value: any): this;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information

Right now, there is no "convenient" way to set application-wide globals in Express-based application. We have to get the adapter first (`getHttpAdapter()`), get the underlying instance (`getInstance()`), and then set the variables there. With this change, an API has been exposed so that we can directly set them from the `app` instance. The relevant doc can be found here: https://expressjs.com/en/4x/api.html#app.locals.