### PR TITLE
feat(core/errors): adds potential solution to circular dependency for UNKNOWN_DEPENDENCIES_MESSAGE

### DIFF
--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -67,6 +67,11 @@ Potential solutions:
   @Module({
     imports: [ /* the Module containing ${dependencyName} */ ]
   })
+- If ${dependencyName} imports from ${type.toString()}, was it injected using forwardRef() utility function to resolve the circular dependency?
+  constructor(
+    @Inject(forwardRef(() => ${dependencyName}))
+    private ${dependencyName}: ${dependencyName},
+  ) {}
 `;
 
   if (isNil(index)) {

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -23,6 +23,11 @@ describe('Error Messages', () => {
       @Module({
         imports: [ /* the Module containing dependency */ ]
       })
+      - If dependency imports from CatService, was it injected using forwardRef() utility function to resolve the circular dependency?
+      constructor(
+        @Inject(forwardRef(() => dependency))
+        private dependency: dependency,
+      ) {}
       `);
 
       class CatService {}
@@ -46,6 +51,11 @@ describe('Error Messages', () => {
       @Module({
       imports: [ /* the Module containing dependency */ ]
       })
+      - If dependency imports from CatService, was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}
       `);
 
       const actualMessage = stringCleaner(
@@ -67,6 +77,11 @@ describe('Error Messages', () => {
       @Module({
         imports: [ /* the Module containing dependency */ ]
       })
+      - If dependency imports from CatService, was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}
       `);
 
       function CatFunction() {}
@@ -88,7 +103,12 @@ describe('Error Messages', () => {
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
-      `);
+      - If dependency imports from CatService, was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}
+        `);
 
       const actualMessage = stringCleaner(
         new UnknownDependenciesException('CatService', {
@@ -109,6 +129,11 @@ describe('Error Messages', () => {
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
+      - If dependency imports from CatService, was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}  
       `);
 
       class MetaType {
@@ -142,6 +167,11 @@ describe('Error Messages', () => {
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
+      - If dependency imports from Symbol(CatProvider), was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}  
       `);
 
       const actualMessage = stringCleaner(
@@ -163,6 +193,11 @@ describe('Error Messages', () => {
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
+      - If dependency imports from CatProvider, was it injected using forwardRef() utility function to resolve the circular dependency?
+        constructor(
+          @Inject(forwardRef(() => dependency))
+          private dependency: dependency,
+        ) {}  
       `);
 
       const actualMessage = stringCleaner(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe:
I suppose it is not really a new feature. It just extends the error message when Nest cannot resolve dependency.

## What is the current behavior?
Example: We have class A and class B. Class A injects class B in the constructor. At the same time, the class B imports something from class A file, and we got circular dependency. But there is no potential solution to circular dependencies in the error message (solution such as e.g. injecting dependency with `forwardRef()` function). I have encountered this problem several times, and always wasted a lot of time because, and the solution is simple.

Issue Number: N/A

## What is the new behavior?
If Nest isn't able to resolve dependency, it will suggest using injecting it with `forwardRef()` function as one of the potential solutions.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information