### PR TITLE
fix(microservices): do not parse kafka schema messages

### DIFF
--- a/packages/microservices/helpers/kafka-parser.ts
+++ b/packages/microservices/helpers/kafka-parser.ts
@@ -18,9 +18,19 @@ export class KafkaParser {
     return data;
   }
 
-  public static decode(value: Buffer): object | string | null {
+  public static decode(value: Buffer): object | string | null | Buffer {
     if (isNil(value)) {
       return null;
+    }
+
+    // a value with leading zero byte indicates a schema payload.
+    // The content is possibly binary and should not be touched.
+    if (
+      Buffer.isBuffer(value) &&
+      value.length > 0 &&
+      value.readUInt8(0) === 0
+    ) {
+      return value;
     }
 
     let result = value.toString();

--- a/packages/microservices/test/helpers/kafka-parser.spec.ts
+++ b/packages/microservices/test/helpers/kafka-parser.spec.ts
@@ -37,6 +37,18 @@ describe('KafkaParser', () => {
       });
     });
 
+    it('binary buffer using kafka schema registry preamble', () => {
+      const kafkaSchemaPreambleWithSchemaId = [0x00, 0x00, 0x00, 0x00, 0x01];
+      expect(
+        KafkaParser.parse({
+          value: Buffer.from(kafkaSchemaPreambleWithSchemaId),
+        }),
+      ).to.deep.eq({
+        headers: {},
+        value: Buffer.from(kafkaSchemaPreambleWithSchemaId),
+      });
+    });
+
     it('buffer number', () => {
       expect(
         KafkaParser.parse({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
When using the kafka schema registry values with a zero byte preamble indicate a schema message. The following four bytes contain the schema id, followed by a possibly binary message. The binary message must not be decoded to string, as this will possibly mutate the original bytes to comply with utf-8, thus breaking the message and making it unreadable.

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
All values are converted to utf-8 strings, regardless of their binary or not nature.

Issue Number: N/A


## What is the new behavior?
value is checked for zero byte preamble. When found the payload will not be touched.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

## Other information
Details regarding kafka schema registry: https://docs.confluent.io/platform/current/schema-registry/index.html