### PR TITLE
perf(core): use const enum for `HttpStatus`

### DIFF
--- a/packages/common/enums/http-status.enum.ts
+++ b/packages/common/enums/http-status.enum.ts
@@ -1,4 +1,4 @@
-export enum HttpStatus {
+export const enum HttpStatus {
   CONTINUE = 100,
   SWITCHING_PROTOCOLS = 101,
   PROCESSING = 102,


### PR DESCRIPTION
`const enum`s are inlined at compile-time in TypeScript, while regular `enum`s use array and object lookups.  This should provide minor performance and size improvements

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```

Not totally a refactor, because there are features with regular `enum`s you cannot do with `const enum`s

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] barely
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If any Nest.js users use reverse mappings, they will need to find another way to get that behavior.  I'd imagine for HTTP status codes, that would be a very uncommon thing to happen.

## Other information