### PR TITLE
feat(microservices): support ncc when using grpc

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -31,7 +31,14 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
       require('@grpc/grpc-js'),
     );
 
-    grpcProtoLoaderPackage = loadPackage(protoLoader, ClientGrpcProxy.name);
+    grpcProtoLoaderPackage = loadPackage(
+      protoLoader,
+      ClientGrpcProxy.name,
+      () =>
+        protoLoader === GRPC_DEFAULT_PROTO_LOADER
+          ? require('@grpc/proto-loader')
+          : require(protoLoader),
+    );
     this.grpcClients = this.createClients();
   }
 
@@ -278,7 +285,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
       const packageDefinition =
         this.getOptionsProp(this.options, 'packageDefinition') ||
         grpcProtoLoaderPackage.loadSync(file, loader);
-      
+
       const packageObject =
         grpcPackage.loadPackageDefinition(packageDefinition);
       return packageObject;

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -48,7 +48,14 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
     grpcPackage = this.loadPackage('@grpc/grpc-js', ServerGrpc.name, () =>
       require('@grpc/grpc-js'),
     );
-    grpcProtoLoaderPackage = this.loadPackage(protoLoader, ServerGrpc.name);
+    grpcProtoLoaderPackage = this.loadPackage(
+      protoLoader,
+      ServerGrpc.name,
+      () =>
+        protoLoader === GRPC_DEFAULT_PROTO_LOADER
+          ? require('@grpc/proto-loader')
+          : require(protoLoader),
+    );
   }
 
   public async listen(


### PR DESCRIPTION
A well-performed nestjs standard project, which transport is `Transport.GRPC` and  protoLoader is `@grpc/proto-loader`, is not compatible with  npm package `@vercel/ncc`. The reason is - ncc compiling js file use static analysation. Therefore, `require(someVar)` is not supported by ncc, but `require("some-string")` works well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- Step1: run `nest build` in a standard nestjs project that its transport is `Transport.GRPC` and its protoLoader is `@grpc/proto-loader`
- Step2: run `npm i -g @vercel/ncc && ncc build dist/main.js -m -o out`
- Step3: run `node out/index.js` to bootstrap, but fail


## What is the new behavior?
- Step1: run `nest build` in a standard nestjs project that its transport is `Transport.GRPC` and its protoLoader is `@grpc/proto-loader`
- Step2: run `npm i -g @vercel/ncc && ncc build dist/main.js -m -o out`
- Step3: run `node out/index.js` to bootstrap, success.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information