### PR TITLE
fix(platform-fastify): update fastify-static and point-of-view interface.ts files

### DIFF
--- a/packages/platform-fastify/interfaces/external/fastify-static-options.interface.ts
+++ b/packages/platform-fastify/interfaces/external/fastify-static-options.interface.ts
@@ -23,8 +23,21 @@ interface ListOptions {
   render: ListRender;
 }
 
-export interface FastifyStaticOptions {
-  root: string;
+// Passed on to `send`
+interface SendOptions {
+  acceptRanges?: boolean;
+  cacheControl?: boolean;
+  dotfiles?: 'allow' | 'deny' | 'ignore';
+  etag?: boolean;
+  extensions?: string[];
+  immutable?: boolean;
+  index?: string[] | false;
+  lastModified?: boolean;
+  maxAge?: string | number;
+}
+
+export interface FastifyStaticOptions extends SendOptions {
+  root: string | string[];
   prefix?: string;
   prefixAvoidTrailingSlash?: boolean;
   serve?: boolean;
@@ -32,17 +45,18 @@ export interface FastifyStaticOptions {
   schemaHide?: boolean;
   setHeaders?: (...args: any[]) => void;
   redirect?: boolean;
-  wildcard?: boolean | string;
+  wildcard?: boolean;
   list?: boolean | ListOptions;
+  allowedPath?: (pathName: string, root?: string) => boolean;
 
   // Passed on to `send`
   acceptRanges?: boolean;
   cacheControl?: boolean;
-  dotfiles?: boolean;
+  dotfiles?: 'allow' | 'deny' | 'ignore';
   etag?: boolean;
   extensions?: string[];
   immutable?: boolean;
-  index?: string[];
+  index?: string[] | false;
   lastModified?: boolean;
   maxAge?: string | number;
 }

--- a/packages/platform-fastify/interfaces/external/point-of-view-options.interface.ts
+++ b/packages/platform-fastify/interfaces/external/point-of-view-options.interface.ts
@@ -5,6 +5,7 @@
 export interface PointOfViewOptions {
   engine: {
     ejs?: any;
+    eta?: any;
     nunjucks?: any;
     pug?: any;
     handlebars?: any;
@@ -12,6 +13,8 @@ export interface PointOfViewOptions {
     mustache?: any;
     'art-template'?: any;
     twig?: any;
+    liquid?: any;
+    dot?: any;
   };
   templates?: string;
   includeViewExtension?: boolean;
@@ -23,4 +26,5 @@ export interface PointOfViewOptions {
   layout?: string;
   root?: string;
   viewExt?: string;
+  propertyName?: string;
 }


### PR DESCRIPTION
Both the fastify-static and point-of-view packages interface.ts files are updated to match the
versions used in the package.json file. The point-of-view package added support for eta, liquid
and dot engine.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

My problem was that I couldn't use the Eta engine for Fastify, but the latest point-of-view package did support it. The changes I made are just copies of the latest linked files.

Issue Number: I did not open an issue, I just tried to help en fix it myself.

## What is the new behavior?

Eta engine works.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Let me know if there is a problem with this pull request.

Great work guys!