### PR TITLE
feature(microservices): receive and collect Kafka messages from diffe…

### DIFF
--- a/integration/microservices/e2e/multiple-kafka.spec.ts
+++ b/integration/microservices/e2e/multiple-kafka.spec.ts
@@ -1,0 +1,75 @@
+import { INestApplication } from '@nestjs/common';
+import { Transport } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { KafkaMultipleController } from '../src/kafka-multiple/kafka-multiple.controller';
+import { KafkaMultipleMessagesController } from '../src/kafka-multiple/kafka-multiple.messages.controller';
+
+describe('Kafka multiple', function () {
+  let appServer: any;
+  let app: INestApplication;
+  let appMS1: INestApplication;
+  let appMS2: INestApplication;
+
+  // set timeout to be longer (especially for the after hook)
+  this.timeout(30000);
+
+  const startServer = async () => {
+    const module = await Test.createTestingModule({
+      controllers: [KafkaMultipleController],
+    }).compile();
+
+    app = module.createNestApplication();
+
+    appServer = app.getHttpAdapter().getInstance();
+
+    app.enableShutdownHooks();
+
+    await app.init();
+  };
+
+  const startMS = async (id: number): Promise<INestApplication> => {
+    const module = await Test.createTestingModule({
+      controllers: [KafkaMultipleMessagesController],
+    }).compile();
+
+    const app = module.createNestApplication();
+    app.connectMicroservice({
+      transport: Transport.KAFKA,
+      options: {
+        client: {
+          brokers: ['localhost:9092'],
+        },
+        consumer: {
+          groupId: `group_${id}`,
+        },
+      },
+    });
+
+    app.enableShutdownHooks();
+    await app.startAllMicroservicesAsync();
+    await app.init();
+
+    return app;
+  };
+
+  it('Start Kafka app', async () => {
+    await startServer();
+    appMS1 = await startMS(1);
+    appMS2 = await startMS(2);
+  }).timeout(30000);
+
+  it('should receive multiple messages from same topic', () => {
+    return request(appServer)
+      .post('/mathPlusOne')
+      .send({ value: 2 })
+      .expect(200)
+      .expect(200, [3, 3]);
+  });
+
+  after(`Stopping Kafka app`, async () => {
+    await app.close();
+    await appMS1.close();
+    await appMS2.close();
+  });
+});

--- a/integration/microservices/src/kafka-multiple/kafka-multiple.controller.ts
+++ b/integration/microservices/src/kafka-multiple/kafka-multiple.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Controller,
+  OnModuleDestroy,
+  OnModuleInit,
+  Post,
+  Res,
+  HttpCode,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { Logger } from '@nestjs/common/services/logger.service';
+import { Client, ClientKafka, Transport } from '@nestjs/microservices';
+
+@Controller()
+export class KafkaMultipleController implements OnModuleInit, OnModuleDestroy {
+  protected readonly logger = new Logger(KafkaMultipleController.name);
+
+  @Client({
+    transport: Transport.KAFKA,
+    options: {
+      client: {
+        brokers: ['localhost:9092'],
+      },
+    },
+  })
+  public readonly client: ClientKafka;
+
+  async onModuleInit() {
+    const requestPatterns = ['math.plus.one'];
+
+    requestPatterns.forEach(pattern => {
+      this.client.subscribeToResponseOf(pattern);
+    });
+    await this.client.connect();
+  }
+
+  async onModuleDestroy() {
+    await this.client.close();
+  }
+
+  @HttpCode(200)
+  @Post('mathPlusOne')
+  public mathPlusOne(@Body() data: any, @Res() res: Response): void {
+    const result = [];
+    this.client
+      .sendToMultiple('math.plus.one', {
+        value: data.value,
+      })
+      .subscribe(
+        val => result.push(Number.parseInt(val)),
+        null,
+        () => res.send(result),
+      );
+  }
+}

--- a/integration/microservices/src/kafka-multiple/kafka-multiple.messages.controller.ts
+++ b/integration/microservices/src/kafka-multiple/kafka-multiple.messages.controller.ts
@@ -1,0 +1,26 @@
+import {
+  Body,
+  Controller,
+  OnModuleDestroy,
+  OnModuleInit,
+  Post,
+} from '@nestjs/common';
+import { Logger } from '@nestjs/common/services/logger.service';
+import { Observable } from 'rxjs';
+import {
+  Client,
+  ClientKafka,
+  MessagePattern,
+  Transport,
+} from '@nestjs/microservices';
+import { Payload } from '../../../../packages/microservices';
+
+@Controller()
+export class KafkaMultipleMessagesController {
+  protected readonly logger = new Logger(KafkaMultipleMessagesController.name);
+
+  @MessagePattern('math.plus.one')
+  public mathPlusOne(data: any): any {
+    return Number.parseInt(data.value) + 1;
+  }
+}


### PR DESCRIPTION
Receive and collect Kafka messages from different consumer groups with the same message pattern


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Collect multiple results from different Kafka consumer groups for the same topic (MS pattern). Useful if you want to e.g. split up a hardware consuming operation into multiple ones and run them in parallel. Or collect data from different MS...

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
No docs created yet... until the MR will be approved.