### PR TITLE
fix(nats): propagate client request error

### DIFF
--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -68,7 +68,8 @@ export class ClientNats extends ClientProxy {
       if (message.id && message.id !== packet.id) {
         return undefined;
       }
-      const { err, response, isDisposed } = message;
+      const { response, isDisposed } = message;
+      const err = response instanceof Error ? response : message.err;
       if (isDisposed || err) {
         return callback({
           err,


### PR DESCRIPTION
Whenever sending request through NATs driver, we should check if received response
is an error and propogate it.

Fixes #6684

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #6684


## What is the new behavior?
Now NATs error always will be propogated.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information