### PR TITLE
fix(core): fix middleware wouldn't run if setGlobalPrefix with exclude

### DIFF
--- a/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
+++ b/integration/nest-application/global-prefix/e2e/global-prefix.spec.ts
@@ -90,6 +90,15 @@ describe('Global prefix', () => {
     await request(server).get('/hello/foo').expect(200);
   });
 
+  it(`should be applied middleware on globalPrefix exclude path`, async () => {
+    app.setGlobalPrefix('/api/v1', { exclude: ['/hello'] });
+
+    server = app.getHttpServer();
+    await app.init();
+
+    await request(server).get('/hello').expect('hello');
+  });
+
   afterEach(async () => {
     await app.close();
   });

--- a/integration/nest-application/global-prefix/src/app.controller.ts
+++ b/integration/nest-application/global-prefix/src/app.controller.ts
@@ -1,7 +1,16 @@
-import { Controller, Get, Post } from '@nestjs/common';
+import { Controller, Get, Post, Req } from '@nestjs/common';
+import { Request } from 'express';
 
 @Controller()
 export class AppController {
+  @Get('hello')
+  getValueSetByMiddleware(@Req() req: Request & { hello: boolean }): string {
+    if (req.hello) {
+      return 'hello';
+    }
+    return 'not-hello';
+  }
+
   @Get('hello/:name')
   getHello(): string {
     return 'hello';

--- a/integration/nest-application/global-prefix/src/app.module.ts
+++ b/integration/nest-application/global-prefix/src/app.module.ts
@@ -1,7 +1,20 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { AppController } from './app.controller';
+import { Request, Response, NextFunction } from 'express';
 
 @Module({
   controllers: [AppController],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    const middlewareFunction = (
+      req: Request & { hello: boolean },
+      res: Response,
+      next: NextFunction,
+    ) => {
+      req.hello = true;
+      next();
+    };
+    consumer.apply(middlewareFunction).forRoutes('*');
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #7896

When you use middleware consumer with setGlobalPrefix exclude option, It is not applied to that exclude path.

## What is the new behavior?

Apply middleware to exclude path, too.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
