### PR TITLE
fix(core): support all valid process events

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -158,7 +158,7 @@ export class NestApplicationContext implements INestApplicationContext {
     }
 
     signals = iterate(signals)
-      .map((signal: string) => signal.toString().toUpperCase().trim())
+      .map((signal: string) => signal.toString().trim())
       // filter out the signals which is already listening to
       .filter(signal => !this.activeShutdownSignals.includes(signal))
       .toArray();


### PR DESCRIPTION
This removes the `.toUpperCase()` when parsing signals passed into `enableShutdownHooks`.
This allows for signals like `disconnect` to be used in situations where the app should shut down with the IPC channel is closed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Unable to specify shutdown signals that are not uppercase like disconnect.

Issue Number: #7957


## What is the new behavior?
Signals are not capitalized before being listened to

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
If an app is relying on the capitalization of the signal to be made for them, then their hooks will not fire after this change.
We could mitigate this by listening to both upper and lowercase event names OR we could suggest users change any lowercase signal names to uppercase.

## Other information