### PR TITLE
Fix: grpc errors are always { "error": "2 UNKNOWN: Unknown Error" }

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -222,7 +222,7 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
       const handler = methodHandler(call.request, call.metadata, call);
       this.transformToObservable(await handler).subscribe({
         next: data => callback(null, data),
-        error: (err: any) => callback(err),
+        error: (err: any) => callback(err()),
       });
     };
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

Sorry all of them are not followed as I am new to this project. I would hope some of you helping on it.

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Having this grpc method implemented:
```
@Controller()
export class HeroesService {
  constructor() {}

  @GrpcMethod()
  async findOne(req: HeroById): Promise<Hero> {
    throw new RpcException({
      code: status.NOT_FOUND,
      details: 'test',
    });
  }
}
```

It responses with unknown error regardless what error is thrown.
```
{
  "error": "2 UNKNOWN: Unknown Error"
}
```

## What is the new behavior?

Responses with a proper error message:
```
{
  "error": "5 NOT_FOUND: test"
}
```

## Does this PR introduce a breaking change?

- [x] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Yes / No. Because it is a fix, it breaks the unexpected behaviour before.

## Other information