### PR TITLE
feat(microservices): Add options param to serializer

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -191,7 +191,9 @@ export class ClientKafka extends ClientProxy {
 
   protected async dispatchEvent(packet: OutgoingEvent): Promise<any> {
     const pattern = this.normalizePattern(packet.pattern);
-    const outgoingEvent = await this.serializer.serialize(packet.data);
+    const outgoingEvent = await this.serializer.serialize(packet.data, {
+      pattern,
+    });
     const message = Object.assign(
       {
         topic: pattern,
@@ -231,7 +233,7 @@ export class ClientKafka extends ClientProxy {
       const replyTopic = this.getResponsePatternName(pattern);
       const replyPartition = this.getReplyTopicPartition(replyTopic);
 
-      Promise.resolve(this.serializer.serialize(packet.data))
+      Promise.resolve(this.serializer.serialize(packet.data, { pattern }))
         .then((serializedPacket: KafkaRequest) => {
           serializedPacket.headers[KafkaHeaders.CORRELATION_ID] = packet.id;
           serializedPacket.headers[KafkaHeaders.REPLY_TOPIC] = replyTopic;

--- a/packages/microservices/interfaces/serializer.interface.ts
+++ b/packages/microservices/interfaces/serializer.interface.ts
@@ -5,7 +5,7 @@ import {
 } from './packet.interface';
 
 export interface Serializer<TInput = any, TOutput = any> {
-  serialize(value: TInput): TOutput;
+  serialize(value: TInput, options?: Record<string, any>): TOutput;
 }
 
 export type ProducerSerializer = Serializer<


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the Kafka Client/Server calls the serializer passing only the packet/message value as parameter.

Issue Number: N/A


## What is the new behavior?
From now the Kafka Client is calling the serializer passing the packet value and also an options object containing the pattern (topic name) as parameters. 
With the optional options parameter the Serializer interface is now matching the Deserializer interface. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This change doesn't introduce a breaking change because the options parameter is optional.    


## Other information
I'm deserializing/serializing messages using Avro Schemas with the Schema Registry, in order to do that the custom serializer needs to be aware of the topic/pattern name of each message.
Since this is an issue that other people may have I decided to contribute opening this PR.

