### PR TITLE
feat(common): add `resetContext()` to `ConsoleLogger`

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -27,6 +27,7 @@ const DEFAULT_LOG_LEVELS: LogLevel[] = [
 @Injectable()
 export class ConsoleLogger implements LoggerService {
   private static lastTimestampAt?: number;
+  private originalContext?: string;
 
   constructor();
   constructor(context: string);
@@ -39,6 +40,9 @@ export class ConsoleLogger implements LoggerService {
   ) {
     if (!options.logLevels) {
       options.logLevels = DEFAULT_LOG_LEVELS;
+    }
+    if (context) {
+      this.originalContext = context;
     }
   }
 
@@ -144,6 +148,13 @@ export class ConsoleLogger implements LoggerService {
    */
   setContext(context: string) {
     this.context = context;
+  }
+
+  /**
+   * Resets the logger context to the value that was passed in the constructor.
+   */
+  resetContext() {
+    this.context = this.originalContext;
   }
 
   isLevelEnabled(level: LogLevel): boolean {

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import 'reflect-metadata';
 import * as sinon from 'sinon';
-import { Logger, LoggerService } from '../../services';
+import { ConsoleLogger, Logger, LoggerService } from '../../services';
 
 describe('Logger', () => {
   describe('[static methods]', () => {
@@ -236,6 +236,24 @@ describe('Logger', () => {
       });
     });
   });
+
+  describe('ConsoleLogger', () => {
+    it('should allow setting and resetting of context', () => {
+      const logger = new ConsoleLogger()
+      expect(logger['context']).to.be.undefined;
+      logger.setContext('context');
+      expect(logger['context']).to.equal('context');
+      logger.resetContext();
+      expect(logger['context']).to.be.undefined;
+
+      const loggerWithContext = new ConsoleLogger('context');
+      expect(loggerWithContext['context']).to.equal('context');
+      loggerWithContext.setContext('other')
+      expect(loggerWithContext['context']).to.equal('other');
+      loggerWithContext.resetContext();
+      expect(loggerWithContext['context']).to.equal('context');
+    })
+  })
 
   describe('[instance methods]', () => {
     describe('when the default logger is used', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

For the default `ConsoleLogger`, the context can now be resetted to the value given in the constructor. This allows for temporarily changing the context and then returning back to the original context without calling `setContext()` and having to store the original value.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information