### PR TITLE
feat(cache): allow for cache interceptor to be more easily extended

### DIFF
--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -27,6 +27,7 @@ export class CacheInterceptor implements NestInterceptor {
   @Inject(HTTP_ADAPTER_HOST)
   protected readonly httpAdapterHost: HttpAdapterHost;
 
+  protected allowedMethods = ['GET'];
   constructor(
     @Inject(CACHE_MANAGER) protected readonly cacheManager: any,
     @Inject(REFLECTOR) protected readonly reflector: any,
@@ -75,7 +76,7 @@ export class CacheInterceptor implements NestInterceptor {
     }
 
     const request = context.getArgByIndex(0);
-    if (httpAdapter.getRequestMethod(request) !== 'GET') {
+    if (!this.allowedMethods.includes(httpAdapter.getRequestMethod(request))) {
       return undefined;
     }
     return httpAdapter.getRequestUrl(request);

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -63,7 +63,7 @@ export class CacheInterceptor implements NestInterceptor {
     }
   }
 
-  trackBy(context: ExecutionContext): string | undefined {
+  protected trackBy(context: ExecutionContext): string | undefined {
     const httpAdapter = this.httpAdapterHost.httpAdapter;
     const isHttpApp = httpAdapter && !!httpAdapter.getRequestMethod;
     const cacheMetadata = this.reflector.get(
@@ -76,9 +76,14 @@ export class CacheInterceptor implements NestInterceptor {
     }
 
     const request = context.getArgByIndex(0);
-    if (!this.allowedMethods.includes(httpAdapter.getRequestMethod(request))) {
+    if (!this.isRequestCacheable(context)) {
       return undefined;
     }
     return httpAdapter.getRequestUrl(request);
+  }
+
+  protected isRequestCacheable(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    return this.allowedMethods.includes(req.method);
   }
 }


### PR DESCRIPTION
With the `CacheIntercetpor` now using a `protected` array of allowed methods
it will be easier to allow for adding new methods to be cached without having to
rewrite the entire `trackBy` method. This will allow for users to add methods
like `HEAD` to be cached.

fix: #6427

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Adding a new method to trackBy for the `CacheInterceptor` due to needing to re-write the `trackBy` method.

Issue Number: #6427 


## What is the new behavior?

Now a simple array can be overwritten which is much easier.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information