### PR TITLE
feat(platform-express): file interceptor no files validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "cache-manager": "3.4.4",
     "cache-manager-redis-store": "2.0.0",
     "chai": "4.3.4",
-    "chai-as-promised": "7.1.1",
+    "chai-as-promised": "^7.1.1",
     "clang-format": "1.5.0",
     "commitlint-circle": "1.0.0",
     "concurrently": "6.2.1",

--- a/packages/platform-express/multer/interceptors/file.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/file.interceptor.ts
@@ -6,6 +6,7 @@ import {
   NestInterceptor,
   Optional,
   Type,
+  BadRequestException,
 } from '@nestjs/common';
 import * as multer from 'multer';
 import { Observable } from 'rxjs';
@@ -18,6 +19,7 @@ type MulterInstance = any;
 
 export function FileInterceptor(
   fieldName: string,
+  errorOptions: { throwsOnNotFound: boolean } = { throwsOnNotFound: false },
   localOptions?: MulterOptions,
 ): Type<NestInterceptor> {
   class MixinInterceptor implements NestInterceptor {
@@ -48,6 +50,12 @@ export function FileInterceptor(
             if (err) {
               const error = transformException(err);
               return reject(error);
+            }
+            if (errorOptions.throwsOnNotFound) {
+              const req = ctx.getRequest();
+              if (req.file?.fieldname !== fieldName) {
+                return reject(new BadRequestException(`Unexpected field`));
+              }
             }
             resolve();
           },

--- a/packages/platform-express/test/multer/interceptors/any-files.interceptor.spec.ts
+++ b/packages/platform-express/test/multer/interceptors/any-files.interceptor.spec.ts
@@ -1,11 +1,14 @@
-import { CallHandler } from '@nestjs/common';
+import { BadRequestException, CallHandler } from '@nestjs/common';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
 import { of } from 'rxjs';
 import * as sinon from 'sinon';
 import { AnyFilesInterceptor } from '../../../multer/interceptors/any-files.interceptor';
 
-describe('FilesInterceptor', () => {
+describe('AnyFilesInterceptor', () => {
   it('should return metatype with expected structure', async () => {
     const targetClass = AnyFilesInterceptor();
     expect(targetClass.prototype.intercept).to.not.be.undefined;
@@ -26,6 +29,41 @@ describe('FilesInterceptor', () => {
         .returns(callback);
 
       await target.intercept(new ExecutionContextHost([]), handler);
+
+      expect(arraySpy.called).to.be.true;
+      expect(arraySpy.calledWith()).to.be.true;
+    });
+    it('should return error if throwsOnNotFound is set to true and file is not present', async () => {
+      const fieldName = 'file';
+      const target = new (AnyFilesInterceptor({ throwsOnNotFound: true }))();
+      const callback = (req, res, next) => {
+        next();
+      };
+      const arraySpy = sinon
+        .stub((target as any).multer, 'any')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.be.rejectedWith(BadRequestException);
+
+      expect(arraySpy.called).to.be.true;
+      expect(arraySpy.calledWith()).to.be.true;
+    });
+    it('should not return error if throwsOnNotFound is set to true and file is present', async () => {
+      const fieldName = 'file';
+      const target = new (AnyFilesInterceptor({ throwsOnNotFound: true }))();
+      const callback = (req, res, next) => {
+        req.files = [{ fieldname: fieldName }];
+        next();
+      };
+      const arraySpy = sinon
+        .stub((target as any).multer, 'any')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.not.be.rejectedWith(BadRequestException);
 
       expect(arraySpy.called).to.be.true;
       expect(arraySpy.calledWith()).to.be.true;

--- a/packages/platform-express/test/multer/interceptors/file.interceptor.spec.ts
+++ b/packages/platform-express/test/multer/interceptors/file.interceptor.spec.ts
@@ -1,6 +1,9 @@
-import { CallHandler } from '@nestjs/common';
+import { BadRequestException, CallHandler } from '@nestjs/common';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
 import { of } from 'rxjs';
 import * as sinon from 'sinon';
 import { FileInterceptor } from '../../../multer/interceptors/file.interceptor';
@@ -26,6 +29,47 @@ describe('FileInterceptor', () => {
         .returns(callback);
 
       await target.intercept(new ExecutionContextHost([]), handler);
+
+      expect(singleSpy.called).to.be.true;
+      expect(singleSpy.calledWith(fieldName)).to.be.true;
+    });
+    it('should return error if throwsOnNotFound is set to true and file is not present', async () => {
+      const fieldName = 'file';
+      const newFieldName = 'definetelynotwhatyouexpect';
+      const target = new (FileInterceptor(fieldName, {
+        throwsOnNotFound: true,
+      }))();
+      const callback = (req, res, next) => {
+        req.file = { newFieldName: fieldName };
+        next();
+      };
+      const singleSpy = sinon
+        .stub((target as any).multer, 'single')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.be.rejectedWith(BadRequestException);
+
+      expect(singleSpy.called).to.be.true;
+      expect(singleSpy.calledWith(fieldName)).to.be.true;
+    });
+    it('should not return error if throwsOnNotFound is set to true and file is present', async () => {
+      const fieldName = 'file';
+      const target = new (FileInterceptor(fieldName, {
+        throwsOnNotFound: true,
+      }))();
+      const callback = (req, res, next) => {
+        req.file = { fieldname: fieldName };
+        next();
+      };
+      const singleSpy = sinon
+        .stub((target as any).multer, 'single')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.not.be.rejectedWith(BadRequestException);
 
       expect(singleSpy.called).to.be.true;
       expect(singleSpy.calledWith(fieldName)).to.be.true;

--- a/packages/platform-express/test/multer/interceptors/files.interceptor.spec.ts
+++ b/packages/platform-express/test/multer/interceptors/files.interceptor.spec.ts
@@ -1,6 +1,9 @@
-import { CallHandler } from '@nestjs/common';
+import { BadRequestException, CallHandler } from '@nestjs/common';
 import { ExecutionContextHost } from '@nestjs/core/helpers/execution-context-host';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
 import { of } from 'rxjs';
 import * as sinon from 'sinon';
 import { FilesInterceptor } from '../../../multer/interceptors/files.interceptor';
@@ -20,7 +23,7 @@ describe('FilesInterceptor', () => {
     it('should call array() with expected params', async () => {
       const fieldName = 'file';
       const maxCount = 10;
-      const target = new (FilesInterceptor(fieldName, maxCount))();
+      const target = new (FilesInterceptor(fieldName, undefined, maxCount))();
 
       const callback = (req, res, next) => next();
       const arraySpy = sinon
@@ -28,6 +31,64 @@ describe('FilesInterceptor', () => {
         .returns(callback);
 
       await target.intercept(new ExecutionContextHost([]), handler);
+
+      expect(arraySpy.called).to.be.true;
+      expect(arraySpy.calledWith(fieldName, maxCount)).to.be.true;
+    });
+    it('should return error if throwsOnNotFound is set to true and file is not present', async () => {
+      const fieldName = 'file';
+      const maxCount = 10;
+      const newFieldName = 'definetelynotwhatyouexpect';
+      const target = new (FilesInterceptor(
+        fieldName,
+        { throwsOnNotFound: true },
+        maxCount,
+      ))();
+      const callback = (req, res, next) => {
+        req.files = [];
+        next();
+      };
+      const arraySpy = sinon
+        .stub((target as any).multer, 'array')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.be.rejectedWith(BadRequestException);
+
+      expect(arraySpy.called).to.be.true;
+      expect(arraySpy.calledWith(fieldName, maxCount)).to.be.true;
+    });
+    it('should not return error if throwsOnNotFound is set to true and file is present', async () => {
+      const maxCount = 10;
+      const fieldName = 'file';
+      const target = new (FilesInterceptor(
+        fieldName,
+        { throwsOnNotFound: true },
+        maxCount,
+      ))();
+      const callback = (req, res, next) => {
+        const file = {
+          fieldname: fieldName,
+          originalname: 'temp.gif',
+          encoding: '7bit',
+          mimetype: 'image/gif',
+          buffer: {
+            type: 'Buffer',
+            data: [],
+          },
+          size: 0,
+        };
+        req.files = [file, file];
+        next();
+      };
+      const arraySpy = sinon
+        .stub((target as any).multer, 'array')
+        .returns(callback);
+      const request = { body: {} };
+      await expect(
+        target.intercept(new ExecutionContextHost([request]), handler),
+      ).to.not.be.rejectedWith(BadRequestException);
 
       expect(arraySpy.called).to.be.true;
       expect(arraySpy.calledWith(fieldName, maxCount)).to.be.true;

--- a/sample/29-file-upload/src/app.controller.ts
+++ b/sample/29-file-upload/src/app.controller.ts
@@ -4,9 +4,15 @@ import {
   Get,
   Post,
   UploadedFile,
+  UploadedFiles,
   UseInterceptors,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
+import {
+  FileInterceptor,
+  FilesInterceptor,
+  FileFieldsInterceptor,
+  AnyFilesInterceptor,
+} from '@nestjs/platform-express';
 import { Express } from 'express';
 import { AppService } from './app.service';
 import { SampleDto } from './sample.dto';
@@ -20,15 +26,57 @@ export class AppController {
     return this.appService.getHello();
   }
 
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', { throwsOnNotFound: true }))
   @Post('file')
   uploadFile(
     @Body() body: SampleDto,
     @UploadedFile() file: Express.Multer.File,
   ) {
+    const buf = file.buffer.toString();
     return {
       body,
-      file: file.buffer.toString(),
+      file: buf,
+    };
+  }
+
+  @UseInterceptors(FilesInterceptor('files', { throwsOnNotFound: true }))
+  @Post('fileArr')
+  uploadFileArray(
+    @Body() body: SampleDto,
+    @UploadedFiles() files: Express.Multer.File[],
+  ) {
+    const bufs = files.map(f => f.buffer.toString());
+    return {
+      body,
+      files: bufs,
+    };
+  }
+
+  @UseInterceptors(AnyFilesInterceptor({ throwsOnNotFound: true }))
+  @Post('anyFiles')
+  uploadAnyFiles(
+    @Body() body: SampleDto,
+    @UploadedFiles() files: Express.Multer.File[],
+  ) {
+    const bufs = files.map(f => f.buffer.toString());
+    return {
+      body,
+      files: bufs,
+    };
+  }
+
+  @UseInterceptors(FileFieldsInterceptor([{ name: 'file' }, { name: 'file2' }]))
+  @Post('files')
+  uploadFiles(
+    @Body() body: SampleDto,
+    @UploadedFiles() files: { [name: string]: Express.Multer.File[] },
+  ) {
+    const bufs = Object.values(files)
+      .map(arr => arr.map(f => f.buffer.toString()))
+      .reduce((a, o) => [...a, ...o]);
+    return {
+      body,
+      files: bufs,
     };
   }
 }


### PR DESCRIPTION
This adds an option for file interceptor to throw if no files are found

Closes #4752

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 4752


## What is the new behavior?

This introduces new throwsOnNotFound parameter to FileInterceptor, FilesInterceptor and AnyFilesInterceptor which will throw an error when there is no files found.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

For existing applications there will be the need to migrate the code using FileInterceptor, FilesInterceptor and ANyFilesInterceptor so that the arguments include new throwsOnNotFound parameter


## Other information