### PR TITLE
feat(): accept array of host filters

### DIFF
--- a/integration/hello-world/e2e/fastify-adapter.spec.ts
+++ b/integration/hello-world/e2e/fastify-adapter.spec.ts
@@ -63,6 +63,22 @@ describe('Hello world (fastify adapter)', () => {
       });
   });
 
+  it(`/GET { host: [":tenant.example1.com", ":tenant.example2.com"] } not matched`, () => {
+    return app
+      .inject({
+        method: 'GET',
+        url: '/host-array',
+      })
+      .then(({ payload }) => {
+        expect(JSON.parse(payload)).to.be.eql({
+          error: 'Internal Server Error',
+          message:
+            'HTTP adapter does not support filtering on hosts: [":tenant.example1.com", ":tenant.example2.com"]',
+          statusCode: 500,
+        });
+      });
+  });
+
   it(`/GET inject with LightMyRequest chaining API`, () => {
     return app
       .inject()

--- a/integration/hello-world/e2e/hello-world.spec.ts
+++ b/integration/hello-world/e2e/hello-world.spec.ts
@@ -28,6 +28,16 @@ describe('Hello world (default adapter)', () => {
       path: '/host',
       greeting: 'Host Greeting! tenant=acme',
     },
+    {
+      host: 'acme.example1.com',
+      path: '/host-array',
+      greeting: 'Host Greeting! tenant=acme',
+    },
+    {
+      host: 'acme.example2.com',
+      path: '/host-array',
+      greeting: 'Host Greeting! tenant=acme',
+    },
   ].forEach(({ host, path, greeting }) => {
     describe(`host=${host}`, () => {
       describe('/GET', () => {

--- a/integration/hello-world/src/app.module.ts
+++ b/integration/hello-world/src/app.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { HelloModule } from './hello/hello.module';
+import { HostArrayModule } from './host-array/host-array.module';
 import { HostModule } from './host/host.module';
 
 @Module({
-  imports: [HelloModule, HostModule],
+  imports: [HelloModule, HostModule, HostArrayModule],
 })
 export class ApplicationModule {}

--- a/integration/hello-world/src/host-array/dto/test.dto.ts
+++ b/integration/hello-world/src/host-array/dto/test.dto.ts
@@ -1,0 +1,10 @@
+import { IsString, IsNotEmpty, IsNumber } from 'class-validator';
+
+export class TestDto {
+  @IsString()
+  @IsNotEmpty()
+  string: string;
+
+  @IsNumber()
+  number: number;
+}

--- a/integration/hello-world/src/host-array/host-array.controller.ts
+++ b/integration/hello-world/src/host-array/host-array.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, Header, HostParam, Param } from '@nestjs/common';
+import { Observable, of } from 'rxjs';
+import { HostArrayService } from './host-array.service';
+import { UserByIdPipe } from './users/user-by-id.pipe';
+
+@Controller({
+  path: 'host-array',
+  host: [':tenant.example1.com', ':tenant.example2.com'],
+})
+export class HostArrayController {
+  constructor(private readonly hostService: HostArrayService) {}
+
+  @Get()
+  @Header('Authorization', 'Bearer')
+  greeting(@HostParam('tenant') tenant: string): string {
+    return `${this.hostService.greeting()} tenant=${tenant}`;
+  }
+
+  @Get('async')
+  async asyncGreeting(@HostParam('tenant') tenant: string): Promise<string> {
+    return `${await this.hostService.greeting()} tenant=${tenant}`;
+  }
+
+  @Get('stream')
+  streamGreeting(@HostParam('tenant') tenant: string): Observable<string> {
+    return of(`${this.hostService.greeting()} tenant=${tenant}`);
+  }
+
+  @Get('local-pipe/:id')
+  localPipe(
+    @Param('id', UserByIdPipe)
+    user: any,
+    @HostParam('tenant') tenant: string,
+  ): any {
+    return { ...user, tenant };
+  }
+}

--- a/integration/hello-world/src/host-array/host-array.module.ts
+++ b/integration/hello-world/src/host-array/host-array.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HostArrayController } from './host-array.controller';
+import { HostArrayService } from './host-array.service';
+import { UsersService } from './users/users.service';
+
+@Module({
+  controllers: [HostArrayController],
+  providers: [HostArrayService, UsersService],
+})
+export class HostArrayModule {}

--- a/integration/hello-world/src/host-array/host-array.service.ts
+++ b/integration/hello-world/src/host-array/host-array.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class HostArrayService {
+  greeting(): string {
+    return 'Host Greeting!';
+  }
+}

--- a/integration/hello-world/src/host-array/users/user-by-id.pipe.ts
+++ b/integration/hello-world/src/host-array/users/user-by-id.pipe.ts
@@ -1,0 +1,11 @@
+import { PipeTransform, Injectable, ArgumentMetadata } from '@nestjs/common';
+import { UsersService } from './users.service';
+
+@Injectable()
+export class UserByIdPipe implements PipeTransform<string> {
+  constructor(private readonly usersService: UsersService) {}
+
+  transform(value: string, metadata: ArgumentMetadata) {
+    return this.usersService.findById(value);
+  }
+}

--- a/integration/hello-world/src/host-array/users/users.service.ts
+++ b/integration/hello-world/src/host-array/users/users.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class UsersService {
+  findById(id: string) {
+    return { id, host: true };
+  }
+}

--- a/packages/common/decorators/core/controller.decorator.ts
+++ b/packages/common/decorators/core/controller.decorator.ts
@@ -27,7 +27,7 @@ export interface ControllerOptions extends ScopeOptions {
    *
    * @see [Routing](https://docs.nestjs.com/controllers#routing)
    */
-  host?: string;
+  host?: string | string[];
 }
 
 /**

--- a/packages/common/test/decorators/controller.decorator.spec.ts
+++ b/packages/common/test/decorators/controller.decorator.spec.ts
@@ -4,6 +4,7 @@ import { Controller } from '../../decorators/core/controller.decorator';
 describe('@Controller', () => {
   const reflectedPath = 'test';
   const reflectedHost = 'api.example.com';
+  const reflectedHostArray = ['api1.example.com', 'api2.example.com'];
 
   @Controller(reflectedPath)
   class Test {}
@@ -13,6 +14,9 @@ describe('@Controller', () => {
 
   @Controller({ path: reflectedPath, host: reflectedHost })
   class PathAndHostDecorator {}
+
+  @Controller({ path: reflectedPath, host: reflectedHostArray })
+  class PathAndHostArrayDecorator {}
 
   @Controller({ host: reflectedHost })
   class HostOnlyDecorator {}
@@ -29,6 +33,8 @@ describe('@Controller', () => {
     expect(host).to.be.eql(reflectedHost);
     const host2 = Reflect.getMetadata('host', HostOnlyDecorator);
     expect(host2).to.be.eql(reflectedHost);
+    const host3 = Reflect.getMetadata('host', PathAndHostArrayDecorator);
+    expect(host3).to.be.eql(reflectedHostArray);
   });
 
   it('should set default path when no object passed as param', () => {

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -73,7 +73,7 @@ export class RouterExplorer {
     module: string,
     applicationRef: T,
     basePath: string,
-    host: string,
+    host: string | string[],
   ) {
     const { instance } = instanceWrapper;
     const routerPaths = this.scanForPaths(instance);
@@ -150,7 +150,7 @@ export class RouterExplorer {
     instanceWrapper: InstanceWrapper,
     moduleKey: string,
     basePath: string,
-    host: string,
+    host: string | string[],
   ) {
     (routePaths || []).forEach(pathProperties => {
       const { path, requestMethod } = pathProperties;
@@ -179,7 +179,7 @@ export class RouterExplorer {
     instanceWrapper: InstanceWrapper,
     moduleKey: string,
     basePath: string,
-    host: string,
+    host: string | string[],
   ) {
     const {
       path: paths,
@@ -216,14 +216,20 @@ export class RouterExplorer {
     });
   }
 
-  private applyHostFilter(host: string, handler: Function) {
+  private applyHostFilter(host: string | string[], handler: Function) {
     if (!host) {
       return handler;
     }
 
     const httpAdapterRef = this.container.getHttpAdapterRef();
-    const keys = [];
-    const re = pathToRegexp(host, keys);
+
+    const hosts = Array.isArray(host) ? host : [host];
+    const expressions = hosts.map((host: string) => {
+      const keys = [];
+      const re = pathToRegexp(host, keys);
+
+      return { re, keys };
+    });
 
     return <TRequest extends Record<string, any> = any, TResponse = any>(
       req: TRequest,
@@ -232,15 +238,26 @@ export class RouterExplorer {
     ) => {
       (req as Record<string, any>).hosts = {};
       const hostname = httpAdapterRef.getRequestHostname(req) || '';
-      const match = hostname.match(re);
-      if (match) {
-        keys.forEach((key, i) => (req.hosts[key.name] = match[i + 1]));
-        return handler(req, res, next);
+
+      for (const exp of expressions) {
+        const match = hostname.match(exp.re);
+        if (match) {
+          exp.keys.forEach((key, i) => (req.hosts[key.name] = match[i + 1]));
+          return handler(req, res, next);
+        }
       }
       if (!next) {
-        throw new InternalServerErrorException(
-          `HTTP adapter does not support filtering on host: "${host}"`,
-        );
+        if (Array.isArray(host)) {
+          throw new InternalServerErrorException(
+            `HTTP adapter does not support filtering on hosts: ["${host.join(
+              '", "',
+            )}"]`,
+          );
+        } else {
+          throw new InternalServerErrorException(
+            `HTTP adapter does not support filtering on host: "${host}"`,
+          );
+        }
       }
       return next();
     };

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -132,7 +132,7 @@ export class RoutesResolver implements Resolver {
 
   private getHostMetadata(
     metatype: Type<unknown> | Function,
-  ): string | undefined {
+  ): string | string[] | undefined {
     return Reflect.getMetadata(HOST_METADATA, metatype);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently only one host pattern can be specified. Some complicated expressions can be written in [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) syntax to accept multiple hosts, but not all combinations are possible.

For example, there's currently no way (as far as I can tell) to accept hosts `foo.org` and `:param.bar.com` without also accepting `:param.foo.org` and `bar.com`: 

```ts
@Controller({ host: ':param?(foo.org|bar.com)' })
```

## What is the new behavior?

With this change, an array of hosts can be specified instead:

```ts
@Controller({ host: ['foo.org', ':param.bar.com'] })
```

Now `foo.org` and `:param.bar.com` are both accepted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In the event that multiple patterns match a given host, the first match will be used.