### PR TITLE
Fix get url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ We cannot accept code without this.
 
 1. Create your patch, **including appropriate test cases**.
 1. Follow our [Coding Rules](#rules).
-1. Run the full Nest test suite (see [common scripts](#common-scripts)),
+1. Run the full Nest test suite (see [Development Setup](#development-setup)),
    and ensure that all tests pass.
 1. Commit your changes using a descriptive commit message that follows our
    [commit message conventions](#commit). Adherence to these conventions

--- a/integration/nest-application/get-url/e2e/express.spec.ts
+++ b/integration/nest-application/get-url/e2e/express.spec.ts
@@ -1,4 +1,5 @@
 import { ExpressAdapter } from '@nestjs/platform-express';
+import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as express from 'express';
@@ -6,52 +7,52 @@ import { AppModule } from '../src/app.module';
 import { randomPort } from './utils';
 
 describe('Get URL (Express Application)', () => {
-  let testModule: TestingModule;
+  let app: INestApplication;
   let port: number;
 
   beforeEach(async () => {
-    testModule = await Test.createTestingModule({
+    port = await randomPort();
+    const testModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();
+    app = testModule.createNestApplication(new ExpressAdapter(express()));
   });
 
-  beforeEach(async () => {
-    port = await randomPort();
+  afterEach(async () => {
+    app && (await app.close());
   });
 
   it('should be able to get the IPv6 address', async () => {
-    const app = testModule.createNestApplication(new ExpressAdapter(express()));
     await app.listen(port);
     expect(await app.getUrl()).to.be.eql(`http://[::1]:${port}`);
-    await app.close();
   });
   it('should be able to get the IPv4 address', async () => {
-    const app = testModule.createNestApplication(new ExpressAdapter(express()));
-    await app.listen(port, '127.0.0.5');
-    expect(await app.getUrl()).to.be.eql(`http://127.0.0.5:${port}`);
-    await app.close();
+    await app.listen(port, '127.0.0.1');
+    expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
   });
   it('should return 127.0.0.1 for 0.0.0.0', async () => {
-    const app = testModule.createNestApplication(new ExpressAdapter(express()));
     await app.listen(port, '0.0.0.0');
     expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
-    await app.close();
   });
-  it('should return 127.0.0.1 even in a callback', () => {
-    const app = testModule.createNestApplication(new ExpressAdapter(express()));
-    return app.listen(port, async () => {
+  it('should be able to get the IPv4 address after app is listening', async () => {
+    await app.listenAsync(port, '0.0.0.0');
+    expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
+  });
+  it('should be able to get the IPv4 address in a callback', done => {
+    app.listen(port, '0.0.0.0', async () => {
       expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
-      await app.close();
+      done();
     });
   });
   it('should throw an error for calling getUrl before listen', async () => {
-    const app = testModule.createNestApplication(new ExpressAdapter(express()));
+    let err: any;
     try {
       await app.getUrl();
-    } catch (err) {
-      expect(err).to.be.eql(
-        'app.listen() needs to be called before calling app.getUrl()',
-      );
+    } catch (error) {
+      err = error;
     }
+    expect(err).to.be.eql(
+      'app.listen() needs to be called before calling app.getUrl()',
+    );
   });
 });

--- a/integration/nest-application/get-url/e2e/fastify.spec.ts
+++ b/integration/nest-application/get-url/e2e/fastify.spec.ts
@@ -1,50 +1,53 @@
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import { Test, TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
 import { expect } from 'chai';
 import { AppModule } from '../src/app.module';
 import { randomPort } from './utils';
 
 describe('Get URL (Fastify Application)', () => {
-  let testModule: TestingModule;
   let port: number;
-
-  beforeEach(async () => {
-    testModule = await Test.createTestingModule({
-      imports: [AppModule],
-    }).compile();
-  });
+  let app: INestApplication;
 
   beforeEach(async () => {
     port = await randomPort();
+    const testModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    app = testModule.createNestApplication(new FastifyAdapter());
+  });
+
+  afterEach(async () => {
+    app && (await app.close());
   });
 
   it('should be able to get the IPv4 address', async () => {
-    const app = testModule.createNestApplication(new FastifyAdapter());
-    await app.listen(port, '127.0.0.5');
-    expect(await app.getUrl()).to.be.eql(`http://127.0.0.5:${port}`);
-    await app.close();
+    await app.listen(port, '127.0.0.1');
+    expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
   });
   it('should return 127.0.0.1 for 0.0.0.0', async () => {
-    const app = testModule.createNestApplication(new FastifyAdapter());
     await app.listen(port, '0.0.0.0');
     expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
-    await app.close();
   });
-  it('should return 127.0.0.1 even in a callback', () => {
-    const app = testModule.createNestApplication(new FastifyAdapter());
-    return app.listen(port, async () => {
+  it('should be able to get the IPv4 address after app is listening', async () => {
+    await app.listenAsync(port, '0.0.0.0');
+    expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
+  });
+  it('should be able to get the IPv4 address in a callback', done => {
+    app.listen(port, '0.0.0.0', async () => {
       expect(await app.getUrl()).to.be.eql(`http://127.0.0.1:${port}`);
-      await app.close();
+      done();
     });
   });
   it('should throw an error for calling getUrl before listen', async () => {
-    const app = testModule.createNestApplication(new FastifyAdapter());
+    let err: any;
     try {
       await app.getUrl();
-    } catch (err) {
-      expect(err).to.be.eql(
-        'app.listen() needs to be called before calling app.getUrl()',
-      );
+    } catch (error) {
+      err = error;
     }
+    expect(err).to.be.eql(
+      'app.listen() needs to be called before calling app.getUrl()',
+    );
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The promise returned by `app.getUrl()` never resolves if called after the http server starts listening. See notes in the issue. This was marked resolved previously, but was not actually fixed.

Issue Number: #5798

## What is the new behavior?
The promise is created before starting the http server, resolves after the server starts listening, and is stored for future calls to `getUrl`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
I also did some cleanup in the tests for these:
* moved `app.close()` to an `afterEach`. Previously, this was at the end of each test, so would not be run if a test failed
* fixed the test for the error from calling `getUrl` before `listen`. Previously, the `expect` was in the catch block, so the test would be a false positive if no error was thrown