### PR TITLE
fix(common): accept optional argument in middleware callback

### DIFF
--- a/packages/common/interfaces/middleware/nest-middleware.interface.ts
+++ b/packages/common/interfaces/middleware/nest-middleware.interface.ts
@@ -1,3 +1,3 @@
 export interface NestMiddleware<TRequest = any, TResponse = any> {
-  use(req: TRequest, res: TResponse, next: () => void): any;
+  use(req: TRequest, res: TResponse, next: (err?: any) => void): any;
 }


### PR DESCRIPTION
According to the current typing, the `next()` callback in middleware does not accept an argument.
I tested with both Express and Fastify that in practice, it does.

Passing an argument to the `next()` callback makes it very easy to abort requests from middleware (e.g. using the provided `HttpException` classes), without needing to work with the underlying response object.

It's easy to ignore the type error, but adding an optional argument in the interface makes this functionality more discoverable and because the argument is optional, the change is backwards compatible.

I found this issue discussing potential approaches before making this PR: https://github.com/nestjs/docs.nestjs.com/issues/215
