### PR TITLE
style():  rename tests name to follow global style

### DIFF
--- a/integration/cors/e2e/express.spec.ts
+++ b/integration/cors/e2e/express.spec.ts
@@ -43,7 +43,7 @@ describe('Express Cors', () => {
         await app.init();
       });
 
-      it(`Should add cors headers based on the first config`, async () => {
+      it(`should add cors headers based on the first config`, async () => {
         return request(app.getHttpServer())
           .get('/')
           .expect('access-control-allow-origin', 'example.com')
@@ -53,7 +53,7 @@ describe('Express Cors', () => {
           .expect('content-length', '0');
       });
 
-      it(`Should add cors headers based on the second config`, async () => {
+      it(`should add cors headers based on the second config`, async () => {
         return request(app.getHttpServer())
           .options('/')
           .expect('access-control-allow-origin', 'sample.com')
@@ -91,7 +91,7 @@ describe('Express Cors', () => {
         await app.init();
       });
 
-      it(`Should add cors headers based on the first config`, async () => {
+      it(`should add cors headers based on the first config`, async () => {
         return request(app.getHttpServer())
           .get('/')
           .expect('access-control-allow-origin', 'example.com')
@@ -101,7 +101,7 @@ describe('Express Cors', () => {
           .expect('content-length', '0');
       });
 
-      it(`Should add cors headers based on the second config`, async () => {
+      it(`should add cors headers based on the second config`, async () => {
         return request(app.getHttpServer())
           .options('/')
           .expect('access-control-allow-origin', 'sample.com')

--- a/integration/cors/e2e/fastify.spec.ts
+++ b/integration/cors/e2e/fastify.spec.ts
@@ -43,7 +43,7 @@ describe('Fastify Cors', () => {
         await app.init();
       });
 
-      it(`Should add cors headers based on the first config`, async () => {
+      it(`should add cors headers based on the first config`, async () => {
         return request(app.getHttpServer())
           .get('/')
           .expect('access-control-allow-origin', 'example.com')
@@ -53,7 +53,7 @@ describe('Fastify Cors', () => {
           .expect('content-length', '0');
       });
 
-      it(`Should add cors headers based on the second config`, async () => {
+      it(`should add cors headers based on the second config`, async () => {
         return request(app.getHttpServer())
           .options('/')
           .expect('access-control-allow-origin', 'sample.com')
@@ -91,7 +91,7 @@ describe('Fastify Cors', () => {
         await app.init();
       });
 
-      it(`Should add cors headers based on the first config`, async () => {
+      it(`should add cors headers based on the first config`, async () => {
         return request(app.getHttpServer())
           .get('/')
           .expect('access-control-allow-origin', 'example.com')
@@ -101,7 +101,7 @@ describe('Fastify Cors', () => {
           .expect('content-length', '0');
       });
 
-      it(`Should add cors headers based on the second config`, async () => {
+      it(`should add cors headers based on the second config`, async () => {
         return request(app.getHttpServer())
           .options('/')
           .expect('access-control-allow-origin', 'sample.com')
@@ -147,6 +147,7 @@ describe('Fastify Cors', () => {
     after(async () => {
       await app.close();
     });
+    
     describe('Application Options', () => {
       before(async () => {
         const module = await Test.createTestingModule({


### PR DESCRIPTION
Some initital tests name used "Should" instead "should", so i rename them

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Current only eight testes don't follow the style and are using "Should" with "S" in uppercase on test name.

![Captura de tela de 2021-10-09 18-45-45](https://user-images.githubusercontent.com/48860569/136674463-89edb8b1-8fd9-4b69-861c-1fb30a503db0.png)

## What is the new behavior?
![Captura de tela de 2021-10-09 18-40-25](https://user-images.githubusercontent.com/48860569/136674402-4fdcf292-495b-452a-a1b8-40ff72c6b2b2.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information