### PR TITLE
fix(microservices): fix event pattern behavior

### DIFF
--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -166,7 +166,7 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
     const handler = this.getHandlerByPattern(packet.pattern);
     // if the correlation id or reply topic is not set
     // then this is an event (events could still have correlation id)
-    if ((handler && handler.isEventHandler) || !correlationId || !replyTopic) {
+    if (handler?.isEventHandler || !correlationId || !replyTopic) {
       return this.handleEvent(packet.pattern, packet, kafkaContext);
     }
 

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -163,9 +163,10 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
       payload.partition,
       payload.topic,
     ]);
+    const handler = this.getHandlerByPattern(packet.pattern);
     // if the correlation id or reply topic is not set
     // then this is an event (events could still have correlation id)
-    if (!correlationId || !replyTopic) {
+    if ((handler && handler.isEventHandler) || !correlationId || !replyTopic) {
       return this.handleEvent(packet.pattern, packet, kafkaContext);
     }
 
@@ -174,7 +175,7 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
       replyPartition,
       correlationId,
     );
-    const handler = this.getHandlerByPattern(packet.pattern);
+
     if (!handler) {
       return publish({
         id: correlationId,

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -283,10 +283,32 @@ describe('ServerKafka', () => {
       expect(handleEventSpy.called).to.be.true;
     });
 
-    it('should call "handleEvent" if correlation identifier is present by the reply topic is not present', async () => {
+    it('should call "handleEvent" if correlation identifier is present but the reply topic is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
       await server.handleMessage(eventWithCorrelationIdPayload);
       expect(handleEventSpy.called).to.be.true;
+    });
+
+    it('should call "handleEvent" if correlation identifier and reply topic are present but the handler is of type eventHandler', async () => {
+      const handler = sinon.spy();
+      (handler as any).isEventHandler = true;
+      (server as any).messageHandlers = objectToMap({
+        [topic]: handler,
+      });
+      const handleEventSpy = sinon.spy(server, 'handleEvent');
+      await server.handleMessage(payload);
+      expect(handleEventSpy.called).to.be.true;
+    });
+
+    it('should NOT call "handleEvent" if correlation identifier and reply topic are present but the handler is not of type eventHandler', async () => {
+      const handler = sinon.spy();
+      (handler as any).isEventHandler = false;
+      (server as any).messageHandlers = objectToMap({
+        [topic]: handler,
+      });
+      const handleEventSpy = sinon.spy(server, 'handleEvent');
+      await server.handleMessage(payload);
+      expect(handleEventSpy.called).to.be.false;
     });
 
     it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {


### PR DESCRIPTION
When listening to messages from Kafka using EventPattern the message should not be replied to even if it contains correlation id and reply topic.

BREAKING CHANGE: existing methods where EventPattern is used instead of MessagePattern do not send message to a reply topic anymore which might cause bugs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
```ts
  @EventPattern('event.pattern.test')
  async eventPattern(
    @Payload() message: any,
  ): Promise<any> {
    return
  }
```
This method sends a message to the reply topic with empty key and content. 

Issue Number: N/A


## What is the new behavior?
```ts
  @EventPattern('event.pattern.test')
  async eventPattern(
    @Payload() message: any,
  ): Promise<any> {
    return
  }
```
This method no longer sends a message to the reply topic.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information