### PR TITLE
feat(websockets): messagebody param extract

### DIFF
--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -39,9 +39,7 @@ export interface WsHandlerMetadata {
 export class WsContextCreator {
   private readonly contextUtils = new ContextUtils();
   private readonly wsParamsFactory = new WsParamsFactory();
-  private readonly handlerMetadataStorage = new HandlerMetadataStorage<
-    WsHandlerMetadata
-  >();
+  private readonly handlerMetadataStorage = new HandlerMetadataStorage<WsHandlerMetadata>();
 
   constructor(
     private readonly wsProxy: WsProxy,
@@ -223,7 +221,7 @@ export class WsContextCreator {
       }
       const numericType = Number(type);
       const extractValue = (...args: any[]) =>
-        paramsFactory.exchangeKeyForValue(numericType, args);
+        paramsFactory.exchangeKeyForValue(numericType, data, args);
 
       return { index, extractValue, type: numericType, data, pipes };
     });

--- a/packages/websockets/decorators/message-body.decorator.ts
+++ b/packages/websockets/decorators/message-body.decorator.ts
@@ -2,12 +2,59 @@ import { PipeTransform, Type } from '@nestjs/common';
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 import { createPipesWsParamDecorator } from '../utils/param.utils';
 
+/**
+ * Websockets message body parameter decorator.
+ *
+ * @publicApi
+ */
 export function MessageBody(): ParameterDecorator;
+/**
+ * Websockets message body parameter decorator.
+ *
+ * Example:
+ * ```typescript
+ * queryDb(@MessageBody(new ValidationPipe()) dto: DTO)
+ * ```
+ * @param pipes one or more pipes - either instances or classes - to apply to
+ * the bound parameter.
+ *
+ * @publicApi
+ */
 export function MessageBody(
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator;
+/**
+ * Websockets message body parameter decorator. Extracts a property from the
+ * message body object and populates the decorated parameter with the value of `body`.
+ * May also apply pipes to the bound parameter.
+ *
+ * For example, extracting all params:
+ * ```typescript
+ * findMany(@MessageBody() ids: string[])
+ * ```
+ *
+ * For example, extracting a single param:
+ * ```typescript
+ * queryDb(@MessageBody('data') dto: { data: string })
+ * ```
+ *
+ * For example, extracting a single param with pipe:
+ * ```typescript
+ * queryDb(@MessageBody('data', new ValidationPipe()) dto: { data: string })
+ * ```
+ * @param property name of single property to extract from the `req` object
+ * @param pipes one or more pipes - either instances or classes - to apply to
+ * the bound parameter.
+ *
+ * @publicApi
+ */
 export function MessageBody(
+  property: string,
+  ...pipes: (Type<PipeTransform> | PipeTransform)[]
+): ParameterDecorator;
+export function MessageBody(
+  property?: string | (Type<PipeTransform> | PipeTransform),
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator {
-  return createPipesWsParamDecorator(WsParamtype.PAYLOAD)(...pipes);
+  return createPipesWsParamDecorator(WsParamtype.PAYLOAD)(property, ...pipes);
 }

--- a/packages/websockets/factories/ws-params-factory.ts
+++ b/packages/websockets/factories/ws-params-factory.ts
@@ -1,7 +1,7 @@
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 
 export class WsParamsFactory {
-  public exchangeKeyForValue(type: number, args: unknown[]) {
+  public exchangeKeyForValue(type: number, data: string, args: unknown[]) {
     if (!args) {
       return null;
     }
@@ -9,7 +9,7 @@ export class WsParamsFactory {
       case WsParamtype.SOCKET:
         return args[0];
       case WsParamtype.PAYLOAD:
-        return args[1];
+        return data ? args[1][data] : args[1];
       default:
         return null;
     }

--- a/packages/websockets/test/factories/ws-params-factory.spec.ts
+++ b/packages/websockets/test/factories/ws-params-factory.spec.ts
@@ -16,26 +16,31 @@ describe('WsParamsFactory', () => {
       describe(`WsParamtype.PAYLOAD`, () => {
         it('should return a message payload object', () => {
           expect(
-            factory.exchangeKeyForValue(WsParamtype.PAYLOAD, args),
+            factory.exchangeKeyForValue(WsParamtype.PAYLOAD, null, args),
           ).to.be.eql(data);
+        });
+        it('should return a message payload object with parameter extraction', () => {
+          expect(
+            factory.exchangeKeyForValue(WsParamtype.PAYLOAD, 'data', args),
+          ).to.be.eql(data.data);
         });
       });
       describe(`WsParamtype.SOCKET`, () => {
         it('should return a connected socket object', () => {
           expect(
-            factory.exchangeKeyForValue(WsParamtype.SOCKET, args),
+            factory.exchangeKeyForValue(WsParamtype.SOCKET, null, args),
           ).to.be.eql(client);
         });
       });
     });
     describe('when key is not available', () => {
       it('should return null', () => {
-        expect(factory.exchangeKeyForValue(-1, [])).to.be.eql(null);
+        expect(factory.exchangeKeyForValue(-1, null, [])).to.be.eql(null);
       });
     });
     describe('when args are not available', () => {
       it('should return null', () => {
-        expect(factory.exchangeKeyForValue(null, null)).to.be.eql(null);
+        expect(factory.exchangeKeyForValue(null, null, null)).to.be.eql(null);
       });
     });
   });

--- a/packages/websockets/utils/param.utils.ts
+++ b/packages/websockets/utils/param.utils.ts
@@ -1,5 +1,6 @@
 import { PipeTransform, Type } from '@nestjs/common';
 import { assignMetadata } from '@nestjs/common/decorators/http/route-params.decorator';
+import { isNil, isString } from '@nestjs/common/utils/shared.utils';
 import 'reflect-metadata';
 import { PARAM_ARGS_METADATA } from '../constants';
 import { WsParamtype } from '../enums/ws-paramtype.enum';
@@ -24,14 +25,18 @@ export function createWsParamDecorator(
 }
 
 export const createPipesWsParamDecorator = (paramtype: WsParamtype) => (
+  data?: any,
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator => (target, key, index) => {
   const args =
     Reflect.getMetadata(PARAM_ARGS_METADATA, target.constructor, key) || {};
+  const hasParamData = isNil(data) || isString(data);
+  const paramData = hasParamData ? data : undefined;
+  const paramPipes = hasParamData ? pipes : [data, ...pipes];
 
   Reflect.defineMetadata(
     PARAM_ARGS_METADATA,
-    assignMetadata(args, paramtype, index, undefined, ...pipes),
+    assignMetadata(args, paramtype, index, paramData, ...paramPipes),
     target.constructor,
     key,
   );


### PR DESCRIPTION
Add the ability to extract a paramater from the websocket's `MessageBody` decorator.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

(My first time creating a PR here, might need some guidance on updating documentation.)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `MessageBody` websockets decorator cannot extract an object property from the body of the payload.

Issue Number: N/A

## What is the new behavior?

The `MessageBody` decorator can extract an object property like so:

```typescript
subMessage(@MessageBody('data') payload: { data: string }) {}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

### Motivation

Some applications will benefit from this feature as it makes using pipes much more simple and effective. if you spread your body object properties across many function parameters.