### PR TITLE
feat(platform): add option to register raw body to request

### DIFF
--- a/integration/nest-application/raw-body/e2e/express.spec.ts
+++ b/integration/nest-application/raw-body/e2e/express.spec.ts
@@ -1,0 +1,36 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { ExpressModule } from '../src/express.module';
+
+describe('Raw body (Express Application)', () => {
+  let app: NestExpressApplication;
+  const body = '{ "amount":0.0 }';
+
+  beforeEach(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [ExpressModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestExpressApplication>(
+      undefined,
+      { rawBody: true },
+    );
+  });
+
+  it('should return exact post body', async () => {
+    await app.init();
+    const response = await request(app.getHttpServer())
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .send(body)
+      .expect(201);
+
+    expect(response.body).to.eql({ raw: '{ "amount":0.0 }' });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/integration/nest-application/raw-body/e2e/express.spec.ts
+++ b/integration/nest-application/raw-body/e2e/express.spec.ts
@@ -27,7 +27,20 @@ describe('Raw body (Express Application)', () => {
       .send(body)
       .expect(201);
 
-    expect(response.body).to.eql({ raw: '{ "amount":0.0 }' });
+    expect(response.body).to.eql({
+      parsed: {
+        amount: 0,
+      },
+      raw: '{ "amount":0.0 }',
+    });
+  });
+
+  it('should work if post body is empty', async () => {
+    await app.init();
+    await request(app.getHttpServer())
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .expect(201);
   });
 
   afterEach(async () => {

--- a/integration/nest-application/raw-body/e2e/fastify.spec.ts
+++ b/integration/nest-application/raw-body/e2e/fastify.spec.ts
@@ -27,7 +27,20 @@ describe('Raw body (Fastify Application)', () => {
       .send(body)
       .expect(201);
 
-    expect(response.body).to.eql({ raw: '{ "amount":0.0 }' });
+    expect(response.body).to.eql({
+      parsed: {
+        amount: 0,
+      },
+      raw: '{ "amount":0.0 }',
+    });
+  });
+
+  it('should work if post body is empty', async () => {
+    await app.init();
+    await request(app.getHttpServer())
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .expect(201);
   });
 
   afterEach(async () => {

--- a/integration/nest-application/raw-body/e2e/fastify.spec.ts
+++ b/integration/nest-application/raw-body/e2e/fastify.spec.ts
@@ -1,0 +1,36 @@
+import { NestFastifyApplication } from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { FastifyModule } from '../src/fastify.module';
+
+describe('Raw body (Fastify Application)', () => {
+  let app: NestFastifyApplication;
+  const body = '{ "amount":0.0 }';
+
+  beforeEach(async () => {
+    const moduleFixture = await Test.createTestingModule({
+      imports: [FastifyModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(null, {
+      rawBody: true,
+    });
+  });
+
+  it('should return exact post body', async () => {
+    await app.init();
+    const response = await request(app.getHttpServer())
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json')
+      .send(body)
+      .expect(201);
+
+    expect(response.body).to.eql({ raw: '{ "amount":0.0 }' });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/integration/nest-application/raw-body/src/express.controller.ts
+++ b/integration/nest-application/raw-body/src/express.controller.ts
@@ -1,10 +1,13 @@
-import { Controller, Post, Req } from '@nestjs/common';
+import { Controller, Post, Req, RawBodyRequest } from '@nestjs/common';
 import { Request } from 'express';
 
 @Controller()
 export class ExpressController {
   @Post()
-  getRawBody(@Req() req: Request) {
-    return { raw: req.rawBody.toString() };
+  getRawBody(@Req() req: RawBodyRequest<Request>) {
+    return {
+      parsed: req.body,
+      raw: req.rawBody.toString(),
+    };
   }
 }

--- a/integration/nest-application/raw-body/src/express.controller.ts
+++ b/integration/nest-application/raw-body/src/express.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Post, Req } from '@nestjs/common';
+import { Request } from 'express';
+
+@Controller()
+export class ExpressController {
+  @Post()
+  getRawBody(@Req() req: Request) {
+    return { raw: req.rawBody.toString() };
+  }
+}

--- a/integration/nest-application/raw-body/src/express.module.ts
+++ b/integration/nest-application/raw-body/src/express.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { ExpressController } from './express.controller';
+
+@Module({
+  controllers: [ExpressController],
+})
+export class ExpressModule {}

--- a/integration/nest-application/raw-body/src/fastify.controller.ts
+++ b/integration/nest-application/raw-body/src/fastify.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Post, Req } from '@nestjs/common';
+import { FastifyRequest } from 'fastify';
+
+@Controller()
+export class FastifyController {
+  @Post()
+  getRawBody(@Req() req: FastifyRequest) {
+    return { raw: req.rawBody.toString() };
+  }
+}

--- a/integration/nest-application/raw-body/src/fastify.controller.ts
+++ b/integration/nest-application/raw-body/src/fastify.controller.ts
@@ -1,10 +1,13 @@
-import { Controller, Post, Req } from '@nestjs/common';
-import { FastifyRequest } from 'fastify';
+import { Controller, Post, Req, RawBodyRequest } from '@nestjs/common';
+import type { FastifyRequest } from 'fastify';
 
 @Controller()
 export class FastifyController {
   @Post()
-  getRawBody(@Req() req: FastifyRequest) {
-    return { raw: req.rawBody.toString() };
+  getRawBody(@Req() req: RawBodyRequest<FastifyRequest>) {
+    return {
+      parsed: req.body,
+      raw: req.rawBody.toString(),
+    };
   }
 }

--- a/integration/nest-application/raw-body/src/fastify.module.ts
+++ b/integration/nest-application/raw-body/src/fastify.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { FastifyController } from './fastify.controller';
+
+@Module({
+  controllers: [FastifyController],
+})
+export class FastifyModule {}

--- a/integration/nest-application/raw-body/tsconfig.json
+++ b/integration/nest-application/raw-body/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/common/http/interfaces/index.ts
+++ b/packages/common/http/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './http-module.interface';
+export * from './raw-body-request.interface';

--- a/packages/common/http/interfaces/raw-body-request.interface.ts
+++ b/packages/common/http/interfaces/raw-body-request.interface.ts
@@ -1,0 +1,1 @@
+export type RawBodyRequest<T> = T & { rawBody?: Buffer };

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -67,8 +67,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   getRequestMethod?(request: TRequest): string;
   getRequestUrl?(request: TRequest): string;
   getInstance(): any;
-  registerParserMiddleware(): any;
-  registerParserMiddleware(options?: NestApplicationOptions): any;
+  registerParserMiddleware(...args: any[]): any;
   enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>): any;
   getHttpServer(): any;
   initHttpServer(options: NestApplicationOptions): void;

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -68,6 +68,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   getRequestUrl?(request: TRequest): string;
   getInstance(): any;
   registerParserMiddleware(): any;
+  registerParserMiddleware(options?: NestApplicationOptions): any;
   enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>): any;
   getHttpServer(): any;
   initHttpServer(options: NestApplicationOptions): void;

--- a/packages/common/interfaces/nest-application-options.interface.ts
+++ b/packages/common/interfaces/nest-application-options.interface.ts
@@ -21,4 +21,8 @@ export interface NestApplicationOptions extends NestApplicationContextOptions {
    * Set of configurable HTTPS options
    */
   httpsOptions?: HttpsOptions;
+  /**
+   * Whether to register the raw request body on the request. Use `req.rawBody`.
+   */
+  rawBody?: boolean;
 }

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -110,8 +110,7 @@ export abstract class AbstractHttpAdapter<
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   abstract setHeader(response, name: string, value: string);
-  abstract registerParserMiddleware(prefix?: string);
-  abstract registerParserMiddleware(options?: NestApplicationOptions);
+  abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
   abstract enableCors(
     options: CorsOptions | CorsOptionsDelegate<TRequest>,
     prefix?: string,

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -111,6 +111,7 @@ export abstract class AbstractHttpAdapter<
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   abstract setHeader(response, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string);
+  abstract registerParserMiddleware(options?: NestApplicationOptions);
   abstract enableCors(
     options: CorsOptions | CorsOptionsDelegate<TRequest>,
     prefix?: string,

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -178,7 +178,7 @@ export class NestApplication
   }
 
   public registerParserMiddleware() {
-    this.httpAdapter.registerParserMiddleware();
+    this.httpAdapter.registerParserMiddleware(this.appOptions);
   }
 
   public async registerRouter() {

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -178,7 +178,9 @@ export class NestApplication
   }
 
   public registerParserMiddleware() {
-    this.httpAdapter.registerParserMiddleware(this.appOptions);
+    const prefix = this.config.getGlobalPrefix();
+    const rawBody = !!this.appOptions?.rawBody;
+    this.httpAdapter.registerParserMiddleware(prefix, rawBody);
   }
 
   public async registerRouter() {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -183,7 +183,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
-    let bodyParserJsonOptions: OptionsJson;
+    let bodyParserJsonOptions: OptionsJson | undefined;
     if (rawBody === true) {
       bodyParserJsonOptions = {
         verify: (req, _res, buffer) => {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -1,5 +1,6 @@
 import {
   InternalServerErrorException,
+  RawBodyRequest,
   RequestMethod,
   StreamableFile,
   VersioningType,
@@ -32,12 +33,6 @@ import * as express from 'express';
 import * as http from 'http';
 import * as https from 'https';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
-
-declare module 'express' {
-  export interface Request {
-    rawBody?: Buffer;
-  }
-}
 
 export class ExpressAdapter extends AbstractHttpAdapter {
   private readonly routerMethodFactory = new RouterMethodFactory();
@@ -186,9 +181,9 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     let bodyParserJsonOptions: OptionsJson | undefined;
     if (rawBody === true) {
       bodyParserJsonOptions = {
-        verify: (req, _res, buffer) => {
+        verify: (req: RawBodyRequest<http.IncomingMessage>, _res, buffer) => {
           if (Buffer.isBuffer(buffer)) {
-            req['rawBody'] = buffer;
+            req.rawBody = buffer;
           }
 
           return true;

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -182,13 +182,9 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     this.httpServer = http.createServer(this.getInstance());
   }
 
-  public registerParserMiddleware(prefix?: string);
-  public registerParserMiddleware(options?: NestApplicationOptions);
-  public registerParserMiddleware(
-    prefixOrOptions?: string | NestApplicationOptions,
-  ) {
+  public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
     let bodyParserJsonOptions: OptionsJson;
-    if (isObject(prefixOrOptions) && prefixOrOptions.rawBody) {
+    if (rawBody === true) {
       bodyParserJsonOptions = {
         verify: (req, _res, buffer) => {
           if (Buffer.isBuffer(buffer)) {

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -439,17 +439,13 @@ export class FastifyAdapter<
     this.register(import('fastify-cors'), options);
   }
 
-  public registerParserMiddleware(prefix?: string);
-  public registerParserMiddleware(options?: NestApplicationOptions);
-  public registerParserMiddleware(
-    prefixOrOptions?: string | NestApplicationOptions,
-  ) {
+  public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
     if (this._isParserRegistered) {
       return;
     }
     this.register(import('fastify-formbody'));
 
-    if (isObject(prefixOrOptions) && prefixOrOptions.rawBody) {
+    if (rawBody === true) {
       this.getInstance().addContentTypeParser<string>(
         'application/json',
         { parseAs: 'string' },

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -435,7 +435,7 @@ export class FastifyAdapter<
     }
     this.register(import('fastify-formbody'));
 
-    if (rawBody === true) {
+    if (rawBody) {
       this.registerContentParserWithRawBody();
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Optionally provide the raw request body in the `Request` object of `express`. Relevant usecase: webhooks.

Many webhook solutions use HMAC signing of the `POST` body. But having the `bodyParser` enabled for NestJS makes this a no-go. The current workaround: disable `bodyParser` in its entirety, and add a middleware to your application that turns it back on, except for the route(s) you want it disabled for.

I think this is a non-NestJS way of doing it. Hence this PR.

Issue Number: N/A


## What is the new behavior?

This PR introduces a `rawBody` option when creating your NestJS application. When enabled, it adds the raw body to `req.rawBody`.

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Relevant messaging with @jmcdo29 in Discord: https://discord.com/channels/520622812742811698/819061892861526016/953687647216369724