### PR TITLE
feat(common): Add custom versioning support.

### DIFF
--- a/integration/versioning/e2e/custom-versioning-fastify.spec.ts
+++ b/integration/versioning/e2e/custom-versioning-fastify.spec.ts
@@ -1,0 +1,954 @@
+import { INestApplication, VersioningType } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { FastifyRequest } from 'fastify'
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Custom Versioning (fastify)', () => {
+  const extractor = (request: FastifyRequest): string | string[] => { 
+    const versions = [request.headers['accept'] ?? '']
+                .flatMap(v => v.split(','))
+                .map(header => header.match(/v(\d+\.?\d*)\+json$/))
+                .filter(match => match && match.length)
+                .map( matchArray => matchArray[1])
+                .sort()
+                .reverse()
+
+    return versions
+  }
+  let app: INestApplication;
+
+  // ======================================================================== //
+  describe('without global default version', () => {
+    before(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter(),
+      );
+      app.enableVersioning({
+        type: VersioningType.CUSTOM,
+        extractor
+      });
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    describe('GET /', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello World V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /:param', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Parameter V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: '',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /multiple', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/multiple').expect(404);
+      });
+    });
+
+    describe('GET /neutral', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .expect(200)
+          .expect('Neutral');
+      });
+    });
+
+    describe('GET /override', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/override').expect(404);
+      });
+    });
+
+    describe('GET /override-partial', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .expect(404);
+      });
+    });
+
+    describe('GET /foo/bar', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+    });
+
+    after(async () => {
+      await app.close();
+    });
+  });
+
+  // ======================================================================== //
+  describe('with the global default version: "1"', () => {
+    before(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter(),
+      );
+      app.enableVersioning({
+        type: VersioningType.CUSTOM,
+        extractor,
+        defaultVersion: '1',
+      });
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    describe('GET /', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello World V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /:param', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Parameter V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: '',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /multiple', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/multiple').expect(404);
+      });
+    });
+
+    describe('GET /neutral', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .expect(200)
+          .expect('Neutral');
+      });
+    });
+
+    describe('GET /override', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/override').expect(404);
+      });
+    });
+
+    describe('GET /override-partial', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V2, if two versions are requested, select the highest version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .expect(404);
+      });
+    });
+
+    describe('GET /foo/bar', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(404);
+      });
+
+      it('V2, if a non-existent version is requested, select the highest supported version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json, application/foo.v2+json',
+          })
+          .expect('Hello FooBar!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/foo/bar').expect(404);
+      });
+    });
+
+    after(async () => {
+      await app.close();
+    });
+  });
+});

--- a/integration/versioning/e2e/custom-versioning.spec.ts
+++ b/integration/versioning/e2e/custom-versioning.spec.ts
@@ -1,0 +1,711 @@
+import { INestApplication, VersioningType } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { Request } from 'express'
+
+describe('Custom Versioning', () => {
+  const extractor = (request: Request): string | string[] => { 
+    const versions = request.header('Accept')
+                ?.split(",")
+                .map(header => header.match(/v(\d+\.?\d*)\+json$/))
+                .filter(match => match && match.length)
+                .map( matchArray => matchArray[1])
+                .sort()
+                .reverse()
+
+    return versions
+  }
+  let app: INestApplication;
+
+  // ======================================================================== //
+  describe('without global default version', () => {
+    before(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      app.enableVersioning({
+        type: VersioningType.CUSTOM,
+        extractor
+      });
+      await app.init();
+    });
+
+    describe('GET /', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello World V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      // There's a known limitation of the express-adapter, where
+      // it cannot handle selection of the highest matched version properly.
+      //
+      // it('V2, if two versions are requested, select the highest version', () => {
+      //   return request(app.getHttpServer())
+      //     .get('/')
+      //     .set({
+      //       Accept: 'application/foo.v1+json, application/foo.v2+json',
+      //     })
+      //     .expect(200)
+      //     .expect('Hello World V2!');
+      // });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /:param', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Parameter V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: '',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /multiple', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2, if an unsupported version is specified, select the lower supported version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v2+json, application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/multiple').expect(404);
+      });
+    });
+
+    describe('GET /neutral', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .expect(200)
+          .expect('Neutral');
+      });
+    });
+
+    describe('GET /override', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      // There's a known limitation of the express-adapter, where
+      // it cannot handle selection of the highest matched version properly.
+      //
+      // it('V2, if two versions are requested, select the highest version', () => {
+      //   return request(app.getHttpServer())
+      //     .get('/override')
+      //     .set({
+      //       Accept: 'application/foo.v1+json, application/foo.v2+json',
+      //     })
+      //     .expect(200)
+      //     .expect('Override Version 2');
+      // });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/override').expect(404);
+      });
+    });
+
+    describe('GET /override-partial', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .expect(404);
+      });
+    });
+
+    describe('GET /foo/bar', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+    });
+
+    after(async () => {
+      await app.close();
+    });
+  });
+
+  // ======================================================================== //
+  describe('with the global default version: "1"', () => {
+    before(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      app.enableVersioning({
+        type: VersioningType.CUSTOM,
+        extractor,
+        defaultVersion: '1',
+      });
+      await app.init();
+    });
+
+    describe('GET /', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello World V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Hello World V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /:param', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Parameter V1!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Parameter V2!');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/param/hello')
+          .set({
+            Accept: '',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/').expect(404);
+      });
+    });
+
+    describe('GET /multiple', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Multiple Versions 1 or 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/multiple')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/multiple').expect(404);
+      });
+    });
+
+    describe('GET /neutral', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(200)
+          .expect('Neutral');
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/neutral')
+          .expect(200)
+          .expect('Neutral');
+      });
+    });
+
+    describe('GET /override', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/override').expect(404);
+      });
+    });
+
+    describe('GET /override-partial', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(200)
+          .expect('Override Partial Version 2');
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer())
+          .get('/override-partial')
+          .expect(404);
+      });
+    });
+
+    describe('GET /foo/bar', () => {
+      it('V1', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v1+json',
+          })
+          .expect(200)
+          .expect('Hello FooBar!');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v2+json',
+          })
+          .expect(404);
+      });
+
+      it('V3', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/foo.v3+json',
+          })
+          .expect(404);
+      });
+
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/foo/bar')
+          .set({
+            Accept: 'application/json',
+          })
+          .expect(404);
+      });
+
+      it('No Header', () => {
+        return request(app.getHttpServer()).get('/foo/bar').expect(404);
+      });
+    });
+
+    after(async () => {
+      await app.close();
+    });
+  });
+});

--- a/packages/common/enums/version-type.enum.ts
+++ b/packages/common/enums/version-type.enum.ts
@@ -5,4 +5,5 @@ export enum VersioningType {
   URI,
   HEADER,
   MEDIA_TYPE,
+  CUSTOM,
 }

--- a/packages/common/interfaces/version-options.interface.ts
+++ b/packages/common/interfaces/version-options.interface.ts
@@ -55,6 +55,20 @@ export interface MediaTypeVersioningOptions {
   key: string;
 }
 
+export interface CustomVersioningOptions {
+  type: VersioningType.CUSTOM;
+
+  /**
+   * A function that accepts a request object (specific to the underlying platform, ie Express or Fastify)
+   * and returns a single version value or an ordered array of versions, in order from HIGHEST to LOWEST.
+   *
+   * Ex. Returned version array = ['3.1', '3.0', '2.5', '2', '1.9']
+   *
+   * Use type assertion or narrowing to identify the specific request type.
+   */
+  extractor: (request: unknown) => string | string[];
+}
+
 interface VersioningCommonOptions {
   /**
    * The default version to be used as a fallback when you did not provide some
@@ -67,4 +81,9 @@ interface VersioningCommonOptions {
  * @publicApi
  */
 export type VersioningOptions = VersioningCommonOptions &
-  (HeaderVersioningOptions | UriVersioningOptions | MediaTypeVersioningOptions);
+  (
+    | HeaderVersioningOptions
+    | UriVersioningOptions
+    | MediaTypeVersioningOptions
+    | CustomVersioningOptions
+  );

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -353,6 +353,38 @@ export class RouterExplorer {
       if (versioningOptions.type === VersioningType.URI) {
         return handler(req, res, next);
       }
+
+      // Custom Extractor Versioning Handler
+      if (versioningOptions.type === VersioningType.CUSTOM) {
+        const extractedVersion = versioningOptions.extractor(req);
+
+        if (Array.isArray(version)) {
+          if (
+            Array.isArray(extractedVersion) &&
+            version.filter(extractedVersion.includes).length
+          ) {
+            return handler(req, res, next);
+          } else if (
+            isString(extractedVersion) &&
+            version.includes(extractedVersion)
+          ) {
+            return handler(req, res, next);
+          }
+        } else {
+          if (
+            Array.isArray(extractedVersion) &&
+            extractedVersion.includes(version)
+          ) {
+            return handler(req, res, next);
+          } else if (
+            isString(extractedVersion) &&
+            version === extractedVersion
+          ) {
+            return handler(req, res, next);
+          }
+        }
+      }
+
       // Media Type (Accept Header) Versioning Handler
       if (versioningOptions.type === VersioningType.MEDIA_TYPE) {
         const MEDIA_TYPE_HEADER = 'Accept';

--- a/packages/core/test/router/router-explorer.spec.ts
+++ b/packages/core/test/router/router-explorer.spec.ts
@@ -588,6 +588,182 @@ describe('RouterExplorer', () => {
       });
     });
 
+    describe('when the versioning type is CUSTOM', () => {
+      const extractor = (request: { headers: { accept?: string } }) => {
+        const match = request.headers.accept?.match(/v(\d+\.?\d*)\+json$/);
+        if (match) {
+          return match[1];
+        }
+        return null;
+      };
+
+      it('should return next if there is no pertinent request object', () => {
+        const version = '1';
+        const versioningOptions: VersioningOptions = {
+          type: VersioningType.CUSTOM,
+          extractor,
+        };
+        const handler = sinon.stub();
+
+        const routePathMetadata: RoutePathMetadata = {
+          methodVersion: version,
+          versioningOptions,
+        };
+        const versionFilter = (routerBuilder as any).applyVersionFilter(
+          null,
+          routePathMetadata,
+          handler,
+        );
+
+        const req = { headers: {} };
+        const res = {};
+        const next = sinon.stub();
+
+        versionFilter(req, res, next);
+
+        expect(next.called).to.be.true;
+      });
+
+      it('should return next if there is no version in the request object value', () => {
+        const version = '1';
+        const versioningOptions: VersioningOptions = {
+          type: VersioningType.CUSTOM,
+          extractor,
+        };
+        const handler = sinon.stub();
+
+        const routePathMetadata: RoutePathMetadata = {
+          methodVersion: version,
+          versioningOptions,
+        };
+        const versionFilter = (routerBuilder as any).applyVersionFilter(
+          null,
+          routePathMetadata,
+          handler,
+        );
+
+        const req = { headers: { accept: 'application/json;' } };
+        const res = {};
+        const next = sinon.stub();
+
+        versionFilter(req, res, next);
+
+        expect(next.called).to.be.true;
+      });
+
+      describe('when the handler version is an array', () => {
+        it('should return next if the version in the request object value does not match the handler version', () => {
+          const version = ['1', '2'];
+          const versioningOptions: VersioningOptions = {
+            type: VersioningType.CUSTOM,
+            extractor,
+          };
+          const handler = sinon.stub();
+
+          const routePathMetadata: RoutePathMetadata = {
+            methodVersion: version,
+            versioningOptions,
+          };
+          const versionFilter = (routerBuilder as any).applyVersionFilter(
+            null,
+            routePathMetadata,
+            handler,
+          );
+
+          const req = { headers: { accept: 'application/foo.v3+json' } };
+          const res = {};
+          const next = sinon.stub();
+
+          versionFilter(req, res, next);
+
+          expect(next.called).to.be.true;
+        });
+
+        it('should return the handler if the version in the request object value matches the handler version', () => {
+          const version = ['1', '2'];
+          const versioningOptions: VersioningOptions = {
+            type: VersioningType.CUSTOM,
+            extractor,
+          };
+          const handler = sinon.stub();
+
+          const routePathMetadata: RoutePathMetadata = {
+            methodVersion: version,
+            versioningOptions,
+          };
+          const versionFilter = (routerBuilder as any).applyVersionFilter(
+            null,
+            routePathMetadata,
+            handler,
+          );
+
+          const req = { headers: { accept: 'application/foo.v2+json' } };
+          const res = {};
+          const next = sinon.stub();
+
+          versionFilter(req, res, next);
+
+          expect(handler.calledWith(req, res, next)).to.be.true;
+        });
+      });
+
+      describe('when the handler version is a string', () => {
+        it('should return next if the version in the request object value does not match the handler version', () => {
+          const version = '1';
+          const versioningOptions: VersioningOptions = {
+            type: VersioningType.CUSTOM,
+            extractor,
+          };
+          const handler = sinon.stub();
+
+          const routePathMetadata: RoutePathMetadata = {
+            methodVersion: version,
+            versioningOptions,
+          };
+          const versionFilter = (routerBuilder as any).applyVersionFilter(
+            null,
+            routePathMetadata,
+            handler,
+          );
+
+          const req = { headers: { accept: 'application/foo.v2+json' } };
+          const res = {};
+          const next = sinon.stub();
+
+          versionFilter(req, res, next);
+
+          expect(next.called).to.be.true;
+        });
+
+        it('should return the handler if the version in the request object value matches the handler version', () => {
+          const version = '1';
+          const versioningOptions: VersioningOptions = {
+            type: VersioningType.CUSTOM,
+            extractor,
+          };
+          const handler = sinon.stub();
+
+          const routePathMetadata: RoutePathMetadata = {
+            methodVersion: version,
+            versioningOptions,
+          };
+          const versionFilter = (routerBuilder as any).applyVersionFilter(
+            null,
+            routePathMetadata,
+            handler,
+          );
+
+          const req = { headers: { accept: 'application/foo.v1+json' } };
+          const res = {};
+          const next = sinon.stub();
+
+          versionFilter(req, res, next);
+
+          expect(handler.calledWith(req, res, next)).to.be.true;
+        });
+      });
+    });
+
     describe('when the versioning type is HEADER', () => {
       it('should return next if there is no Custom Header', () => {
         const version = '1';

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -196,6 +196,42 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       if (versioningOptions.type === VersioningType.URI) {
         return handler(req, res, next);
       }
+
+      // Custom Extractor Versioning Handler
+      if (versioningOptions.type === VersioningType.CUSTOM) {
+        const extractedVersion = versioningOptions.extractor(req);
+
+        if (Array.isArray(version)) {
+          if (
+            Array.isArray(extractedVersion) &&
+            version.filter(v => extractedVersion.includes(v)).length
+          ) {
+            return handler(req, res, next);
+          } else if (
+            isString(extractedVersion) &&
+            version.includes(extractedVersion)
+          ) {
+            return handler(req, res, next);
+          }
+        } else if (isString(version)) {
+          //Known bug here - if there are multiple versions supported across separate
+          //handlers/controllers, we can't select the highest matching handler.
+          //Since this code is evaluated per-handler, then we can't see if the highest
+          //specified version exists in a different handler.
+          if (
+            Array.isArray(extractedVersion) &&
+            extractedVersion.includes(version)
+          ) {
+            return handler(req, res, next);
+          } else if (
+            isString(extractedVersion) &&
+            version === extractedVersion
+          ) {
+            return handler(req, res, next);
+          }
+        }
+      }
+
       // Media Type (Accept Header) Versioning Handler
       if (versioningOptions.type === VersioningType.MEDIA_TYPE) {
         const MEDIA_TYPE_HEADER = 'Accept';

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -114,23 +114,24 @@ export class FastifyAdapter<
       }
     },
     storage() {
-      const versions = new Map();
+      const versions = new Map<string, unknown>();
       return {
         get(version: string | Array<string>) {
+          if (Array.isArray(version)) {
+            return versions.get(version.find(v => versions.has(v))) || null;
+          }
           return versions.get(version) || null;
         },
-        set(
-          versionOrVersions: string | Array<string>,
-          store: Map<string, any>,
-        ) {
-          const storeVersionConstraint = version =>
+        set(versionOrVersions: string | Array<string>, store: unknown) {
+          const storeVersionConstraint = (version: string) =>
             versions.set(version, store);
           if (Array.isArray(versionOrVersions))
             versionOrVersions.forEach(storeVersionConstraint);
           else storeVersionConstraint(versionOrVersions);
         },
         del(version: string | Array<string>) {
-          versions.delete(version);
+          if (Array.isArray(version)) version.forEach(v => versions.delete(v));
+          else versions.delete(version);
         },
         empty() {
           versions.clear();
@@ -165,6 +166,10 @@ export class FastifyAdapter<
         if (customHeaderVersionParameter) {
           return customHeaderVersionParameter;
         }
+      }
+      // Custom Versioning Handler
+      else if (this.versioningOptions.type === VersioningType.CUSTOM) {
+        return this.versioningOptions.extractor(req);
       }
       return undefined;
     },


### PR DESCRIPTION
Specifically, addes a 'Custom' VersioningType that allows for an
extractor function to be provided that receives the Request object
(either Express or Fastify) and returns a string or array of strings
pulled from said request. Examples include extracting custom header
values, URL params, POST request bodies, and more.

Fixes #8441

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) 


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8441 


## What is the new behavior?
As the commit message says, this allows users to provide a custom 'extractor' function, from which they can pull out any information and provide it to the Express/Fastify adapters for further routing.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information