### PR TITLE
feat(common): add abstract type to catch decorator

### DIFF
--- a/packages/common/decorators/core/catch.decorator.ts
+++ b/packages/common/decorators/core/catch.decorator.ts
@@ -1,5 +1,5 @@
 import { CATCH_WATERMARK, FILTER_CATCH_EXCEPTIONS } from '../../constants';
-import { Type } from '../../interfaces';
+import { Type, Abstract } from '../../interfaces';
 
 /**
  * Decorator that marks a class as a Nest exception filter. An exception filter
@@ -18,7 +18,9 @@ import { Type } from '../../interfaces';
  *
  * @publicApi
  */
-export function Catch(...exceptions: Type<any>[]): ClassDecorator {
+export function Catch(
+  ...exceptions: Array<Type<any> | Abstract<any>>
+): ClassDecorator {
   return (target: object) => {
     Reflect.defineMetadata(CATCH_WATERMARK, true, target);
     Reflect.defineMetadata(FILTER_CATCH_EXCEPTIONS, exceptions, target);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
This PR makes `@Catch` decorator to accept Abstract class with any class.

## What is the new behavior?
In my project, there are custom error classes implemented by inheriting one abstract class.

In order to handle these errors in the Exception Filter, I wanted to put an abstract class, the top class of custom errors, in `@Catch` decorator.
However, since `@Catch` decorator only allows `Type<any>` class, abstract class cannot be added.

The `@Catch` decorator is catching errors internally using the `instanceof` keyword.
Therefore, if nestjs allow the abstract class to be caught, it is natural for custom error classes that inherit the abstract class to be caught.

```ts
// custom errors
abstract class CustomError extends Error {}
class AError extends CustomError {}
class BError extends CustomError {}
class CError extends CustomError {}

// exception filter
@Catch(CustomError)
class CustomErrorExceptionFilter implements ExceptionFilter {
  catch(exception: CustomError, host: ArgumentHost): any {
    if (exception instanceof AError) {
      // handle AError
    } else if (exception instanceof BError) {
      // handle BError
    } else if (exception instanceof CError) {
      // handle CError
    }
  }
}
```

Currently, you can catch all errors that inherit the `abstract class CustomError` by using type assertion with `@Catch(CustomError as any)` without this PR.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information