### PR TITLE
fix(core): update hosts definition to match path-to-regexp

### DIFF
--- a/packages/common/decorators/core/controller.decorator.ts
+++ b/packages/common/decorators/core/controller.decorator.ts
@@ -27,7 +27,7 @@ export interface ControllerOptions extends ScopeOptions {
    *
    * @see [Routing](https://docs.nestjs.com/controllers#routing)
    */
-  host?: string | string[];
+  host?: string | RegExp | Array<string | RegExp>;
 }
 
 /**

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -217,14 +217,17 @@ export class RouterExplorer {
     });
   }
 
-  private applyHostFilter(host: string | RegExp | Array<string | RegExp>, handler: Function) {
+  private applyHostFilter(
+    host: string | RegExp | Array<string | RegExp>,
+    handler: Function,
+  ) {
     if (!host) {
       return handler;
     }
 
     const httpAdapterRef = this.container.getHttpAdapterRef();
     const hosts = Array.isArray(host) ? host : [host];
-    const hostRegExps = hosts.map((host: string) => {
+    const hostRegExps = hosts.map((host: string | RegExp) => {
       const keys = [];
       const regexp = pathToRegexp(host, keys);
       return { regexp, keys };

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -73,7 +73,7 @@ export class RouterExplorer {
     module: string,
     applicationRef: T,
     basePath: string,
-    host: string | string[],
+    host: string | RegExp | Array<string | RegExp>,
   ) {
     const { instance } = instanceWrapper;
     const routerPaths = this.scanForPaths(instance);
@@ -151,7 +151,7 @@ export class RouterExplorer {
     instanceWrapper: InstanceWrapper,
     moduleKey: string,
     basePath: string,
-    host: string | string[],
+    host: string | RegExp | Array<string | RegExp>,
   ) {
     (routePaths || []).forEach(pathProperties => {
       const { path, requestMethod } = pathProperties;
@@ -180,7 +180,7 @@ export class RouterExplorer {
     instanceWrapper: InstanceWrapper,
     moduleKey: string,
     basePath: string,
-    host: string | string[],
+    host: string | RegExp | Array<string | RegExp>,
   ) {
     const {
       path: paths,
@@ -217,7 +217,7 @@ export class RouterExplorer {
     });
   }
 
-  private applyHostFilter(host: string | string[], handler: Function) {
+  private applyHostFilter(host: string | RegExp | Array<string | RegExp>, handler: Function) {
     if (!host) {
       return handler;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe:
```
Non-functional update to type definition to match the definition in a dependency

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/7120


## What is the new behavior?
The type definition for hosts now matches the one defined in [path-to-regexp](https://github.com/pillarjs/path-to-regexp/blob/master/src/index.ts#L601). Using `// @ts-ignore` is no longer required to pass regex in

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This does not provide a code path for providing keys to path-to-regexp. When using regex hosts, the dev is forced into using numeric host params (ex: `@HostParam('0')`, see issue for full example) for capture groups instead of named host params