### PR TITLE
fix(microservices): custom strategy typings

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -27,7 +27,7 @@ export type MicroserviceOptions =
   | CustomStrategy;
 
 export interface CustomStrategy {
-  strategy: Server & CustomTransportStrategy;
+  strategy: CustomTransportStrategy;
   options?: {};
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

The options interface for providing a configuration for a microservices `CustomStrategy` currently indicates that the strategy *must* also implement a `Server`. While it may be desirable for a custom strategy to extend a server for leveraging common functionality it is not a requirement for all custom strategies.

A concrete example of such a strategy which allows for microservice implementations that manage their own independent registrations through Module lifecycle as opposed to through the `Server` approach is as follows:

```typescript
import { CustomTransportStrategy } from '@nestjs/microservices';

class KeepAliveStrategy implements CustomTransportStrategy {
  private closing = false;

  wait() {
    if (!this.closing) {
      setTimeout(this.wait, 1000);
    }
  }

  listen(callback: () => void) {
    callback();
    this.wait();
  }

  close() {
    this.closing = true;
  }
}

```

Registering this strategy works as intended but has incompatible typings. Registering it as a microservice without providing a generic argument works but lacks all type safety eg:

```typescript
const workerApp = await NestFactory.createMicroservice(AppModule, {
    strategy: KeepAliveStrategy,
});
```

Issue Number: N/A


## What is the new behavior?
A `CustomStrategy` for microservices is only required to implement a `CustomTransportStrategy`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Not really sure whether to call this a fix or a feature. It doesn't have any downstream impact as people implementing `CustomStrategy` are free to continue to use the `Server` base class. Alternatively we could also add an additional type to the `MicroserviceOptions` with looser typing that specifically allows for a strategy only approach.

I could also see there being some use to incorporating the `KeepAliveStrategy` directly as it has broad application for people who are building microservices on top of the module system like with `@golevelup/nestjs-rabbitmq` which is used by a large portion of the community