### PR TITLE
fix @nestjs/common/ValidationPipe

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -110,7 +110,7 @@ export class ValidationPipe implements PipeTransform<any> {
     const isNil = value !== originalValue;
     const isPrimitive = this.isPrimitive(value);
     this.stripProtoKeys(value);
-    let entity = classTransformer.plainToClass(
+    let entity = classTransformer.(classTransformer.plainToClass ?? classTransformer.plainToInstance)(
       metatype,
       value,
       this.transformOptions,
@@ -145,7 +145,7 @@ export class ValidationPipe implements PipeTransform<any> {
       return originalValue;
     }
     return Object.keys(this.validatorOptions).length > 0
-      ? classTransformer.classToPlain(entity, this.transformOptions)
+      ? (classTransformer.classToPlain ?? classTransformer.instanceToPlain)(entity, this.transformOptions)
       : value;
   }
 

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -110,7 +110,7 @@ export class ValidationPipe implements PipeTransform<any> {
     const isNil = value !== originalValue;
     const isPrimitive = this.isPrimitive(value);
     this.stripProtoKeys(value);
-    let entity = classTransformer.(classTransformer.plainToClass ?? classTransformer.plainToInstance)(
+    let entity = (classTransformer.plainToClass ?? classTransformer.plainToInstance)(
       metatype,
       value,
       this.transformOptions,


### PR DESCRIPTION
When including the **useGlobalPipes(new ValidationPipe())** method, we get an error that there is no such **classToPlain** and **plainToClass** method. The NESTJS dependencies say that we can use any version of the class-transformer library. Only since version v0.4.1 the **classToPlain** and **plainToClass** methods have been replaced with **instanceToPlain** and **plainToInstance**.