### PR TITLE
feat(microservices): allow to set custom transport to decorators

### DIFF
--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -1,4 +1,9 @@
-import { isObject, isNumber, isNil } from '@nestjs/common/utils/shared.utils';
+import {
+  isObject,
+  isNumber,
+  isNil,
+  isSymbol,
+} from '@nestjs/common/utils/shared.utils';
 import {
   PATTERN_HANDLER_METADATA,
   PATTERN_METADATA,
@@ -13,26 +18,29 @@ import { Transport } from '../enums';
  */
 export const EventPattern: {
   <T = string>(metadata?: T): MethodDecorator;
-  <T = string>(metadata?: T, transport?: Transport): MethodDecorator;
+  <T = string>(metadata?: T, transport?: Transport | symbol): MethodDecorator;
   <T = string>(metadata?: T, extras?: Record<string, any>): MethodDecorator;
   <T = string>(
     metadata?: T,
-    transport?: Transport,
+    transport?: Transport | symbol,
     extras?: Record<string, any>,
   ): MethodDecorator;
 } = <T = string>(
   metadata?: T,
-  transportOrExtras?: Transport | Record<string, any>,
+  transportOrExtras?: Transport | symbol | Record<string, any>,
   maybeExtras?: Record<string, any>,
 ): MethodDecorator => {
-  let transport: Transport;
+  let transport: Transport | symbol;
   let extras: Record<string, any>;
-  if (isNumber(transportOrExtras) && isNil(maybeExtras)) {
+  if (
+    (isNumber(transportOrExtras) || isSymbol(transportOrExtras)) &&
+    isNil(maybeExtras)
+  ) {
     transport = transportOrExtras;
   } else if (isObject(transportOrExtras) && isNil(maybeExtras)) {
     extras = transportOrExtras;
   } else {
-    transport = transportOrExtras as Transport;
+    transport = transportOrExtras as Transport | symbol;
     extras = maybeExtras;
   }
   return (

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -1,4 +1,9 @@
-import { isObject, isNumber, isNil } from '@nestjs/common/utils/shared.utils';
+import {
+  isObject,
+  isNumber,
+  isNil,
+  isSymbol,
+} from '@nestjs/common/utils/shared.utils';
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import {
   PATTERN_HANDLER_METADATA,
@@ -23,7 +28,7 @@ export const MessagePattern: {
   <T = PatternMetadata | string>(metadata?: T): MethodDecorator;
   <T = PatternMetadata | string>(
     metadata?: T,
-    transport?: Transport,
+    transport?: Transport | symbol,
   ): MethodDecorator;
   <T = PatternMetadata | string>(
     metadata?: T,
@@ -31,22 +36,25 @@ export const MessagePattern: {
   ): MethodDecorator;
   <T = PatternMetadata | string>(
     metadata?: T,
-    transport?: Transport,
+    transport?: Transport | symbol,
     extras?: Record<string, any>,
   ): MethodDecorator;
 } = <T = PatternMetadata | string>(
   metadata?: T,
-  transportOrExtras?: Transport | Record<string, any>,
+  transportOrExtras?: Transport | symbol | Record<string, any>,
   maybeExtras?: Record<string, any>,
 ): MethodDecorator => {
-  let transport: Transport;
+  let transport: Transport | symbol;
   let extras: Record<string, any>;
-  if (isNumber(transportOrExtras) && isNil(maybeExtras)) {
+  if (
+    (isNumber(transportOrExtras) || isSymbol(transportOrExtras)) &&
+    isNil(maybeExtras)
+  ) {
     transport = transportOrExtras;
   } else if (isObject(transportOrExtras) && isNil(maybeExtras)) {
     extras = transportOrExtras;
   } else {
-    transport = transportOrExtras as Transport;
+    transport = transportOrExtras as Transport | symbol;
     extras = maybeExtras;
   }
   return (

--- a/packages/microservices/interfaces/custom-transport-strategy.interface.ts
+++ b/packages/microservices/interfaces/custom-transport-strategy.interface.ts
@@ -1,7 +1,7 @@
 import { Transport } from '../enums';
 
 export interface CustomTransportStrategy {
-  readonly transportId?: Transport;
+  readonly transportId?: Transport | symbol;
   listen(callback: (...optionalParams: unknown[]) => any): any;
   close(): any;
 }

--- a/packages/microservices/test/listeners-controller.spec.ts
+++ b/packages/microservices/test/listeners-controller.spec.ts
@@ -21,8 +21,11 @@ describe('ListenersController', () => {
     metadataExplorer: ListenerMetadataExplorer,
     server: any,
     serverTCP: any,
+    serverCustom: any,
+    customTransport: Symbol,
     addSpy: sinon.SinonSpy,
     addSpyTCP: sinon.SinonSpy,
+    addSpyCustom: sinon.SinonSpy,
     proxySpy: sinon.SinonSpy,
     container: NestContainer,
     injector: Injector,
@@ -60,6 +63,12 @@ describe('ListenersController', () => {
     serverTCP = {
       addHandler: addSpyTCP,
       transportId: Transport.TCP,
+    };
+    addSpyCustom = sinon.spy();
+    customTransport = Symbol();
+    serverCustom = {
+      addHandler: addSpyCustom,
+      transportId: customTransport,
     };
   });
 
@@ -117,6 +126,20 @@ describe('ListenersController', () => {
       explorer.expects('explore').returns(handlers);
       instance.registerPatternHandlers(new InstanceWrapper(), serverTCP, '');
       expect(addSpyTCP.calledTwice).to.be.true;
+    });
+    it(`should call "addHandler" method of server with custom transportID for pattern handler with the same custom token`, () => {
+      const serverHandlers = [
+        {
+          pattern: { cmd: 'test' },
+          targetCallback: 'tt',
+          transport: customTransport,
+        },
+        { pattern: 'test2', targetCallback: '2', transport: Transport.KAFKA },
+      ];
+
+      explorer.expects('explore').returns(serverHandlers);
+      instance.registerPatternHandlers(new InstanceWrapper(), serverCustom, '');
+      expect(addSpyCustom.calledOnce).to.be.true;
     });
     it(`should call "addHandler" method of server with extras data`, () => {
       const serverHandlers = [


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:https://github.com/nestjs/nest/issues/9341


## What is the new behavior?
A self-defined Symbol from a custom transpoter can be set for EventPattern & MessagePattern decorator to avoid binding patterns to wrong microservices in multiple microservices circumstances.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information