### PR TITLE
fix: fix factory provider definition

### DIFF
--- a/packages/common/interfaces/modules/provider.interface.ts
+++ b/packages/common/interfaces/modules/provider.interface.ts
@@ -101,7 +101,7 @@ export interface FactoryProvider<T = any> {
   /**
    * Factory function that returns an instance of the provider to be injected.
    */
-  useFactory: (...args: any[]) => T;
+  useFactory: (...args: any[]) => T | Promise<T>;
   /**
    * Optional list of providers to be injected into the context of the Factory function.
    */


### PR DESCRIPTION
According to this [document](https://docs.nestjs.com/fundamentals/async-providers), if factory provider's `useFactory` function is async, `useFactory` function should return `Promise<T>`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information