### PR TITLE
fix(core): `getInstanceName` wrong return when passing a dynamic module

### DIFF
--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -1,4 +1,4 @@
-import { ForwardReference, Type } from '@nestjs/common';
+import type { ForwardReference, Type, DynamicModule } from '@nestjs/common';
 import { isNil, isSymbol } from '@nestjs/common/utils/shared.utils';
 import {
   InjectorDependency,
@@ -7,14 +7,19 @@ import {
 import { Module } from '../injector/module';
 
 /**
- * Returns the name of an instance
+ * Returns the name of an instance or `undefined`
  * @param instance The instance which should get the name from
  */
 const getInstanceName = (instance: unknown): string => {
   if ((instance as ForwardReference)?.forwardRef) {
     return (instance as ForwardReference).forwardRef()?.name;
   }
-  return (instance as Type<any>)?.name;
+
+  if ((instance as DynamicModule)?.module) {
+    return (instance as DynamicModule).module?.name;
+  }
+
+  return (instance as Type)?.name;
 };
 
 /**
@@ -97,7 +102,7 @@ export const UNDEFINED_FORWARDREF_MESSAGE = (
 
 (Read more: https://docs.nestjs.com/fundamentals/circular-dependency)
 Scope [${stringifyScope(scope)}]
-  `;
+`;
 
 export const INVALID_MODULE_MESSAGE = (
   parentModule: any,
@@ -107,7 +112,7 @@ export const INVALID_MODULE_MESSAGE = (
   const parentModuleName = parentModule?.name || 'module';
 
   return `Nest cannot create the ${parentModuleName} instance.
-Received an unexpected value at index [${index}] of the ${parentModuleName} "imports" array. 
+Received an unexpected value at index [${index}] of the ${parentModuleName} "imports" array.
 
 Scope [${stringifyScope(scope)}]`;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Taking the following set up

```ts
// a.module.ts
import { Module } from '@nestjs/common'
import { B } from './b.module'

@Module({ imports: [B] })
export class A {}
import { Module } from '@nestjs/common'
import { A } from './a.module'

// b.module.ts
@Module({ imports: [A] })
export class B {}

// app.module.ts
import { Module, DynamicModule, Injectable, Inject } from '@nestjs/common'
import { A } from './a.module'

const dynamicModule: DynamicModule = {
  module: class Foo {},
  imports: [A], // <--------
}

@Module({
  imports: [dynamicModule],
})
export class AppModule {}
```

when Nest can't resolve the module imported from within a dynamic module, the error shown is the following:

![image](https://user-images.githubusercontent.com/13461315/145912100-ab86e73c-8022-4f54-9062-16b1100741a3.png)

the name of the dynamic module is being lost.

## What is the new behavior?

Prompt the name of the dynamic module

For instance, the above code will outputs this:

![image](https://user-images.githubusercontent.com/13461315/145912148-c00367c7-d60a-44f9-b837-9eefcbd3afd4.png)

Notice that if we use an anymous class instead, the name will be `module` because there's no way to distinguish between `module: class {}` and `module: class module {}` as class's name is defined by the JS engine.

Also, `getInstanceName` still can return `undefined` because it is being used in another places as well, this is why I didn't added any fallback value (like `'(unknown)'`)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No