### PR TITLE
fix(common): Truncate float numbers on ParseIntPipe

### DIFF
--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -46,7 +46,7 @@ export class ParseIntPipe implements PipeTransform<string> {
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
     const isNumeric =
       ['string', 'number'].includes(typeof value) &&
-      /^-?\d+$/.test(value) &&
+      /^[+-]?([0-9]*[.])?[0-9]+$/.test(value) &&
       isFinite(value as any);
     if (!isNumeric) {
       throw this.exceptionFactory(

--- a/packages/common/test/pipes/parse-int.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-int.pipe.spec.ts
@@ -1,8 +1,7 @@
-import * as sinon from 'sinon';
 import { expect } from 'chai';
+import { HttpException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseIntPipe } from '../../pipes/parse-int.pipe';
-import { HttpException } from '../../exceptions';
 
 class CustomTestError extends HttpException {
   constructor() {
@@ -29,6 +28,12 @@ describe('ParseIntPipe', () => {
         const num = '-3';
         expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(
           -3,
+        );
+      });
+      it('should truncate float numbers', async () => {
+        const num = '123.45';
+        expect(await target.transform(num, {} as ArgumentMetadata)).to.equal(
+          123,
         );
       });
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Until version 8.0.6 the `ParseIntPipe` was truncating decimal values returning the integer part of them. From version 8.0.7 to date, it's throwing a validation error instead.

Issue Number: N/A


## What is the new behavior?

The behaviour has been corrected to truncate decimal values returning the integer part instead of throwing a validation error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information