### PR TITLE
Consistent naming

### DIFF
--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -8,7 +8,7 @@ import { fromEvent, Observable } from 'rxjs';
 import { filter, first, map, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { Server, ServerOptions, Socket } from 'socket.io';
 
-export class IoAdapter extends AbstractWsAdapter {
+export class IOAdapter extends AbstractWsAdapter {
   public create(
     port: number,
     options?: ServerOptions & { namespace?: string; server?: any },


### PR DESCRIPTION
`IoAdapter` ->` IOAdapter` to be consistent with `createIOServer`
Definitely a breaking change for older codebases but.. why have that inconsistency in the first place?
