### PR TITLE
feat(microservices): use createInbox method

### DIFF
--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -97,16 +97,19 @@ export class ClientNats extends ClientProxy {
       const packet = this.assignPacketId(partialPacket);
       const channel = this.normalizePattern(partialPacket.pattern);
       const serializedPacket = this.serializer.serialize(packet);
+      const inbox = natsPackage.createInbox();
 
       const subscriptionHandler = this.createSubscriptionHandler(
         packet,
         callback,
       );
-      this.natsClient.publish(channel, serializedPacket, {
-        reply: packet.id,
-      });
-      const subscription = this.natsClient.subscribe(packet.id, {
+
+      const subscription = this.natsClient.subscribe(inbox, {
         callback: subscriptionHandler,
+      });
+
+      this.natsClient.publish(channel, serializedPacket, {
+        reply: inbox,
       });
 
       return () => subscription.unsubscribe();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When a message is published via NATS as the reply subject is the packet ID used

Issue Number: N/A


## What is the new behavior?
Now the method `createInbox` is used to create the response subject like in this [example](https://docs.nats.io/developing-with-nats/sending/replyto)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Now you can set the prefix of the reply subject using the `inboxPrefix` option. The prefix allows you a better control who is allowed to reply via the [configuration](https://docs.nats.io/nats-server/configuration/securing_nats/authorization#examples).