### PR TITLE
refactor(platform-express): expose Multer file type

### DIFF
--- a/packages/platform-express/multer/interfaces/multer-options.interface.ts
+++ b/packages/platform-express/multer/interfaces/multer-options.interface.ts
@@ -1,6 +1,27 @@
 /**
  * @see https://github.com/expressjs/multer
  */
+
+ export interface MulterFile {
+    /** Field name specified in the form */
+    fieldname: string;
+    /** Name of the file on the user's computer */
+    originalname: string;
+    /** Encoding type of the file */
+    encoding: string;
+    /** Mime type of the file */
+    mimetype: string;
+    /** Size of the file in bytes */
+    size: number;
+    /** The folder to which the file has been saved (DiskStorage) */
+    destination: string;
+    /** The name of the file within the destination (DiskStorage) */
+    filename: string;
+    /** Location of the uploaded file (DiskStorage) */
+    path: string;
+    /** A Buffer of the entire file (MemoryStorage) */
+    buffer: Buffer;
+ }
 export interface MulterOptions {
   dest?: string;
   /** The storage engine to use for uploaded files. */
@@ -31,26 +52,7 @@ export interface MulterOptions {
 
   fileFilter?(
     req: any,
-    file: {
-      /** Field name specified in the form */
-      fieldname: string;
-      /** Name of the file on the user's computer */
-      originalname: string;
-      /** Encoding type of the file */
-      encoding: string;
-      /** Mime type of the file */
-      mimetype: string;
-      /** Size of the file in bytes */
-      size: number;
-      /** The folder to which the file has been saved (DiskStorage) */
-      destination: string;
-      /** The name of the file within the destination (DiskStorage) */
-      filename: string;
-      /** Location of the uploaded file (DiskStorage) */
-      path: string;
-      /** A Buffer of the entire file (MemoryStorage) */
-      buffer: Buffer;
-    },
+    file: MulterFile,
     callback: (error: Error | null, acceptFile: boolean) => void,
   ): void;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The issue is that when trying to use `Multer`, we have no access to the type of Multer file therefore we have to use `any` or something like `Parameters<MulterOptions['fileFilter']>['1']` which's pretty unreadable. 

## What is the new behavior?
Type of file object is extracted into a type named `MulterType` and exported directly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```