### PR TITLE
fix(core): apply existing headers to sse responses

### DIFF
--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -444,6 +444,7 @@ export class RouterExecutionContext {
           result,
           (res as any).raw || res,
           (req as any).raw || req,
+          { additionalHeaders: res.getHeaders?.() },
         );
       };
     }

--- a/packages/core/test/router/router-execution-context.spec.ts
+++ b/packages/core/test/router/router-execution-context.spec.ts
@@ -19,6 +19,7 @@ import { PipesConsumer } from '../../pipes/pipes-consumer';
 import { PipesContextCreator } from '../../pipes/pipes-context-creator';
 import { RouteParamsFactory } from '../../router/route-params-factory';
 import { RouterExecutionContext } from '../../router/router-execution-context';
+import { HeaderStream } from '../../router/sse-stream';
 import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
 
 describe('RouterExecutionContext', () => {
@@ -469,6 +470,38 @@ describe('RouterExecutionContext', () => {
             'You must return an Observable stream to use Server-Sent Events (SSE).',
           );
         }
+      });
+
+      it('should apply any headers that exists on the response', async () => {
+        const result = of('test');
+        const response = new PassThrough() as HeaderStream;
+        response.write = sinon.spy();
+        response.writeHead = sinon.spy();
+        response.flushHeaders = sinon.spy();
+        response.getHeaders = sinon
+          .stub()
+          .returns({ 'access-control-headers': 'some-cors-value' });
+
+        const request = new PassThrough();
+        request.on = sinon.spy();
+
+        sinon.stub(contextCreator, 'reflectRenderTemplate').returns(undefined);
+        sinon.stub(contextCreator, 'reflectSse').returns('/');
+
+        const handler = contextCreator.createHandleResponseFn(
+          null,
+          true,
+          undefined,
+          200,
+        ) as HandlerResponseBasicFn;
+        await handler(result, response, request);
+
+        expect(
+          (response.writeHead as sinon.SinonSpy).calledWith(
+            200,
+            sinon.match.hasNested('access-control-headers', 'some-cors-value'),
+          ),
+        ).to.be.true;
       });
     });
   });

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -138,6 +138,21 @@ data: hello
     sse.pipe(sink);
   });
 
+  it('sets additional headers when provided', callback => {
+    const sse = new SseStream();
+    const sink = new Sink(
+      (status: number, headers: string | OutgoingHttpHeaders) => {
+        expect(headers).to.contain.keys('access-control-headers');
+        expect(headers['access-control-headers']).to.equal('some-cors-value');
+        callback();
+        return sink;
+      },
+    );
+    sse.pipe(sink, {
+      additionalHeaders: { 'access-control-headers': 'some-cors-value' },
+    });
+  });
+
   it('allows an eventsource to connect', callback => {
     let sse: SseStream;
     const server = createServer((req, res) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When sending an sse response with fastify no headers applied to the fastify reply would be applied to the headers of the sse response

Issue Number: #8717


## What is the new behavior?

Any headers from the express `response` or fastify `reply` will be read and then applied to the sse response.
This has been tested with `express` and `fastify` with `app.enableCors()`

<img width="654" alt="Screen Shot 2021-11-29 at 20 14 22" src="https://user-images.githubusercontent.com/8206108/143985263-3089af09-9efd-4d9a-951e-1f10148f0e44.png">

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

