### PR TITLE
fix(core): sse end response when observable completes

### DIFF
--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -86,8 +86,13 @@ export class RouterResponseController {
   public async sse<
     TInput extends Observable<unknown> = any,
     TResponse extends HeaderStream = any,
-    TRequest extends IncomingMessage = any
+    TRequest extends IncomingMessage = any,
   >(result: TInput, response: TResponse, request: TRequest) {
+    // It's possible that we sent headers already so don't use a stream
+    if (response.writableEnded) {
+      return;
+    }
+
     this.assertObservable(result);
 
     const stream = new SseStream(request);
@@ -105,10 +110,13 @@ export class RouterResponseController {
             }),
         ),
       )
-      .subscribe();
+      .subscribe({
+        complete: () => {
+          response.end();
+        },
+      });
 
     request.on('close', () => {
-      response.end();
       subscription.unsubscribe();
     });
   }

--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -14,6 +14,7 @@ function toDataString(data: string | object): string {
 }
 
 interface WriteHeaders {
+  writableEnded?: boolean;
   writeHead?(
     statusCode: number,
     reasonPhrase?: string,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

If we want to stop sending data (for example user logged out), the server-sent events endpoint should send a 204 telling the client not to reconnect. For now this will throw an `Headers already sent` error. This patch allows to do so. 

For example: 

```typescript
import { Controller, Get, MessageEvent, Res, Sse, Post } from '@nestjs/common';
import { Response } from 'express';
import { join } from 'path';
import { interval, Observable, timer, empty, fromEvent } from 'rxjs';
import { map, takeUntil, timeout } from 'rxjs/operators';

@Controller()
export class AppController {
  private abortController: AbortController
  
  @Post()
  post(@Res() response: Response) {
    this.abortController.abort()
    response.sendStatus(202)
  }

  @Sse('sse')
  sse(@Res() response: Response): Observable<MessageEvent> {
    if (this.abortController.signal.aborted) {
      response.sendStatus(204)
      return empty()
    }

    return interval(1000).pipe(takeUntil(fromEvent(this.abortController.signal, 'abort')), map((_) => ({ data: { hello: 'world' } })));
  }
}
```