### PR TITLE
feat(common): allow deprecated Logger constructor

### DIFF
--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -83,9 +83,9 @@ export class Logger implements LoggerService {
   constructor();
   constructor(context: string);
   /**
-   * @deprecated timestamp is deprecated. Use "{ timestamp?: boolean }" object instead.
+   * @deprecated isTimestampEnabled is deprecated. Use "{ timestamp?: boolean }" object instead.
    */
-  constructor(context: string, timestamp?: boolean);
+  constructor(context: string, isTimestampEnabled?: boolean);
   constructor(context: string, options?: { timestamp?: boolean });
   constructor(
     @Optional() protected context?: string,

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -82,13 +82,21 @@ export class Logger implements LoggerService {
 
   constructor();
   constructor(context: string);
+  /**
+   * @deprecated timestamp is deprecated. Use "{ timestamp?: boolean }" object instead.
+   */
+  constructor(context: string, timestamp?: boolean);
   constructor(context: string, options?: { timestamp?: boolean });
   constructor(
     @Optional() protected context?: string,
-    @Optional() protected options: { timestamp?: boolean } = {},
+    @Optional() protected options: { timestamp?: boolean } | boolean = {},
   ) {}
 
   get localInstance(): LoggerService {
+    if (typeof this.options === 'boolean') {
+      this.options = { timestamp: this.options };
+    }
+
     if (Logger.staticInstanceRef === DEFAULT_LOGGER) {
       if (this.localInstanceRef) {
         return this.localInstanceRef;

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -375,6 +375,54 @@ describe('Logger', () => {
       });
     });
 
+    describe('when the default logger is used and global context is set and timestamp enabled (deprecated)', () => {
+      const globalContext = 'GlobalContext';
+      const logger = new Logger(globalContext, true);
+
+      let processStdoutWriteSpy: sinon.SinonSpy;
+      let processStderrWriteSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        processStdoutWriteSpy = sinon.spy(process.stdout, 'write');
+        processStderrWriteSpy = sinon.spy(process.stderr, 'write');
+      });
+
+      afterEach(() => {
+        processStdoutWriteSpy.restore();
+        processStderrWriteSpy.restore();
+      });
+
+      it('should print multiple messages to the console and append global context', () => {
+        const messages = ['message 1', 'message 2', 'message 3'];
+
+        logger.log(messages[0], messages[1], messages[2]);
+
+        expect(processStdoutWriteSpy.calledThrice).to.be.true;
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          `[${globalContext}]`,
+        );
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          messages[0],
+        );
+
+        expect(processStdoutWriteSpy.secondCall.firstArg).to.include(
+          `[${globalContext}]`,
+        );
+        expect(processStdoutWriteSpy.secondCall.firstArg).to.include(
+          messages[1],
+        );
+        expect(processStdoutWriteSpy.secondCall.firstArg).to.include('ms');
+
+        expect(processStdoutWriteSpy.thirdCall.firstArg).to.include(
+          `[${globalContext}]`,
+        );
+        expect(processStdoutWriteSpy.thirdCall.firstArg).to.include(
+          messages[2],
+        );
+        expect(processStdoutWriteSpy.thirdCall.firstArg).to.include('ms');
+      });
+    });
+
     describe('when the default logger is used and global context is set and timestamp enabled', () => {
       const globalContext = 'GlobalContext';
       const logger = new Logger(globalContext, { timestamp: true });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/7478


## What is the new behavior?

```typescript
// ~v7: ok
// v8: error
const logger = new Logger("Logger", true);
```

↓

```typescript
// ~v7: ok
// v8: ok (however, add @deprecated tag)
const logger = new Logger("Logger", true);
```

![4be1e189b8b8117c8091aebedb89dcbc](https://user-images.githubusercontent.com/694454/124956396-e93d9780-e052-11eb-88e6-c10aec638618.jpg)



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information