### PR TITLE
fix(core): detect conventional middleware class #6586

### DIFF
--- a/packages/core/middleware/utils.ts
+++ b/packages/core/middleware/utils.ts
@@ -29,7 +29,7 @@ export const mapToClass = <T extends Function | Type<any>>(
   excludedRoutes: RouteInfoRegex[],
   httpAdapter: HttpServer,
 ) => {
-  if (isClass(middleware)) {
+  if (isMiddlewareClass(middleware)) {
     if (excludedRoutes.length <= 0) {
       return middleware;
     }
@@ -59,8 +59,17 @@ export const mapToClass = <T extends Function | Type<any>>(
   );
 };
 
-export function isClass(middleware: any): middleware is Type<any> {
-  return middleware.toString().substring(0, 5) === 'class';
+export function isMiddlewareClass(middleware: any): middleware is Type<any> {
+  const middlewareStr = middleware.toString();
+  if (middlewareStr.substring(0, 5) === 'class') {
+    return true;
+  }
+  const middlewareArr = middlewareStr.split(' ');
+  return (
+    middlewareArr[0] === 'function' &&
+    /[A-Z]/.test(middlewareArr[1]?.[0]) &&
+    typeof middleware.prototype?.use === 'function'
+  );
 }
 
 export function assignToken(metatype: Type<any>, token = uuid()): Type<any> {

--- a/packages/core/test/middleware/utils.spec.ts
+++ b/packages/core/test/middleware/utils.spec.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 import {
   assignToken,
   filterMiddleware,
-  isClass,
+  isMiddlewareClass,
   isRouteExcluded,
   mapToClass,
 } from '../../middleware/utils';
@@ -63,15 +63,15 @@ describe('middleware utils', () => {
       });
     });
   });
-  describe('isClass', () => {
+  describe('isMiddlewareClass', () => {
     describe('when middleware is a class', () => {
       it('should returns true', () => {
-        expect(isClass(Test)).to.be.true;
+        expect(isMiddlewareClass(Test)).to.be.true;
       });
     });
     describe('when middleware is a function', () => {
       it('should returns false', () => {
-        expect(isClass(fnMiddleware)).to.be.false;
+        expect(isMiddlewareClass(fnMiddleware)).to.be.false;
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
throws following error when using class middleware with babel
```
TypeError: Cannot call a class as a function
```

Issue Number: #6586


## What is the new behavior?
detects middleware class after it has been transformed by babel


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
It checks for a conventional class by detecting if the function starts with a capitol letter.

https://github.com/nestjs/nest/pull/6587/files#diff-121f827f94f0efc4a83805b785189f67d64b8a4e06d814a38e8ca7e0b42aa2e9R70

This is how the `typechecker` library checks for conventional classes.

https://github.com/bevry/typechecker/blob/master/source/index.ts#L5

To prevent edge cases, I use duck typing to check if it's a middleware class with the `use` method.

https://github.com/nestjs/nest/pull/6587/files#diff-121f827f94f0efc4a83805b785189f67d64b8a4e06d814a38e8ca7e0b42aa2e9R71

I also renamed it from `isClass` to `isMiddlewareClass` since I'm using duck typing to safely check for conventional classes.

This should have no effect on existing code.