### PR TITLE
Updating @nestjs/swagger plugin name to @nestjs/swagger/plugin

### DIFF
--- a/sample/11-swagger/nest-cli.json
+++ b/sample/11-swagger/nest-cli.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "plugins": [
       {
-        "name": "@nestjs/swagger",
+        "name": "@nestjs/swagger/plugin",
         "options": {
           "introspectComments": true
         }


### PR DESCRIPTION
`@nestjs/swagger` plugin is not working anymore on the example https://github.com/nestjs/nest/tree/master/sample/11-swagger

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information