### PR TITLE
fix(common): catch number encoding in ParseIntPipe

### DIFF
--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -46,7 +46,7 @@ export class ParseIntPipe implements PipeTransform<string> {
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
     const isNumeric =
       ['string', 'number'].includes(typeof value) &&
-      /^\d+$/.test(value) &&
+      /^-?\d+$/.test(value) &&
       !isNaN(parseFloat(value)) &&
       isFinite(value as any);
     if (!isNumeric) {

--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -46,6 +46,7 @@ export class ParseIntPipe implements PipeTransform<string> {
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
     const isNumeric =
       ['string', 'number'].includes(typeof value) &&
+      /^\d+$/.test(value) &&
       !isNaN(parseFloat(value)) &&
       isFinite(value as any);
     if (!isNumeric) {

--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -47,7 +47,6 @@ export class ParseIntPipe implements PipeTransform<string> {
     const isNumeric =
       ['string', 'number'].includes(typeof value) &&
       /^-?\d+$/.test(value) &&
-      !isNaN(parseFloat(value)) &&
       isFinite(value as any);
     if (!isNumeric) {
       throw this.exceptionFactory(

--- a/packages/common/test/pipes/parse-int.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-int.pipe.spec.ts
@@ -25,6 +25,10 @@ describe('ParseIntPipe', () => {
           parseInt(num, 10),
         );
       });
+      it('should return negative number', async () => {
+        const num = '-3';
+        expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(-3);
+      });
     });
     describe('when validation fails', () => {
       it('should throw an error', async () => {

--- a/packages/common/test/pipes/parse-int.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-int.pipe.spec.ts
@@ -32,6 +32,11 @@ describe('ParseIntPipe', () => {
           target.transform('123abc', {} as ArgumentMetadata),
         ).to.be.rejectedWith(CustomTestError);
       });
+      it('should throw an error when number has wrong number encoding', async () => {
+        return expect(
+          target.transform('0xFF', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
ParseIntPipe allows numbers with encoding such as 0x, 0b and e.t.c.

Issue Number: N/A


## What is the new behavior?
ParseIntPipe will allow only integer numbers with 10 base

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information