### PR TITLE
feat(common): add an optional type arg to `register` and `registerAsync` of `CacheModule`

### DIFF
--- a/packages/common/cache/cache.module.ts
+++ b/packages/common/cache/cache.module.ts
@@ -27,7 +27,9 @@ export class CacheModule {
    *
    * @see [Customize caching](https://docs.nestjs.com/techniques/caching#customize-caching)
    */
-  static register(options: CacheModuleOptions = {}): DynamicModule {
+  static register<StoreConfig extends Record<any, any> = Record<string, any>>(
+    options: CacheModuleOptions<StoreConfig> = {} as any,
+  ): DynamicModule {
     return {
       module: CacheModule,
       global: options.isGlobal,
@@ -43,20 +45,22 @@ export class CacheModule {
    *
    * @see [Async configuration](https://docs.nestjs.com/techniques/caching#async-configuration)
    */
-  static registerAsync(options: CacheModuleAsyncOptions): DynamicModule {
+  static registerAsync<
+    StoreConfig extends Record<any, any> = Record<string, any>,
+  >(options: CacheModuleAsyncOptions<StoreConfig>): DynamicModule {
     return {
       module: CacheModule,
       global: options.isGlobal,
       imports: options.imports,
       providers: [
-        ...this.createAsyncProviders(options),
+        ...this.createAsyncProviders<StoreConfig>(options),
         ...(options.extraProviders || []),
       ],
     };
   }
 
-  private static createAsyncProviders(
-    options: CacheModuleAsyncOptions,
+  private static createAsyncProviders<StoreConfig extends Record<any, any>>(
+    options: CacheModuleAsyncOptions<StoreConfig>,
   ): Provider[] {
     if (options.useExisting || options.useFactory) {
       return [this.createAsyncOptionsProvider(options)];
@@ -70,9 +74,9 @@ export class CacheModule {
     ];
   }
 
-  private static createAsyncOptionsProvider(
-    options: CacheModuleAsyncOptions,
-  ): Provider {
+  private static createAsyncOptionsProvider<
+    StoreConfig extends Record<any, any>,
+  >(options: CacheModuleAsyncOptions<StoreConfig>): Provider {
     if (options.useFactory) {
       return {
         provide: CACHE_MODULE_OPTIONS,
@@ -82,7 +86,7 @@ export class CacheModule {
     }
     return {
       provide: CACHE_MODULE_OPTIONS,
-      useFactory: async (optionsFactory: CacheOptionsFactory) =>
+      useFactory: async (optionsFactory: CacheOptionsFactory<StoreConfig>) =>
         optionsFactory.createCacheOptions(),
       inject: [options.useExisting || options.useClass],
     };

--- a/packages/common/cache/interfaces/cache-module.interface.ts
+++ b/packages/common/cache/interfaces/cache-module.interface.ts
@@ -1,13 +1,16 @@
 import { ModuleMetadata, Provider, Type } from '../../interfaces';
 import { CacheManagerOptions } from './cache-manager.interface';
 
-export interface CacheModuleOptions extends CacheManagerOptions {
-  /**
-   * If "true', register `CacheModule` as a global module.
-   */
-  isGlobal?: boolean;
-  [key: string]: any;
-}
+export type CacheModuleOptions<StoreConfig extends Record<any, any>> =
+  // Store-specfic configuration takes precedence over cache module options due
+  // to how `createCacheManager` is implemented.
+  CacheManagerOptions &
+    StoreConfig & {
+      /**
+       * If "true', register `CacheModule` as a global module.
+       */
+      isGlobal?: boolean;
+    };
 
 /**
  * Interface describing a `CacheOptionsFactory`.  Providers supplying configuration
@@ -17,8 +20,10 @@ export interface CacheModuleOptions extends CacheManagerOptions {
  *
  * @publicApi
  */
-export interface CacheOptionsFactory {
-  createCacheOptions(): Promise<CacheModuleOptions> | CacheModuleOptions;
+export interface CacheOptionsFactory<StoreConfig extends Record<any, any>> {
+  createCacheOptions():
+    | Promise<CacheModuleOptions<StoreConfig>>
+    | CacheModuleOptions<StoreConfig>;
 }
 
 /**
@@ -28,25 +33,27 @@ export interface CacheOptionsFactory {
  *
  * @publicApi
  */
-export interface CacheModuleAsyncOptions
+export interface CacheModuleAsyncOptions<StoreConfig extends Record<any, any>>
   extends Pick<ModuleMetadata, 'imports'> {
   /**
    * Injection token resolving to an existing provider. The provider must implement
    * the `CacheOptionsFactory` interface.
    */
-  useExisting?: Type<CacheOptionsFactory>;
+  useExisting?: Type<CacheOptionsFactory<StoreConfig>>;
   /**
    * Injection token resolving to a class that will be instantiated as a provider.
    * The class must implement the `CacheOptionsFactory` interface.
    */
-  useClass?: Type<CacheOptionsFactory>;
+  useClass?: Type<CacheOptionsFactory<StoreConfig>>;
   /**
    * Function returning options (or a Promise resolving to options) to configure the
    * cache module.
    */
   useFactory?: (
     ...args: any[]
-  ) => Promise<CacheModuleOptions> | CacheModuleOptions;
+  ) =>
+    | Promise<CacheModuleOptions<StoreConfig>>
+    | CacheModuleOptions<StoreConfig>;
   /**
    * Dependencies that a Factory may inject.
    */

--- a/packages/common/cache/interfaces/cache-module.interface.ts
+++ b/packages/common/cache/interfaces/cache-module.interface.ts
@@ -1,7 +1,9 @@
 import { ModuleMetadata, Provider, Type } from '../../interfaces';
 import { CacheManagerOptions } from './cache-manager.interface';
 
-export type CacheModuleOptions<StoreConfig extends Record<any, any>> =
+export type CacheModuleOptions<
+  StoreConfig extends Record<any, any> = Record<string, any>,
+> =
   // Store-specfic configuration takes precedence over cache module options due
   // to how `createCacheManager` is implemented.
   CacheManagerOptions &
@@ -20,7 +22,9 @@ export type CacheModuleOptions<StoreConfig extends Record<any, any>> =
  *
  * @publicApi
  */
-export interface CacheOptionsFactory<StoreConfig extends Record<any, any>> {
+export interface CacheOptionsFactory<
+  StoreConfig extends Record<any, any> = Record<string, any>,
+> {
   createCacheOptions():
     | Promise<CacheModuleOptions<StoreConfig>>
     | CacheModuleOptions<StoreConfig>;
@@ -33,8 +37,9 @@ export interface CacheOptionsFactory<StoreConfig extends Record<any, any>> {
  *
  * @publicApi
  */
-export interface CacheModuleAsyncOptions<StoreConfig extends Record<any, any>>
-  extends Pick<ModuleMetadata, 'imports'> {
+export interface CacheModuleAsyncOptions<
+  StoreConfig extends Record<any, any> = Record<string, any>,
+> extends Pick<ModuleMetadata, 'imports'> {
   /**
    * Injection token resolving to an existing provider. The provider must implement
    * the `CacheOptionsFactory` interface.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8579

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/141785207-05b0a9a4-313f-48ab-a90e-7e33f969a3ea.png) 

![image](https://user-images.githubusercontent.com/13461315/141785685-d6e6c5a6-7bfa-4356-ab7c-7fd3ae891ff1.png) 

![image](https://user-images.githubusercontent.com/13461315/141787894-f9f01dc7-b901-4c59-9319-7d4b03f3d0c0.png)

Notice that those type args on `CacheModule#register` and `CacheModule#registerAsync` and so on are optional. The default is still `Record<string, any>`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information