### PR TITLE
Adapted NatsOptions to original ClientOpts

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -133,7 +133,7 @@ export interface NatsOptions {
     userJWT?: ()=>string | string,
     verbose?: boolean,
     waitOnFirstConnect?: boolean,
-    yieldTime?: number
+    yieldTime?: number;
     [key: string]: any;
   };
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -15,6 +15,7 @@ import { Server } from '../server/server';
 import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
+import * as tls from 'tls';
 
 export type MicroserviceOptions =
   | GrpcOptions

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -103,39 +103,37 @@ export interface MqttOptions {
 export interface NatsOptions {
   transport?: Transport.NATS;
   options?: {
-    encoding?: string;
-    url?: string;
-    name?: string;
-    user?: string;
-    pass?: string;
-    maxPingOut?: number;
-    maxReconnectAttempts?: number;
-    reconnectTimeWait?: number;
-    reconnectJitter?: number;
-    reconnectJitterTLS?: number;
-    reconnectDelayHandler?: any;
-    servers?: string[];
-    nkey?: any;
-    reconnect?: boolean;
-    pedantic?: boolean;
-    tls?: any;
-    queue?: string;
-    serializer?: Serializer;
-    deserializer?: Deserializer;
-    userJWT?: string;
-    nonceSigner?: any;
-    userCreds?: any;
-    useOldRequestStyle?: boolean;
-    pingInterval?: number;
-    preserveBuffers?: boolean;
-    waitOnFirstConnect?: boolean;
-    verbose?: boolean;
-    noEcho?: boolean;
-    noRandomize?: boolean;
-    timeout?: number;
-    token?: string;
-    yieldTime?: number;
-    tokenHandler?: any;
+    encoding?: BufferEncoding,
+    json?: boolean,
+    maxPingOut?: number,
+    maxReconnectAttempts?: number,
+    name?: string,
+    nkey?: string,
+    noEcho?: boolean
+    noRandomize?: boolean,
+    nonceSigner?: Function,
+    pass?: string,
+    pedantic?: boolean,
+    pingInterval?: number,
+    preserveBuffers?: boolean,
+    reconnect?: boolean,
+    reconnectJitter?: number,
+    reconnectJitterTLS?: number,
+    reconnectDelayHandler?: ()=>number,
+    reconnectTimeWait?: number,
+    servers?: Array<string>,
+    timeout?: number,
+    tls?: boolean | tls.TlsOptions,
+    token?: string,
+    tokenHandler?: ()=>string,
+    url?: string,
+    useOldRequestStyle?: boolean,
+    user?: string,
+    userCreds?: string,
+    userJWT?: ()=>string | string,
+    verbose?: boolean,
+    waitOnFirstConnect?: boolean,
+    yieldTime?: number
     [key: string]: any;
   };
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -104,36 +104,36 @@ export interface MqttOptions {
 export interface NatsOptions {
   transport?: Transport.NATS;
   options?: {
-    encoding?: BufferEncoding,
-    json?: boolean,
-    maxPingOut?: number,
-    maxReconnectAttempts?: number,
-    name?: string,
-    nkey?: string,
+    encoding?: BufferEncoding;
+    json?: boolean;
+    maxPingOut?: number;
+    maxReconnectAttempts?: number;
+    name?: string;
+    nkey?: string;
     noEcho?: boolean
-    noRandomize?: boolean,
-    nonceSigner?: Function,
-    pass?: string,
-    pedantic?: boolean,
-    pingInterval?: number,
-    preserveBuffers?: boolean,
-    reconnect?: boolean,
-    reconnectJitter?: number,
-    reconnectJitterTLS?: number,
-    reconnectDelayHandler?: ()=>number,
-    reconnectTimeWait?: number,
-    servers?: Array<string>,
-    timeout?: number,
-    tls?: boolean | tls.TlsOptions,
-    token?: string,
-    tokenHandler?: ()=>string,
-    url?: string,
-    useOldRequestStyle?: boolean,
-    user?: string,
-    userCreds?: string,
-    userJWT?: ()=>string | string,
-    verbose?: boolean,
-    waitOnFirstConnect?: boolean,
+    noRandomize?: boolean;
+    nonceSigner?: Function;
+    pass?: string;
+    pedantic?: boolean;
+    pingInterval?: number;
+    preserveBuffers?: boolean;
+    reconnect?: boolean;
+    reconnectJitter?: number;
+    reconnectJitterTLS?: number;
+    reconnectDelayHandler?: ()=>number;
+    reconnectTimeWait?: number;
+    servers?: Array<string>;
+    timeout?: number;
+    tls?: boolean | tls.TlsOptions;
+    token?: string;
+    tokenHandler?: ()=>string;
+    url?: string;
+    useOldRequestStyle?: boolean;
+    user?: string;
+    userCreds?: string;
+    userJWT?: ()=>string | string;
+    verbose?: boolean;
+    waitOnFirstConnect?: boolean;
     yieldTime?: number;
     [key: string]: any;
   };


### PR DESCRIPTION
Adapted the ClientProxy `NatsOptions` to be exactly on par with original NatsOpts: https://github.com/nats-io/nats.js/blob/v1.4.12/index.d.ts#L68 (v1.4.12). As of my understanding Nest.js is just passing all the options to nats.js so they should be the same.

This was needed because interfaces were not compatible, e.g. userJWT in Nest NatsOptions expected a string but original NatsOpts has `string | () => string`.