### PR TITLE
chore(deps): updates class-validator to ^0.13.1

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "cache-manager": "*",
     "class-transformer": "*",
-    "class-validator": "*",
+    "class-validator": "^0.13.1",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^7.1.0"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

not quite sure how to fill the requested information in the description. This isn't really an error, how would you test  this? This is not a bugfix per se...

## What is the current behavior?

due to the wildcard dependency, npm@8 issues a audit warning for vulnerable @nestjs/common.
See[CVE-2019-18413](https://github.com/advisories/GHSA-fj58-h2fr-3pp2)

```sh
# npm audit report

class-validator  *
Severity: moderate
SQL Injection and Cross-site Scripting in class-validator - https://github.com/advisories/GHSA-fj58-h2fr-3pp2
fix available via `npm audit fix --force`
Will install @nestjs/common@7.5.5, which is a breaking change
node_modules/class-validator
  @nestjs/common  4.3.0 - 5.0.0-rc.4 || >=7.6.0-next.1
  Depends on vulnerable versions of class-validator
  node_modules/@nestjs/common
    @nestjs/core  >=8.0.0-alpha.1
    Depends on vulnerable versions of @nestjs/common
    node_modules/@nestjs/core
      @nestjs/graphql  <=2.0.0 || >=7.3.1-next.1
      Depends on vulnerable versions of @nestjs/common
      Depends on vulnerable versions of @nestjs/core
      Depends on vulnerable versions of @nestjs/mapped-types
      node_modules/@nestjs/graphql
    @nestjs/platform-express  >=8.0.0-alpha.1
    Depends on vulnerable versions of @nestjs/common
    node_modules/@nestjs/platform-express
    @nestjs/testing  >=8.0.0-alpha.1
    Depends on vulnerable versions of @nestjs/common
    node_modules/@nestjs/testing
  @nestjs/mapped-types  *
  Depends on vulnerable versions of class-validator
  node_modules/@nestjs/mapped-types
```

Issue Number: N/A


## What is the new behavior?

npm audit warning is gone

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information