### PR TITLE
feat(common): specify parent property for validation of nested objects

### DIFF
--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -8,6 +8,7 @@ import {
   IsOptional,
   IsString,
   ValidateNested,
+  IsArray,
 } from 'class-validator';
 import { HttpStatus } from '../../enums';
 import { UnprocessableEntityException } from '../../exceptions';
@@ -153,6 +154,32 @@ describe('ValidationPipe', () => {
             'prop must be a string',
             'test.prop1 must be a string',
             'test.prop2 must be a boolean value',
+          ]);
+        }
+      });
+
+      class TestModelForNestedArrayValidation {
+        @IsString()
+        public prop: string;
+
+        @IsArray()
+        @ValidateNested()
+        @Type(() => TestModel2)
+        public test: TestModel2[];
+      }
+      it('should provide complete path for nested errors', async () => {
+        try {
+          const model = new TestModelForNestedArrayValidation();
+          model.test = [new TestModel2()];
+          await target.transform(model, {
+            type: 'body',
+            metatype: TestModelForNestedArrayValidation,
+          });
+        } catch (err) {
+          expect(err.getResponse().message).to.be.eql([
+            'prop must be a string',
+            'test.0.prop1 must be a string',
+            'test.0.prop2 must be a boolean value',
           ]);
         }
       });


### PR DESCRIPTION
Passed the complete path of the parent property as an argument. Earlier, the information regarding the parent was getting lost due to flattening of array in case of validation of nested objects.

Closes #5380

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #5380 


## What is the new behavior?
Passed the complete path of the parent property as an argument. Earlier, the information regarding the parent was getting lost due to flattening of array in case of validation of nested objects.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information