### PR TITLE
fix(core): use `toString()` as a fallback for dependent's name

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -798,8 +798,7 @@ export class Injector {
     }
     const tokenName = this.getTokenName(token);
     const dependentName =
-      (inquirer?.name && (inquirer.name.name || inquirer.name.toString?.())) ??
-      'unknown';
+      (inquirer?.name && inquirer.name.toString?.()) ?? 'unknown';
     const isAlias = dependentName === tokenName;
 
     const messageToPrint = `Resolving dependency ${clc.cyanBright(

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -797,7 +797,9 @@ export class Injector {
       return;
     }
     const tokenName = this.getTokenName(token);
-    const dependentName = inquirer?.name ?? 'unknown';
+    const dependentName =
+      (inquirer?.name && (inquirer.name.name || inquirer.name.toString?.())) ??
+      'unknown';
     const isAlias = dependentName === tokenName;
 
     const messageToPrint = `Resolving dependency ${clc.cyanBright(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8560

## What is the new behavior?

`NEST_DEBUG=true` prints providers token properly when `Symbol` is used, as well when any other kind object is used if they implement `.toString()` method

Also, instead of using `instanceWrapper.name` (which is `any`), we use `instanceWrapper.name.name` and `instanceWrapper.name.toString()` as a fallback. Let me know if this is fine. [Here's the JS code with tests](https://www.typescriptlang.org/play?removeComments=true&pretty=true#code/JYOwLgpgTgZghgYwgAgGIHt3IN4ChkHIhwC2EAXMnCAJ4DcuAvrjAK4gJjDojIyYAKAB4B+ShnQBKSgGcwUUAHMc+QlAhhWUXsJEA6YmWQAyY8mEHSES0YA+t5EJvWw6AMryl+gZN-IRIsgA5OwA1iDoAO4gQUy4CDwy6AA21snoigKqBPzoPgA0yAD0RchhEdHZfILYxaVCQlWERFaUQQ2xzYyS+VW5ArUlLWRNhIYUyAjJcDIyOMxdPX01dWiYowTjlFMzcxLzVd29zf2DpW40JABGKQI0khvDExfXt0E0QQ+Lx4SnqwCMjy2yAAcqxrtABEF-p9DksTishuUoiAga1kAB5K4AKwgnD0CHUcEgAhArGSyS+hCOuEkQA) of this change

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information