### PR TITLE
feat(microservices): add new `extras` param to `MessagePattern` and `EventPattern` decorators

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -20,6 +20,7 @@ export const SUBSCRIBE = 'subscribe';
 export const CANCEL_EVENT = 'cancelled';
 
 export const PATTERN_METADATA = 'microservices:pattern';
+export const PATTERN_EXTRAS_METADATA = 'microservices:pattern_extras';
 export const TRANSPORT_METADATA = 'microservices:transport';
 export const CLIENT_CONFIGURATION_METADATA = 'microservices:client';
 export const PATTERN_HANDLER_METADATA = 'microservices:handler_type';

--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -2,6 +2,7 @@ import {
   PATTERN_HANDLER_METADATA,
   PATTERN_METADATA,
   TRANSPORT_METADATA,
+  PATTERN_EXTRAS_METADATA,
 } from '../constants';
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { Transport } from '../enums';
@@ -12,6 +13,7 @@ import { Transport } from '../enums';
 export const EventPattern = <T = string>(
   metadata?: T,
   transport?: Transport,
+  extras?: Record<string, any>,
 ): MethodDecorator => {
   return (
     target: object,
@@ -25,6 +27,7 @@ export const EventPattern = <T = string>(
       descriptor.value,
     );
     Reflect.defineMetadata(TRANSPORT_METADATA, transport, descriptor.value);
+    Reflect.defineMetadata(PATTERN_EXTRAS_METADATA, extras, descriptor.value);
     return descriptor;
   };
 };

--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -22,18 +22,18 @@ export const EventPattern: {
   ): MethodDecorator;
 } = <T = string>(
   metadata?: T,
-  arg1?: Transport | Record<string, any>,
-  arg2?: Record<string, any>,
+  transportOrExtras?: Transport | Record<string, any>,
+  maybeExtras?: Record<string, any>,
 ): MethodDecorator => {
   let transport: Transport;
   let extras: Record<string, any>;
-  if (isNumber(arg1) && isNil(arg2)) {
-    transport = arg1;
-  } else if (isObject(arg1) && isNil(arg2)) {
-    extras = arg1;
+  if (isNumber(transportOrExtras) && isNil(maybeExtras)) {
+    transport = transportOrExtras;
+  } else if (isObject(transportOrExtras) && isNil(maybeExtras)) {
+    extras = transportOrExtras;
   } else {
-    transport = arg1 as Transport;
-    extras = arg2;
+    transport = transportOrExtras as Transport;
+    extras = maybeExtras;
   }
   return (
     target: object,

--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -10,11 +10,30 @@ import { Transport } from '../enums';
 /**
  * Subscribes to incoming events which fulfils chosen pattern.
  */
-export const EventPattern = <T = string>(
+export const EventPattern: {
+  <T = string>(metadata?: T): MethodDecorator;
+  <T = string>(metadata?: T, transport?: Transport): MethodDecorator;
+  <T = string>(metadata?: T, extras?: Record<string, any>): MethodDecorator;
+  <T = string>(
+    metadata?: T,
+    transport?: Transport,
+    extras?: Record<string, any>,
+  ): MethodDecorator;
+} = <T = string>(
   metadata?: T,
-  transport?: Transport,
-  extras?: Record<string, any>,
+  arg1?: Transport | Record<string, any>,
+  arg2?: Record<string, any>,
 ): MethodDecorator => {
+  let transport: Transport;
+  let extras: Record<string, any>;
+  if (typeof arg1 === 'number' && !arg2) {
+    transport = arg1;
+  } else if (typeof arg1 === 'object' && arg1 !== null && !arg2) {
+    extras = arg1;
+  } else {
+    transport = arg1 as Transport;
+    extras = arg2;
+  }
   return (
     target: object,
     key: string | symbol,

--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -1,3 +1,4 @@
+import { isObject, isNumber, isNil } from '@nestjs/common/utils/shared.utils';
 import {
   PATTERN_HANDLER_METADATA,
   PATTERN_METADATA,
@@ -6,7 +7,6 @@ import {
 } from '../constants';
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { Transport } from '../enums';
-import { isObject, isNumber, isNil } from '../../common/utils/shared.utils';
 
 /**
  * Subscribes to incoming events which fulfils chosen pattern.

--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -6,6 +6,7 @@ import {
 } from '../constants';
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { Transport } from '../enums';
+import { isObject, isNumber, isNil } from '../../common/utils/shared.utils';
 
 /**
  * Subscribes to incoming events which fulfils chosen pattern.
@@ -26,9 +27,9 @@ export const EventPattern: {
 ): MethodDecorator => {
   let transport: Transport;
   let extras: Record<string, any>;
-  if (typeof arg1 === 'number' && !arg2) {
+  if (isNumber(arg1) && isNil(arg2)) {
     transport = arg1;
-  } else if (typeof arg1 === 'object' && arg1 !== null && !arg2) {
+  } else if (isObject(arg1) && isNil(arg2)) {
     extras = arg1;
   } else {
     transport = arg1 as Transport;

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -18,11 +18,36 @@ export enum GrpcMethodStreamingType {
 /**
  * Subscribes to incoming messages which fulfils chosen pattern.
  */
-export const MessagePattern = <T = PatternMetadata | string>(
+export const MessagePattern: {
+  <T = PatternMetadata | string>(metadata?: T): MethodDecorator;
+  <T = PatternMetadata | string>(
+    metadata?: T,
+    transport?: Transport,
+  ): MethodDecorator;
+  <T = PatternMetadata | string>(
+    metadata?: T,
+    extras?: Record<string, any>,
+  ): MethodDecorator;
+  <T = PatternMetadata | string>(
+    metadata?: T,
+    transport?: Transport,
+    extras?: Record<string, any>,
+  ): MethodDecorator;
+} = <T = PatternMetadata | string>(
   metadata?: T,
-  transport?: Transport,
-  extras?: Record<string, any>,
+  arg1?: Transport | Record<string, any>,
+  arg2?: Record<string, any>,
 ): MethodDecorator => {
+  let transport: Transport;
+  let extras: Record<string, any>;
+  if (typeof arg1 === 'number' && !arg2) {
+    transport = arg1;
+  } else if (typeof arg1 === 'object' && arg1 !== null && !arg2) {
+    extras = arg1;
+  } else {
+    transport = arg1 as Transport;
+    extras = arg2;
+  }
   return (
     target: object,
     key: string | symbol,

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -8,6 +8,7 @@ import {
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { PatternMetadata } from '../interfaces/pattern-metadata.interface';
 import { Transport } from '../enums';
+import { isObject, isNumber, isNil } from '../../common/utils/shared.utils';
 
 export enum GrpcMethodStreamingType {
   NO_STREAMING = 'no_stream',
@@ -40,9 +41,9 @@ export const MessagePattern: {
 ): MethodDecorator => {
   let transport: Transport;
   let extras: Record<string, any>;
-  if (typeof arg1 === 'number' && !arg2) {
+  if (isNumber(arg1) && isNil(arg2)) {
     transport = arg1;
-  } else if (typeof arg1 === 'object' && arg1 !== null && !arg2) {
+  } else if (isObject(arg1) && isNil(arg2)) {
     extras = arg1;
   } else {
     transport = arg1 as Transport;

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -1,3 +1,4 @@
+import { isObject, isNumber, isNil } from '@nestjs/common/utils/shared.utils';
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
   PATTERN_HANDLER_METADATA,
@@ -8,7 +9,6 @@ import {
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { PatternMetadata } from '../interfaces/pattern-metadata.interface';
 import { Transport } from '../enums';
-import { isObject, isNumber, isNil } from '../../common/utils/shared.utils';
 
 export enum GrpcMethodStreamingType {
   NO_STREAMING = 'no_stream',

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -3,6 +3,7 @@ import {
   PATTERN_HANDLER_METADATA,
   PATTERN_METADATA,
   TRANSPORT_METADATA,
+  PATTERN_EXTRAS_METADATA,
 } from '../constants';
 import { PatternHandler } from '../enums/pattern-handler.enum';
 import { PatternMetadata } from '../interfaces/pattern-metadata.interface';
@@ -20,6 +21,7 @@ export enum GrpcMethodStreamingType {
 export const MessagePattern = <T = PatternMetadata | string>(
   metadata?: T,
   transport?: Transport,
+  extras?: Record<string, any>,
 ): MethodDecorator => {
   return (
     target: object,
@@ -33,6 +35,7 @@ export const MessagePattern = <T = PatternMetadata | string>(
       descriptor.value,
     );
     Reflect.defineMetadata(TRANSPORT_METADATA, transport, descriptor.value);
+    Reflect.defineMetadata(PATTERN_EXTRAS_METADATA, extras, descriptor.value);
     return descriptor;
   };
 };

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -36,18 +36,18 @@ export const MessagePattern: {
   ): MethodDecorator;
 } = <T = PatternMetadata | string>(
   metadata?: T,
-  arg1?: Transport | Record<string, any>,
-  arg2?: Record<string, any>,
+  transportOrExtras?: Transport | Record<string, any>,
+  maybeExtras?: Record<string, any>,
 ): MethodDecorator => {
   let transport: Transport;
   let extras: Record<string, any>;
-  if (isNumber(arg1) && isNil(arg2)) {
-    transport = arg1;
-  } else if (isObject(arg1) && isNil(arg2)) {
-    extras = arg1;
+  if (isNumber(transportOrExtras) && isNil(maybeExtras)) {
+    transport = transportOrExtras;
+  } else if (isObject(transportOrExtras) && isNil(maybeExtras)) {
+    extras = transportOrExtras;
   } else {
-    transport = arg1 as Transport;
-    extras = arg2;
+    transport = transportOrExtras as Transport;
+    extras = maybeExtras;
   }
   return (
     target: object,

--- a/packages/microservices/interfaces/message-handler.interface.ts
+++ b/packages/microservices/interfaces/message-handler.interface.ts
@@ -4,4 +4,5 @@ export interface MessageHandler<TInput = any, TContext = any, TResult = any> {
   (data: TInput, ctx?: TContext): Promise<Observable<TResult>>;
   next?: (data: TInput, ctx?: TContext) => Promise<Observable<TResult>>;
   isEventHandler?: boolean;
+  extras?: Record<string, any>;
 }

--- a/packages/microservices/listener-metadata-explorer.ts
+++ b/packages/microservices/listener-metadata-explorer.ts
@@ -7,6 +7,7 @@ import {
   PATTERN_HANDLER_METADATA,
   PATTERN_METADATA,
   TRANSPORT_METADATA,
+  PATTERN_EXTRAS_METADATA,
 } from './constants';
 import { Transport } from './enums';
 import { PatternHandler } from './enums/pattern-handler.enum';
@@ -24,6 +25,7 @@ export interface EventOrMessageListenerDefinition {
   isEventHandler: boolean;
   targetCallback: (...args: any[]) => any;
   transport?: Transport;
+  extras?: Record<string, any>;
 }
 
 export interface MessageRequestProperties {
@@ -58,11 +60,13 @@ export class ListenerMetadataExplorer {
     }
     const pattern = Reflect.getMetadata(PATTERN_METADATA, targetCallback);
     const transport = Reflect.getMetadata(TRANSPORT_METADATA, targetCallback);
+    const extras = Reflect.getMetadata(PATTERN_EXTRAS_METADATA, targetCallback);
     return {
       methodKey,
       targetCallback,
       pattern,
       transport,
+      extras,
       isEventHandler: handlerType === PatternHandler.EVENT,
     };
   }

--- a/packages/microservices/listeners-controller.ts
+++ b/packages/microservices/listeners-controller.ts
@@ -71,48 +71,55 @@ export class ListenersController {
           isUndefined(server.transportId) ||
           transport === server.transportId,
       )
-      .forEach(({ pattern, targetCallback, methodKey, isEventHandler }) => {
-        if (isStatic) {
-          const proxy = this.contextCreator.create(
-            instance as object,
-            targetCallback,
+      .forEach(
+        ({ pattern, targetCallback, methodKey, extras, isEventHandler }) => {
+          if (isStatic) {
+            const proxy = this.contextCreator.create(
+              instance as object,
+              targetCallback,
+              moduleKey,
+              methodKey,
+              STATIC_CONTEXT,
+              undefined,
+              defaultCallMetadata,
+            );
+            if (isEventHandler) {
+              const eventHandler: MessageHandler = (...args: unknown[]) => {
+                const originalArgs = args;
+                const [dataOrContextHost] = originalArgs;
+                if (dataOrContextHost instanceof RequestContextHost) {
+                  args = args.slice(1, args.length);
+                }
+                const originalReturnValue = proxy(...args);
+                const returnedValueWrapper = eventHandler.next?.(
+                  ...(originalArgs as Parameters<MessageHandler>),
+                );
+                returnedValueWrapper?.then(returnedValue =>
+                  this.connectIfStream(returnedValue as Observable<unknown>),
+                );
+                return originalReturnValue;
+              };
+              return server.addHandler(
+                pattern,
+                eventHandler,
+                isEventHandler,
+                extras,
+              );
+            } else {
+              return server.addHandler(pattern, proxy, isEventHandler, extras);
+            }
+          }
+          const asyncHandler = this.createRequestScopedHandler(
+            instanceWrapper,
+            pattern,
+            moduleRef,
             moduleKey,
             methodKey,
-            STATIC_CONTEXT,
-            undefined,
             defaultCallMetadata,
           );
-          if (isEventHandler) {
-            const eventHandler: MessageHandler = (...args: unknown[]) => {
-              const originalArgs = args;
-              const [dataOrContextHost] = originalArgs;
-              if (dataOrContextHost instanceof RequestContextHost) {
-                args = args.slice(1, args.length);
-              }
-              const originalReturnValue = proxy(...args);
-              const returnedValueWrapper = eventHandler.next?.(
-                ...(originalArgs as Parameters<MessageHandler>),
-              );
-              returnedValueWrapper?.then(returnedValue =>
-                this.connectIfStream(returnedValue as Observable<unknown>),
-              );
-              return originalReturnValue;
-            };
-            return server.addHandler(pattern, eventHandler, isEventHandler);
-          } else {
-            return server.addHandler(pattern, proxy, isEventHandler);
-          }
-        }
-        const asyncHandler = this.createRequestScopedHandler(
-          instanceWrapper,
-          pattern,
-          moduleRef,
-          moduleKey,
-          methodKey,
-          defaultCallMetadata,
-        );
-        server.addHandler(pattern, asyncHandler, isEventHandler);
-      });
+          server.addHandler(pattern, asyncHandler, isEventHandler, extras);
+        },
+      );
   }
 
   public assignClientsToProperties(instance: Controller | Injectable) {

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -44,9 +44,11 @@ export abstract class Server {
     pattern: any,
     callback: MessageHandler,
     isEventHandler = false,
+    extras: Record<string, any> = {},
   ) {
     const normalizedPattern = this.normalizePattern(pattern);
     callback.isEventHandler = isEventHandler;
+    callback.extras = extras;
 
     if (this.messageHandlers.has(normalizedPattern) && isEventHandler) {
       const headRef = this.messageHandlers.get(normalizedPattern);

--- a/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
@@ -1,15 +1,23 @@
 import { expect } from 'chai';
-import { PATTERN_METADATA } from '../../constants';
+import { PATTERN_METADATA, PATTERN_EXTRAS_METADATA } from '../../constants';
 import { EventPattern } from '../../decorators/event-pattern.decorator';
 
 describe('@EventPattern', () => {
   const pattern = { role: 'test' };
+  const extras = { param: 'value' };
   class TestComponent {
-    @EventPattern(pattern)
+    @EventPattern(pattern, undefined, extras)
     public static test() {}
   }
   it(`should enhance method with ${PATTERN_METADATA} metadata`, () => {
     const metadata = Reflect.getMetadata(PATTERN_METADATA, TestComponent.test);
     expect(metadata).to.be.eql(pattern);
+  });
+  it(`should enhance method with ${PATTERN_EXTRAS_METADATA} metadata`, () => {
+    const metadata = Reflect.getMetadata(
+      PATTERN_EXTRAS_METADATA,
+      TestComponent.test,
+    );
+    expect(metadata).to.be.deep.equal(extras);
   });
 });

--- a/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { PATTERN_METADATA, PATTERN_EXTRAS_METADATA } from '../../constants';
+import {
+  PATTERN_EXTRAS_METADATA,
+  PATTERN_METADATA,
+  TRANSPORT_METADATA,
+} from '../../constants';
+import { Transport } from '../../enums/transport.enum';
 import { EventPattern } from '../../decorators/event-pattern.decorator';
 
 describe('@EventPattern', () => {
@@ -19,5 +24,97 @@ describe('@EventPattern', () => {
       TestComponent.test,
     );
     expect(metadata).to.be.deep.equal(extras);
+  });
+
+  describe('decorator overloads', () => {
+    class TestComponent1 {
+      @EventPattern(pattern)
+      public static test() {}
+    }
+    class TestComponent2 {
+      @EventPattern(pattern, Transport.TCP)
+      public static test() {}
+    }
+    class TestComponent3 {
+      @EventPattern(pattern, extras)
+      public static test() {}
+    }
+    class TestComponent4 {
+      @EventPattern(pattern, Transport.TCP, extras)
+      public static test() {}
+    }
+
+    it(`should enhance method with ${PATTERN_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent1.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent1.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent1.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.undefined;
+      expect(extrasArg).to.be.undefined;
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${TRANSPORT_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent2.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent2.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent2.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.eql(Transport.TCP);
+      expect(extrasArg).to.be.undefined;
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${PATTERN_EXTRAS_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent3.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent3.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent3.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.undefined;
+      expect(extrasArg).to.be.eql(extras);
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${TRANSPORT_METADATA} and \
+${PATTERN_EXTRAS_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent4.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent4.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent4.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.eql(Transport.TCP);
+      expect(extrasArg).to.be.eql(extras);
+    });
   });
 });

--- a/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { PATTERN_METADATA } from '../../constants';
+import { PATTERN_METADATA, PATTERN_EXTRAS_METADATA } from '../../constants';
 import {
   GrpcMethod,
   GrpcMethodStreamingType,
@@ -10,13 +10,21 @@ import {
 
 describe('@MessagePattern', () => {
   const pattern = { role: 'test' };
+  const extras = { param: 'value' };
   class TestComponent {
-    @MessagePattern(pattern)
+    @MessagePattern(pattern, undefined, extras)
     public static test() {}
   }
   it(`should enhance method with ${PATTERN_METADATA} metadata`, () => {
     const metadata = Reflect.getMetadata(PATTERN_METADATA, TestComponent.test);
     expect(metadata).to.be.eql(pattern);
+  });
+  it(`should enhance method with ${PATTERN_EXTRAS_METADATA} metadata`, () => {
+    const metadata = Reflect.getMetadata(
+      PATTERN_EXTRAS_METADATA,
+      TestComponent.test,
+    );
+    expect(metadata).to.be.deep.equal(extras);
   });
 });
 

--- a/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { PATTERN_METADATA, PATTERN_EXTRAS_METADATA } from '../../constants';
+import {
+  PATTERN_METADATA,
+  PATTERN_EXTRAS_METADATA,
+  TRANSPORT_METADATA,
+} from '../../constants';
+import { Transport } from '../../enums/transport.enum';
 import {
   GrpcMethod,
   GrpcMethodStreamingType,
@@ -25,6 +30,98 @@ describe('@MessagePattern', () => {
       TestComponent.test,
     );
     expect(metadata).to.be.deep.equal(extras);
+  });
+
+  describe('decorator overloads', () => {
+    class TestComponent1 {
+      @MessagePattern(pattern)
+      public static test() {}
+    }
+    class TestComponent2 {
+      @MessagePattern(pattern, Transport.TCP)
+      public static test() {}
+    }
+    class TestComponent3 {
+      @MessagePattern(pattern, extras)
+      public static test() {}
+    }
+    class TestComponent4 {
+      @MessagePattern(pattern, Transport.TCP, extras)
+      public static test() {}
+    }
+
+    it(`should enhance method with ${PATTERN_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent1.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent1.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent1.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.undefined;
+      expect(extrasArg).to.be.undefined;
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${TRANSPORT_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent2.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent2.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent2.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.eql(Transport.TCP);
+      expect(extrasArg).to.be.undefined;
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${PATTERN_EXTRAS_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent3.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent3.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent3.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.undefined;
+      expect(extrasArg).to.be.eql(extras);
+    });
+
+    it(`should enhance method with ${PATTERN_METADATA}, ${TRANSPORT_METADATA} and \
+${PATTERN_EXTRAS_METADATA} metadata`, () => {
+      const metadataArg = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent4.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent4.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent4.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.eql(Transport.TCP);
+      expect(extrasArg).to.be.eql(extras);
+    });
   });
 });
 

--- a/packages/microservices/test/listeners-controller.spec.ts
+++ b/packages/microservices/test/listeners-controller.spec.ts
@@ -118,6 +118,22 @@ describe('ListenersController', () => {
       instance.registerPatternHandlers(new InstanceWrapper(), serverTCP, '');
       expect(addSpyTCP.calledTwice).to.be.true;
     });
+    it(`should call "addHandler" method of server with extras data`, () => {
+      const serverHandlers = [
+        { pattern: 'test', targetCallback: 'tt', extras: { param: 'value' } },
+      ];
+      explorer.expects('explore').returns(serverHandlers);
+      instance.registerPatternHandlers(new InstanceWrapper(), serverTCP, '');
+      expect(addSpyTCP.calledOnce).to.be.true;
+      expect(
+        addSpyTCP.calledWith(
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match.any,
+          sinon.match({ param: 'value' }),
+        ),
+      ).to.be.true;
+    });
     describe('when request scoped', () => {
       it(`should call "addHandler" with deferred proxy`, () => {
         explorer.expects('explore').returns(handlers);

--- a/packages/microservices/test/listeners-metadata-explorer.spec.ts
+++ b/packages/microservices/test/listeners-metadata-explorer.spec.ts
@@ -77,6 +77,7 @@ describe('ListenerMetadataExplorer', () => {
         'targetCallback',
         'pattern',
         'transport',
+        'extras',
       ]);
       expect(metadata.pattern).to.eql(pattern);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current implementation allows passing only `pattern` and `transport` to the microservice transport. No way to attach any handler-specific rich types.

Issue Number: N/A


## What is the new behavior?
The new implementation adds optional "extras" parameter for `MessagePattern` and `EventPattern` decorators that allows embedding any extra params into each message handler method and improves the experience of creating custom microservice transports.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information