### PR TITLE
fix(core): use class refs as keys (container)

### DIFF
--- a/integration/injector/e2e/injector.spec.ts
+++ b/integration/injector/e2e/injector.spec.ts
@@ -1,7 +1,10 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
+import { UnknownDependenciesException } from '@nestjs/core/errors/exceptions/unknown-dependencies.exception';
 import { UnknownExportException } from '@nestjs/core/errors/exceptions/unknown-export.exception';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import {
   DYNAMIC_TOKEN,
   DYNAMIC_VALUE,
@@ -9,6 +12,13 @@ import {
 } from '../src/dynamic/dynamic.module';
 import { ExportsModule } from '../src/exports/exports.module';
 import { InjectModule } from '../src/inject/inject.module';
+import { InjectSameNameModule } from '../src/inject/inject-same-name.module';
+import {
+  SelfInjectionProviderModule,
+  SelfInjectionProviderCustomTokenModule,
+  SelfInjectionForwardProviderModule,
+} from '../src/self-injection/self-injection-provider.module';
+chai.use(chaiAsPromised);
 
 describe('Injector', () => {
   describe('when "providers" and "exports" properties are inconsistent', () => {
@@ -24,6 +34,16 @@ describe('Injector', () => {
     });
   });
 
+  describe("When class injects a provider with the same as class's name", () => {
+    it('should compile with success', async () => {
+      const builder = Test.createTestingModule({
+        imports: [InjectSameNameModule],
+      });
+
+      await expect(builder.compile()).to.eventually.be.fulfilled;
+    });
+  });
+
   describe('when Nest cannot resolve dependencies', () => {
     it(`should fail with "RuntimeException"`, async () => {
       try {
@@ -34,6 +54,42 @@ describe('Injector', () => {
       } catch (err) {
         expect(err).to.be.instanceof(RuntimeException);
       }
+    });
+
+    describe('due to self-injection providers', () => {
+      it('should fail with "UnknownDependenciesException" due to self-injection via same class reference', async () => {
+        const builder = Test.createTestingModule({
+          imports: [SelfInjectionProviderModule],
+        });
+
+        await expect(
+          builder.compile(),
+        ).to.eventually.be.rejected.and.be.an.instanceOf(
+          UnknownDependenciesException,
+        );
+      });
+      it('should fail with "UnknownDependenciesException" due to self-injection via forwardRef to the same class reference', async () => {
+        const builder = Test.createTestingModule({
+          imports: [SelfInjectionForwardProviderModule],
+        });
+
+        await expect(
+          builder.compile(),
+        ).to.eventually.be.rejected.and.be.an.instanceOf(
+          UnknownDependenciesException,
+        );
+      });
+      it('should fail with "UnknownDependenciesException" due to self-injection via custom provider', async () => {
+        const builder = Test.createTestingModule({
+          imports: [SelfInjectionProviderCustomTokenModule],
+        });
+
+        await expect(
+          builder.compile(),
+        ).to.eventually.be.rejected.and.be.an.instanceOf(
+          UnknownDependenciesException,
+        );
+      });
     });
   });
 

--- a/integration/injector/src/inject/inject-same-name.module.ts
+++ b/integration/injector/src/inject/inject-same-name.module.ts
@@ -1,0 +1,16 @@
+import { Module, Injectable, Inject } from '@nestjs/common';
+
+@Injectable()
+class CoreService {
+  constructor(@Inject(CoreService.name) private readonly coreService: any) {}
+}
+
+@Module({
+  providers: [
+    {
+      provide: CoreService.name,
+      useValue: 'anything',
+    },
+  ],
+})
+export class InjectSameNameModule {}

--- a/integration/injector/src/self-injection/self-injection-provider.module.ts
+++ b/integration/injector/src/self-injection/self-injection-provider.module.ts
@@ -1,0 +1,40 @@
+import { Module, Injectable, Inject, forwardRef } from '@nestjs/common';
+
+@Injectable()
+class ServiceInjectingItself {
+  constructor(private readonly coreService: ServiceInjectingItself) {}
+}
+
+@Injectable()
+class ServiceInjectingItselfForwared {
+  constructor(
+    @Inject(forwardRef(() => ServiceInjectingItself))
+    private readonly coreService: ServiceInjectingItself,
+  ) {}
+}
+
+@Injectable()
+class ServiceInjectingItselfViaCustomToken {
+  constructor(@Inject('AnotherToken') private readonly coreService: any) {}
+}
+
+@Module({
+  providers: [ServiceInjectingItself],
+})
+export class SelfInjectionProviderModule {}
+
+@Module({
+  providers: [ServiceInjectingItselfForwared],
+})
+export class SelfInjectionForwardProviderModule {}
+
+@Module({
+  providers: [
+    ServiceInjectingItselfViaCustomToken,
+    {
+      provide: 'AnotherToken',
+      useClass: ServiceInjectingItselfViaCustomToken,
+    },
+  ],
+})
+export class SelfInjectionProviderCustomTokenModule {}

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -430,8 +430,9 @@ export class Injector {
     inquirer?: InstanceWrapper,
     keyOrIndex?: string | number,
   ): Promise<InstanceWrapper<T>> {
+    const token = wrapper.token || wrapper.name;
     const { name } = dependencyContext;
-    if (wrapper && wrapper.name === name) {
+    if (wrapper && token === name) {
       throw new UnknownDependenciesException(
         wrapper.name,
         dependencyContext,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #9245 _(bugfix)_

This also closes #8894 _(feature)_ in some sort as of now self-injections will raise the `UnknownDependenciesException` error. This might not be the right error but at least now nestjs won't get stuck nor crashes silently. We could improve that later if needed.


## What is the new behavior?

Now this pattern is allowed:

```ts
class Foo {
  constructor(@Inject('Foo') private foo: string) {}
}

@Module({
  providers: [
    {
      provide: Foo, // This token isn't the same as the one in the provider below
      useClasss: Foo,
    },
    {
      provide: 'Foo',
      useValue: 'bar',
    },
  ],
})
class AppModule {}
```

and it wasn't prior to v8.

To see it in action, play with this repo: https://gitlab.com/micalevisk/nestjs-issue-9245 it has a patch with the change I've made in this PR.

Also, the following self-injections of providers are still not allowed but now the app will crashes with a 'cannot resolve dependency' error, which is better than a silent crash:

```ts
class Foo {
  constructor(private foo: Foo) {}
  // constructor(@Inject('bar') private bar: any) {} // nor this one
}

@Module({
  providers: [
    {
      provide: 'bar',
      useClasss: Foo,
    },
  ],
})
class AppModule {}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No