### PR TITLE
sample(02-gateways): Fix Redis adapter

### DIFF
--- a/sample/02-gateways/src/adapters/redis-io.adapter.ts
+++ b/sample/02-gateways/src/adapters/redis-io.adapter.ts
@@ -1,16 +1,23 @@
 import { IoAdapter } from '@nestjs/platform-socket.io';
-import { Server, ServerOptions } from 'socket.io';
+import { ServerOptions } from 'socket.io';
 import { createAdapter } from '@socket.io/redis-adapter';
 import { createClient } from 'redis';
 
-const io = new Server();
-const pubClient = createClient({ url: `redis://localhost:6379` });
-const subClient = pubClient.duplicate();
-const redisAdapter = io.adapter(createAdapter(pubClient, subClient));
 export class RedisIoAdapter extends IoAdapter {
+  private adapterConstructor: ReturnType<typeof createAdapter>;
+
+  async connectToRedis(): Promise<void> {
+    const pubClient = createClient({ url: `redis://localhost:6379` });
+    const subClient = pubClient.duplicate();
+
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    this.adapterConstructor = createAdapter(pubClient, subClient);
+  }
+
   createIOServer(port: number, options?: ServerOptions): any {
     const server = super.createIOServer(port, options);
-    server.adapter(redisAdapter);
+    server.adapter(this.adapterConstructor);
     return server;
   }
 }

--- a/sample/02-gateways/src/main.ts
+++ b/sample/02-gateways/src/main.ts
@@ -1,14 +1,13 @@
 import { NestFactory } from '@nestjs/core';
-import { RedisIoAdapter } from './adapters/redis-io.adapter';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  const redisIoAdapter = new RedisIoAdapter(app);
-  await redisIoAdapter.connectToRedis();
-
-  app.useWebSocketAdapter(redisIoAdapter);
+  // Uncomment these lines to use the Redis adapter:
+  // const redisIoAdapter = new RedisIoAdapter(app);
+  // await redisIoAdapter.connectToRedis();
+  // app.useWebSocketAdapter(redisIoAdapter);
 
   await app.listen(3000);
   console.log(`Application is running on: ${await app.getUrl()}`);

--- a/sample/02-gateways/src/main.ts
+++ b/sample/02-gateways/src/main.ts
@@ -1,8 +1,15 @@
 import { NestFactory } from '@nestjs/core';
+import { RedisIoAdapter } from './adapters/redis-io.adapter';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const redisIoAdapter = new RedisIoAdapter(app);
+  await redisIoAdapter.connectToRedis();
+
+  app.useWebSocketAdapter(redisIoAdapter);
+
   await app.listen(3000);
   console.log(`Application is running on: ${await app.getUrl()}`);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Other... Please describe: Fix `sample/02-gateways`

---

**Issue 1:** The Redis adapter is not used in the sample app

**Repro steps:**

- Run a redis server at `redis://localhost:6379`
- Change the redis URL in `RedisIoAdapter` to a non-existent redis URL (for example: `redis://localhost:6380`)
- Run `yarn start`

**Current behavior**: App runs normally because the `RedisIoAdapter` is not used anywhere in the app.
**Expected behavior**: App should crash with `ECONNREFUSED 127.0.0.1:6380`

---

**Issue 2:** The Redis adapter is not initialized correctly in the sample app

Following #9158, the `redis` and `@socket.io/redis-adapter` dependencies were updated, but the new changes do not reflect the new API.  See: https://socket.io/docs/v4/redis-adapter/#usage

The causes are:
- A server is created with `const io = new Server();`, but the server should be re-used from `const server = super.createIOServer(port, options);`
- As of `redis@4`, we are required to call `connect()` on the clients before the adapter can be created

**Repro steps:**

- Run a redis server at `redis://localhost:6379`
- Import the `RedisIoAdapter` into the bootstrap function and use it with `app.useWebSocketAdapter(new RedisIoAdapter(app));`

**Current behavior:** App crashes with `this.server.adapter(...) is not a constructor`
**Expected behavior:** App should work and connect to the redis server

## What is the current behavior?

The websockets sample does not work.

## What is the new behavior?

The websockets sample works when a correct redis URL is provided.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

A better solution would be to create a `RedisModule` that provides the `RedisIoAdapter`. We can then have an `async onModuleInit` on the `RedisIoAdapter` that connects to the redis clients, so the connection is made when the app is initialized and we don't have to manually call the awkward `connectToRedis` method.

That will allow us to have a cleaner bootstrap:

```ts
async function bootstrap() {
  const app = await NestFactory.create(AppModule);

  app.useWebSocketAdapter(app.get(RedisIoAdapter));

  await app.listen(3000);
}
```

I decided not to go this route because it's more verbose, even though it's a much sturdier implementation. However if you think we should do it, I am happy to make this change.