### PR TITLE
fix: reorder kafka config assignment to pass down a custom log creator

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -142,13 +142,13 @@ export class ClientKafka extends ClientProxy {
   }
 
   public createClient<T = any>(): T {
-    return new kafkaPackage.Kafka(
-      Object.assign(this.options.client || {}, {
-        clientId: this.clientId,
-        brokers: this.brokers,
-        logCreator: KafkaLogger.bind(null, this.logger),
-      }) as KafkaConfig,
+    const kafkaConfig: KafkaConfig = Object.assign(
+      { logCreator: KafkaLogger.bind(null, this.logger) },
+      this.options.client,
+      { brokers: this.brokers, clientId: this.clientId },
     );
+
+    return new kafkaPackage.Kafka(kafkaConfig);
   }
 
   public createResponseCallback(): (payload: EachMessagePayload) => any {

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -204,6 +204,30 @@ describe('ClientKafka', () => {
       .callsFake(() => kafkaClient);
   });
 
+  describe('createClient', () => {
+    beforeEach(() => {
+      client = new ClientKafka({});
+    });
+
+    it(`should accept a custom logCreator in client options`, () => {
+      const logCreatorSpy = sinon.spy(() => 'test');
+      const logCreator = () => logCreatorSpy;
+
+      client = new ClientKafka({
+        client: {
+          brokers: [],
+          logCreator,
+        },
+      });
+
+      const logger = client.createClient().logger();
+
+      logger.info({ namespace: '', level: 1, log: 'test' });
+
+      expect(logCreatorSpy.called).to.be.true;
+    });
+  });
+
   describe('subscribeToResponseOf', () => {
     let normalizePatternSpy: sinon.SinonSpy;
     let getResponsePatternNameSpy: sinon.SinonSpy;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) <= Sort of! if types are a means to document code, then this makes them more precise! 


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/6797


## What is the new behavior?

Users may not pass a `logCreator` option into their `KafkaClient` implementations.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

Users will not have been passing in `logCreator` functions to this method. If they were, they are likely already correctly typed.

## Other information

There's a few different variations on this change, which I'm going to comment on inline!