### PR TITLE
feat(common): accept factory closure as cache key generator

### DIFF
--- a/packages/common/cache/decorators/cache-key.decorator.ts
+++ b/packages/common/cache/decorators/cache-key.decorator.ts
@@ -1,5 +1,6 @@
 import { SetMetadata } from '../../decorators';
 import { CACHE_KEY_METADATA } from '../cache.constants';
+import { ExecutionContext } from "../../interfaces";
 
 /**
  * Decorator that sets the caching key used to store/retrieve cached items for
@@ -14,4 +15,6 @@ import { CACHE_KEY_METADATA } from '../cache.constants';
  *
  * @publicApi
  */
-export const CacheKey = (key: string) => SetMetadata(CACHE_KEY_METADATA, key);
+type CacheKeyFactory = (ctx: ExecutionContext) => Promise<string> | string;
+
+export const CacheKey = (key: string | CacheKeyFactory) => SetMetadata(CACHE_KEY_METADATA, key);


### PR DESCRIPTION
change @CacheKey decorator to accept a callback function to provide appropriate cache key.

any custom class which extends CacheInterceptor might require to change the implementation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
@CacheKey decorator receives a defined string to store the output using that name. Currently it is impossible to change the cache key using the context object. For example: you can't change the cache key according to request body data. 

Issue Number: N/A


## What is the new behavior?
@CacheKey accepts a specific string or a callback which receives ExecutionContext parameter and must return the key string.

```typescript
  @Get('/')
  @UseInterceptors(CacheInterceptor)
  @CacheTTL(30)
  @CacheKey((context: ExecutionContext) => {
      const request = context.switchToHttp().getRequest();
      return request.body.version;
  })
  async get() {
    return await this.service.get();
  }
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information