### PR TITLE
feat(testing): adds builder method for optional custom logger

### DIFF
--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -1,4 +1,4 @@
-import { Logger, Module } from '@nestjs/common';
+import { Logger, LoggerService, Module } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
 import { ApplicationConfig } from '@nestjs/core/application-config';
 import { NestContainer } from '@nestjs/core/injector/container';
@@ -16,7 +16,7 @@ export class TestingModuleBuilder {
   private readonly scanner: DependenciesScanner;
   private readonly instanceLoader = new InstanceLoader(this.container);
   private readonly module: any;
-  private testingLogger: Logger = null;
+  private testingLogger: LoggerService = null;
 
   constructor(metadataScanner: MetadataScanner, metadata: ModuleMetadata) {
     this.scanner = new DependenciesScanner(
@@ -27,7 +27,7 @@ export class TestingModuleBuilder {
     this.module = this.createModule(metadata);
   }
 
-  public setLogger(testingLogger: Logger) {
+  public setLogger(testingLogger: LoggerService) {
     this.testingLogger = testingLogger;
     return this;
   }

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -16,6 +16,7 @@ export class TestingModuleBuilder {
   private readonly scanner: DependenciesScanner;
   private readonly instanceLoader = new InstanceLoader(this.container);
   private readonly module: any;
+  private testingLogger: Logger = null;
 
   constructor(metadataScanner: MetadataScanner, metadata: ModuleMetadata) {
     this.scanner = new DependenciesScanner(
@@ -24,6 +25,11 @@ export class TestingModuleBuilder {
       this.applicationConfig,
     );
     this.module = this.createModule(metadata);
+  }
+
+  public setLogger(testingLogger: Logger) {
+    this.testingLogger = testingLogger;
+    return this;
   }
 
   public overridePipe<T = any>(typeOrToken: T): OverrideBy {
@@ -98,6 +104,6 @@ export class TestingModuleBuilder {
   }
 
   private applyLogger() {
-    Logger.overrideLogger(new TestingLogger());
+    Logger.overrideLogger(this.testingLogger || new TestingLogger());
   }
 }

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -16,7 +16,7 @@ export class TestingModuleBuilder {
   private readonly scanner: DependenciesScanner;
   private readonly instanceLoader = new InstanceLoader(this.container);
   private readonly module: any;
-  private testingLogger: LoggerService = null;
+  private testingLogger: LoggerService;
 
   constructor(metadataScanner: MetadataScanner, metadata: ModuleMetadata) {
     this.scanner = new DependenciesScanner(


### PR DESCRIPTION
Adds a method that enables to set a new custom logger (extended from the Logger class) for testing. If this method is not used (therefore the logger gets never set) it falls back to the already existing TestingLogger of the testing module.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
(see https://github.com/nestjs/docs.nestjs.com/pull/1633)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current TestModuleBuilder uses a built-in `TestingLogger` that is applied when the TestModule gets compiled.
This `TestingLogger` is, intentionally, a minimal implementation of the LoggerService interface that is needed for a Logger. The method that applies the Logger is private and therefore not accessible when the TestModule is prepared.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
The Logger can be customized using a new method `setLogger` that is compatible within the Builder-Pattern that is already in use for providers, guards etc It introduces a new property `testingLogger` (defaulting to `null`). ‚setLogger‘ sets this property. When the TestModule gets compiled it is checked if this customLogger property is set and uses it instead. Or falls back to the TestingLogger otherwise if the property is still null.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

A little insight why this might be needed. In my current project we use winston and configure winston to use different transports based on the enviroment. 
e.g. 
dev/test => console-transport only
prod => REST-transport

The winston logger then gets applied to the LoggerService which is then instantiated with different contexts in every controller, service etc. So the initial application of a logging instance is already one that has been configured for the environment. 

