### PR TITLE
refactor(common): Make LoggerService's instance property and getInstance() method protected to allow sub-classes access to it

### DIFF
--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -114,7 +114,7 @@ export class Logger implements LoggerService {
       );
   }
 
-  private getInstance(): typeof Logger | LoggerService {
+  protected getInstance(): typeof Logger | LoggerService {
     const { instance } = Logger;
     return instance === this ? Logger : instance;
   }

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -25,7 +25,7 @@ export class Logger implements LoggerService {
     'verbose',
   ];
   private static lastTimestamp?: number;
-  private static instance?: typeof Logger | LoggerService = Logger;
+  protected static instance?: typeof Logger | LoggerService = Logger;
 
   constructor(
     @Optional() protected context?: string,


### PR DESCRIPTION
Make static property `instance`and static method `getInstance()` protected so derived classes get access to the overriden logger instance

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Nest's Logger Class enables the app to override the Logger class by re-setting a static property named instance, which holds the logging instance (e.g. a winston logger instance). The static property is private by default. The access via `getInstance()` method to this instance property is also private which prevents any derived logger class to access it. 

Issue Number: N/A


## What is the new behavior?
Both the static property and the static method are changed to protected so that any sub-class of the logger can access the logger instance (e.g. to tweak the instance or create child logger etc.)

## Does this PR introduce a breaking change?
```
[ ] Yes
[ X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information