### PR TITLE
feat(common): set default StreamableFile length automatically when possible

### DIFF
--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -16,6 +16,7 @@ export class StreamableFile {
       this.stream = new Readable();
       this.stream.push(bufferOrReadStream);
       this.stream.push(null);
+      this.options.length ??= bufferOrReadStream.length;
     } else if (bufferOrReadStream.pipe && isFunction(bufferOrReadStream.pipe)) {
       this.stream = bufferOrReadStream;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Users must always explicitly provide `options.length` when constructing a `StreamableFile`.

## What is the new behavior?

When a `Uint8Array` is provided to the constructor of `StreamableFile`, `options.length` will be `??=` to the `Uint8Array`'s length.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information