### PR TITLE
fix(microservices): modify `server-kafka.ts` to allow parallel execution

### DIFF
--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -181,11 +181,10 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
         err: NO_MESSAGE_HANDLER,
       });
     }
-
-    const response$ = this.transformToObservable(
-      await handler(packet.data, kafkaContext),
-    ) as Observable<any>;
-    response$ && this.send(response$, publish);
+    Promise.all([handler(packet.data, kafkaContext)]).then(([result])=> {
+      const response$ = this.transformToObservable(result) as Observable<any>;
+      response$ && this.send(response$, publish);
+    })
   }
 
   public sendMessage(

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -181,10 +181,11 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
         err: NO_MESSAGE_HANDLER,
       });
     }
-    Promise.all([handler(packet.data, kafkaContext)]).then(([result])=> {
+    // run handler into promise: this modification allow to make parallel kafka requests
+    Promise.all([handler(packet.data, kafkaContext)]).then(([result]) => {
       const response$ = this.transformToObservable(result) as Observable<any>;
       response$ && this.send(response$, publish);
-    })
+    });
   }
 
   public sendMessage(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Using a Kafka consumer/producer pair, I have found that the consumer process incoming requests in such a way that each processed message is waiting for the previous one, and if it takes a long time to get the result, then this approach becomes impractical due to the large waiting queue.

Issue Number: N/A

## What is the new behavior?

My solution allows not to wait for the execution of the previous message, and ensures correct parallel computations.
I wrapped the callable handler function in a Promise, keeping the same principle as previously used.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This solution no need any migration and will make the Kafka microservices more fast and reactive.

## Other information