### PR TITLE
docs(websockets): update GatewayMetadata pingTimeout default value to 20000 ms

### DIFF
--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -36,7 +36,7 @@ export interface GatewayMetadata {
   connectTimeout?: number;
   /**
    * How many ms without a pong packet to consider the connection closed
-   * @default 5000
+   * @default 20000
    */
   pingTimeout?: number;
   /**

--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -31,22 +31,22 @@ export interface GatewayMetadata {
   parser?: any;
   /**
    * How many ms before a client without namespace is closed
-   * @default 45000
+   * @default 45_000
    */
   connectTimeout?: number;
   /**
    * How many ms without a pong packet to consider the connection closed
-   * @default 20000
+   * @default 20_000
    */
   pingTimeout?: number;
   /**
    * How many ms before sending a new ping packet
-   * @default 25000
+   * @default 25_000
    */
   pingInterval?: number;
   /**
    * How many ms before an uncompleted transport upgrade is cancelled
-   * @default 10000
+   * @default 10_000
    */
   upgradeTimeout?: number;
   /**
@@ -116,7 +116,7 @@ export interface GatewayMetadata {
   destroyUpgrade?: boolean;
   /**
    * Milliseconds after which unhandled requests are ended
-   * @default 1000
+   * @default 1_000
    */
   destroyUpgradeTimeout?: number;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the documentation for websockets, the default value for pingTimeout property of GatewayMetadata interface is set to 5000 ms.

Issue Number: N/A


## What is the new behavior?
After setting the DEBUG env variable (i.e. DEBUG=*), the default value for pingTimeout property is actually logged as 20000 ms (and not 5000 ms as mentioned in the docs).

<img width="856" alt="pingtimeout" src="https://user-images.githubusercontent.com/78868247/155027125-db9b2191-0399-475a-a338-e5f07e7ae9f8.png">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information