### PR TITLE
fix(core): useLogger type boolean instead of false

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -129,7 +129,7 @@ export class NestApplicationContext implements INestApplicationContext {
     this.unsubscribeFromProcessSignals();
   }
 
-  public useLogger(logger: LoggerService | LogLevel[] | false) {
+  public useLogger(logger: LoggerService | LogLevel[] | boolean) {
     Logger.overrideLogger(logger);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When trying to invoke the function `useLogger` with a variable that's of type `LoggerService | LogLevel[] | boolean`, like the default logger option in the Nest Application, it fails because of this error:
```
Type 'true' is not assignable to type 'false | LoggerService | LogLevel[]'.
```

## What is the new behavior?
The typing `false` is changed to type `boolean`, which will fix the typing error

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information