### PR TITLE
feat(common)!: disallow usage of `inject` on class and value providers at type level

### DIFF
--- a/packages/common/interfaces/modules/provider.interface.ts
+++ b/packages/common/interfaces/modules/provider.interface.ts
@@ -46,6 +46,12 @@ export interface ClassProvider<T = any> {
    * Optional enum defining lifetime of the provider that is injected.
    */
   scope?: Scope;
+  /**
+   * This option is only available on factory providers!
+   *
+   * @see [Use factory](https://docs.nestjs.com/fundamentals/custom-providers#factory-providers-usefactory)
+   */
+  inject?: never;
 }
 
 /**
@@ -72,6 +78,12 @@ export interface ValueProvider<T = any> {
    * Instance of a provider to be injected.
    */
   useValue: T;
+  /**
+   * This option is only available on factory providers!
+   *
+   * @see [Use factory](https://docs.nestjs.com/fundamentals/custom-providers#factory-providers-usefactory)
+   */
+  inject?: never;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #9357

## What is the new behavior?

At build time, we can no longer have the option `inject` when writing a class or value providers

![image](https://user-images.githubusercontent.com/13461315/160138748-50923614-4980-419d-ac2a-6c760299926f.png)


The TS error would be like this:

```
Type '{ provide: string; useValue: number; inject: never[]; }' is not assignable to type 'Provider<any>'.
  Object literal may only specify known properties, and 'useValue' does not exist in type 'FactoryProvider<any>'.
```

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

This will break the build step of projects that are using the `inject` value when defining a class or a value provider even tho this option does nothing on these providers.