### PR TITLE
feat(testing): add auto-mocking capabilities

### DIFF
--- a/integration/auto-mock/src/bar.service.ts
+++ b/integration/auto-mock/src/bar.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { FooService } from './foo.service';
+
+@Injectable()
+export class BarService {
+
+  constructor(private readonly foo: FooService) {}
+
+  bar() {
+    this.foo.foo();
+  }
+}

--- a/integration/auto-mock/src/foo.service.ts
+++ b/integration/auto-mock/src/foo.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FooService {
+  foo() {
+    console.log('foo called');
+  }
+}

--- a/integration/auto-mock/test/bar.service.spec.ts
+++ b/integration/auto-mock/test/bar.service.spec.ts
@@ -37,7 +37,7 @@ describe('Auto-Mocking with token in factory', () => {
       providers: [BarService],
     })
       .useMocker((token) => {
-        if (token === FooService as any) {
+        if (token === FooService) {
           return { foo: sinon.stub };
         }
       })

--- a/integration/auto-mock/test/bar.service.spec.ts
+++ b/integration/auto-mock/test/bar.service.spec.ts
@@ -1,8 +1,11 @@
 import { Test } from '@nestjs/testing';
-import { expect } from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
 import { BarService } from '../src/bar.service';
 import { FooService } from '../src/foo.service';
+chai.use(chaiAsPromised);
+const { expect } = chai;
 
 describe('Auto-Mocking Bar Deps', () => {
   let service: BarService;
@@ -16,7 +19,6 @@ describe('Auto-Mocking Bar Deps', () => {
       .compile();
     service = moduleRef.get(BarService);
     fooService = moduleRef.get(FooService);
-    console.log(fooService);
   });
 
   it('should be defined', () => {
@@ -26,5 +28,36 @@ describe('Auto-Mocking Bar Deps', () => {
   it('should call bar.bar', () => {
     service.bar();
     expect(stub.called);
+  });
+});
+
+describe('Auto-Mocking with token in factory', () => {
+  it('can mock the dependencies', async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [BarService],
+    })
+      .useMocker((token) => {
+        if (token === FooService.name) {
+          return { foo: sinon.stub };
+        }
+      })
+      .compile();
+    const service = moduleRef.get(BarService);
+    const fooServ = moduleRef.get<{ foo: sinon.SinonStub }>('FooService');
+    service.bar();
+    expect(fooServ.foo.called);
+  });
+  it('cannot mock the dependencies', async () => {
+
+    const moduleRef = Test.createTestingModule({
+      providers: [BarService],
+    })
+      .useMocker((token) => {
+        if (token === FooService.name + 'something that fails the token') {
+          return { foo: sinon.stub };
+        }
+      })
+      .compile;
+    expect(moduleRef()).to.eventually.throw()
   });
 });

--- a/integration/auto-mock/test/bar.service.spec.ts
+++ b/integration/auto-mock/test/bar.service.spec.ts
@@ -37,13 +37,13 @@ describe('Auto-Mocking with token in factory', () => {
       providers: [BarService],
     })
       .useMocker((token) => {
-        if (token === FooService.name) {
+        if (token === FooService as any) {
           return { foo: sinon.stub };
         }
       })
       .compile();
     const service = moduleRef.get(BarService);
-    const fooServ = moduleRef.get<{ foo: sinon.SinonStub }>('FooService');
+    const fooServ = moduleRef.get<{ foo: sinon.SinonStub }>(FooService as any);
     service.bar();
     expect(fooServ.foo.called);
   });

--- a/integration/auto-mock/test/bar.service.spec.ts
+++ b/integration/auto-mock/test/bar.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { BarService } from '../src/bar.service';
+
+describe('Auto-Mocking Bar Deps', () => {
+  let service: BarService;
+  let stub = sinon.stub();
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [BarService],
+    })
+      .useMocker(() => ({ foo: stub }))
+      .compile();
+    service = moduleRef.get(BarService);
+  });
+
+  it('should be defined', () => {
+    expect(service).not.to.be.undefined;
+  });
+  it('should call bar.bar', () => {
+    console.log(service);
+    service.bar();
+    expect(stub.called);
+  });
+});

--- a/integration/auto-mock/test/bar.service.spec.ts
+++ b/integration/auto-mock/test/bar.service.spec.ts
@@ -2,10 +2,12 @@ import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { BarService } from '../src/bar.service';
+import { FooService } from '../src/foo.service';
 
 describe('Auto-Mocking Bar Deps', () => {
   let service: BarService;
-  let stub = sinon.stub();
+  let fooService: FooService;
+  const stub = sinon.stub();
   beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       providers: [BarService],
@@ -13,13 +15,15 @@ describe('Auto-Mocking Bar Deps', () => {
       .useMocker(() => ({ foo: stub }))
       .compile();
     service = moduleRef.get(BarService);
+    fooService = moduleRef.get(FooService);
+    console.log(fooService);
   });
 
   it('should be defined', () => {
     expect(service).not.to.be.undefined;
+    expect(fooService).not.to.be.undefined;
   });
   it('should call bar.bar', () => {
-    console.log(service);
     service.bar();
     expect(stub.called);
   });

--- a/integration/auto-mock/tsconfig.json
+++ b/integration/auto-mock/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -775,7 +775,7 @@ export class Injector {
     return param === INQUIRER && parentInquirer;
   }
 
-  private addDependencyMetadata(
+  protected addDependencyMetadata(
     keyOrIndex: number | string,
     hostWrapper: InstanceWrapper,
     instanceWrapper: InstanceWrapper,

--- a/packages/core/injector/instance-loader.ts
+++ b/packages/core/injector/instance-loader.ts
@@ -8,9 +8,9 @@ import { InternalCoreModule } from './internal-core-module';
 import { Module } from './module';
 
 export class InstanceLoader {
-  private readonly injector = new Injector();
+  protected readonly injector = new Injector();
   constructor(
-    private readonly container: NestContainer,
+    protected readonly container: NestContainer,
     private readonly logger = new Logger(InstanceLoader.name, {
       timestamp: true,
     }),

--- a/packages/testing/interfaces/index.ts
+++ b/packages/testing/interfaces/index.ts
@@ -1,2 +1,3 @@
+export * from './mock-factory';
 export * from './override-by-factory-options.interface';
 export * from './override-by.interface';

--- a/packages/testing/interfaces/mock-factory.ts
+++ b/packages/testing/interfaces/mock-factory.ts
@@ -1,0 +1,1 @@
+export type MockFactory = (token?: string) => any;

--- a/packages/testing/interfaces/mock-factory.ts
+++ b/packages/testing/interfaces/mock-factory.ts
@@ -1,1 +1,3 @@
-export type MockFactory = (token?: string) => any;
+import { InstanceToken } from '@nestjs/core/injector/module';
+
+export type MockFactory = (token?: InstanceToken) => any;

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -54,10 +54,9 @@ export class TestingInjector extends Injector {
         const modRef = new (moduleRef.createModuleReferenceType())();
         (this.container.getInternalCoreModuleRef() as any)._providers.set(
           name,
-          mockedInstance,
+          newWrapper,
         );
         (this.container.getInternalCoreModuleRef() as any)._exports.add(name);
-        console.log((modRef as any).container.getInternalCoreModuleRef());
         return newWrapper;
       } else {
         throw err;

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -55,9 +55,15 @@ export class TestingInjector extends Injector {
           host: moduleRef,
           metatype: wrapper.metatype,
         });
-        const internalCoreModule = this.container.getInternalCoreModuleRef() as any;
-        internalCoreModule._providers.set(name, newWrapper);
-        internalCoreModule._exports.add(name);
+        const internalCoreModule = this.container.getInternalCoreModuleRef();
+        internalCoreModule.addCustomProvider(
+          {
+            provide: name,
+            useValue: mockedInstance,
+          },
+          internalCoreModule.providers,
+        );
+        internalCoreModule.addExportedProvider(name);
         return newWrapper;
       } else {
         throw err;

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -5,12 +5,18 @@ import {
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { STATIC_CONTEXT } from '@nestjs/core/injector/constants';
-import { Scope } from '@nestjs/common';
+import { NestContainer } from '@nestjs/core';
 
 export class TestingInjector extends Injector {
-  private mocker?: <T extends any = {}>() => T;
+  protected mocker?: <T extends any = {}>() => T;
+
+  protected container: NestContainer;
   setMocker(mocker: () => any): void {
     this.mocker = mocker;
+  }
+
+  setContainer(container: NestContainer) {
+    this.container = container;
   }
 
   async resolveComponentInstance<T>(
@@ -35,13 +41,23 @@ export class TestingInjector extends Injector {
       return retWrapper;
     } catch (err) {
       if (this.mocker) {
+        const mockedInstance = this.mocker<T>();
         const newWrapper = new InstanceWrapper({
           name,
           isAlias: false,
           scope: wrapper.scope,
-          instance: this.mocker<T>(),
+          instance: mockedInstance,
           isResolved: true,
+          host: moduleRef,
+          metatype: wrapper.metatype,
         });
+        const modRef = new (moduleRef.createModuleReferenceType())();
+        (this.container.getInternalCoreModuleRef() as any)._providers.set(
+          name,
+          mockedInstance,
+        );
+        (this.container.getInternalCoreModuleRef() as any)._exports.add(name);
+        console.log((modRef as any).container.getInternalCoreModuleRef());
         return newWrapper;
       } else {
         throw err;

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -1,0 +1,51 @@
+import {
+  Injector,
+  InjectorDependencyContext,
+} from '@nestjs/core/injector/injector';
+import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import { Module } from '@nestjs/core/injector/module';
+import { STATIC_CONTEXT } from '@nestjs/core/injector/constants';
+import { Scope } from '@nestjs/common';
+
+export class TestingInjector extends Injector {
+  private mocker?: <T extends any = {}>() => T;
+  setMocker(mocker: () => any): void {
+    this.mocker = mocker;
+  }
+
+  async resolveComponentInstance<T>(
+    moduleRef: Module,
+    name: any,
+    dependencyContext: InjectorDependencyContext,
+    wrapper: InstanceWrapper<T>,
+    contextId = STATIC_CONTEXT,
+    inquirer?: InstanceWrapper,
+    keyOrIndex?: string | number,
+  ): Promise<InstanceWrapper> {
+    try {
+      const retWrapper = await super.resolveComponentInstance(
+        moduleRef,
+        name,
+        dependencyContext,
+        wrapper,
+        contextId,
+        inquirer,
+        keyOrIndex,
+      );
+      return retWrapper;
+    } catch (err) {
+      if (this.mocker) {
+        const newWrapper = new InstanceWrapper({
+          name,
+          isAlias: false,
+          scope: wrapper.scope,
+          instance: this.mocker<T>(),
+          isResolved: true,
+        });
+        return newWrapper;
+      } else {
+        throw err;
+      }
+    }
+  }
+}

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -1,5 +1,6 @@
 import { NestContainer } from '@nestjs/core';
 import { InstanceLoader } from '@nestjs/core/injector/instance-loader';
+import { MockFactory } from './interfaces';
 import { TestingInjector } from './testing-injector';
 
 export class TestingInstanceLoader extends InstanceLoader {
@@ -7,7 +8,7 @@ export class TestingInstanceLoader extends InstanceLoader {
 
   async createInstancesOfDependencies(
     container?: NestContainer,
-    mocker?: () => any,
+    mocker?: MockFactory,
   ): Promise<void> {
     this.injector.setContainer(container);
     mocker && this.injector.setMocker(mocker);

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -1,0 +1,11 @@
+import { InstanceLoader } from '@nestjs/core/injector/instance-loader';
+import { TestingInjector } from './testing-injector';
+
+export class TestingInstanceLoader extends InstanceLoader {
+  protected injector = new TestingInjector();
+
+  async createInstancesOfDependencies(mocker?: () => any): Promise<void> {
+    mocker && this.injector.setMocker(mocker);
+    await super.createInstancesOfDependencies();
+  }
+}

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -1,10 +1,15 @@
+import { NestContainer } from '@nestjs/core';
 import { InstanceLoader } from '@nestjs/core/injector/instance-loader';
 import { TestingInjector } from './testing-injector';
 
 export class TestingInstanceLoader extends InstanceLoader {
   protected injector = new TestingInjector();
 
-  async createInstancesOfDependencies(mocker?: () => any): Promise<void> {
+  async createInstancesOfDependencies(
+    container?: NestContainer,
+    mocker?: () => any,
+  ): Promise<void> {
+    this.injector.setContainer(container);
     mocker && this.injector.setMocker(mocker);
     await super.createInstancesOfDependencies();
   }

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -1,5 +1,5 @@
-import { NestContainer } from '@nestjs/core';
 import { InstanceLoader } from '@nestjs/core/injector/instance-loader';
+import { Module } from '@nestjs/core/injector/module';
 import { MockFactory } from './interfaces';
 import { TestingInjector } from './testing-injector';
 
@@ -7,10 +7,10 @@ export class TestingInstanceLoader extends InstanceLoader {
   protected injector = new TestingInjector();
 
   async createInstancesOfDependencies(
-    container?: NestContainer,
+    modules: Map<string, Module> = this.container.getModules(),
     mocker?: MockFactory,
   ): Promise<void> {
-    this.injector.setContainer(container);
+    this.injector.setContainer(this.container);
     mocker && this.injector.setMocker(mocker);
     await super.createInstancesOfDependencies();
   }

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -4,7 +4,11 @@ import { ApplicationConfig } from '@nestjs/core/application-config';
 import { NestContainer } from '@nestjs/core/injector/container';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { DependenciesScanner } from '@nestjs/core/scanner';
-import { OverrideBy, OverrideByFactoryOptions } from './interfaces';
+import {
+  MockFactory,
+  OverrideBy,
+  OverrideByFactoryOptions,
+} from './interfaces';
 import { TestingLogger } from './services/testing-logger.service';
 import { TestingInstanceLoader } from './testing-instance-loader';
 import { TestingModule } from './testing-module';
@@ -17,7 +21,7 @@ export class TestingModuleBuilder {
   private readonly instanceLoader = new TestingInstanceLoader(this.container);
   private readonly module: any;
   private testingLogger: LoggerService;
-  private mocker?: () => any;
+  private mocker?: MockFactory;
 
   constructor(metadataScanner: MetadataScanner, metadata: ModuleMetadata) {
     this.scanner = new DependenciesScanner(
@@ -37,7 +41,7 @@ export class TestingModuleBuilder {
     return this.override(typeOrToken, false);
   }
 
-  public useMocker(mocker: () => any): TestingModuleBuilder {
+  public useMocker(mocker: MockFactory): TestingModuleBuilder {
     this.mocker = mocker;
     return this;
   }

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -63,7 +63,10 @@ export class TestingModuleBuilder {
     await this.scanner.scan(this.module);
 
     this.applyOverloadsMap();
-    await this.instanceLoader.createInstancesOfDependencies(this.mocker);
+    await this.instanceLoader.createInstancesOfDependencies(
+      this.container,
+      this.mocker,
+    );
     this.scanner.applyApplicationProviders();
 
     const root = this.getRootModule();

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -68,7 +68,7 @@ export class TestingModuleBuilder {
 
     this.applyOverloadsMap();
     await this.instanceLoader.createInstancesOfDependencies(
-      this.container,
+      this.container.getModules(),
       this.mocker,
     );
     this.scanner.applyApplicationProviders();


### PR DESCRIPTION
In the current `Test` module there isn't an easy way to say "If this
dependency doesn't exist use this mock function instead." With this new
`useMocker` fluent function it becomes possible to tell the `TestingInjector`
to replace the undefined dependency with the automocking function. In doing so
classes that have a large number of dependencies no longer must be mocked one-by-one
. This is especially great when it comes to packages like `@golevelup/ts-jest`
which can create mocked dependencies of interfaces and classes with a single function.
I'm sure I've probably missed an edge case in here, so please let me know if you have
any major concerns.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently there isn't an easy way to automatically mock dependencies.
Issue Number: N/A


## What is the new behavior?

There is now a way to testll Nest how to automatically mock dependencies

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I'm sure there's an edge case I've missed somewhere, but overall I think the code change is correct. I'm more than willing to write some docs for this too. The idea came from  @Underfisk in a Discord conversation, about making use of something similar to functionality SpringBoot has. This PR really shines when it is used with `@golevelup/ts-jest`'s `createMock` method which, as mentioned, can create full mocks of classes and stub them using `jest.fn()` for each method (I personally use it for most of my mock creation now cause it's just so dead simple)