### PR TITLE
refactor(common): use class-transformer v0.5.0 method names

### DIFF
--- a/packages/common/interfaces/external/transformer-package.interface.ts
+++ b/packages/common/interfaces/external/transformer-package.interface.ts
@@ -2,12 +2,12 @@ import { Type } from '../type.interface';
 import { ClassTransformOptions } from './class-transform-options.interface';
 
 export interface TransformerPackage {
-  plainToClass<T>(
+  plainToInstance<T>(
     cls: Type<T>,
     plain: unknown,
     options?: ClassTransformOptions,
   ): T | T[];
-  classToPlain(
+  instanceToPlain(
     object: unknown,
     options?: ClassTransformOptions,
   ): Record<string, any> | Record<string, any>[];

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -110,7 +110,7 @@ export class ValidationPipe implements PipeTransform<any> {
     const isNil = value !== originalValue;
     const isPrimitive = this.isPrimitive(value);
     this.stripProtoKeys(value);
-    let entity = classTransformer.plainToClass(
+    let entity = classTransformer.plainToInstance(
       metatype,
       value,
       this.transformOptions,
@@ -145,7 +145,7 @@ export class ValidationPipe implements PipeTransform<any> {
       return originalValue;
     }
     return Object.keys(this.validatorOptions).length > 0
-      ? classTransformer.classToPlain(entity, this.transformOptions)
+      ? classTransformer.instanceToPlain(entity, this.transformOptions)
       : value;
   }
 

--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -79,7 +79,7 @@ export class ClassSerializerInterceptor implements NestInterceptor {
     options: ClassTransformOptions,
   ): PlainLiteralObject {
     return plainOrClass
-      ? classTransformer.classToPlain(plainOrClass, options)
+      ? classTransformer.instanceToPlain(plainOrClass, options)
       : plainOrClass;
   }
 

--- a/sample/01-cats-app/src/common/pipes/validation.pipe.ts
+++ b/sample/01-cats-app/src/common/pipes/validation.pipe.ts
@@ -5,7 +5,7 @@ import {
   PipeTransform,
   Type,
 } from '@nestjs/common';
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class ValidationPipe implements PipeTransform<any> {
     if (!metatype || !this.toValidate(metatype)) {
       return value;
     }
-    const object = plainToClass(metatype, value);
+    const object = plainToInstance(metatype, value);
     const errors = await validate(object);
     if (errors.length > 0) {
       throw new BadRequestException('Validation failed');

--- a/sample/10-fastify/src/common/pipes/validation.pipe.ts
+++ b/sample/10-fastify/src/common/pipes/validation.pipe.ts
@@ -5,7 +5,7 @@ import {
   PipeTransform,
   Type,
 } from '@nestjs/common';
-import { plainToClass } from 'class-transformer';
+import { plainToInstance } from 'class-transformer';
 import { validate } from 'class-validator';
 
 @Injectable()
@@ -15,7 +15,7 @@ export class ValidationPipe implements PipeTransform<any> {
     if (!metatype || !this.toValidate(metatype)) {
       return value;
     }
-    const object = plainToClass(metatype, value);
+    const object = plainToInstance(metatype, value);
     const errors = await validate(object);
     if (errors.length > 0) {
       throw new BadRequestException('Validation failed');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
See #8637 

Issue Number: #8637 


## What is the new behavior?
No new behavior


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Anyone using the interface to declare their own package for class-transformer will have to use the new method names. 

## Other information
This is probaly not something we should do. I am open to suggestions, as this is my first contribution! Ideally, I would like to convert the method names of the new changes to the old names to make this not a breaking change. Buut, I don't want to make that decision as I would like to gather some feedback. 

As a quick fix, downgrade to version class-transformer 0.4.0. Be warned that you would be vulnerable to the security issue(s) of that version.