### PR TITLE
Hotfix/sse stream sink content

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -86,7 +86,7 @@ export class SseStream extends Transform {
       destination.flushHeaders();
     }
 
-    destination.write(':\n');
+    destination.write('\n');
     return super.pipe(destination, options);
   }
 

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -299,7 +299,7 @@ describe('RouterResponseController', () => {
       request.destroy();
       await written(response);
       expect(response.content).to.eql(
-        `:
+        `
 id: 1
 data: test
 
@@ -421,7 +421,7 @@ data: test
 
         await written(response);
         expect(response.content).to.eql(
-          `:
+          `
 event: error
 id: 1
 data: Some error

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -40,9 +40,12 @@ class Sink extends Writable implements HeaderStream {
 
 describe('SseStream', () => {
   it('writes multiple multiline messages', async () => {
+    // Arrange
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
+    // Act
     sse.writeMessage(
       {
         data: 'hello\nworld',
@@ -57,8 +60,10 @@ describe('SseStream', () => {
     );
     sse.end();
     await written(sink);
+
+    // Assert
     expect(sink.content).to.equal(
-      `:
+      `
 id: 1
 data: hello
 data: world
@@ -72,9 +77,12 @@ data: monde
   });
 
   it('writes object messages as JSON', async () => {
+    // Arrange
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
+    // Act
     sse.writeMessage(
       {
         data: { hello: 'world' },
@@ -83,8 +91,10 @@ data: monde
     );
     sse.end();
     await written(sink);
+
+    // Assert
     expect(sink.content).to.equal(
-      `:
+      `
 id: 1
 data: {"hello":"world"}
 
@@ -93,9 +103,12 @@ data: {"hello":"world"}
   });
 
   it('writes all message attributes', async () => {
+    // Arrange
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
+    // Act
     sse.writeMessage(
       {
         type: 'tea-time',
@@ -107,8 +120,10 @@ data: {"hello":"world"}
     );
     sse.end();
     await written(sink);
+
+    // Assert
     expect(sink.content).to.equal(
-      `:
+      `
 event: tea-time
 id: the-id
 retry: 222
@@ -119,9 +134,11 @@ data: hello
   });
 
   it('sets headers on destination when it looks like a HTTP Response', callback => {
+    // Arrange
     const sse = new SseStream();
     const sink = new Sink(
       (status: number, headers: string | OutgoingHttpHeaders) => {
+        // Assert
         expect(headers).to.deep.equal({
           'Content-Type': 'text/event-stream',
           Connection: 'keep-alive',
@@ -139,9 +156,11 @@ data: hello
   });
 
   it('sets additional headers when provided', callback => {
+    // Arrange
     const sse = new SseStream();
     const sink = new Sink(
       (status: number, headers: string | OutgoingHttpHeaders) => {
+        // Assert
         expect(headers).to.contain.keys('access-control-headers');
         expect(headers['access-control-headers']).to.equal('some-cors-value');
         callback();
@@ -154,16 +173,20 @@ data: hello
   });
 
   it('allows an eventsource to connect', callback => {
+    // Arrange
     let sse: SseStream;
     const server = createServer((req, res) => {
       sse = new SseStream(req);
       sse.pipe(res);
     });
+
+    // Act
     server.listen(() => {
       const es = new EventSource(
         `http://localhost:${(server.address() as AddressInfo).port}`,
       );
       es.onmessage = e => {
+        // Assert
         expect(e.data).to.equal('hello');
         es.close();
         server.close(callback);


### PR DESCRIPTION
closes nestjs/nest#8877

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using SSE feature, the first message received by client contains only colons (":").

Issue Number: #8877


## What is the new behavior?
When using SSE feature, the first message received by client contains only newline character ("\n").

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
N/A

## Other information
I chose to keep the newline character as suggested by @jpineaufr. I **think** it was added to pretty print the message.
I also added the [AAA Pattern](https://github.com/goldbergyoni/javascript-testing-best-practices#-%EF%B8%8F-12-structure-tests-by-the-aaa-pattern) to the test file to improve readability. I think we could improve it further with some utility functions to encapsulate parts of the code and make use of "give", "when" and "then", like so:

```typescript
const { sse, sink } = givenANewSseWithSink()
   
whenMessageIs({
  type: 'tea-time',
  id: 'the-id',
  retry: 222,
  data: 'hello',
})

await written(sink);

expect(sink.content).to.equal(
 `
event: tea-time
id: the-id
retry: 222
data: hello

`,
    );
```