### PR TITLE
fix(core): marking files as pipeable

### DIFF
--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -343,6 +343,8 @@ export class RouterExecutionContext {
       type === RouteParamtypes.BODY ||
       type === RouteParamtypes.QUERY ||
       type === RouteParamtypes.PARAM ||
+      type === RouteParamtypes.FILE ||
+      type === RouteParamtypes.FILES ||
       isString(type)
     );
   }

--- a/packages/core/test/router/router-execution-context.spec.ts
+++ b/packages/core/test/router/router-execution-context.spec.ts
@@ -262,6 +262,8 @@ describe('RouterExecutionContext', () => {
         expect(contextCreator.isPipeable(RouteParamtypes.BODY)).to.be.true;
         expect(contextCreator.isPipeable(RouteParamtypes.QUERY)).to.be.true;
         expect(contextCreator.isPipeable(RouteParamtypes.PARAM)).to.be.true;
+        expect(contextCreator.isPipeable(RouteParamtypes.FILE)).to.be.true;
+        expect(contextCreator.isPipeable(RouteParamtypes.FILES)).to.be.true;
         expect(contextCreator.isPipeable('custom')).to.be.true;
       });
     });


### PR DESCRIPTION
The two decorators @UploadedFile and @UploadedFiles have been marked as pipeable,
however this had no affect as this method was preventing their execution.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the interface for `@UploadedFile` and `@UploadedFiles` describes the possibility of adding pipes to somehow transform the file object. However, this does not work at the moment since the `isPipeable` method does not accept `FILE` and `FILES` as "pipeable". 

Issue Number: https://github.com/nestjs/nest/issues/4752 (original feature request) / https://github.com/nestjs/nest/pull/6344#issuecomment-810241251 (specific bug targeted by this PR)


## What is the new behavior?

The pipes are actually run and can alter the file object and the files array. 


## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Personally I would tend to refactor that many comparisons of a value to a set so that I can call `.has()`. If that is something you want, then I can update the PR