### PR TITLE
refactor(core): avoid running useless instance wrapper's checks

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -640,15 +640,11 @@ export class Injector {
       contextId,
       inquirerId,
     );
-    const isStatic = wrapper.isStatic(contextId, inquirer);
-    const isInRequestScope = wrapper.isInRequestScope(contextId, inquirer);
-    const isLazyTransient = wrapper.isLazyTransient(contextId, inquirer);
-    const isExplicitlyRequested = wrapper.isExplicitlyRequested(
-      contextId,
-      inquirer,
-    );
     const isInContext =
-      isStatic || isInRequestScope || isLazyTransient || isExplicitlyRequested;
+      wrapper.isStatic(contextId, inquirer) ||
+      wrapper.isInRequestScope(contextId, inquirer) ||
+      wrapper.isLazyTransient(contextId, inquirer) ||
+      wrapper.isExplicitlyRequested(contextId, inquirer);
 
     if (isNil(inject) && isInContext) {
       instanceHost.instance = wrapper.forwardRef


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Regarding the code below, in _my Nestjs project_, `isStatic` is `true` for most of the cases, thus making the other `isX` conditions pretty useless (AFIK). Also, this `isX` variables aren't used anywhere besides on L651

https://github.com/nestjs/nest/blob/8759c6ba20c8bfa08584189de1cba2fe5fed6e57/packages/core/injector/injector.ts#L643-L651

I'm assuming that each `isX` methods can take some meaningful time, degradading a bit the time taken to bootstrap the app (I didn't benchmarked it enough tho, this is why I'm using `refactor` type over `perf`)

Using [clinic.js flame tool](https://clinicjs.org/flame), with my NestJS project (with +27 NestJS modules), I got this:

<details>
<summary>old flamegraph</summary>

![image](https://user-images.githubusercontent.com/13461315/138027132-9b1df5ab-eb55-45ef-b1f7-b00da1a96bf6.png)

</details>

## What is the new behavior?

Leveraging on short-circuit evaluation to avoid invoking those useless(?) calls

<details>
<summary>new flamegraph</summary>

![image](https://user-images.githubusercontent.com/13461315/138027205-963aedcc-fb09-47cb-94d4-e75d305b2f07.png)

notice that `instantiateClass` block becomes less wider, which means it takes less time.

</details>

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Maybe I'm a bit wrong on the negative impact of not using short-circuit since I've tested it only in my project (REST API with a bunch of modules with the default scope), but I still think that this minor refactoring is reasonable because it doesn't degraded the readability at all since all methods have good names. And also because this change is pretty small.