### PR TITLE
Observable is not assignable to type Observable

### DIFF
--- a/sample/28-sse/src/app.controller.ts
+++ b/sample/28-sse/src/app.controller.ts
@@ -16,6 +16,6 @@ export class AppController {
 
   @Sse('sse')
   sse(): Observable<MessageEvent> {
-    return interval(1000).pipe(map((_) => ({ data: { hello: 'world' } })));
+    return interval(1000).pipe(map((_) => ({ data: { hello: 'world' } } as MessageEvent )));
   }
 }


### PR DESCRIPTION
Fix: Type 'Observable<{ data: { hello: string; }; }>' is not assignable to type 'Observable<MessageEvent<any>>'.   Type '{ data: { hello: string; }; }' is missing the following properties from type 'MessageEvent<any>': lastEventId, origin, ports, source, and 22 more.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Samplecode for SSE

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information