### PR TITLE
fix(common): change cache ttl decorator to apply non expiring ttl

### DIFF
--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -37,11 +37,7 @@ export class CacheInterceptor implements NestInterceptor {
     next: CallHandler,
   ): Promise<Observable<any>> {
     const key = this.trackBy(context);
-    const ttlMetadata = this.reflector.get(
-      CACHE_TTL_METADATA,
-      context.getHandler(),
-    );
-    const ttlValueOrFactory = ttlMetadata === 0 ? 0 : ttlMetadata || null;
+    const ttlValueOrFactory = this.reflector.get(CACHE_TTL_METADATA, context.getHandler()) ?? null;
 
     if (!key) {
       return next.handle();

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -37,8 +37,11 @@ export class CacheInterceptor implements NestInterceptor {
     next: CallHandler,
   ): Promise<Observable<any>> {
     const key = this.trackBy(context);
-    const ttlValueOrFactory =
-      this.reflector.get(CACHE_TTL_METADATA, context.getHandler()) || null;
+    const ttlMetadata = this.reflector.get(
+      CACHE_TTL_METADATA,
+      context.getHandler(),
+    );
+    const ttlValueOrFactory = ttlMetadata === 0 ? 0 : ttlMetadata || null;
 
     if (!key) {
       return next.handle();


### PR DESCRIPTION
When used, @CacheTTL(0) will set non expiring value on endpoint.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The CacheTTL decorator use reflector to get cache ttl metadata.
When that data equals to 0, ttl value is settled to null. Because 0 is falsy value!
Same PR was created(#4506), but still different to expected behavior.

Issue Number: #4447


## What is the new behavior?
When set ttl value 0 to CacheTTL decorator, it's not expired.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information