### PR TITLE
feat(common): do not use colors in CLI if not supported

### DIFF
--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -1,6 +1,7 @@
-type ColorTextFn = (text: string) => string;
+import {WriteStream} from 'tty';
 
-const isColorAllowed = () => !process.env.NO_COLOR;
+type ColorTextFn = (text: string) => string;
+const isColorAllowed = () => !process.env.NO_COLOR || WriteStream.prototype.hasColors();
 const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 

--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -1,8 +1,9 @@
-import {WriteStream} from 'tty';
+import { WriteStream } from 'tty';
 
 type ColorTextFn = (text: string) => string;
 
-const isColorAllowed = () => !process.env.NO_COLOR && WriteStream.prototype.hasColors();
+const isColorAllowed = () =>
+  !process.env.NO_COLOR && WriteStream.prototype.hasColors();
 const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 

--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -1,7 +1,7 @@
 import {WriteStream} from 'tty';
 
 type ColorTextFn = (text: string) => string;
-const isColorAllowed = () => !process.env.NO_COLOR || WriteStream.prototype.hasColors();
+const isColorAllowed = () => !process.env.NO_COLOR && WriteStream.prototype.hasColors();
 const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 

--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -1,6 +1,7 @@
 import {WriteStream} from 'tty';
 
 type ColorTextFn = (text: string) => string;
+
 const isColorAllowed = () => !process.env.NO_COLOR && WriteStream.prototype.hasColors();
 const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`isColorAllowed()` will return `true` even when the terminal can't support colors.

Issue Number: N/A

## What is the new behavior?

Colors will be enabled if the `NO_COLOR` environment variable is not an empty string and `tty.WriteStream.prototype.hasColors()` returns `true`.

Requires Node.js v10.16.0 or newer.

This means that users of the default NestJS logger can avoid having broken ANSI escape codes in their logs without any extra configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

On the off chance someone is logging to a TTY that supports color, but `tty.WriteStream.prototype.hasColors()` says it doesn't, users can use [the built-in `FORCE_COLOR` environment variable](https://nodejs.org/dist/latest-v16.x/docs/api/tty.html#writestreamgetcolordepthenv) to override what is detected.