### PR TITLE
fix(core): run destroy and shutdown hooks in ascending topological order

### DIFF
--- a/integration/hooks/e2e/before-app-shutdown.spec.ts
+++ b/integration/hooks/e2e/before-app-shutdown.spec.ts
@@ -20,12 +20,13 @@ describe('BeforeApplicationShutdown', () => {
     expect(instance.beforeApplicationShutdown.called).to.be.true;
   });
 
-  it('should sort modules by distance (topological sort) - DESC order', async () => {
+  it('should sort modules by distance (topological sort) - ASC order', async () => {
+    const order: string[] = [];
+
     @Injectable()
     class BB implements BeforeApplicationShutdown {
-      public field: string;
       async beforeApplicationShutdown() {
-        this.field = 'b-field';
+        order.push('BB');
       }
     }
 
@@ -37,11 +38,8 @@ describe('BeforeApplicationShutdown', () => {
 
     @Injectable()
     class AA implements BeforeApplicationShutdown {
-      public field: string;
-      constructor(private bb: BB) {}
-
       async beforeApplicationShutdown() {
-        this.field = this.bb.field + '_a-field';
+        order.push('AA');
       }
     }
     @Module({
@@ -58,7 +56,6 @@ describe('BeforeApplicationShutdown', () => {
     await app.init();
     await app.close();
 
-    const instance = module.get(AA);
-    expect(instance.field).to.equal('b-field_a-field');
+    expect(order).to.be.deep.equal(['AA', 'BB']);
   });
 });

--- a/integration/hooks/e2e/on-app-shutdown.spec.ts
+++ b/integration/hooks/e2e/on-app-shutdown.spec.ts
@@ -20,12 +20,13 @@ describe('OnApplicationShutdown', () => {
     expect(instance.onApplicationShutdown.called).to.be.true;
   });
 
-  it('should sort modules by distance (topological sort) - DESC order', async () => {
+  it('should sort modules by distance (topological sort) - ASC order', async () => {
+    const order: string[] = [];
+
     @Injectable()
     class BB implements OnApplicationShutdown {
-      public field: string;
       async onApplicationShutdown() {
-        this.field = 'b-field';
+        order.push('BB');
       }
     }
 
@@ -37,11 +38,8 @@ describe('OnApplicationShutdown', () => {
 
     @Injectable()
     class AA implements OnApplicationShutdown {
-      public field: string;
-      constructor(private bb: BB) {}
-
       async onApplicationShutdown() {
-        this.field = this.bb.field + '_a-field';
+        order.push('AA');
       }
     }
     @Module({
@@ -58,7 +56,6 @@ describe('OnApplicationShutdown', () => {
     await app.init();
     await app.close();
 
-    const instance = module.get(AA);
-    expect(instance.field).to.equal('b-field_a-field');
+    expect(order).to.be.deep.equal(['AA', 'BB']);
   });
 });

--- a/integration/hooks/e2e/on-module-destroy.spec.ts
+++ b/integration/hooks/e2e/on-module-destroy.spec.ts
@@ -40,12 +40,13 @@ describe('OnModuleDestroy', () => {
     await app.init().then(obj => expect(obj).to.not.be.undefined);
   });
 
-  it('should sort modules by distance (topological sort) - DESC order', async () => {
+  it('should sort modules by distance (topological sort) - ASC order', async () => {
+    const order: string[] = [];
+
     @Injectable()
     class BB implements OnModuleDestroy {
-      public field: string;
       async onModuleDestroy() {
-        this.field = 'b-field';
+        order.push('BB');
       }
     }
 
@@ -57,11 +58,8 @@ describe('OnModuleDestroy', () => {
 
     @Injectable()
     class AA implements OnModuleDestroy {
-      public field: string;
-      constructor(private bb: BB) {}
-
       async onModuleDestroy() {
-        this.field = this.bb.field + '_a-field';
+        order.push('AA');
       }
     }
     @Module({
@@ -78,7 +76,6 @@ describe('OnModuleDestroy', () => {
     await app.init();
     await app.close();
 
-    const instance = module.get(AA);
-    expect(instance.field).to.equal('b-field_a-field');
+    expect(order).to.be.deep.equal(['AA', 'BB']);
   });
 });

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -39,7 +39,8 @@ export class NestApplicationContext implements INestApplicationContext {
   private readonly moduleCompiler = new ModuleCompiler();
   private shutdownCleanupRef?: (...args: unknown[]) => unknown;
   private _instanceLinksHost: InstanceLinksHost;
-  private _moduleRefsByDistance?: Array<Module>;
+  private _moduleRefsByDistanceAsc?: Array<Module>;
+  private _moduleRefsByDistanceDesc?: Array<Module>;
 
   private get instanceLinksHost() {
     if (!this._instanceLinksHost) {
@@ -222,8 +223,8 @@ export class NestApplicationContext implements INestApplicationContext {
    * modules and its children.
    */
   protected async callInitHook(): Promise<void> {
-    const modulesSortedByDistance = this.getModulesSortedByDistance();
-    for (const module of modulesSortedByDistance) {
+    const modulesSortedByDistanceDesc = this.getModulesSortedByDistanceDesc();
+    for (const module of modulesSortedByDistanceDesc) {
       await callModuleInitHook(module);
     }
   }
@@ -233,8 +234,8 @@ export class NestApplicationContext implements INestApplicationContext {
    * modules and its children.
    */
   protected async callDestroyHook(): Promise<void> {
-    const modulesSortedByDistance = this.getModulesSortedByDistance();
-    for (const module of modulesSortedByDistance) {
+    const modulesSortedByDistanceAsc = this.getModulesSortedByDistanceAsc();
+    for (const module of modulesSortedByDistanceAsc) {
       await callModuleDestroyHook(module);
     }
   }
@@ -244,8 +245,8 @@ export class NestApplicationContext implements INestApplicationContext {
    * modules and its children.
    */
   protected async callBootstrapHook(): Promise<void> {
-    const modulesSortedByDistance = this.getModulesSortedByDistance();
-    for (const module of modulesSortedByDistance) {
+    const modulesSortedByDistanceDesc = this.getModulesSortedByDistanceDesc();
+    for (const module of modulesSortedByDistanceDesc) {
       await callModuleBootstrapHook(module);
     }
   }
@@ -255,8 +256,8 @@ export class NestApplicationContext implements INestApplicationContext {
    * modules and children.
    */
   protected async callShutdownHook(signal?: string): Promise<void> {
-    const modulesSortedByDistance = this.getModulesSortedByDistance();
-    for (const module of modulesSortedByDistance) {
+    const modulesSortedByDistanceAsc = this.getModulesSortedByDistanceAsc();
+    for (const module of modulesSortedByDistanceAsc) {
       await callAppShutdownHook(module, signal);
     }
   }
@@ -266,8 +267,8 @@ export class NestApplicationContext implements INestApplicationContext {
    * modules and children.
    */
   protected async callBeforeShutdownHook(signal?: string): Promise<void> {
-    const modulesSortedByDistance = this.getModulesSortedByDistance();
-    for (const module of modulesSortedByDistance) {
+    const modulesSortedByDistanceAsc = this.getModulesSortedByDistanceAsc();
+    for (const module of modulesSortedByDistanceAsc) {
       await callBeforeAppShutdownHook(module, signal);
     }
   }
@@ -319,16 +320,29 @@ export class NestApplicationContext implements INestApplicationContext {
     return instance;
   }
 
-  private getModulesSortedByDistance(): Module[] {
-    if (this._moduleRefsByDistance) {
-      return this._moduleRefsByDistance;
+  private getModulesSortedByDistanceDesc(): Module[] {
+    if (this._moduleRefsByDistanceDesc) {
+      return this._moduleRefsByDistanceDesc;
     }
     const modulesContainer = this.container.getModules();
     const compareFn = (a: Module, b: Module) => b.distance - a.distance;
 
-    this._moduleRefsByDistance = Array.from(modulesContainer.values()).sort(
+    this._moduleRefsByDistanceDesc = Array.from(modulesContainer.values()).sort(
       compareFn,
     );
-    return this._moduleRefsByDistance;
+    return this._moduleRefsByDistanceDesc;
+  }
+
+  private getModulesSortedByDistanceAsc(): Module[] {
+    if (this._moduleRefsByDistanceAsc) {
+      return this._moduleRefsByDistanceAsc;
+    }
+    const modulesContainer = this.container.getModules();
+    const compareFn = (a: Module, b: Module) => a.distance - b.distance;
+
+    this._moduleRefsByDistanceAsc = Array.from(modulesContainer.values()).sort(
+      compareFn,
+    );
+    return this._moduleRefsByDistanceAsc;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If Module A depends on Module B, Module B's providers will be destroyed (`onModuleDestroy`) before Module A's providers. This means that when `onModuleDestroy` runs inside of a provider in Module A, any providers it uses from Module B will have already been destroyed. It seems like as a rule, a service should not have to guard against its dependencies being destroyed.

As a contrived example, imagine that Module A has a service (`ServiceA`) that should write a row to a database when the module is destroyed, and Module B contains the database service (`DBService`). Inside Module B, `DBService` disconnects from the database in `onModuleDestroy`. With the way things work today, Module B will be destroyed before Module A, so the `DBService` will be disconnected before `ServiceA`'s `onModuleDestroy`.

Note that in v7, modules were destroyed in the expected order. The change to `onModuleDestroy` order is a regression in v8. I'm less familiar with `onApplicationShutdown` and `beforeApplicationShutdown`. It seems like the order for those should match `onModuleDestroy` so I made that change, but let me know if that's not the case.


## What is the new behavior?

If Module A depends on Module B, Module A's providers should be destroyed before Module B's. This allows Module A's providers to access Module B's providers in `onModuleDestroy`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information