### PR TITLE
fix: iisnode uses pipe name instead of port number

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -59,12 +59,8 @@ type FastifyHttpsOptions<
 
 export class FastifyAdapter<
   TServer extends RawServerBase = RawServerDefault,
-  TRawRequest extends RawRequestDefaultExpression<
-    TServer
-  > = RawRequestDefaultExpression<TServer>,
-  TRawResponse extends RawReplyDefaultExpression<
-    TServer
-  > = RawReplyDefaultExpression<TServer>
+  TRawRequest extends RawRequestDefaultExpression<TServer> = RawRequestDefaultExpression<TServer>,
+  TRawResponse extends RawReplyDefaultExpression<TServer> = RawReplyDefaultExpression<TServer>
 > extends AbstractHttpAdapter<
   TServer,
   FastifyRequest<RequestGenericInterface, TServer, TRawRequest>,
@@ -113,9 +109,6 @@ export class FastifyAdapter<
     callback?: () => void,
   ): void;
   public listen(port: string | number, ...args: any[]): Promise<string> {
-    if (typeof port === 'string') {
-      port = parseInt(port);
-    }
     return this.instance.listen(port, ...args);
   }
 

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -55,16 +55,16 @@ export interface NestFastifyApplication extends INestApplication {
    * @returns A Promise that, when resolved, is a reference to the underlying HttpServer.
    */
   listen(
-    port: number,
+    port: number | string,
     callback?: (err: Error, address: string) => void,
   ): Promise<any>;
   listen(
-    port: number,
+    port: number | string,
     address: string,
     callback?: (err: Error, address: string) => void,
   ): Promise<any>;
   listen(
-    port: number,
+    port: number | string,
     address: string,
     backlog: number,
     callback?: (err: Error, address: string) => void,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Actually, [fastify](https://github.com/fastify/fastify/blob/d044549a20ddb4324f6f76c9d7f9032807cbff93/types/instance.d.ts#L50) uses port as `number | string` but we are using `parseInt(port)` to convert port to `number`. Unfortunately, Azure App service uses `pipe` name as port and it's a string (`\\.\pipe\d226d7b0-64a0-4d04-96d4-a75e1278b7a9`).

Some references:
https://richiban.uk/2019/01/09/gotchas-getting-next-js-to-run-in-azure-app-services/
http://tostring.it/2014/07/09/nodejs-azure-and-iis/, 

Issue Number: N/A


## What is the new behavior?
Should keep port is number or string

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information