### PR TITLE
fix(sse): stream sink content

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -86,7 +86,7 @@ export class SseStream extends Transform {
       destination.flushHeaders();
     }
 
-    destination.write(':\n');
+    destination.write('\n');
     return super.pipe(destination, options);
   }
 

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -299,7 +299,7 @@ describe('RouterResponseController', () => {
       request.destroy();
       await written(response);
       expect(response.content).to.eql(
-        `:
+        `
 id: 1
 data: test
 
@@ -421,7 +421,7 @@ data: test
 
         await written(response);
         expect(response.content).to.eql(
-          `:
+          `
 event: error
 id: 1
 data: Some error

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -43,6 +43,7 @@ describe('SseStream', () => {
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
     sse.writeMessage(
       {
         data: 'hello\nworld',
@@ -57,8 +58,9 @@ describe('SseStream', () => {
     );
     sse.end();
     await written(sink);
+
     expect(sink.content).to.equal(
-      `:
+      `
 id: 1
 data: hello
 data: world
@@ -75,6 +77,7 @@ data: monde
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
     sse.writeMessage(
       {
         data: { hello: 'world' },
@@ -83,8 +86,9 @@ data: monde
     );
     sse.end();
     await written(sink);
+
     expect(sink.content).to.equal(
-      `:
+      `
 id: 1
 data: {"hello":"world"}
 
@@ -96,6 +100,7 @@ data: {"hello":"world"}
     const sse = new SseStream();
     const sink = new Sink();
     sse.pipe(sink);
+
     sse.writeMessage(
       {
         type: 'tea-time',
@@ -107,8 +112,9 @@ data: {"hello":"world"}
     );
     sse.end();
     await written(sink);
+
     expect(sink.content).to.equal(
-      `:
+      `
 event: tea-time
 id: the-id
 retry: 222
@@ -148,6 +154,7 @@ data: hello
         return sink;
       },
     );
+
     sse.pipe(sink, {
       additionalHeaders: { 'access-control-headers': 'some-cors-value' },
     });
@@ -159,6 +166,7 @@ data: hello
       sse = new SseStream(req);
       sse.pipe(res);
     });
+
     server.listen(() => {
       const es = new EventSource(
         `http://localhost:${(server.address() as AddressInfo).port}`,


### PR DESCRIPTION
closes nestjs/nest#8877

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using SSE feature, the first message received by client contains only colons (":").

Issue Number: #8877


## What is the new behavior?
When using SSE feature, the first message received by client contains only newline character ("\n").

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
N/A

## Other information
I chose to keep the newline character as suggested by @jpineaufr. I **think** it was added to pretty print the message. Also, we could improve tests readability with some utility functions to encapsulate parts of the code and make use of "give", "when" and "then", like so:

```typescript
const { sse, sink } = givenANewSseWithSink()
   
whenMessageIs({
  type: 'tea-time',
  id: 'the-id',
  retry: 222,
  data: 'hello',
})

await written(sink);

expect(sink.content).to.equal(
 `
event: tea-time
id: the-id
retry: 222
data: hello

`,
    );
```