### PR TITLE
fix(websockets): fix typings for gatewaymetadata origins

### DIFF
--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -31,7 +31,7 @@ export interface GatewayMetadata {
    * Accepted origins
    * @default '*:*'
    */
-  origins?: string;
+  origins?: string | string[];
 
   parser?: any;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe:
```

The websockets package proxifies types from [socket.io](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/socket.io/index.d.ts)'s, but they diverged in the `origins` metadata param. This PR just fixes it, without modifying current API, hence no docs or tests were added.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
According to typings GatewayMetadata's `origins` does not allow an array of strings

Issue Number: N/A


## What is the new behavior?
Now it allows `string` and `string[]`


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I assume this PR could be classified as `docs` change, please, tell me if it is so