### PR TITLE
Breaking Change: Use method's name as default path in @RequestMapping

### DIFF
--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -15,7 +15,6 @@ export const RequestMapping = (
   metadata: RequestMappingMetadata = defaultMetadata,
 ): MethodDecorator => {
   const pathMetadata = metadata[PATH_METADATA];
-  const path = pathMetadata && pathMetadata.length ? pathMetadata : '/';
   const requestMethod = metadata[METHOD_METADATA] || RequestMethod.GET;
 
   return (
@@ -23,6 +22,8 @@ export const RequestMapping = (
     key: string | symbol,
     descriptor: TypedPropertyDescriptor<any>,
   ) => {
+    const path = pathMetadata?.length ? pathMetadata : key;
+
     Reflect.defineMetadata(PATH_METADATA, path, descriptor.value);
     Reflect.defineMetadata(METHOD_METADATA, requestMethod, descriptor.value);
     return descriptor;

--- a/packages/common/test/decorators/request-mapping.decorator.spec.ts
+++ b/packages/common/test/decorators/request-mapping.decorator.spec.ts
@@ -44,7 +44,7 @@ describe('@RequestMapping', () => {
     expect(method).to.be.eql(RequestMethod.GET);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as name of the method by default', () => {
     class Test {
       @RequestMapping({})
       public static test() {}
@@ -56,7 +56,7 @@ describe('@RequestMapping', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -36,7 +36,7 @@ describe('@Get', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @Get()
       public static test() {}
@@ -48,8 +48,8 @@ describe('@Get', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 
@@ -86,7 +86,7 @@ describe('@Post', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @Post()
       public static test(
@@ -106,8 +106,8 @@ describe('@Post', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 
@@ -144,7 +144,7 @@ describe('@Delete', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @Delete()
       public static test() {}
@@ -156,8 +156,8 @@ describe('@Delete', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 
@@ -194,7 +194,7 @@ describe('@All', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @All()
       public static test() {}
@@ -206,8 +206,8 @@ describe('@All', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 
@@ -244,7 +244,7 @@ describe('@Put', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @Put()
       public static test() {}
@@ -256,8 +256,8 @@ describe('@Put', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 
@@ -294,7 +294,7 @@ describe('@Patch', () => {
     expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
   });
 
-  it('should set path on "/" by default', () => {
+  it('should set path as method name by default', () => {
     class Test {
       @Patch()
       public static test() {}
@@ -306,8 +306,8 @@ describe('@Patch', () => {
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
 
-    expect(path).to.be.eql('/');
-    expect(pathUsingArray).to.be.eql('/');
+    expect(path).to.be.eql('test');
+    expect(pathUsingArray).to.be.eql('testUsingArray');
   });
 });
 

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -28,13 +28,13 @@ describe('RoutesResolver', () => {
 
   @Controller({ host: 'api.example.com' })
   class TestHostRoute {
-    @Get()
+    @Get('/')
     public getTest() {}
   }
 
   @Controller({ version: '1' })
   class TestVersionRoute {
-    @Get()
+    @Get('/')
     public getTest() {}
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features) **Didn't do it intentionally to first discuss this change with maintainers and community**.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behaviour?

```typescript
@Controller('auth')
export class AuthController {

    @Get('login')
    login() {
    }

    @Post('logout')
    logout() {
    }

    @Get()
    check() {
    }

    @Post('register')
    register() {
    }
}
```

Currently, the above controller will be mapped as-

1. `/auth/login`
2. `/auth/logout`
3. `/auth`
4. `/auth/register`

## What is the new behaviour?

After this PR, the exact mapping can be achieved via this change-

```typescript
@Controller('auth')
export class AuthController {

    @Get()
    login() {
    }

    @Post()
    logout() {
    }

    @Get('/')
    check() {
    }

    @Post()
    register() {
    }
}
```

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

To achieve the default path `"/"`, the existing applications which are not passing any value to any of the request decorators [`@Get`, `@Post`...](https://github.com/nestjs/nest/blob/v8.0.9/packages/common/decorators/http/request-mapping.decorator.ts#L48-L111), they will have to pass `/` to those decorators.

## Motivation

Today, if we do not pass any value to the [request method decorators](https://github.com/nestjs/nest/blob/v8.0.9/packages/common/decorators/http/request-mapping.decorator.ts#L48-L111), the default value of the path is assigned to `"/"` and **we can't have multiple methods within the same controller with the empty path as the last one will override the previous one**.

While, as of today, developers have to use duplicate strings if their path and method names are the same (check the example in the above current behaviour). So if their pathname is the same as their method name, why should they pass the same method name as an argument to decorators?

This change is definitely a **Breaking Change** but this will DRY the decorators **if their method names are the same** (which I assume is the case with most of the applications) because the tendency of having the same path methods is going to be much higher than having default path methods (i.e. only one).

This PR is open for discussion. I'll update the docs once we get a go-ahead from the maintainers and community.

Being the newbie in NestJS (not in web development), I have not spent time running the code locally (although I have updated & ran the unit tests).

Thoughts? Suggestions?