### PR TITLE
fix(common,core): auto flush logs after `useLogger` call

### DIFF
--- a/packages/common/interfaces/nest-application-context.interface.ts
+++ b/packages/common/interfaces/nest-application-context.interface.ts
@@ -50,7 +50,8 @@ export interface INestApplicationContext {
   close(): Promise<void>;
 
   /**
-   * Sets custom logger service
+   * Sets custom logger service.
+   * Flushes buffered logs if auto flush is on.
    * @returns {void}
    */
   useLogger(logger: LoggerService | LogLevel[] | false): void;

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -34,6 +34,7 @@ import { Module } from './injector/module';
 export class NestApplicationContext implements INestApplicationContext {
   protected isInitialized = false;
   protected readonly injector = new Injector();
+
   private shouldFlushLogsOnOverride = false;
 
   private readonly activeShutdownSignals = new Array<string>();

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -36,7 +36,6 @@ export class NestApplicationContext implements INestApplicationContext {
   protected readonly injector = new Injector();
 
   private shouldFlushLogsOnOverride = false;
-
   private readonly activeShutdownSignals = new Array<string>();
   private readonly moduleCompiler = new ModuleCompiler();
   private shutdownCleanupRef?: (...args: unknown[]) => unknown;

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -34,6 +34,7 @@ import { Module } from './injector/module';
 export class NestApplicationContext implements INestApplicationContext {
   protected isInitialized = false;
   protected readonly injector = new Injector();
+  private shouldFlushLogsOnOverride = false;
 
   private readonly activeShutdownSignals = new Array<string>();
   private readonly moduleCompiler = new ModuleCompiler();
@@ -131,10 +132,21 @@ export class NestApplicationContext implements INestApplicationContext {
 
   public useLogger(logger: LoggerService | LogLevel[] | false) {
     Logger.overrideLogger(logger);
+
+    if (this.shouldFlushLogsOnOverride) {
+      this.flushLogs();
+    }
   }
 
   public flushLogs() {
     Logger.flush();
+  }
+
+  /**
+   * Define that it must flush logs right after defining a custom logger.
+   */
+  public flushLogsOnOverride() {
+    this.shouldFlushLogsOnOverride = true;
   }
 
   /**

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -142,6 +142,9 @@ export class NestFactoryStatic {
     const context = this.createNestInstance<NestApplicationContext>(
       new NestApplicationContext(container, [], root),
     );
+    if (this.autoFlushLogs) {
+      context.flushLogsOnOverride();
+    }
     return context.init();
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #8733

I tested it locally with the following usages -- assuming that there was a call to `app.useLogger`:

```js
NestFactory.createApplicationContext(AppModule)
```
flushes (even tho the aren't logs buffered).

```js
NestFactory.createApplicationContext(AppModule, { bufferLogs: true })
```
flushes.

```js
NestFactory.createApplicationContext(AppModule, { bufferLogs: true, autoFlushLogs: true })
```
flushes.

```js
NestFactory.createApplicationContext(AppModule, { bufferLogs: true, autoFlushLogs: false })
```
do not flushes.

## What is the new behavior?

When using `NestApplicationContext` app and `autoFlushLogs` is on, invoking `useLogger` method on it will flushes its logs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

A naive attempt to address that issue without much effort. I have few concerns regarding my solution but I didn't come with anything better (nor easy to follow). Feel free to rejected it then :p