### PR TITLE
build: generate multiple formats (cjs, esm)

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
     "supertest": "6.2.2",
     "ts-morph": "13.0.3",
     "ts-node": "10.4.0",
+    "tsup": "^5.10.0",
     "typeorm": "0.2.41",
     "typescript": "4.3.5",
     "wrk": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "changelog": "lerna-changelog",
     "prebuild:prod": "npm run clean",
     "build:prod": "gulp build",
+    "build:multi": "npx tsup --dts --sourcemap --format esm,cjs",
     "build:samples": "gulp install:samples && npm run build && gulp build:samples && gulp test:samples && gulp test:e2e:samples",
     "clean": "gulp clean:bundle",
     "codechecks:benchmarks": "codechecks ./tools/benchmarks/check-benchmarks.ts",

--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -3,7 +3,7 @@ import { Type } from '@nestjs/common/interfaces/type.interface';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
 import stringify from 'fast-safe-stringify';
-import * as hash from 'object-hash';
+import hash from 'object-hash';
 
 export class ModuleTokenFactory {
   private readonly moduleIdsCache = new WeakMap<Type<unknown>, string>();

--- a/packages/core/middleware/utils.ts
+++ b/packages/core/middleware/utils.ts
@@ -2,7 +2,7 @@ import { RequestMethod } from '@nestjs/common';
 import { HttpServer, RouteInfo, Type } from '@nestjs/common/interfaces';
 import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { iterate } from 'iterare';
-import * as pathToRegexp from 'path-to-regexp';
+import pathToRegexp from 'path-to-regexp';
 import { v4 as uuid } from 'uuid';
 import { ExcludeRouteMetadata } from '../router/interfaces/exclude-route-metadata.interface';
 import { isRouteExcluded } from '../router/utils';

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -29,7 +29,7 @@ import {
 } from '@nestjs/common/utils/shared.utils';
 import { iterate } from 'iterare';
 import { platform } from 'os';
-import * as pathToRegexp from 'path-to-regexp';
+import pathToRegexp from 'path-to-regexp';
 import { AbstractHttpAdapter } from './adapters';
 import { ApplicationConfig } from './application-config';
 import { MESSAGES } from './constants';

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -19,7 +19,7 @@ import {
   isString,
   isUndefined,
 } from '@nestjs/common/utils/shared.utils';
-import * as pathToRegexp from 'path-to-regexp';
+import pathToRegexp from 'path-to-regexp';
 import { ApplicationConfig } from '../application-config';
 import { UnknownRequestMappingException } from '../errors/exceptions/unknown-request-mapping.exception';
 import { GuardsConsumer } from '../guards/guards-consumer';

--- a/packages/microservices/client/client-tcp.ts
+++ b/packages/microservices/client/client-tcp.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import * as net from 'net';
+import net from 'net';
 import { EmptyError, lastValueFrom } from 'rxjs';
 import { share, tap } from 'rxjs/operators';
 import {

--- a/packages/microservices/external/kafka.interface.ts
+++ b/packages/microservices/external/kafka.interface.ts
@@ -6,8 +6,8 @@
 
 /// <reference types="node" />
 
-import * as net from 'net';
-import * as tls from 'tls';
+import net from 'net';
+import tls from 'tls';
 
 type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never };
 type XOR<T, U> = T | U extends object

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -1,6 +1,5 @@
 import { isString, isUndefined } from '@nestjs/common/utils/shared.utils';
-import * as net from 'net';
-import { Server as NetSocket, Socket } from 'net';
+import net, { Server as NetSocket, Socket } from 'net';
 import { Observable } from 'rxjs';
 import {
   CLOSE_EVENT,

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -2,34 +2,34 @@ import {
   InternalServerErrorException,
   RequestMethod,
   StreamableFile,
-  VersioningType,
+  VersioningType
 } from '@nestjs/common';
 import {
   VersioningOptions,
   VersionValue,
-  VERSION_NEUTRAL,
+  VERSION_NEUTRAL
 } from '@nestjs/common/interfaces';
 import {
   CorsOptions,
-  CorsOptionsDelegate,
+  CorsOptionsDelegate
 } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 import {
   isFunction,
   isNil,
   isObject,
-  isString,
+  isString
 } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
 import { RouterMethodFactory } from '@nestjs/core/helpers/router-method-factory';
 import {
   json as bodyParserJson,
-  urlencoded as bodyParserUrlencoded,
+  urlencoded as bodyParserUrlencoded
 } from 'body-parser';
-import * as cors from 'cors';
-import * as express from 'express';
-import * as http from 'http';
-import * as https from 'https';
+import cors from 'cors';
+import express from 'express';
+import http from 'http';
+import https from 'https';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
 
 export class ExpressAdapter extends AbstractHttpAdapter {

--- a/packages/platform-express/multer/interceptors/any-files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/any-files.interceptor.ts
@@ -7,7 +7,7 @@ import {
   Optional,
   Type,
 } from '@nestjs/common';
-import * as multer from 'multer';
+import multer from 'multer';
 import { Observable } from 'rxjs';
 import { MULTER_MODULE_OPTIONS } from '../files.constants';
 import { MulterModuleOptions } from '../interfaces';

--- a/packages/platform-express/multer/interceptors/file-fields.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/file-fields.interceptor.ts
@@ -7,7 +7,7 @@ import {
   Optional,
   Type,
 } from '@nestjs/common';
-import * as multer from 'multer';
+import multer from 'multer';
 import { Observable } from 'rxjs';
 import { MULTER_MODULE_OPTIONS } from '../files.constants';
 import { MulterModuleOptions } from '../interfaces';

--- a/packages/platform-express/multer/interceptors/file.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/file.interceptor.ts
@@ -7,7 +7,7 @@ import {
   Optional,
   Type,
 } from '@nestjs/common';
-import * as multer from 'multer';
+import multer from 'multer';
 import { Observable } from 'rxjs';
 import { MULTER_MODULE_OPTIONS } from '../files.constants';
 import { MulterModuleOptions } from '../interfaces';

--- a/packages/platform-express/multer/interceptors/files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/files.interceptor.ts
@@ -7,7 +7,7 @@ import {
   Optional,
   Type,
 } from '@nestjs/common';
-import * as multer from 'multer';
+import multer from 'multer';
 import { Observable } from 'rxjs';
 import { MULTER_MODULE_OPTIONS } from '../files.constants';
 import { MulterModuleOptions } from '../interfaces';

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 import {
   HttpStatus,
   Logger,
@@ -29,10 +30,10 @@ import {
   RawServerDefault,
   RequestGenericInterface,
 } from 'fastify';
-import * as Reply from 'fastify/lib/reply';
+import Reply from 'fastify/lib/reply';
 import { RouteShorthandMethod } from 'fastify/types/route';
-import * as http2 from 'http2';
-import * as https from 'https';
+import http2 from 'http2';
+import https from 'https';
 import {
   Chain as LightMyRequestChain,
   InjectOptions,
@@ -100,6 +101,7 @@ export class FastifyAdapter<
     TRawResponse
   > = FastifyInstance<TServer, TRawRequest, TRawResponse>,
 > extends AbstractHttpAdapter<TServer, TRequest, TReply> {
+  // @ts-ignore
   protected readonly instance: TInstance;
 
   private _isParserRegistered: boolean;
@@ -195,6 +197,7 @@ export class FastifyAdapter<
             },
             ...(instanceOrOptions as FastifyServerOptions),
           });
+    // @ts-ignore
     this.setInstance(instance);
   }
 
@@ -350,6 +353,7 @@ export class FastifyAdapter<
       return await this.instance.close();
     } catch (err) {
       // Check if server is still running
+      // @ts-ignore
       if (err.code !== 'ERR_SERVER_NOT_RUNNING') {
         throw err;
       }
@@ -358,6 +362,7 @@ export class FastifyAdapter<
   }
 
   public initHttpServer() {
+    // @ts-ignore
     this.httpServer = this.instance.server;
   }
 

--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -4,12 +4,13 @@ import { AbstractWsAdapter } from '@nestjs/websockets';
 import {
   CLOSE_EVENT,
   CONNECTION_EVENT,
-  ERROR_EVENT,
+  ERROR_EVENT
 } from '@nestjs/websockets/constants';
 import { MessageMappingProperties } from '@nestjs/websockets/gateway-metadata-explorer';
-import * as http from 'http';
-import { EMPTY, fromEvent, Observable } from 'rxjs';
+import http from 'http';
+import { fromEvent, Observable } from 'rxjs';
 import { filter, first, mergeMap, share, takeUntil } from 'rxjs/operators';
+import { URL } from 'url';
 
 let wsPackage: any = {};
 

--- a/packages/tsconfig.base.json
+++ b/packages/tsconfig.base.json
@@ -16,6 +16,7 @@
     "allowJs": false,
     "strict": true,
     "strictNullChecks": false,
+    "esModuleInterop": true,
     "types": ["node"]
   },
   "exclude": ["../node_modules", "./**/*.spec.ts"]

--- a/packages/websockets/sockets-container.ts
+++ b/packages/websockets/sockets-container.ts
@@ -1,4 +1,4 @@
-import * as hash from 'object-hash';
+import hash from 'object-hash';
 import { GatewayMetadata, ServerAndEventStreamsHost } from './interfaces';
 
 export class SocketsContainer {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "allowJs": true,
     "outDir": "dist",
     "lib": ["es7"],
+    "esModuleInterop": true,
     "paths": {
       "@nestjs/common": ["./packages/common"],
       "@nestjs/common/*": ["./packages/common/*"],

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  splitting: false,
+  sourcemap: true,
+  outDir: 'node_modules/@nestjs',
+  clean: true,
+  entryPoints: [
+    'packages/common/index.ts',
+    'packages/core/index.ts',
+    'packages/microservices/index.ts',
+    'packages/platform-express/index.ts',
+    'packages/platform-fastify/index.ts',
+    'packages/platform-socket.io/index.ts',
+    'packages/platform-ws/index.ts',
+    'packages/testing/index.ts',
+    'packages/websockets/index.ts'
+  ],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current grunt build process can only generate `cjs` module format but the lots of other projects moved on to use the `mjs` (aks ESM) format.

Issue Number: N/A


## What is the new behavior?
This PR adds new build process (prod) to generate multiple formats using [tusp](https://github.com/egoist/tsup).

`npm run build:multi` will compile and generate `cjs` and `mjs` format and also `*.d.ts`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information