### PR TITLE
fix(packaging): limit global types to "node"

### DIFF
--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -15,7 +15,8 @@
     "sourceMap": false,
     "allowJs": false,
     "strict": true,
-    "strictNullChecks": false
+    "strictNullChecks": false,
+    "types": ["node"]
   },
   "exclude": ["../node_modules", "./**/*.spec.ts"]
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) N/A
- [ ] Docs have been added / updated (for bug fixes / features) N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `vinyl-fs` types are being referenced in a triple-slash directive in `core/router/sse-stream.d.ts` because `@types/vinyl-fs` includes a global change to the `NodeJS.WritableStream` interface. This can cause problems in packages using nest, as `@types/vinyl-fs` is not included as a dependency (nor should it be) so typescript may not be able to resolve the reference. I've seen this issue locally and in CI, but it may not always appear with `tsc`

Issue Number: #7247 

## What is the new behavior?

The new behavior only brings in the global node types, as this seems to be the only @types package should be included:

```sh
# run on a clean build of all @nestjs packages
$  grep -r '/// <reference' .
./core/router/sse-stream.d.ts:/// <reference types="node" />
./core/router/sse-stream.d.ts:/// <reference types="vinyl-fs" />
./core/router/router-response-controller.d.ts:/// <reference types="node" />
./core/helpers/handler-metadata-storage.d.ts:/// <reference types="node" />
./platform-express/multer/interfaces/multer-options.interface.d.ts:/// <reference types="node" />
./microservices/external/mqtt-options.interface.d.ts:/// <reference types="node" />
./microservices/external/kafka.interface.d.ts:/// <reference types="node" />
./microservices/external/mqtt-client.interface.d.ts:/// <reference types="node" />
./microservices/external/nats-client.interface.d.ts:/// <reference types="node" />
./microservices/client/client-rmq.d.ts:/// <reference types="node" />
./microservices/client/client-mqtt.d.ts:/// <reference types="node" />
./microservices/test/json-socket/helpers.d.ts:/// <reference types="node" />
./microservices/server/server-tcp.d.ts:/// <reference types="node" />
./microservices/server/server-mqtt.d.ts:/// <reference types="node" />
./microservices/serializers/kafka-request.serializer.d.ts:/// <reference types="node" />
./microservices/helpers/json-socket.d.ts:/// <reference types="node" />
./microservices/helpers/kafka-reply-partition-assigner.d.ts:/// <reference types="node" />
./microservices/helpers/kafka-parser.d.ts:/// <reference types="node" />
./platform-fastify/adapters/fastify-adapter.d.ts:/// <reference types="node" />
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Arguably this could mean that `@types/node` should be included as a `peerDependency` of `@nestjs/core`, `@nestjs/platform-express`, `@nestjs/microservices`, and `@nestjs/platform-fastify` but I think it's safe to assume that anyone using those will have @types/node installed already.