### PR TITLE
fix(websockets): require @nestjs/platform-socket.io correctly

### DIFF
--- a/packages/websockets/package.json
+++ b/packages/websockets/package.json
@@ -22,6 +22,7 @@
   "peerDependencies": {
     "@nestjs/common": "^7.0.0",
     "@nestjs/core": "^7.0.0",
+    "@nestjs/platform-socket.io": "^7.0.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.0.0"
   }

--- a/packages/websockets/socket-module.ts
+++ b/packages/websockets/socket-module.ts
@@ -104,6 +104,7 @@ export class SocketModule<HttpServer = any> {
     const { IoAdapter } = loadAdapter(
       '@nestjs/platform-socket.io',
       'WebSockets',
+      () => require('@nestjs/platform-socket.io'),
     );
     const ioAdapter = new IoAdapter(this.httpServer);
     this.applicationConfig.setIoAdapter(ioAdapter);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The undeclared peer dependency `@nestjs/platform-socket.io` is required from `@nestjs/core` instead of `@nestjs/websockets`

Issue Number: N/A


## What is the new behavior?

The peer dependency is declared and required from `@nestjs/websockets`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

See https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies
Similar to https://github.com/nestjs/nest/pull/5477