### PR TITLE
fix(microservices): generate service method in lower and uppercase

### DIFF
--- a/integration/microservices/e2e/sum-grpc.spec.ts
+++ b/integration/microservices/e2e/sum-grpc.spec.ts
@@ -48,9 +48,14 @@ describe('GRPC transport', () => {
     );
   });
 
-  it(`GRPC Sending and Receiving HTTP POST`, () => {
-    return request(server)
+  it(`GRPC Sending and Receiving HTTP POST`, async () => {
+    await request(server)
       .post('/sum')
+      .send([1, 2, 3, 4, 5])
+      .expect(200, { result: 15 });
+
+    await request(server)
+      .post('/upperMethod/sum')
       .send([1, 2, 3, 4, 5])
       .expect(200, { result: 15 });
   });

--- a/integration/microservices/src/grpc/grpc.controller.ts
+++ b/integration/microservices/src/grpc/grpc.controller.ts
@@ -40,6 +40,14 @@ export class GrpcController {
     return svc.sum({ data });
   }
 
+  // Test that getService generate both lower and uppercase method
+  @Post('upperMethod/sum')
+  @HttpCode(200)
+  callWithOptions(@Body() data: number[]): Observable<number> {
+    const svc = this.client.getService<any>('Math');
+    return svc.Sum({ data });
+  }
+
   @GrpcMethod('Math')
   async sum({ data }: { data: number[] }): Promise<any> {
     return of({

--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -53,8 +53,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
     const grpcService = {} as T;
 
     protoMethods.forEach(m => {
-      const key = m[0].toLowerCase() + m.slice(1, m.length);
-      grpcService[key] = this.createServiceMethod(grpcClient, m);
+      grpcService[m] = this.createServiceMethod(grpcClient, m);
     });
     return grpcService;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9047 


## What is the new behavior?

`gRPCClientProxy.GetService` now generates service methods both in uppercase and lowercase instead of forcing it to lowercase.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information