### PR TITLE
feat(common): extend streamable-file header support

### DIFF
--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -9,7 +9,8 @@ import { join } from 'path';
 import * as request from 'supertest';
 import { AppModule } from '../src/app.module';
 
-const readmeString = readFileSync(join(process.cwd(), 'Readme.md')).toString();
+const readme = readFileSync(join(process.cwd(), 'Readme.md'));
+const readmeString = readme.toString();
 
 describe('Express FileSend', () => {
   let app: NestExpressApplication;
@@ -53,12 +54,18 @@ describe('Express FileSend', () => {
         expect(res.body.toString()).to.be.eq(readmeString);
       });
   });
-  it('should return a file with correct content type and disposition', async () => {
+  it('should return a file with correct headers', async () => {
     return request(app.getHttpServer())
       .get('/file/with/headers')
       .expect(200)
       .expect('Content-Type', 'text/markdown')
       .expect('Content-Disposition', 'attachment; filename="Readme.md"')
+      .expect('Content-Length', readme.byteLength.toString())
+      .expect('Accept-Ranges', 'bytes')
+      .expect(
+        'Content-Range',
+        `bytes 0-${readme.byteLength - 1}/${readme.byteLength}`,
+      )
       .expect(res => {
         expect(res.text).to.be.eq(readmeString);
       });

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -25,11 +25,15 @@ export class AppService {
   }
 
   getFileWithHeaders(): StreamableFile {
+    const file = readFileSync(join(process.cwd(), 'Readme.md'));
     return new StreamableFile(
       createReadStream(join(process.cwd(), 'Readme.md')),
       {
         type: 'text/markdown',
         disposition: 'attachment; filename="Readme.md"',
+        length: file.byteLength,
+        acceptRanges: 'bytes',
+        range: `bytes 0-${file.byteLength - 1}/${file.byteLength}`,
       },
     );
   }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -26,8 +26,19 @@ export class StreamableFile {
   }
 
   getHeaders() {
-    const { type = 'application/octet-stream', disposition = null } =
-      this.options;
-    return { type, disposition };
+    const {
+      type = 'application/octet-stream',
+      disposition = undefined,
+      acceptRanges = undefined,
+      length = undefined,
+      range = undefined,
+    } = this.options;
+    return {
+      type,
+      disposition,
+      acceptRanges,
+      length,
+      range,
+    };
   }
 }

--- a/packages/common/file-stream/streamable-options.interface.ts
+++ b/packages/common/file-stream/streamable-options.interface.ts
@@ -1,4 +1,7 @@
 export interface StreamableFileOptions {
   type?: string;
   disposition?: string;
+  length?: number;
+  range?: string;
+  acceptRanges?: string;
 }

--- a/packages/common/test/file-stream/streamable-file.spec.ts
+++ b/packages/common/test/file-stream/streamable-file.spec.ts
@@ -17,6 +17,38 @@ describe('StreamableFile', () => {
       expect(streamableFile.getStream()).to.equal(stream);
     });
   });
+  describe('when options is empty', () => {
+    it('should return application/octet-stream for type and undefined for others', () => {
+      const stream = new Readable();
+      const streamableFile = new StreamableFile(stream);
+      expect(streamableFile.getHeaders()).to.deep.equal({
+        type: 'application/octet-stream',
+        disposition: undefined,
+        acceptRanges: undefined,
+        length: undefined,
+        range: undefined,
+      });
+    });
+  });
+  describe('when options is defined', () => {
+    it('should pass provided headers', () => {
+      const stream = new Readable();
+      const streamableFile = new StreamableFile(stream, {
+        type: 'application/pdf',
+        acceptRanges: '123',
+        disposition: 'inline',
+        length: 100,
+        range: '456',
+      });
+      expect(streamableFile.getHeaders()).to.deep.equal({
+        type: 'application/pdf',
+        acceptRanges: '123',
+        disposition: 'inline',
+        length: 100,
+        range: '456',
+      });
+    });
+  });
   describe('otherwise', () => {
     describe('when input is a Buffer instance', () => {
       it('should create a readable stream and push the input buffer', () => {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -48,11 +48,35 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     }
     if (body instanceof StreamableFile) {
       const streamHeaders = body.getHeaders();
-      if (response.getHeader('Content-Type') === undefined) {
+      if (
+        response.getHeader('Content-Type') === undefined &&
+        streamHeaders.type
+      ) {
         response.setHeader('Content-Type', streamHeaders.type);
       }
-      if (response.getHeader('Content-Disposition') === undefined) {
+      if (
+        response.getHeader('Content-Disposition') === undefined &&
+        streamHeaders.disposition
+      ) {
         response.setHeader('Content-Disposition', streamHeaders.disposition);
+      }
+      if (
+        response.getHeader('Content-Length') === undefined &&
+        streamHeaders.length
+      ) {
+        response.setHeader('Content-Length', streamHeaders.length);
+      }
+      if (
+        response.getHeader('Content-Range') === undefined &&
+        streamHeaders.range
+      ) {
+        response.setHeader('Content-Range', streamHeaders.range);
+      }
+      if (
+        response.getHeader('Accept-Ranges') === undefined &&
+        streamHeaders.acceptRanges
+      ) {
+        response.setHeader('Accept-Ranges', streamHeaders.acceptRanges);
       }
       return body.getStream().pipe(response);
     }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -282,11 +282,35 @@ export class FastifyAdapter<
     }
     if (body instanceof StreamableFile) {
       const streamHeaders = body.getHeaders();
-      if (fastifyReply.getHeader('Content-Type') === undefined) {
+      if (
+        fastifyReply.getHeader('Content-Type') === undefined &&
+        streamHeaders.type
+      ) {
         fastifyReply.header('Content-Type', streamHeaders.type);
       }
-      if (fastifyReply.getHeader('Content-Disposition') === undefined) {
+      if (
+        fastifyReply.getHeader('Content-Disposition') === undefined &&
+        streamHeaders.disposition
+      ) {
         fastifyReply.header('Content-Disposition', streamHeaders.disposition);
+      }
+      if (
+        fastifyReply.getHeader('Content-Length') === undefined &&
+        streamHeaders.length
+      ) {
+        fastifyReply.header('Content-Length', streamHeaders.length);
+      }
+      if (
+        fastifyReply.getHeader('Content-Range') === undefined &&
+        streamHeaders.range
+      ) {
+        fastifyReply.header('Content-Range', streamHeaders.range);
+      }
+      if (
+        fastifyReply.getHeader('Accept-Ranges') === undefined &&
+        streamHeaders.acceptRanges
+      ) {
+        fastifyReply.header('Accept-Ranges', streamHeaders.acceptRanges);
       }
       body = body.getStream();
     }


### PR DESCRIPTION
Provide option to specify additional headers when using StreamableFile.
No need to access the native response option.

BREAKING CHANGE: not specifying content-disposition header and
StreamableFile option disposition would send header value 'null'
instead of not sending the header at all.
This changes to not sending the header if no value is specified.
This commit closes issue #9229.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information