### PR TITLE
feature(microservices): allow deserializers to be async and await result

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -155,7 +155,7 @@ export class ClientKafka extends ClientProxy {
   }
 
   public createResponseCallback(): (payload: EachMessagePayload) => any {
-    return (payload: EachMessagePayload) => {
+    return async (payload: EachMessagePayload) => {
       const rawMessage = this.parser.parse<KafkaMessage>(
         Object.assign(payload.message, {
           topic: payload.topic,
@@ -165,9 +165,8 @@ export class ClientKafka extends ClientProxy {
       if (isUndefined(rawMessage.headers[KafkaHeaders.CORRELATION_ID])) {
         return;
       }
-      const { err, response, isDisposed, id } = this.deserializer.deserialize(
-        rawMessage,
-      );
+      const { err, response, isDisposed, id } =
+        await this.deserializer.deserialize(rawMessage);
       const callback = this.routingMap.get(id);
       if (!callback) {
         return;

--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -94,10 +94,10 @@ export class ClientMqtt extends ClientProxy {
   }
 
   public createResponseCallback(): (channel: string, buffer: Buffer) => any {
-    return (channel: string, buffer: Buffer) => {
+    return async (channel: string, buffer: Buffer) => {
       const packet = JSON.parse(buffer.toString());
       const { err, response, isDisposed, id } =
-        this.deserializer.deserialize(packet);
+        await this.deserializer.deserialize(packet);
 
       const callback = this.routingMap.get(id);
       if (!callback) {

--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -63,14 +63,14 @@ export class ClientNats extends ClientProxy {
     packet: ReadPacket & PacketId,
     callback: (packet: WritePacket) => any,
   ) {
-    return (error: unknown | undefined, natsMsg: NatsMsg) => {
+    return async (error: unknown | undefined, natsMsg: NatsMsg) => {
       if (error) {
         return callback({
           err: error,
         });
       }
       const rawPacket = natsMsg.data;
-      const message = this.deserializer.deserialize(rawPacket);
+      const message = await this.deserializer.deserialize(rawPacket);
       if (message.id && message.id !== packet.id) {
         return undefined;
       }

--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -135,11 +135,14 @@ export class ClientRedis extends ClientProxy {
     return this.getOptionsProp(this.options, 'retryDelay') || 0;
   }
 
-  public createResponseCallback(): (channel: string, buffer: string) => void {
-    return (channel: string, buffer: string) => {
+  public createResponseCallback(): (
+    channel: string,
+    buffer: string,
+  ) => Promise<void> {
+    return async (channel: string, buffer: string) => {
       const packet = JSON.parse(buffer);
       const { err, response, isDisposed, id } =
-        this.deserializer.deserialize(packet);
+        await this.deserializer.deserialize(packet);
 
       const callback = this.routingMap.get(id);
       if (!callback) {

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -160,11 +160,13 @@ export class ClientRMQ extends ClientProxy {
     });
   }
 
-  public handleMessage(
+  public async handleMessage(
     packet: unknown,
     callback: (packet: WritePacket) => any,
   ) {
-    const { err, response, isDisposed } = this.deserializer.deserialize(packet);
+    const { err, response, isDisposed } = await this.deserializer.deserialize(
+      packet,
+    );
     if (isDisposed || err) {
       callback({
         err,

--- a/packages/microservices/client/client-tcp.ts
+++ b/packages/microservices/client/client-tcp.ts
@@ -60,9 +60,9 @@ export class ClientTCP extends ClientProxy {
     return this.connection;
   }
 
-  public handleResponse(buffer: unknown): void {
+  public async handleResponse(buffer: unknown): Promise<void> {
     const { err, response, isDisposed, id } =
-      this.deserializer.deserialize(buffer);
+      await this.deserializer.deserialize(buffer);
     const callback = this.routingMap.get(id);
     if (!callback) {
       return undefined;

--- a/packages/microservices/interfaces/deserializer.interface.ts
+++ b/packages/microservices/interfaces/deserializer.interface.ts
@@ -5,7 +5,10 @@ import {
 } from './packet.interface';
 
 export interface Deserializer<TInput = any, TOutput = any> {
-  deserialize(value: TInput, options?: Record<string, any>): TOutput;
+  deserialize(
+    value: TInput,
+    options?: Record<string, any>,
+  ): TOutput | Promise<TOutput>;
 }
 
 export type ProducerDeserializer = Deserializer<any, IncomingResponse>;

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -152,12 +152,12 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
         partition: payload.partition,
       }),
     );
-    const headers = (rawMessage.headers as unknown) as Record<string, any>;
+    const headers = rawMessage.headers as unknown as Record<string, any>;
     const correlationId = headers[KafkaHeaders.CORRELATION_ID];
     const replyTopic = headers[KafkaHeaders.REPLY_TOPIC];
     const replyPartition = headers[KafkaHeaders.REPLY_PARTITION];
 
-    const packet = this.deserializer.deserialize(rawMessage, { channel });
+    const packet = await this.deserializer.deserialize(rawMessage, { channel });
     const kafkaContext = new KafkaContext([
       rawMessage,
       payload.partition,
@@ -236,9 +236,8 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
     correlationId: string,
     outgoingMessage: Message,
   ) {
-    outgoingMessage.headers[KafkaHeaders.CORRELATION_ID] = Buffer.from(
-      correlationId,
-    );
+    outgoingMessage.headers[KafkaHeaders.CORRELATION_ID] =
+      Buffer.from(correlationId);
   }
 
   public assignReplyPartition(

--- a/packages/microservices/server/server-mqtt.ts
+++ b/packages/microservices/server/server-mqtt.ts
@@ -97,7 +97,7 @@ export class ServerMqtt extends Server implements CustomTransportStrategy {
     originalPacket?: Record<string, any>,
   ): Promise<any> {
     const rawPacket = this.parseMessage(buffer.toString());
-    const packet = this.deserializer.deserialize(rawPacket, { channel });
+    const packet = await this.deserializer.deserialize(rawPacket, { channel });
     const mqttContext = new MqttContext([channel, originalPacket]);
     if (isUndefined((packet as IncomingRequest).id)) {
       return this.handleEvent(channel, packet, mqttContext);

--- a/packages/microservices/server/server-nats.ts
+++ b/packages/microservices/server/server-nats.ts
@@ -88,7 +88,7 @@ export class ServerNats extends Server implements CustomTransportStrategy {
     const replyTo = natsMsg.reply;
 
     const natsCtx = new NatsContext([callerSubject, natsMsg.headers]);
-    const message = this.deserializer.deserialize(rawMessage, {
+    const message = await this.deserializer.deserialize(rawMessage, {
       channel,
       replyTo,
     });

--- a/packages/microservices/server/server-redis.ts
+++ b/packages/microservices/server/server-redis.ts
@@ -97,7 +97,7 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
     pub: RedisClient,
   ) {
     const rawMessage = this.parseMessage(buffer);
-    const packet = this.deserializer.deserialize(rawMessage, { channel });
+    const packet = await this.deserializer.deserialize(rawMessage, { channel });
     const redisCtx = new RedisContext([channel]);
 
     if (isUndefined((packet as IncomingRequest).id)) {

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -130,7 +130,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     }
     const { content, properties } = message;
     const rawMessage = JSON.parse(content.toString());
-    const packet = this.deserializer.deserialize(rawMessage);
+    const packet = await this.deserializer.deserialize(rawMessage);
     const pattern = isString(packet.pattern)
       ? packet.pattern
       : JSON.stringify(packet.pattern);
@@ -170,7 +170,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     correlationId: string,
   ): void {
     const outgoingResponse = this.serializer.serialize(
-      (message as unknown) as OutgoingResponse,
+      message as unknown as OutgoingResponse,
     );
     const buffer = Buffer.from(JSON.stringify(outgoingResponse));
     this.channel.sendToQueue(replyTo, buffer, { correlationId });

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -69,7 +69,7 @@ export class ServerTCP extends Server implements CustomTransportStrategy {
   }
 
   public async handleMessage(socket: JsonSocket, rawMessage: unknown) {
-    const packet = this.deserializer.deserialize(rawMessage);
+    const packet = await this.deserializer.deserialize(rawMessage);
     const pattern = !isString(packet.pattern)
       ? JSON.stringify(packet.pattern)
       : packet.pattern;

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -3,6 +3,7 @@ import { Subject } from 'rxjs';
 import * as sinon from 'sinon';
 import { ClientRedis } from '../../client/client-redis';
 import { ERROR_EVENT } from '../../constants';
+import { Client } from '../../external/nats-client.interface';
 
 describe('ClientRedis', () => {
   const test = 'test';
@@ -116,19 +117,22 @@ describe('ClientRedis', () => {
     });
   });
   describe('createResponseCallback', () => {
-    let callback: sinon.SinonSpy, subscription;
+    let callback: sinon.SinonSpy, subscription; // : ReturnType<typeof client['createResponseCallback']>;
     const responseMessage = {
       response: 'test',
       id: '1',
     };
 
     describe('not completed', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         callback = sinon.spy();
 
         subscription = client.createResponseCallback();
         client['routingMap'].set(responseMessage.id, callback);
-        subscription('channel', Buffer.from(JSON.stringify(responseMessage)));
+        await subscription(
+          'channel',
+          Buffer.from(JSON.stringify(responseMessage)),
+        );
       });
       it('should call callback with expected arguments', () => {
         expect(

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -218,10 +218,10 @@ describe('ClientRMQ', function () {
 
       beforeEach(async () => {
         unsubscribeSpy = sinon.spy();
-        client['responseEmitter'] = ({
+        client['responseEmitter'] = {
           removeListener: unsubscribeSpy,
           on: sinon.spy(),
-        } as any) as EventEmitter;
+        } as any as EventEmitter;
 
         subscription = await client['publish'](msg, sinon.spy());
         subscription();
@@ -239,13 +239,13 @@ describe('ClientRMQ', function () {
       beforeEach(() => {
         callback = sinon.spy();
       });
-      it('should call callback with correct object', () => {
+      it('should call callback with correct object', async () => {
         const packet = {
           err: true,
           response: 'test',
           isDisposed: false,
         };
-        client.handleMessage(packet, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: packet.err,
@@ -261,12 +261,12 @@ describe('ClientRMQ', function () {
       beforeEach(() => {
         callback = sinon.spy();
       });
-      it('should call callback with correct object', () => {
+      it('should call callback with correct object', async () => {
         const packet = {
           response: 'test',
           isDisposed: true,
         };
-        client.handleMessage(packet, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: undefined,
@@ -283,12 +283,12 @@ describe('ClientRMQ', function () {
       beforeEach(() => {
         callback = sinon.spy();
       });
-      it('should call callback with correct object', () => {
+      it('should call callback with correct object', async () => {
         const packet = {
           response: 'test',
           isDisposed: false,
         };
-        client.handleMessage(packet, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: undefined,

--- a/packages/microservices/test/client/client-tcp.spec.ts
+++ b/packages/microservices/test/client/client-tcp.spec.ts
@@ -65,10 +65,10 @@ describe('ClientTCP', () => {
     const id = '1';
 
     describe('when disposed', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         callback = sinon.spy();
         client['routingMap'].set(id, callback);
-        client.handleResponse({ id, isDisposed: true });
+        await client.handleResponse({ id, isDisposed: true });
       });
       it('should emit disposed callback', () => {
         expect(callback.called).to.be.true;
@@ -83,11 +83,11 @@ describe('ClientTCP', () => {
     });
     describe('when not disposed', () => {
       let buffer;
-      beforeEach(() => {
+      beforeEach(async () => {
         buffer = { id, err: undefined, response: 'res' };
         callback = sinon.spy();
         client['routingMap'].set(id, callback);
-        client.handleResponse(buffer);
+        await client.handleResponse(buffer);
       });
       it('should not end server', () => {
         expect(socket.end.called).to.be.false;

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -277,20 +277,20 @@ describe('ServerKafka', () => {
 
       sinon.stub(server, 'getPublisher').callsFake(() => getPublisherSpy);
     });
-    it('should call "handleEvent" if correlation identifier is not present', () => {
+    it('should call "handleEvent" if correlation identifier is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
-      server.handleMessage(eventPayload);
+      await server.handleMessage(eventPayload);
       expect(handleEventSpy.called).to.be.true;
     });
 
-    it('should call "handleEvent" if correlation identifier is present by the reply topic is not present', () => {
+    it('should call "handleEvent" if correlation identifier is present by the reply topic is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
-      server.handleMessage(eventWithCorrelationIdPayload);
+      await server.handleMessage(eventWithCorrelationIdPayload);
       expect(handleEventSpy.called).to.be.true;
     });
 
-    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, () => {
-      server.handleMessage(payload);
+    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {
+      await server.handleMessage(payload);
       expect(
         getPublisherSpy.calledWith({
           id: payload.message.headers[KafkaHeaders.CORRELATION_ID].toString(),
@@ -298,13 +298,13 @@ describe('ServerKafka', () => {
         }),
       ).to.be.true;
     });
-    it(`should call handler with expected arguments`, () => {
+    it(`should call handler with expected arguments`, async () => {
       const handler = sinon.spy();
       (server as any).messageHandlers = objectToMap({
         [topic]: handler,
       });
 
-      server.handleMessage(payload);
+      await server.handleMessage(payload);
       expect(handler.called).to.be.true;
     });
   });

--- a/packages/microservices/test/server/server-mqtt.spec.ts
+++ b/packages/microservices/test/server/server-mqtt.spec.ts
@@ -108,17 +108,17 @@ describe('ServerMqtt', () => {
       getPublisherSpy = sinon.spy();
       sinon.stub(server, 'getPublisher').callsFake(() => getPublisherSpy);
     });
-    it('should call "handleEvent" if identifier is not present', () => {
+    it('should call "handleEvent" if identifier is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
-      server.handleMessage(
+      await server.handleMessage(
         channel,
         new Buffer(JSON.stringify({ pattern: '', data })),
         null,
       );
       expect(handleEventSpy.called).to.be.true;
     });
-    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, () => {
-      server.handleMessage(
+    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {
+      await server.handleMessage(
         channel,
         new Buffer(JSON.stringify({ id, pattern: '', data })),
         null,
@@ -131,13 +131,13 @@ describe('ServerMqtt', () => {
         }),
       ).to.be.true;
     });
-    it(`should call handler with expected arguments`, () => {
+    it(`should call handler with expected arguments`, async () => {
       const handler = sinon.spy();
       (server as any).messageHandlers = objectToMap({
         [channel]: handler,
       });
 
-      server.handleMessage(
+      await server.handleMessage(
         channel,
         new Buffer(JSON.stringify({ pattern: '', data, id: '2' })),
         null,

--- a/packages/microservices/test/server/server-redis.spec.ts
+++ b/packages/microservices/test/server/server-redis.spec.ts
@@ -107,16 +107,16 @@ describe('ServerRedis', () => {
       getPublisherSpy = sinon.spy();
       sinon.stub(server, 'getPublisher').callsFake(() => getPublisherSpy);
     });
-    it('should call "handleEvent" if identifier is not present', () => {
+    it('should call "handleEvent" if identifier is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
       sinon.stub(server, 'parseMessage').callsFake(() => ({ data } as any));
 
-      server.handleMessage(channel, JSON.stringify({}), null);
+      await server.handleMessage(channel, JSON.stringify({}), null);
       expect(handleEventSpy.called).to.be.true;
     });
-    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, () => {
+    it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {
       sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data } as any));
-      server.handleMessage(channel, JSON.stringify({ id }), null);
+      await server.handleMessage(channel, JSON.stringify({ id }), null);
       expect(
         getPublisherSpy.calledWith({
           id,
@@ -125,14 +125,14 @@ describe('ServerRedis', () => {
         }),
       ).to.be.true;
     });
-    it(`should call handler with expected arguments`, () => {
+    it(`should call handler with expected arguments`, async () => {
       const handler = sinon.spy();
       (server as any).messageHandlers = objectToMap({
         [channel]: handler,
       });
       sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data } as any));
 
-      server.handleMessage(channel, {}, null);
+      await server.handleMessage(channel, {}, null);
       expect(handler.calledWith(data)).to.be.true;
     });
   });

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -100,9 +100,9 @@ describe('ServerRMQ', () => {
     beforeEach(() => {
       sendMessageStub = sinon.stub(server, 'sendMessage').callsFake(() => ({}));
     });
-    it('should call "handleEvent" if identifier is not present', () => {
+    it('should call "handleEvent" if identifier is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
-      server.handleMessage(createMessage({ pattern: '', data: '' }), '');
+      await server.handleMessage(createMessage({ pattern: '', data: '' }), '');
       expect(handleEventSpy.called).to.be.true;
     });
     it('should send NO_MESSAGE_HANDLER error if key does not exists in handlers object', async () => {

--- a/packages/microservices/test/server/server-tcp.spec.ts
+++ b/packages/microservices/test/server/server-tcp.spec.ts
@@ -63,8 +63,8 @@ describe('ServerTCP', () => {
         sendMessage: sinon.spy(),
       };
     });
-    it('should send NO_MESSAGE_HANDLER error if key does not exists in handlers object', () => {
-      server.handleMessage(socket, msg);
+    it('should send NO_MESSAGE_HANDLER error if key does not exists in handlers object', async () => {
+      await server.handleMessage(socket, msg);
       expect(
         socket.sendMessage.calledWith({
           id: msg.id,
@@ -73,12 +73,12 @@ describe('ServerTCP', () => {
         }),
       ).to.be.true;
     });
-    it('should call handler if exists in handlers object', () => {
+    it('should call handler if exists in handlers object', async () => {
       const handler = sinon.spy();
       (server as any).messageHandlers = objectToMap({
         [msg.pattern]: handler as any,
       });
-      server.handleMessage(socket, msg);
+      await server.handleMessage(socket, msg);
       expect(handler.calledOnce).to.be.true;
     });
   });


### PR DESCRIPTION
Linked Issue #7657.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
kafka transport (and other transports) allow configuration of a deserializer via options.
The deserializer cannot be async.

Issue Number: N/A


## What is the new behavior?
deserializers may be async and the deserialization result is awaited

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
I'm trying to integrate a deserializer that allows kafka messages with schema registry. This requires the deserializer to fetch the schema from the registry if it isn't cached yet. Currently the deserializer has to be synchronous and returning a promise instead would break server-kafka (and others).
Given the nature of awaits this change should be fully backward compatibility since `await <not a promise>` would simply yield `<not a promise>`.