### PR TITLE
fix(common): serializer must ignore `StreamableFile` responses

### DIFF
--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -5,6 +5,7 @@ import { CallHandler, ExecutionContext, NestInterceptor } from '../interfaces';
 import { ClassTransformOptions } from '../interfaces/external/class-transform-options.interface';
 import { loadPackage } from '../utils/load-package.util';
 import { isObject } from '../utils/shared.utils';
+import { StreamableFile } from '../file-stream';
 import { CLASS_SERIALIZER_OPTIONS } from './class-serializer.constants';
 
 let classTransformer: any = {};
@@ -47,18 +48,19 @@ export class ClassSerializerInterceptor implements NestInterceptor {
       );
   }
 
+  /**
+   * Serializes responses that are non-null objects nor streamable files.
+   */
   serialize(
     response: PlainLiteralObject | Array<PlainLiteralObject>,
     options: ClassTransformOptions,
-  ): PlainLiteralObject | PlainLiteralObject[] {
-    const isArray = Array.isArray(response);
-    if (!isObject(response) && !isArray) {
+  ): PlainLiteralObject | Array<PlainLiteralObject> {
+    if (!isObject(response) || response instanceof StreamableFile) {
       return response;
     }
-    return isArray
-      ? (response as PlainLiteralObject[]).map(item =>
-          this.transformToPlain(item, options),
-        )
+
+    return Array.isArray(response)
+      ? response.map(item => this.transformToPlain(item, options))
       : this.transformToPlain(response, options);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7909

## What is the new behavior?

We can use `return new StreamableFile(readStream)` (in some controller) along with the built-in serializer `ClassSerializerInterceptor`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I didn't write any tests because this change is pretty straightforward. But let me know if I should do