### PR TITLE
feat(common): Added min and max options to float and int parse pipes

### DIFF
--- a/packages/common/test/pipes/parse-bool.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-bool.pipe.spec.ts
@@ -21,7 +21,9 @@ describe('ParseBoolPipe', () => {
     });
     describe('when validation fails', () => {
       it('should throw an error', async () => {
-        return expect(target.transform('123abc', {} as ArgumentMetadata)).to.be
+        await expect(target.transform('123abc', {} as ArgumentMetadata)).to.be
+          .rejected;
+        await expect(target.transform(undefined, {} as ArgumentMetadata)).to.be
           .rejected;
       });
     });

--- a/packages/common/test/pipes/parse-float.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-float.pipe.spec.ts
@@ -12,11 +12,17 @@ class CustomTestError extends HttpException {
 
 describe('ParseFloatPipe', () => {
   let target: ParseFloatPipe;
+  let min: number | undefined;
+  let max: number | undefined;
+
   beforeEach(() => {
     target = new ParseFloatPipe({
       exceptionFactory: (error: any) => new CustomTestError(),
+      min,
+      max,
     });
   });
+
   describe('transform', () => {
     describe('when validation passes', () => {
       it('should return number', async () => {
@@ -25,12 +31,81 @@ describe('ParseFloatPipe', () => {
           parseFloat(num),
         );
       });
+
+      it('should return negative number', async () => {
+        const num = '-3.33';
+        expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(
+          -3.33,
+        );
+      });
+
+      it('should return zero', async () => {
+        const num = '0';
+        expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(0);
+      });
     });
+
     describe('when validation fails', () => {
       it('should throw an error', async () => {
         return expect(
           target.transform('123.123abc', {} as ArgumentMetadata),
         ).to.be.rejectedWith(CustomTestError);
+      });
+    });
+
+    describe('when a minimum allowed value is provided', () => {
+      before(() => {
+        min = 5.33;
+      });
+
+      after(() => {
+        min = undefined;
+      });
+
+      it('should throw an error when number is less than minimum', async () => {
+        return expect(
+          target.transform('-1.09', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+
+      it('should return the parsed number when number is equal to the minimum', async () => {
+        return expect(
+          await target.transform('5.33', {} as ArgumentMetadata),
+        ).to.equal(5.33);
+      });
+
+      it('should return the parsed number when number is greater than minimum', async () => {
+        return expect(
+          await target.transform('6.07', {} as ArgumentMetadata),
+        ).to.equal(6.07);
+      });
+    });
+
+    describe('when a maximum allowed value is provided', () => {
+      before(() => {
+        max = 5.33;
+      });
+
+      after(() => {
+        max = undefined;
+      });
+
+      it('should throw an error when number is greater than maximum', async () => {
+        return expect(
+          target.transform('6.07', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+
+      it('should return the parsed number when number is equal to the maximum', async () => {
+        return expect(
+          await target.transform('5.33', {} as ArgumentMetadata),
+        ).to.equal(5.33);
+      });
+
+      it('should return the parsed number when number is less than maximum', async () => {
+        return expect(
+          await target.transform('4.99', {} as ArgumentMetadata),
+        ).to.equal(4.99);
       });
     });
   });

--- a/packages/common/test/pipes/parse-int.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-int.pipe.spec.ts
@@ -12,11 +12,17 @@ class CustomTestError extends HttpException {
 
 describe('ParseIntPipe', () => {
   let target: ParseIntPipe;
+  let min: number | undefined;
+  let max: number | undefined;
+
   beforeEach(() => {
     target = new ParseIntPipe({
       exceptionFactory: (error: any) => new CustomTestError(),
+      min,
+      max,
     });
   });
+
   describe('transform', () => {
     describe('when validation passes', () => {
       it('should return number', async () => {
@@ -25,23 +31,87 @@ describe('ParseIntPipe', () => {
           parseInt(num, 10),
         );
       });
+
       it('should return negative number', async () => {
         const num = '-3';
         expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(
           -3,
         );
       });
+
+      it('should return zero', async () => {
+        const num = '0';
+        expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(0);
+      });
     });
+
     describe('when validation fails', () => {
       it('should throw an error', async () => {
         return expect(
           target.transform('123abc', {} as ArgumentMetadata),
         ).to.be.rejectedWith(CustomTestError);
       });
+
       it('should throw an error when number has wrong number encoding', async () => {
         return expect(
           target.transform('0xFF', {} as ArgumentMetadata),
         ).to.be.rejectedWith(CustomTestError);
+      });
+    });
+
+    describe('when a minimum allowed value is provided', () => {
+      before(() => {
+        min = 0;
+      });
+
+      after(() => {
+        min = undefined;
+      });
+
+      it('should throw an error when number is less than minimum', async () => {
+        return expect(
+          target.transform('-1', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+
+      it('should return the parsed number when number is equal to the minimum', async () => {
+        return expect(
+          await target.transform('0', {} as ArgumentMetadata),
+        ).to.equal(0);
+      });
+
+      it('should return the parsed number when number is greater than minimum', async () => {
+        return expect(
+          await target.transform('4', {} as ArgumentMetadata),
+        ).to.equal(4);
+      });
+    });
+
+    describe('when a maximum allowed value is provided', () => {
+      before(() => {
+        max = 3;
+      });
+
+      after(() => {
+        max = undefined;
+      });
+
+      it('should throw an error when number is greater than maximum', async () => {
+        return expect(
+          target.transform('4', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+
+      it('should return the parsed number when number is equal to the maximum', async () => {
+        return expect(
+          await target.transform('3', {} as ArgumentMetadata),
+        ).to.equal(3);
+      });
+
+      it('should return the parsed number when number is less than maximum', async () => {
+        return expect(
+          await target.transform('1', {} as ArgumentMetadata),
+        ).to.equal(1);
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`ParseIntPipe` and `ParseFloatPipe` only perform type conversion.
Issue Number: N/A


## What is the new behavior?

Both pipes now include an optional `min` and `max` option. If provided, a bounds check is performed on the value after parsing.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information