### PR TITLE
Fix ConsoleLogger: logging a few undefined lines

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -226,7 +226,7 @@ export class ConsoleLogger implements LoggerService {
   }
 
   private getContextAndStackAndMessagesToPrint(args: unknown[]) {
-    const { messages, context } = this.getContextAndMessagesToPrint(args);
+    const { messages, context } = this.getContextAndMessagesToPrint(this.removeUndefinedFromArgs(args));
     if (messages?.length <= 1) {
       return { messages, context };
     }
@@ -240,6 +240,10 @@ export class ConsoleLogger implements LoggerService {
       messages: messages.slice(0, messages.length - 1),
       context,
     };
+  }
+
+  removeUndefinedFromArgs(args: unknown[]) {
+    return args.filter((arg => typeof arg !== 'undefined'))
   }
 
   private getColorByLogLevel(level: LogLevel) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When I use something like that
```
import { ConsoleLogger } from '@nestjs/common';

export class MyLogger extends ConsoleLogger {
  error(message: any, stack?: string, context?: string) {
    super.error(message, stack, context);
  }
}
```
then 
```
this.myLogger.error('some line for logging');
```

I get 3 lines in console 
```
[Nest] 38634  - 07/08/2021, 12:58:11 PM   ERROR [Context] some line for logging
[Nest] 38634  - 07/08/2021, 12:58:11 PM   ERROR [Context] undefined
[Nest] 38634  - 07/08/2021, 12:58:11 PM   ERROR [Context] undefined
```
because the ConsoleLogger doesn't have an argument check for undefined

Issue Number: N/A


## What is the new behavior?
I added filter by args (arg !== 'undefined') and now in this case only one line is displayed in the console

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```