### PR TITLE
fix(util): log color allowed

### DIFF
--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -1,6 +1,6 @@
 type ColorTextFn = (text: string) => string;
 
-const isColorAllowed = () => !process.env.NO_COLOR;
+const isColorAllowed = () => process.env.NO_COLOR !== 'true';
 const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 


### PR DESCRIPTION
- dotenv is not support boolean
- https://github.com/motdotla/dotenv/issues/51

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: N/A
- Even if `NO_COLOR=false` is set, it is not set.

## What is the new behavior?
- If not 'NO_COLOR=true', the color will be activated.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information