### PR TITLE
feat(common): add the ability to set some extra metadata about returned files

### DIFF
--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -53,4 +53,14 @@ describe('Express FileSend', () => {
         expect(res.body.toString()).to.be.eq(readmeString);
       });
   });
+  it('should return a file with correct content type and disposition', async () => {
+    return request(app.getHttpServer())
+      .get('/file/with/headers')
+      .expect(200)
+      .expect('Content-Type', 'text/markdown')
+      .expect('Content-Disposition', 'attachment; filename="Readme.md"')
+      .expect(res => {
+        expect(res.text).to.be.eq(readmeString);
+      });
+  });
 });

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -26,4 +26,9 @@ export class AppController {
   getRxJSFile(): Observable<StreamableFile> {
     return this.appService.getRxJSFile();
   }
+
+  @Get('file/with/headers')
+  getFileWithHeaders(): StreamableFile {
+    return this.appService.getFileWithHeaders();
+  }
 }

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -23,4 +23,14 @@ export class AppService {
   getRxJSFile(): Observable<StreamableFile> {
     return of(this.getReadStream());
   }
+
+  getFileWithHeaders(): StreamableFile {
+    return new StreamableFile(
+      createReadStream(join(process.cwd(), 'Readme.md')),
+      {
+        type: 'text/markdown',
+        disposition: 'attachment; filename="Readme.md"',
+      },
+    );
+  }
 }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -1,11 +1,15 @@
 import { Readable } from 'stream';
+import { StreamableFileOptions } from './streamable-options.interface';
 
 export class StreamableFile {
   private readonly stream: Readable;
 
-  constructor(buffer: Buffer);
-  constructor(readable: Readable);
-  constructor(bufferOrReadStream: Buffer | Readable) {
+  constructor(buffer: Buffer, options?: StreamableFileOptions);
+  constructor(readable: Readable, options?: StreamableFileOptions);
+  constructor(
+    bufferOrReadStream: Buffer | Readable,
+    readonly options: StreamableFileOptions = {},
+  ) {
     if (Buffer.isBuffer(bufferOrReadStream)) {
       this.stream = new Readable();
       this.stream.push(bufferOrReadStream);
@@ -20,5 +24,11 @@ export class StreamableFile {
 
   getStream(): Readable {
     return this.stream;
+  }
+
+  getHeaders() {
+    const { type = 'application/octet-stream', disposition = null } =
+      this.options;
+    return { type, disposition };
   }
 }

--- a/packages/common/file-stream/streamable-options.interface.ts
+++ b/packages/common/file-stream/streamable-options.interface.ts
@@ -1,0 +1,4 @@
+export interface StreamableFileOptions {
+  type?: string;
+  disposition?: string;
+}

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -44,8 +44,12 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       return response.send();
     }
     if (body instanceof StreamableFile) {
+      const streamHeaders = body.getHeaders();
       if (response.getHeader('Content-Type') === undefined) {
-        response.setHeader('Content-Type', 'application/octet-stream');
+        response.setHeader('Content-Type', streamHeaders.type);
+      }
+      if (response.getHeader('Content-Disposition') === undefined) {
+        response.setHeader('Content-Disposition', streamHeaders.disposition);
       }
       return body.getStream().pipe(response);
     }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -281,6 +281,13 @@ export class FastifyAdapter<
     }
     if (body instanceof StreamableFile) {
       body = body.getStream();
+      const streamHeaders = body.getHeaders();
+      if (fastifyReply.getHeader('Content-Type') === undefined) {
+        fastifyReply.header('Content-Type', streamHeaders.type);
+      }
+      if (fastifyReply.getHeader('Content-Disposition') === undefined) {
+        fastifyReply.header('Content-Disposition', streamHeaders.disposition);
+      }
     }
     return fastifyReply.send(body);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Right now, we can just return a file and have to inject `@Res({ passthrough: true })` to update the content-type and disposition

## What is the new behavior?

We can pass these options to the `StreamableFile` constructor and let Nest take care of the work for devs

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information