### PR TITLE
fix(microservices): listen method is void return type

### DIFF
--- a/packages/common/interfaces/nest-microservice.interface.ts
+++ b/packages/common/interfaces/nest-microservice.interface.ts
@@ -18,7 +18,7 @@ export interface INestMicroservice extends INestApplicationContext {
    * @returns {Promise}
    *
    */
-  listen(callback: () => void): any;
+  listen(callback: () => void): void;
 
   /**
    * Starts the microservice (can be awaited).

--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -115,7 +115,7 @@ export class NestMicroservice
     return this;
   }
 
-  public listen(callback: () => void) {
+  public listen(callback: () => void): void {
     this.listenAsync().then(callback);
   }
 

--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -115,7 +115,7 @@ export class NestMicroservice
     return this;
   }
 
-  public listen(callback: () => void): void {
+  public listen(callback: () => void) {
     this.listenAsync().then(callback);
   }
 


### PR DESCRIPTION
state correct return type (void) on the `NestMicroservice.listen` method

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
return type is misleading this is not a breaking-change

## Other information