### PR TITLE
fix(core): convert URIError thrown by the HTTP platform to BadRequestException

### DIFF
--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -174,7 +174,10 @@ export class RoutesResolver implements Resolver {
 
   public mapExternalException(err: any) {
     switch (true) {
-      case err instanceof SyntaxError:
+      // SyntaxError is thrown by Express body-parser when given invalid JSON (#422, #430)
+      // URIError is thrown by Express when given a path parameter with an invalid percentage
+      // encoding, e.g. '%FF' (#8915)
+      case err instanceof SyntaxError || err instanceof URIError:
         return new BadRequestException(err.message);
       default:
         return err;

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -319,6 +319,13 @@ describe('RoutesResolver', () => {
           expect(outputErr).to.be.instanceof(BadRequestException);
         });
       });
+      describe('URIError', () => {
+        it('should map to BadRequestException', () => {
+          const err = new URIError();
+          const outputErr = routesResolver.mapExternalException(err);
+          expect(outputErr).to.be.instanceof(BadRequestException);
+        });
+      });
       describe('other', () => {
         it('should behave as an identity', () => {
           const err = new Error();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #8915

## What is the new behavior?

When given a path parameter with an invalid percent encoding, Express throws a `URIError` with the `statusCode` field set to `400` (bad request):  
https://github.com/expressjs/express/blob/4.17.1/lib/router/layer.js#L166

Convert this `URIError` to a `BadRequestException` before providing it to the exception filters. Therefore the exception filters will handle this error in the same way as other bad requests.

Note that this only applies to errors thrown directly from Express or Fastify. A `URIError` thrown from a NestJS construct such as a controller or validation pipe will continue to be provided to the exception filters as is.

Closes #8915

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information