### PR TITLE
feat(core): log port on startup

### DIFF
--- a/packages/core/constants.ts
+++ b/packages/core/constants.ts
@@ -1,6 +1,8 @@
 export const MESSAGES = {
   APPLICATION_START: `Starting Nest application...`,
   APPLICATION_READY: `Nest application successfully started`,
+  APPLICATION_LISTENING: port =>
+    `Nest application is listening on port: ${port}`,
   MICROSERVICE_READY: `Nest microservice successfully started`,
   UNKNOWN_EXCEPTION_MESSAGE: 'Internal server error',
   ERROR_DURING_SHUTDOWN: 'Error happened during shutdown',

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -241,6 +241,7 @@ export class NestApplication
     !this.isInitialized && (await this.init());
     this.isListening = true;
     this.httpAdapter.listen(port, ...args);
+    this.logger.log(MESSAGES.APPLICATION_LISTENING(port));
     return this.httpServer;
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

doesn't apply: tiny change.

## PR Type
What kind of change does this PR introduce?

The port is logged on startup by default.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`nest start` doesn't log on what port it's currently running.

Helpful if you are juggling multiple nest projects.

Improves first impression too: You're new to nest, create an app following the documentation, enter `nest start` , it's doing stuff, but you don't know where.

## What is the new behavior?

the port is now logged: `Nest application is listening on port: 3000`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information