### PR TITLE
fix: FastifyAdapter Middleware no run, ExpressAdapter createMiddlewareFactory

### DIFF
--- a/integration/hello-world/e2e/exclude-middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/exclude-middleware-fastify.spec.ts
@@ -25,6 +25,11 @@ class TestController {
     return RETURN_VALUE;
   }
 
+  @Get('test/test')
+  testTest() {
+    return RETURN_VALUE;
+  }
+
   @Get('test2')
   test2() {
     return RETURN_VALUE;
@@ -83,6 +88,10 @@ describe('Exclude middleware (fastify)', () => {
 
   it(`should exclude "/test" endpoint`, () => {
     return request(app.getHttpServer()).get('/test').expect(200, RETURN_VALUE);
+  });
+
+  it(`should not exclude "/test/test" endpoint`, () => {
+    return request(app.getHttpServer()).get('/test/test').expect(200, MIDDLEWARE_VALUE);
   });
 
   it(`should not exclude "/test2" endpoint`, () => {

--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, MiddlewareConsumer, Module } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  MiddlewareConsumer,
+  Module,
+  Query,
+  RequestMethod,
+} from '@nestjs/common';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -7,14 +14,27 @@ import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import { ApplicationModule } from '../src/app.module';
 
+const INCLUDED_VALUE = 'test_included';
+const QUERY_VALUE = 'test_query';
+const REQ_URL_VALUE = 'test_req_url';
 const RETURN_VALUE = 'test';
 const SCOPED_VALUE = 'test_scoped';
 const WILDCARD_VALUE = 'test_wildcard';
 
 @Controller()
 class TestController {
+  @Get('express_style_wildcard/wildcard_nested')
+  express_style_wildcard() {
+    return RETURN_VALUE;
+  }
+
   @Get('test')
   test() {
+    return RETURN_VALUE;
+  }
+  
+  @Get('query')
+  query() {
     return RETURN_VALUE;
   }
 
@@ -22,21 +42,46 @@ class TestController {
   wildcard_nested() {
     return RETURN_VALUE;
   }
+
+  @Get('tests/included')
+  included() {
+    return RETURN_VALUE;
+  }
+}
+
+@Controller(QUERY_VALUE)
+class TestQueryController {
+  @Get()
+  [QUERY_VALUE](@Query('test') test: string) {
+    return test;
+  }
 }
 
 @Module({
   imports: [ApplicationModule],
-  controllers: [TestController],
+  controllers: [TestController, TestQueryController],
 })
 class TestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
+      .apply((req, res, next) => res.end(INCLUDED_VALUE))
+      .forRoutes({ path: 'tests/included', method: RequestMethod.POST })
+      .apply((req, res, next) => res.end(`${REQ_URL_VALUE}${req.url}`))
+      .forRoutes('req/url/')
+      .apply((req, res, next) => res.end(WILDCARD_VALUE))
+      .forRoutes('express_style_wildcard/*')
       .apply((req, res, next) => res.end(WILDCARD_VALUE))
       .forRoutes('tests/(.*)')
+      .apply((req, res, next) => res.end(QUERY_VALUE))
+      .forRoutes('query')
+      .apply((req, res, next) => next())
+      .forRoutes(TestQueryController)
       .apply((req, res, next) => res.end(SCOPED_VALUE))
       .forRoutes(TestController)
       .apply((req, res, next) => res.end(RETURN_VALUE))
+      .exclude({ path: QUERY_VALUE, method: -1 })
       .forRoutes('(.*)');
+
   }
 }
 
@@ -53,7 +98,7 @@ describe('Middleware (FastifyAdapter)', () => {
     await app.init();
   });
 
-  it(`forRoutes(*)`, () => {
+  it(`forRoutes((.*))`, () => {
     return app
       .inject({
         method: 'GET',
@@ -71,13 +116,74 @@ describe('Middleware (FastifyAdapter)', () => {
       .then(({ payload }) => expect(payload).to.be.eql(SCOPED_VALUE));
   });
 
-  it(`forRoutes(tests/*)`, () => {
+  it(`query?test=${QUERY_VALUE} forRoutes(query)`, () => {
     return app
       .inject({
         method: 'GET',
-        url: '/tests/wildcard',
+        url: '/query',
+        query: {
+          test: QUERY_VALUE
+        }
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(QUERY_VALUE));
+  });
+
+  it(`${QUERY_VALUE}?test=${QUERY_VALUE} forRoutes(${QUERY_VALUE})`, () => {
+    return app
+      .inject({
+        method: 'GET',
+        url: QUERY_VALUE,
+        query: {
+          test: QUERY_VALUE
+        }
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(QUERY_VALUE));
+  });
+
+  it(`forRoutes(tests/(.*))`, () => {
+    return app
+      .inject({
+        method: 'GET',
+        url: '/tests/wildcard_nested',
       })
       .then(({ payload }) => expect(payload).to.be.eql(WILDCARD_VALUE));
+  });
+
+  it(`forRoutes(express_style_wildcard/*)`, () => {
+    return app
+      .inject({
+        method: 'GET',
+        url: '/express_style_wildcard/wildcard_nested',
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(WILDCARD_VALUE));
+  });
+
+  it(`forRoutes(req/url/)`, () => {
+    const reqUrl = '/test'
+    return app
+      .inject({
+        method: 'GET',
+        url: `/req/url${reqUrl}`,
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(`${REQ_URL_VALUE}${reqUrl}`));
+  });
+
+  it(`GET forRoutes(POST tests/included)`, () => {
+    return app
+      .inject({
+        method: 'GET',
+        url: '/tests/included',
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(WILDCARD_VALUE));
+  });
+
+  it(`POST forRoutes(POST tests/included)`, () => {
+    return app
+      .inject({
+        method: 'POST',
+        url: '/tests/included',
+      })
+      .then(({ payload }) => expect(payload).to.be.eql(INCLUDED_VALUE));
   });
 
   afterEach(async () => {

--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -32,7 +32,7 @@ class TestController {
   test() {
     return RETURN_VALUE;
   }
-  
+
   @Get('query')
   query() {
     return RETURN_VALUE;
@@ -69,9 +69,7 @@ class TestModule {
       .apply((req, res, next) => res.end(`${REQ_URL_VALUE}${req.url}`))
       .forRoutes('req/url/')
       .apply((req, res, next) => res.end(WILDCARD_VALUE))
-      .forRoutes('express_style_wildcard/*')
-      .apply((req, res, next) => res.end(WILDCARD_VALUE))
-      .forRoutes('tests/(.*)')
+      .forRoutes('express_style_wildcard/*', 'tests/(.*)')
       .apply((req, res, next) => res.end(QUERY_VALUE))
       .forRoutes('query')
       .apply((req, res, next) => next())
@@ -81,7 +79,6 @@ class TestModule {
       .apply((req, res, next) => res.end(RETURN_VALUE))
       .exclude({ path: QUERY_VALUE, method: -1 })
       .forRoutes('(.*)');
-
   }
 }
 
@@ -122,8 +119,8 @@ describe('Middleware (FastifyAdapter)', () => {
         method: 'GET',
         url: '/query',
         query: {
-          test: QUERY_VALUE
-        }
+          test: QUERY_VALUE,
+        },
       })
       .then(({ payload }) => expect(payload).to.be.eql(QUERY_VALUE));
   });
@@ -134,8 +131,8 @@ describe('Middleware (FastifyAdapter)', () => {
         method: 'GET',
         url: QUERY_VALUE,
         query: {
-          test: QUERY_VALUE
-        }
+          test: QUERY_VALUE,
+        },
       })
       .then(({ payload }) => expect(payload).to.be.eql(QUERY_VALUE));
   });
@@ -159,13 +156,15 @@ describe('Middleware (FastifyAdapter)', () => {
   });
 
   it(`forRoutes(req/url/)`, () => {
-    const reqUrl = '/test'
+    const reqUrl = '/test';
     return app
       .inject({
         method: 'GET',
         url: `/req/url${reqUrl}`,
       })
-      .then(({ payload }) => expect(payload).to.be.eql(`${REQ_URL_VALUE}${reqUrl}`));
+      .then(({ payload }) =>
+        expect(payload).to.be.eql(`${REQ_URL_VALUE}${reqUrl}`),
+      );
   });
 
   it(`GET forRoutes(POST tests/included)`, () => {

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -57,9 +57,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   useStaticAssets?(...args: any[]): this;
   setBaseViewsDir?(path: string | string[]): this;
   setViewEngine?(engineOrOptions: any): this;
-  createMiddlewareFactory(
-    method: RequestMethod,
-  ):
+  createMiddlewareFactory():
     | ((path: string, callback: Function) => any)
     | Promise<(path: string, callback: Function) => any>;
   getRequestHostname?(request: TRequest): string;

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -110,9 +110,7 @@ export abstract class AbstractHttpAdapter<
     options: CorsOptions | CorsOptionsDelegate<TRequest>,
     prefix?: string,
   );
-  abstract createMiddlewareFactory(
-    requestMethod: RequestMethod,
-  ):
+  abstract createMiddlewareFactory():
     | ((path: string, callback: Function) => any)
     | Promise<(path: string, callback: Function) => any>;
   abstract getType(): string;

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -26,6 +26,7 @@ import { MiddlewareBuilder } from './builder';
 import { MiddlewareContainer } from './container';
 import { MiddlewareResolver } from './resolver';
 import { RoutesMapper } from './routes-mapper';
+import { isRequestMethodAll } from './utils';
 
 export class MiddlewareModule {
   private readonly routerProxy = new RouterProxy();
@@ -193,14 +194,14 @@ export class MiddlewareModule {
     if (isUndefined(instance?.use)) {
       throw new InvalidMiddlewareException(metatype.name);
     }
-    const router = await applicationRef.createMiddlewareFactory(method);
     const isStatic = wrapper.isDependencyTreeStatic();
     if (isStatic) {
       const proxy = await this.createProxy(instance);
-      return this.registerHandler(router, path, proxy);
+      return await this.registerHandler(applicationRef, method, path, proxy);
     }
-    this.registerHandler(
-      router,
+    await this.registerHandler(
+      applicationRef,
+      method,
       path,
       async <TRequest, TResponse>(
         req: TRequest,
@@ -260,8 +261,9 @@ export class MiddlewareModule {
     return this.routerProxy.createProxy(middleware, exceptionsHandler);
   }
 
-  private registerHandler(
-    router: (...args: any[]) => void,
+  private async registerHandler(
+    applicationRef: HttpServer,
+    method: RequestMethod,
     path: string,
     proxy: <TRequest, TResponse>(
       req: TRequest,
@@ -271,11 +273,28 @@ export class MiddlewareModule {
   ) {
     const prefix = this.config.getGlobalPrefix();
     const basePath = addLeadingSlash(prefix);
-    if (basePath && path === '/*') {
+    if (basePath.endsWith('/') && path.startsWith('/')) {
       // strip slash when a wildcard is being used
       // and global prefix has been set
-      path = '*';
+      path = path.slice(1);
     }
-    router(basePath + path, proxy);
+    const isMethodAll = isRequestMethodAll(method);
+    const requestMethod = RequestMethod[method];
+    const router = await applicationRef.createMiddlewareFactory();
+    router(
+      basePath + path,
+      isMethodAll
+        ? proxy
+        : <TRequest, TResponse>(
+            req: TRequest,
+            res: TResponse,
+            next: () => void,
+          ) => {
+            if (applicationRef.getRequestMethod(req) === requestMethod) {
+              return proxy(req, res, next);
+            }
+            return next();
+          },
+    );
   }
 }

--- a/packages/core/middleware/utils.ts
+++ b/packages/core/middleware/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 import { RequestMethod } from '@nestjs/common';
 import { HttpServer, RouteInfo, Type } from '@nestjs/common/interfaces';
 import { isFunction } from '@nestjs/common/utils/shared.utils';
@@ -7,6 +6,10 @@ import * as pathToRegexp from 'path-to-regexp';
 import { v4 as uuid } from 'uuid';
 
 type RouteInfoRegex = RouteInfo & { regex: RegExp };
+
+export const isRequestMethodAll = (method: RequestMethod) => {
+  return RequestMethod.ALL === method || (method as number) === -1;
+};
 
 export const filterMiddleware = <T extends Function | Type<any> = any>(
   middleware: T[],
@@ -94,11 +97,7 @@ export function isRouteExcluded(
       : originalUrl;
 
   const isExcluded = excludedRoutes.some(({ method, regex }) => {
-    if (
-      RequestMethod.ALL === method ||
-      RequestMethod[method] === reqMethod ||
-      (method as number) === -1
-    ) {
+    if (isRequestMethodAll(method) || RequestMethod[method] === reqMethod) {
       return regex.exec(pathname);
     }
     return false;

--- a/packages/core/test/middleware/utils.spec.ts
+++ b/packages/core/test/middleware/utils.spec.ts
@@ -100,7 +100,7 @@ describe('middleware utils', () => {
     });
     describe('when route is excluded', () => {
       const path = '/cats/(.*)';
-      const exludedRoutes = [
+      const excludedRoutes = [
         {
           path,
           method: RequestMethod.GET,
@@ -108,7 +108,7 @@ describe('middleware utils', () => {
         },
       ];
       it('should return true', () => {
-        expect(isRouteExcluded({}, exludedRoutes, adapter)).to.be.true;
+        expect(isRouteExcluded({}, excludedRoutes, adapter)).to.be.true;
       });
     });
     describe('when route is not excluded', () => {

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -21,7 +21,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   setHeader(response: any, name: string, value: string): any {}
   registerParserMiddleware(): any {}
   enableCors(options: any): any {}
-  createMiddlewareFactory(requestMethod: RequestMethod): any {}
+  createMiddlewareFactory(): any {}
   getType() {
     return '';
   }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -6,7 +6,6 @@ import {
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 import { isFunction, isNil, isObject } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
-import { RouterMethodFactory } from '@nestjs/core/helpers/router-method-factory';
 import * as bodyParser from 'body-parser';
 import * as cors from 'cors';
 import * as express from 'express';
@@ -16,8 +15,6 @@ import { ServeStaticOptions } from '../interfaces/serve-static-options.interface
 import { Readable } from 'stream';
 
 export class ExpressAdapter extends AbstractHttpAdapter {
-  private readonly routerMethodFactory = new RouterMethodFactory();
-
   constructor(instance?: any) {
     super(instance || express());
   }
@@ -120,12 +117,8 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return this.use(cors(options));
   }
 
-  public createMiddlewareFactory(
-    requestMethod: RequestMethod,
-  ): (path: string, callback: Function) => any {
-    return this.routerMethodFactory
-      .get(this.instance, requestMethod)
-      .bind(this.instance);
+  public createMiddlewareFactory(): (path: string, callback: Function) => any {
+    return this.instance.use.bind(this.instance);
   }
 
   public initHttpServer(options: NestApplicationOptions) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7511 #7564 

## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

in order to the same wildcard(*) be used in express and fastify

http /test/a
FastifyAdapter Middleware forRoutes('*') 

before:

req.url === /test/a

after:

req.url === / (the same as express)

## Other information