### PR TITLE
refactor: jsdoc fixes for INestApplication, INestMicroservice, MiddlewareConsumer and MiddlewareConfigProxy

### DIFF
--- a/packages/common/interfaces/middleware/middleware-config-proxy.interface.ts
+++ b/packages/common/interfaces/middleware/middleware-config-proxy.interface.ts
@@ -6,7 +6,7 @@ export interface MiddlewareConfigProxy {
   /**
    * Excludes routes from the currently processed middleware.
    *
-   * @param  {} ...routes
+   * @param {(string | RouteInfo)[]} routes
    * @returns {MiddlewareConfigProxy}
    */
   exclude(...routes: (string | RouteInfo)[]): MiddlewareConfigProxy;
@@ -15,7 +15,7 @@ export interface MiddlewareConfigProxy {
    * Attaches passed either routes or controllers to the currently configured middleware.
    * If you pass a class, Nest would attach middleware to every path defined within this controller.
    *
-   * @param  {} ...routes
+   * @param {(string | Type | RouteInfo)[]} routes
    * @returns {MiddlewareConsumer}
    */
   forRoutes(...routes: (string | Type<any> | RouteInfo)[]): MiddlewareConsumer;

--- a/packages/common/interfaces/middleware/middleware-consumer.interface.ts
+++ b/packages/common/interfaces/middleware/middleware-consumer.interface.ts
@@ -10,7 +10,7 @@ import { MiddlewareConfigProxy } from './middleware-config-proxy.interface';
  */
 export interface MiddlewareConsumer {
   /**
-   * @param  middleware middleware class/function or array of classes/functions
+   * @param {...(Type | Function)} middleware middleware class/function or array of classes/functions
    * to be attached to the passed routes.
    *
    * @returns {MiddlewareConfigProxy}

--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -21,7 +21,7 @@ export interface INestApplication extends INestApplicationContext {
    * A wrapper function around HTTP adapter method: `adapter.use()`.
    * Example `app.use(cors())`
    *
-   * @returns {void}
+   * @returns {this}
    */
   use(...args: any[]): this;
 
@@ -35,10 +35,10 @@ export interface INestApplication extends INestApplicationContext {
   /**
    * Starts the application.
    *
-   * @param  {number} port
-   * @param  {string} hostname
-   * @param  {Function} callback Optional callback
-   * @returns A Promise that, when resolved, is a reference to the underlying HttpServer.
+   * @param {number|string} port
+   * @param {string} [hostname]
+   * @param {Function} [callback] Optional callback
+   * @returns {Promise} A Promise that, when resolved, is a reference to the underlying HttpServer.
    */
   listen(port: number | string, callback?: () => void): Promise<any>;
   listen(
@@ -50,15 +50,15 @@ export interface INestApplication extends INestApplicationContext {
   /**
    * Returns the url the application is listening at, based on OS and IP version. Returns as an IP value either in IPv6 or IPv4
    *
-   * @returns The IP where the server is listening
+   * @returns {Promise<string>} The IP where the server is listening
    */
   getUrl(): Promise<string>;
 
   /**
    * Starts the application (can be awaited).
    *
-   * @param  {number} port
-   * @param  {string} hostname (optional)
+   * @param {number|string} port
+   * @param {string} [hostname]
    * @returns {Promise}
    */
   listenAsync(port: number | string, hostname?: string): Promise<any>;
@@ -66,17 +66,17 @@ export interface INestApplication extends INestApplicationContext {
   /**
    * Registers a prefix for every HTTP route path.
    *
-   * @param  {string} prefix The prefix for every HTTP route path (for example `/v1/api`)
-   * @returns {void}
+   * @param {string} prefix The prefix for every HTTP route path (for example `/v1/api`)
+   * @returns {this}
    */
   setGlobalPrefix(prefix: string): this;
 
   /**
-   * Setup Ws Adapter which will be used inside Gateways.
+   * Register Ws Adapter which will be used inside Gateways.
    * Use when you want to override default `socket.io` library.
    *
-   * @param  {WebSocketAdapter} adapter
-   * @returns {void}
+   * @param {WebSocketAdapter} adapter
+   * @returns {this}
    */
   useWebSocketAdapter(adapter: WebSocketAdapter): this;
 
@@ -84,8 +84,9 @@ export interface INestApplication extends INestApplicationContext {
    * Connects microservice to the NestApplication instance. Transforms application
    * to a hybrid instance.
    *
-   * @param  {T} options Microservice options object
-   * @param  {NestHybridApplicationOptions} hybridOptions Hybrid options object
+   * @template {object} T
+   * @param {T} options Microservice options object
+   * @param {NestHybridApplicationOptions} hybridOptions Hybrid options object
    * @returns {INestMicroservice}
    */
   connectMicroservice<T extends object = any>(
@@ -103,7 +104,7 @@ export interface INestApplication extends INestApplicationContext {
   /**
    * Returns the underlying native HTTP server.
    *
-   * @returns {any}
+   * @returns {*}
    */
   getHttpServer(): any;
 
@@ -117,8 +118,8 @@ export interface INestApplication extends INestApplicationContext {
   /**
    * Starts all connected microservices asynchronously.
    *
-   * @param  {Function} callback Optional callback function
-   * @returns {void}
+   * @param {Function} [callback] Optional callback function
+   * @returns {this}
    */
   startAllMicroservices(callback?: () => void): this;
 
@@ -133,14 +134,14 @@ export interface INestApplication extends INestApplicationContext {
    * Registers exception filters as global filters (will be used within
    * every HTTP route handler)
    *
-   * @param  {ExceptionFilter[]} ...filters
+   * @param {...ExceptionFilter} filters
    */
   useGlobalFilters(...filters: ExceptionFilter[]): this;
 
   /**
    * Registers pipes as global pipes (will be used within every HTTP route handler)
    *
-   * @param  {PipeTransform[]} ...pipes
+   * @param {...PipeTransform} pipes
    */
   useGlobalPipes(...pipes: PipeTransform<any>[]): this;
 
@@ -148,14 +149,14 @@ export interface INestApplication extends INestApplicationContext {
    * Registers interceptors as global interceptors (will be used within
    * every HTTP route handler)
    *
-   * @param  {NestInterceptor[]} ...interceptors
+   * @param {...NestInterceptor} interceptors
    */
   useGlobalInterceptors(...interceptors: NestInterceptor[]): this;
 
   /**
    * Registers guards as global guards (will be used within every HTTP route handler)
    *
-   * @param  {CanActivate[]} ...guards
+   * @param {...CanActivate} guards
    */
   useGlobalGuards(...guards: CanActivate[]): this;
 

--- a/packages/common/interfaces/nest-microservice.interface.ts
+++ b/packages/common/interfaces/nest-microservice.interface.ts
@@ -14,9 +14,8 @@ export interface INestMicroservice extends INestApplicationContext {
   /**
    * Starts the microservice.
    *
-   * @param  {Function} callback
-   * @returns {Promise}
-   *
+   * @param {Function} callback
+   * @returns {void}
    */
   listen(callback: () => void): any;
 
@@ -29,38 +28,38 @@ export interface INestMicroservice extends INestApplicationContext {
 
   /**
    * Register Ws Adapter which will be used inside Gateways.
-   * Use, when you want to override default `socket.io` library.
+   * Use when you want to override default `socket.io` library.
    *
-   * @param  {WebSocketAdapter} adapter
-   * @returns {void}
+   * @param {WebSocketAdapter} adapter
+   * @returns {this}
    */
   useWebSocketAdapter(adapter: WebSocketAdapter): this;
 
   /**
-   * Registers exception filters as a global filters (will be used within every message pattern handler)
+   * Registers exception filters as global filters (will be used within every message pattern handler)
    *
-   * @param  {ExceptionFilter[]} ...filters
+   * @param {...ExceptionFilter} filters
    */
   useGlobalFilters(...filters: ExceptionFilter[]): this;
 
   /**
-   * Registers pipes as a global pipes (will be used within every message pattern handler)
+   * Registers pipes as global pipes (will be used within every message pattern handler)
    *
-   * @param  {PipeTransform[]} ...pipes
+   * @param {...PipeTransform} pipes
    */
   useGlobalPipes(...pipes: PipeTransform<any>[]): this;
 
   /**
-   * Registers interceptors as a global interceptors (will be used within every message pattern handler)
+   * Registers interceptors as global interceptors (will be used within every message pattern handler)
    *
-   * @param  {NestInterceptor[]} ...interceptors
+   * @param {...NestInterceptor} interceptors
    */
   useGlobalInterceptors(...interceptors: NestInterceptor[]): this;
 
   /**
-   * Registers guards as a global guards (will be used within every message pattern handler)
+   * Registers guards as global guards (will be used within every message pattern handler)
    *
-   * @param  {CanActivate[]} ...guards
+   * @param {...CanActivate} guards
    */
   useGlobalGuards(...guards: CanActivate[]): this;
 


### PR DESCRIPTION
this pr fixes some jsdoc typing in listed interfaces:
- optional parameters (see https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#param-and-returns)
- rest/repeatable parameters (see https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#more-examples and https://jsdoc.app/tags-param.html#multiple-types-and-repeatable-parameters)
- solved some type inconsistencies (type from ts definition put in jsdoc)
- removed double spaces after param keywoard

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information