### PR TITLE
fix: only send exception responses if header is not already sent

### DIFF
--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -53,6 +53,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   end(response: any, message?: string): any;
   render(response: any, view: string, options: any): any;
   redirect(response: any, statusCode: number, url: string): any;
+  isHeadersSent(response: any): boolean;
   setHeader(response: any, name: string, value: string): any;
   setErrorHandler?(handler: Function, prefix?: string): any;
   setNotFoundHandler?(handler: Function, prefix?: string): any;

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -50,6 +50,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   listen(port: number | string, hostname: string, callback?: () => void): any;
   reply(response: any, body: any, statusCode?: number): any;
   status(response: any, statusCode: number): any;
+  end(response: any, message?: string): any;
   render(response: any, view: string, options: any): any;
   redirect(response: any, statusCode: number, url: string): any;
   setHeader(response: any, name: string, value: string): any;

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -105,6 +105,7 @@ export abstract class AbstractHttpAdapter<
   abstract getRequestUrl(request);
   abstract status(response, statusCode: number);
   abstract reply(response, body: any, statusCode?: number);
+  abstract end(response, message?: string);
   abstract render(response, view: string, options: any);
   abstract redirect(response, statusCode: number, url: string);
   abstract setErrorHandler(handler: Function, prefix?: string);

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -110,6 +110,7 @@ export abstract class AbstractHttpAdapter<
   abstract redirect(response, statusCode: number, url: string);
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
+  abstract isHeadersSent(response);
   abstract setHeader(response, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string);
   abstract enableCors(

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -38,7 +38,12 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
           message: res,
         };
 
-    applicationRef.reply(host.getArgByIndex(1), message, exception.getStatus());
+    const response = host.getArgByIndex(1);
+    if (!applicationRef.isHeadersSent(response)) {
+      applicationRef.reply(response, message, exception.getStatus());
+    } else {
+      applicationRef.end(response);
+    }
   }
 
   public handleUnknownError(
@@ -55,7 +60,14 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
           statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
           message: MESSAGES.UNKNOWN_EXCEPTION_MESSAGE,
         };
-    applicationRef.reply(host.getArgByIndex(1), body, body.statusCode);
+
+    const response = host.getArgByIndex(1);
+    if (!applicationRef.isHeadersSent(response)) {
+      applicationRef.reply(response, body, body.statusCode);
+    } else {
+      applicationRef.end(response);
+    }
+
     if (this.isExceptionObject(exception)) {
       return BaseExceptionFilter.logger.error(
         exception.message,

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -13,6 +13,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   getRequestMethod(request: any): any {}
   getRequestUrl(request: any): any {}
   reply(response: any, body: any): any {}
+  end(response: any, message?: any): any {}
   status(response: any, statusCode: number): any {}
   render(response: any, view: string, options: any): any {}
   redirect(response: any, statusCode: number, url: string) {}

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -19,6 +19,7 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   redirect(response: any, statusCode: number, url: string) {}
   setErrorHandler(handler: Function, prefix = '/'): any {}
   setNotFoundHandler(handler: Function, prefix = '/'): any {}
+  isHeadersSent(response: any): any {}
   setHeader(response: any, name: string, value: string): any {}
   registerParserMiddleware(): any {}
   enableCors(options: any): any {}

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -61,7 +61,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public end(response: any, message?: string) {
-    return response.end(message !== undefined ? String(message) : undefined);
+    return response.end(message);
   }
 
   public render(response: any, view: string, options: any) {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -60,6 +60,10 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return response.status(statusCode);
   }
 
+  public end(response: any, message?: string) {
+    return response.end(message !== undefined ? String(message) : undefined);
+  }
+
   public render(response: any, view: string, options: any) {
     return response.render(view, options);
   }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -80,6 +80,10 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return this.use(handler);
   }
 
+  public isHeadersSent(response: any): boolean {
+    return response.headersSent;
+  }
+
   public setHeader(response: any, name: string, value: string) {
     return response.set(name, value);
   }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -301,7 +301,7 @@ export class FastifyAdapter<
   }
 
   public end(response: TReply, message?: string) {
-    response.raw.end(message !== undefined ? String(message) : undefined);
+    response.raw.end(message);
   }
 
   public render(

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -300,6 +300,10 @@ export class FastifyAdapter<
     return (response as TReply).code(statusCode);
   }
 
+  public end(response: TReply, message?: string) {
+    response.raw.end(message !== undefined ? String(message) : undefined);
+  }
+
   public render(
     response: TReply & { view: Function },
     view: string,

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -388,6 +388,10 @@ export class FastifyAdapter<
     );
   }
 
+  public isHeadersSent(response: TReply): boolean {
+    return response.sent;
+  }
+
   public setHeader(response: TReply, name: string, value: string) {
     return response.header(name, value);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
When an exception is thrown it will trigger the exception filter to try to send a reply.
If a header was already sent then the exception filter will fail to send this reply.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This change requires adapters to provide two new methods, `isHeaderSent()` and `end()`

## Other information
