### PR TITLE
feat(microservices): add static headers

### DIFF
--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -144,7 +144,7 @@ export class ClientMqtt extends ClientProxy {
         this.mqttClient.publish(
           this.getRequestPattern(pattern),
           JSON.stringify(serializedPacket),
-          this.mergeOptions(serializedPacket.options),
+          this.mergePacketOptions(serializedPacket.options),
         );
       };
 
@@ -175,7 +175,7 @@ export class ClientMqtt extends ClientProxy {
       this.mqttClient.publish(
         pattern,
         JSON.stringify(serializedPacket),
-        this.mergeOptions(serializedPacket.options),
+        this.mergePacketOptions(serializedPacket.options),
         (err: any) => (err ? reject(err) : resolve()),
       ),
     );
@@ -194,7 +194,7 @@ export class ClientMqtt extends ClientProxy {
     this.serializer = options?.serializer ?? new MqttRequestSerializer();
   }
 
-  protected mergeOptions(
+  protected mergePacketOptions(
     requestOptions?: MqttRecordOptions,
   ): MqttRecordOptions | undefined {
     if (!requestOptions && !this.options?.userProperties) {

--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -197,7 +197,7 @@ export class ClientMqtt extends ClientProxy {
   protected mergeOptions(
     requestOptions?: MqttRecordOptions,
   ): MqttRecordOptions | undefined {
-    if (!requestOptions && !this.options.userProperties) {
+    if (!requestOptions && !this.options?.userProperties) {
       return undefined;
     }
 
@@ -206,7 +206,7 @@ export class ClientMqtt extends ClientProxy {
       properties: {
         ...requestOptions?.properties,
         userProperties: {
-          ...this.options.userProperties,
+          ...this.options?.userProperties,
           ...requestOptions?.properties?.userProperties,
         },
       },

--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -114,9 +114,11 @@ export class ClientNats extends ClientProxy {
         callback: subscriptionHandler,
       });
 
+      const headers = this.mergeHeaders(serializedPacket.headers);
+
       this.natsClient.publish(channel, serializedPacket.data, {
         reply: inbox,
-        headers: serializedPacket.headers,
+        headers,
       });
 
       return () => subscription.unsubscribe();
@@ -128,11 +130,12 @@ export class ClientNats extends ClientProxy {
   protected dispatchEvent(packet: ReadPacket): Promise<any> {
     const pattern = this.normalizePattern(packet.pattern);
     const serializedPacket: NatsRecord = this.serializer.serialize(packet);
+    const headers = this.mergeHeaders(serializedPacket.headers);
 
     return new Promise<void>((resolve, reject) => {
       try {
         this.natsClient.publish(pattern, serializedPacket.data, {
-          headers: serializedPacket.headers,
+          headers,
         });
         resolve();
       } catch (err) {
@@ -148,5 +151,21 @@ export class ClientNats extends ClientProxy {
   protected initializeDeserializer(options: NatsOptions['options']) {
     this.deserializer =
       options?.deserializer ?? new NatsResponseJSONDeserializer();
+  }
+
+  protected mergeHeaders<THeaders = any>(requestHeaders?: THeaders) {
+    if (!requestHeaders && !this.options.headers) {
+      return undefined;
+    }
+
+    const headers = requestHeaders ?? natsPackage.headers();
+
+    for (const [key, value] of Object.entries(this.options.headers || {})) {
+      if (!headers.has(key)) {
+        headers.set(key, value);
+      }
+    }
+
+    return headers;
   }
 }

--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -154,13 +154,13 @@ export class ClientNats extends ClientProxy {
   }
 
   protected mergeHeaders<THeaders = any>(requestHeaders?: THeaders) {
-    if (!requestHeaders && !this.options.headers) {
+    if (!requestHeaders && !this.options?.headers) {
       return undefined;
     }
 
     const headers = requestHeaders ?? natsPackage.headers();
 
-    for (const [key, value] of Object.entries(this.options.headers || {})) {
+    for (const [key, value] of Object.entries(this.options?.headers || {})) {
       if (!headers.has(key)) {
         headers.set(key, value);
       }

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -238,12 +238,12 @@ export class ClientRMQ extends ClientProxy {
   protected mergeHeaders(
     requestHeaders?: Record<string, string>,
   ): Record<string, string> | undefined {
-    if (!requestHeaders && !this.options.headers) {
+    if (!requestHeaders && !this.options?.headers) {
       return undefined;
     }
 
     return {
-      ...this.options.headers,
+      ...this.options?.headers,
       ...requestHeaders,
     };
   }

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -203,6 +203,7 @@ export class ClientRMQ extends ClientProxy {
           replyTo: this.replyQueue,
           persistent: this.persistent,
           ...serializedPacket.options,
+          headers: this.mergeHeaders(serializedPacket.options?.headers),
           correlationId,
         },
       );
@@ -223,6 +224,7 @@ export class ClientRMQ extends ClientProxy {
         {
           persistent: this.persistent,
           ...serializedPacket.options,
+          headers: this.mergeHeaders(serializedPacket.options?.headers),
         },
         (err: unknown) => (err ? reject(err) : resolve()),
       ),
@@ -231,5 +233,18 @@ export class ClientRMQ extends ClientProxy {
 
   protected initializeSerializer(options: RmqOptions['options']) {
     this.serializer = options?.serializer ?? new RmqRequestSerializer();
+  }
+
+  protected mergeHeaders(
+    requestHeaders?: Record<string, string>,
+  ): Record<string, string> | undefined {
+    if (!requestHeaders && !this.options.headers) {
+      return undefined;
+    }
+
+    return {
+      ...this.options.headers,
+      ...requestHeaders,
+    };
   }
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -96,6 +96,7 @@ export interface MqttOptions {
     url?: string;
     serializer?: Serializer;
     deserializer?: Deserializer;
+    userProperties?: Record<string, string | string[]>;
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -157,6 +157,7 @@ export interface RmqOptions {
     deserializer?: Deserializer;
     replyQueue?: string;
     persistent?: boolean;
+    headers?: Record<string, string>;
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -102,6 +102,7 @@ export interface MqttOptions {
 export interface NatsOptions {
   transport?: Transport.NATS;
   options?: {
+    headers?: Record<string, string>;
     authenticator?: any;
     debug?: boolean;
     ignoreClusterUpdates?: boolean;

--- a/packages/microservices/record-builders/rmq.record-builder.ts
+++ b/packages/microservices/record-builders/rmq.record-builder.ts
@@ -8,7 +8,7 @@ export interface RmqRecordOptions {
   BCC?: string | string[];
   contentType?: string;
   contentEncoding?: string;
-  headers?: any;
+  headers?: Record<string, string>;
   priority?: number;
   messageId?: string;
   timestamp?: number;

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -3,10 +3,12 @@ import { empty } from 'rxjs';
 import * as sinon from 'sinon';
 import { ClientMqtt } from '../../client/client-mqtt';
 import { ERROR_EVENT } from '../../constants';
+import { ReadPacket } from '../../interfaces';
+import { MqttRecord } from '../../record-builders';
 
 describe('ClientMqtt', () => {
   const test = 'test';
-  const client = new ClientMqtt({});
+  let client: ClientMqtt = new ClientMqtt({});
 
   describe('getRequestPattern', () => {
     it(`should leave pattern as it is`, () => {
@@ -21,7 +23,7 @@ describe('ClientMqtt', () => {
   });
   describe('publish', () => {
     const pattern = 'test';
-    const msg = { pattern, data: 'data' };
+    let msg: ReadPacket;
     let subscribeSpy: sinon.SinonSpy,
       publishSpy: sinon.SinonSpy,
       onSpy: sinon.SinonSpy,
@@ -33,6 +35,8 @@ describe('ClientMqtt', () => {
 
     const id = '1';
     beforeEach(() => {
+      client = new ClientMqtt({});
+      msg = { pattern, data: 'data' };
       subscribeSpy = sinon.spy((name, fn) => fn());
       publishSpy = sinon.spy();
       onSpy = sinon.spy();
@@ -108,6 +112,52 @@ describe('ClientMqtt', () => {
       });
       it('should remove callback from routin map', () => {
         expect(client['routingMap'].has(id)).to.be.false;
+      });
+    });
+    describe('headers', () => {
+      it('should not generate headers if none are configured', async () => {
+        await client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2]).to.be.undefined;
+      });
+      it('should send packet headers', async () => {
+        const requestHeaders = { '1': '123' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2].properties.userProperties).to.eql(
+          requestHeaders,
+        );
+      });
+      it('should combine packet and static headers', async () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.userProperties = staticHeaders;
+
+        const requestHeaders = { '1': '123' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2].properties.userProperties).to.eql({
+          ...staticHeaders,
+          ...requestHeaders,
+        });
+      });
+      it('should prefer packet headers over static headers', async () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { 'client-id': 'override-client-id' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2].properties.userProperties).to.eql(
+          requestHeaders,
+        );
       });
     });
   });
@@ -277,10 +327,12 @@ describe('ClientMqtt', () => {
     });
   });
   describe('dispatchEvent', () => {
-    const msg = { pattern: 'pattern', data: 'data' };
+    let msg: ReadPacket;
     let publishStub: sinon.SinonStub, mqttClient;
 
     beforeEach(() => {
+      client = new ClientMqtt({});
+      msg = { pattern: 'pattern', data: 'data' };
       publishStub = sinon.stub();
       mqttClient = {
         publish: publishStub,
@@ -299,6 +351,58 @@ describe('ClientMqtt', () => {
       client['dispatchEvent'](msg).catch(err =>
         expect(err).to.be.instanceOf(Error),
       );
+    });
+    describe('headers', () => {
+      it('should not generate headers if none are configured', async () => {
+        publishStub.callsFake((a, b, c, d) => d());
+        await client['dispatchEvent'](msg);
+        expect(publishStub.getCall(0).args[2]).to.be.undefined;
+      });
+      it('should send packet headers', async () => {
+        publishStub.callsFake((a, b, c, d) => d());
+        const requestHeaders = { '1': '123' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['dispatchEvent'](msg);
+        expect(publishStub.getCall(0).args[2].properties.userProperties).to.eql(
+          requestHeaders,
+        );
+      });
+      it('should combine packet and static headers', async () => {
+        publishStub.callsFake((a, b, c, d) => d());
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.userProperties = staticHeaders;
+
+        const requestHeaders = { '1': '123' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['dispatchEvent'](msg);
+        expect(publishStub.getCall(0).args[2].properties.userProperties).to.eql(
+          {
+            ...staticHeaders,
+            ...requestHeaders,
+          },
+        );
+      });
+      it('should prefer packet headers over static headers', async () => {
+        publishStub.callsFake((a, b, c, d) => d());
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { 'client-id': 'override-client-id' };
+        msg.data = new MqttRecord('data', {
+          properties: { userProperties: requestHeaders },
+        });
+
+        await client['dispatchEvent'](msg);
+        expect(publishStub.getCall(0).args[2].properties.userProperties).to.eql(
+          requestHeaders,
+        );
+      });
     });
   });
 });

--- a/packages/microservices/test/client/client-nats.spec.ts
+++ b/packages/microservices/test/client/client-nats.spec.ts
@@ -1,16 +1,16 @@
 import { expect } from 'chai';
-import { JSONCodec, headers as createHeaders } from 'nats';
+import { headers as createHeaders, JSONCodec } from 'nats';
 import * as sinon from 'sinon';
 import { ClientNats } from '../../client/client-nats';
+import { ReadPacket } from '../../interfaces';
+import { NatsRecord } from '../../record-builders';
 
 describe('ClientNats', () => {
-  const client = new ClientNats({});
+  let client: ClientNats;
 
   describe('publish', () => {
+    let msg: ReadPacket;
     const pattern = 'test';
-    const headers = createHeaders();
-    headers.set('1', '123');
-    const msg = { pattern, data: { headers, value: 'data' } };
     const id = 3;
 
     let subscribeSpy: sinon.SinonSpy,
@@ -23,6 +23,8 @@ describe('ClientNats', () => {
       createClient: sinon.SinonStub;
 
     beforeEach(() => {
+      client = new ClientNats({});
+      msg = { pattern, data: 'data' };
       unsubscribeSpy = sinon.spy();
       subscription = {
         unsubscribe: unsubscribeSpy,
@@ -96,7 +98,54 @@ describe('ClientNats', () => {
         expect(unsubscribeSpy.called).to.be.true;
       });
     });
+
+    describe('headers', () => {
+      it('should not generate headers if none are configured', () => {
+        client['publish'](msg, () => {});
+        expect(natsClient.publish.getCall(0).args[2].headers).to.be.undefined;
+      });
+
+      it('should send packet headers', () => {
+        const requestHeaders = createHeaders();
+        requestHeaders.set('1', '123');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['publish'](msg, () => {});
+        expect(natsClient.publish.getCall(0).args[2].headers.get('1')).to.eql(
+          '123',
+        );
+      });
+      it('should combine packet and static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = createHeaders();
+        requestHeaders.set('1', '123');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2].headers.get('client-id')).to.eql(
+          'some-client-id',
+        );
+        expect(publishSpy.getCall(0).args[2].headers.get('1')).to.eql('123');
+      });
+
+      it('should prefer packet headers over static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = createHeaders();
+        requestHeaders.set('client-id', 'override-client-id');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['publish'](msg, () => {});
+        expect(publishSpy.getCall(0).args[2].headers.get('client-id')).to.eql(
+          'override-client-id',
+        );
+      });
+    });
   });
+
   describe('createSubscriptionHandler', () => {
     const pattern = 'test';
     const msg = { pattern, data: 'data', id: '1' };
@@ -279,10 +328,12 @@ describe('ClientNats', () => {
     });
   });
   describe('dispatchEvent', () => {
-    const msg = { pattern: 'pattern', data: 'data' };
+    let msg: ReadPacket;
     let subscribeStub: sinon.SinonStub, natsClient: any;
 
     beforeEach(() => {
+      client = new ClientNats({});
+      msg = { pattern: 'pattern', data: 'data' };
       subscribeStub = sinon
         .stub()
         .callsFake((channel, options) => options.callback());
@@ -298,6 +349,7 @@ describe('ClientNats', () => {
 
       expect(natsClient.publish.called).to.be.true;
     });
+
     it('should throw error', async () => {
       subscribeStub.callsFake((channel, options) =>
         options.callback(new Error()),
@@ -305,6 +357,55 @@ describe('ClientNats', () => {
       client['dispatchEvent'](msg).catch(err =>
         expect(err).to.be.instanceOf(Error),
       );
+    });
+
+    describe('headers', () => {
+      it('should not generate headers if none are configured', () => {
+        client['dispatchEvent'](msg);
+        expect(natsClient.publish.getCall(0).args[2].headers).to.be.undefined;
+      });
+
+      it('should send packet headers', () => {
+        const requestHeaders = createHeaders();
+        requestHeaders.set('1', '123');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['dispatchEvent'](msg);
+        expect(natsClient.publish.getCall(0).args[2].headers.get('1')).to.eql(
+          '123',
+        );
+      });
+
+      it('should combine packet and static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = createHeaders();
+        requestHeaders.set('1', '123');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['dispatchEvent'](msg);
+        expect(
+          natsClient.publish.getCall(0).args[2].headers.get('client-id'),
+        ).to.eql('some-client-id');
+        expect(natsClient.publish.getCall(0).args[2].headers.get('1')).to.eql(
+          '123',
+        );
+      });
+
+      it('should prefer packet headers over static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = createHeaders();
+        requestHeaders.set('client-id', 'override-client-id');
+        msg.data = new NatsRecord('data', requestHeaders);
+
+        client['dispatchEvent'](msg);
+        expect(
+          natsClient.publish.getCall(0).args[2].headers.get('client-id'),
+        ).to.eql('override-client-id');
+      });
     });
   });
 });

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -3,6 +3,8 @@ import { EventEmitter } from 'events';
 import { empty } from 'rxjs';
 import * as sinon from 'sinon';
 import { ClientRMQ } from '../../client/client-rmq';
+import { ReadPacket } from '../../interfaces';
+import { RmqRecord } from '../../record-builders';
 
 describe('ClientRMQ', function () {
   this.retries(10);
@@ -176,12 +178,14 @@ describe('ClientRMQ', function () {
 
   describe('publish', () => {
     const pattern = 'test';
-    const msg = { pattern, data: 'data' };
+    let msg: ReadPacket;
     let connectSpy: sinon.SinonSpy,
       sendToQueueSpy: sinon.SinonSpy,
       eventSpy: sinon.SinonSpy;
 
     beforeEach(() => {
+      client = new ClientRMQ({});
+      msg = { pattern, data: 'data' };
       connectSpy = sinon.spy(client, 'connect');
       eventSpy = sinon.spy();
       sendToQueueSpy = sinon.spy();
@@ -228,6 +232,54 @@ describe('ClientRMQ', function () {
       });
       it('should unsubscribe', () => {
         expect(unsubscribeSpy.called).to.be.true;
+      });
+    });
+
+    describe('headers', () => {
+      it('should not generate headers if none are configured', () => {
+        client['publish'](msg, () => {
+          expect(sendToQueueSpy.getCall(0).args[2].headers).to.be.undefined;
+        });
+      });
+
+      it('should send packet headers', () => {
+        const requestHeaders = { '1': '123' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        client['publish'](msg, () => {
+          expect(sendToQueueSpy.getCall(0).args[2].headers).to.eql(
+            requestHeaders,
+          );
+        });
+      });
+
+      it('should combine packet and static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { '1': '123' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        client['publish'](msg, () => {
+          expect(sendToQueueSpy.getCall(0).args[2].headers).to.eql({
+            ...staticHeaders,
+            ...requestHeaders,
+          });
+        });
+      });
+
+      it('should prefer packet headers over static headers', () => {
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { 'client-id': 'override-client-id' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        client['publish'](msg, () => {
+          expect(sendToQueueSpy.getCall(0).args[2].headers).to.eql(
+            requestHeaders,
+          );
+        });
       });
     });
   });
@@ -320,10 +372,12 @@ describe('ClientRMQ', function () {
     });
   });
   describe('dispatchEvent', () => {
-    const msg = { pattern: 'pattern', data: 'data' };
+    let msg: ReadPacket;
     let sendToQueueStub: sinon.SinonStub, channel;
 
     beforeEach(() => {
+      client = new ClientRMQ({});
+      msg = { pattern: 'pattern', data: 'data' };
       sendToQueueStub = sinon.stub();
       channel = {
         sendToQueue: sendToQueueStub,
@@ -342,6 +396,54 @@ describe('ClientRMQ', function () {
       client['dispatchEvent'](msg).catch(err =>
         expect(err).to.be.instanceOf(Error),
       );
+    });
+
+    describe('headers', () => {
+      it('should not generate headers if none are configured', async () => {
+        sendToQueueStub.callsFake((a, b, c, d) => d());
+        await client['dispatchEvent'](msg);
+        expect(sendToQueueStub.getCall(0).args[2].headers).to.be.undefined;
+      });
+
+      it('should send packet headers', async () => {
+        sendToQueueStub.callsFake((a, b, c, d) => d());
+        const requestHeaders = { '1': '123' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        await client['dispatchEvent'](msg);
+        expect(sendToQueueStub.getCall(0).args[2].headers).to.eql(
+          requestHeaders,
+        );
+      });
+
+      it('should combine packet and static headers', async () => {
+        sendToQueueStub.callsFake((a, b, c, d) => d());
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { '1': '123' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        await client['dispatchEvent'](msg);
+        expect(sendToQueueStub.getCall(0).args[2].headers).to.eql({
+          ...staticHeaders,
+          ...requestHeaders,
+        });
+      });
+
+      it('should prefer packet headers over static headers', async () => {
+        sendToQueueStub.callsFake((a, b, c, d) => d());
+        const staticHeaders = { 'client-id': 'some-client-id' };
+        (client as any).options.headers = staticHeaders;
+
+        const requestHeaders = { 'client-id': 'override-client-id' };
+        msg.data = new RmqRecord('data', { headers: requestHeaders });
+
+        await client['dispatchEvent'](msg);
+        expect(sendToQueueStub.getCall(0).args[2].headers).to.eql(
+          requestHeaders,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

It's currently only possible to send request-specific headers for NATS, RabbitMQ and MQTT

Issue Number: N/A


## What is the new behavior?

This PR allows the developer to add static headers to a client for NATS, RabbitMQ and MQTT. Aside from adding fully static values, it also allows developers to do something like:

```ts
providers: [{
  provide: 'CLIENT_NATS',
  scope: Scope.REQUEST,
  inject: REQUEST,
  useFactory: (req) => new ClientNats({
    headers: {
      requestId: req.header('request-id'),
    }
  })
}]
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I don't know what the public interface on ClientProxy will be for sending request-specific headers, but I tried to deduce it from the changes in `feat/msvc-message-builder` and based the tests on that.