### PR TITLE
fix(core): end response when observable completes

### DIFF
--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -105,7 +105,16 @@ export class RouterResponseController {
             }),
         ),
       )
-      .subscribe();
+      .subscribe({
+        next: () => {},
+        error: err => {
+          response.end()
+          throw err
+        },
+        complete: () => {
+          response.end()
+        }
+      });
 
     request.on('close', () => {
       response.end();

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -323,5 +323,21 @@ data: test
       );
       request.emit('close');
     });
+
+    it('should close the request when observable completes', done => {
+      const result = of('test');
+      const response = new Writable();
+      response.end = () => done();
+      response._write = () => {};
+
+      const request = new Writable();
+      request._write = () => {};
+
+      routerResponseController.sse(
+        result,
+        (response as unknown) as ServerResponse,
+        (request as unknown) as IncomingMessage,
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

The response should end as soon as the stream completes. For now, the connection is kept open until a re-connection is done. This allows to stop the SSE connection from the server, a good use case is that a user is not authenticated anymore and should not be able to reconnect:

```typescript
  @Sse('sse')
  sse(@Res() response: Response): Observable<MessageEvent> {
    if (/** user is logged in **/) {
        return interval(1000).pipe(takeUntil(/** User logout **/), map((_) => ({ data: { hello: 'world' } })));
    }
    
    response.sendStatus(204)
    return empty()
  }
}
```  

For example: