### PR TITLE
fix: flush logs on package resolution failure

### DIFF
--- a/packages/common/utils/load-package.util.ts
+++ b/packages/common/utils/load-package.util.ts
@@ -14,6 +14,7 @@ export function loadPackage(
     return loaderFn ? loaderFn() : require(packageName);
   } catch (e) {
     logger.error(MISSING_REQUIRED_DEPENDENCY(packageName, context));
+    Logger.flush();
     process.exit(1);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When Nest tries to resolve a package that doesn't exist in the `node_modules` **and** when `bufferLogs: true` is set, Nest does not log any errors, it just silently exists leaving the developer wondering what's happening

Issue Number: #8275 

## What is the new behavior?

When Nest tries to resolve a package that doesn't exist in the `node_modules` it'll flush the logs so that the error is properly reported before exiting

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information