### PR TITLE
fix(common): update class-validator interfaces

### DIFF
--- a/packages/common/interfaces/external/validation-error.interface.ts
+++ b/packages/common/interfaces/external/validation-error.interface.ts
@@ -2,29 +2,41 @@
  * Validation error description.
  * @see https://github.com/typestack/class-validator
  *
+ * class-validator@0.13.0
+ *
  * @publicApi
  */
 export interface ValidationError {
   /**
    * Object that was validated.
+   *
+   * OPTIONAL - configurable via the ValidatorOptions.validationError.target option
    */
-  target: Record<string, any>;
+  target?: Record<string, any>;
   /**
    * Object's property that hasn't passed validation.
    */
   property: string;
   /**
-   * Value that hasn't passed validation.
+   * Value that haven't pass a validation.
+   *
+   * OPTIONAL - configurable via the ValidatorOptions.validationError.value option
    */
-  value: any;
+  value?: any;
   /**
    * Constraints that failed validation with error messages.
    */
-  constraints: {
+  constraints?: {
     [type: string]: string;
   };
   /**
    * Contains all nested validation errors of the property.
    */
-  children: ValidationError[];
+  children?: ValidationError[];
+  /*
+   * A transient set of data passed through to the validation result for response mapping
+   */
+  contexts?: {
+    [type: string]: any;
+  };
 }

--- a/packages/common/interfaces/external/validator-options.interface.ts
+++ b/packages/common/interfaces/external/validator-options.interface.ts
@@ -2,11 +2,15 @@
  * Options passed to validator during validation.
  * @see https://github.com/typestack/class-validator
  *
- * class-validator@0.10.1
+ * class-validator@0.13.0
  *
  * @publicApi
  */
 export interface ValidatorOptions {
+  /**
+   * If set to true then class-validator will print extra warning messages to the console when something is not right.
+   */
+  enableDebugMessages?: boolean;
   /**
    * If set to true then validator will skip validation of all properties that are undefined in the validating object.
    */
@@ -34,6 +38,15 @@ export interface ValidatorOptions {
    */
   groups?: string[];
   /**
+   * Set default for `always` option of decorators. Default can be overridden in decorator options.
+   */
+  always?: boolean;
+  /**
+   * If [groups]{@link ValidatorOptions#groups} is not given or is empty,
+   * ignore decorators with at least one group.
+   */
+  strictGroups?: boolean;
+  /**
    * If set to true, the validation will not use default messages.
    * Error message always will be undefined if its not explicitly set.
    */
@@ -55,4 +68,8 @@ export interface ValidatorOptions {
    * Settings true will cause fail validation of unknown objects.
    */
   forbidUnknownValues?: boolean;
+  /**
+   * When set to true, validation of the given property will stop after encountering the first error. Defaults to false.
+   */
+  stopAtFirstError?: boolean;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Issue Number: #6131
Related #6124 

## What is the new behavior?
bundled class-validator external interfaces are compatible with the interfaces from class-validator package.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
* `ValidatorOptions` interface is updated to match upstream interface.
* `ValidationError` interface is now a class in the upstream package and some properties of it are made optional.

Projects using `ValidationError` with `strictNullCheck` may need to add a type guard