### PR TITLE
unnecessary referencing parent directory in import

### DIFF
--- a/packages/platform-express/multer/interfaces/files-upload-module.interface.ts
+++ b/packages/platform-express/multer/interfaces/files-upload-module.interface.ts
@@ -1,6 +1,6 @@
 import { Type } from '@nestjs/common';
 import { ModuleMetadata } from '@nestjs/common/interfaces';
-import { MulterOptions } from '../interfaces/multer-options.interface';
+import { MulterOptions } from './multer-options.interface';
 
 export type MulterModuleOptions = MulterOptions;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
file `files-upload-module.interface.ts` is importing file `multer-options.interface.ts` from the same directory, referencing parent directory unnecessary (i.e. it goes ./FILE instead of ../CURRENT_DIR/FILE)

Issue Number: N/A


## What is the new behavior?
file `files-upload-module.interface.ts` is importing file `multer-options.interface.ts` from the same directory without referencing parent directory

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information