### PR TITLE
fix(microservices): reorder kafka config assigment

### DIFF
--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -107,11 +107,11 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
 
   public createClient<T = any>(): T {
     return new kafkaPackage.Kafka(
-      Object.assign(this.options.client || {}, {
-        clientId: this.clientId,
-        brokers: this.brokers,
-        logCreator: KafkaLogger.bind(null, this.logger),
-      }) as KafkaConfig,
+      Object.assign(
+        { logCreator: KafkaLogger.bind(null, this.logger) },
+        this.options.client,
+        { clientId: this.clientId, brokers: this.brokers }
+      ) as KafkaConfig,
     );
   }
 

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -425,4 +425,24 @@ describe('ServerKafka', () => {
       ).to.be.true;
     });
   });
+
+  describe('createClient', () => {
+    it('should accept a custom logCreator in client options', () => {
+      const logCreatorSpy = sinon.spy(() => 'test');
+      const logCreator = () => logCreatorSpy;
+
+      server = new ServerKafka({
+        client: {
+          brokers: [],
+          logCreator,
+        },
+      });
+
+      const logger = server.createClient().logger();
+
+      logger.info({ namespace: '', level: 1, log: 'test' });
+
+      expect(logCreatorSpy.called).to.be.true;
+    })
+  })
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
KafkaServer don't respects `logCreator` options for `client` configuration

Logs example:
```
[14:03:33.066] INFO (NestFactory): Starting Nest application...
[14:03:33.074] INFO (InstanceLoader): AppModule dependencies initialized
[14:03:33.074] INFO (InstanceLoader): EnvironmentModule dependencies initialized
[14:03:33.074] INFO (InstanceLoader): EnvironmentModule dependencies initialized
[14:03:33.076] INFO (InstanceLoader): LoggerModule dependencies initialized
[14:03:33.076] INFO (InstanceLoader): ConsumerModule dependencies initialized
[14:03:33.091] INFO (InstanceLoader): PostgresModule dependencies initialized
[14:03:34.133] INFO (ServerKafka): INFO [Consumer] Starting {"timestamp":"2021-08-09T14:03:34.133Z","logger":"kafkajs","groupId":"template-consumer_group_id-server"}
[14:03:42.893] INFO (ServerKafka): INFO [ConsumerGroup] Consumer has joined the group {"timestamp":"2021-08-09T14:03:42.893Z","logger":"kafkajs","groupId":"template-consumer_group_id-server","memberId":"template-consumer_client_id-server-65e33e3a-93c4-4f32-984b-e429fee590e0","leaderId":"template-consumer_client_id-server-65e33e3a-93c4-4f32-984b-e429fee590e0","isLeader":true,"memberAssignment":{},"groupProtocol":"RoundRobinAssigner","duration":7176}
[14:03:42.894] INFO (NestMicroservice): Nest microservice successfully started
```

Issue Number: N/A
Related Issue Number: #6797

## What is the new behavior?
KafkaServer now respects `logCreator` options for `client` configuration

Logs example:
```
[14:05:43.382] INFO (NestFactory): Starting Nest application...
[14:05:43.390] INFO (InstanceLoader): AppModule dependencies initialized
[14:05:43.390] INFO (InstanceLoader): EnvironmentModule dependencies initialized
[14:05:43.390] INFO (InstanceLoader): EnvironmentModule dependencies initialized
[14:05:43.392] INFO (InstanceLoader): LoggerModule dependencies initialized
[14:05:43.392] INFO (InstanceLoader): ConsumerModule dependencies initialized
[14:05:43.404] INFO (InstanceLoader): PostgresModule dependencies initialized
[14:05:44.455] INFO (Consumer): Starting
    logger: "kafkajs"
    groupId: "template-consumer_group_id-server"
[14:05:52.183] INFO (ConsumerGroup): Consumer has joined the group
    logger: "kafkajs"
    groupId: "template-consumer_group_id-server"
    memberId: "template-consumer_client_id-server-a9323b25-eef5-412d-99af-7672cebfc4a4"
    leaderId: "template-consumer_client_id-server-a9323b25-eef5-412d-99af-7672cebfc4a4"
    isLeader: true
    memberAssignment: {}
    groupProtocol: "RoundRobinAssigner"
    duration: 5889
[14:05:52.184] INFO (NestMicroservice): Nest microservice successfully started

```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information