### PR TITLE
feat(common): change `private` modifer on built-in pipes to `protected`

### DIFF
--- a/packages/common/pipes/default-value.pipe.ts
+++ b/packages/common/pipes/default-value.pipe.ts
@@ -16,7 +16,7 @@ import { isNil, isNumber } from '../utils/shared.utils';
 export class DefaultValuePipe<T = any, R = any>
   implements PipeTransform<T, T | R>
 {
-  constructor(private readonly defaultValue: R) {}
+  constructor(protected readonly defaultValue: R) {}
 
   transform(value?: T, _metadata?: ArgumentMetadata): T | R {
     if (

--- a/packages/common/pipes/parse-array.pipe.ts
+++ b/packages/common/pipes/parse-array.pipe.ts
@@ -36,7 +36,7 @@ export class ParseArrayPipe implements PipeTransform {
   protected readonly validationPipe: ValidationPipe;
   protected exceptionFactory: (error: string) => any;
 
-  constructor(@Optional() private readonly options: ParseArrayOptions = {}) {
+  constructor(@Optional() protected readonly options: ParseArrayOptions = {}) {
     this.validationPipe = new ValidationPipe({
       transform: true,
       validateCustomDecorators: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Due to TSC error, we cannot extend the built-in pipe `ParseArrayPipe` nor the `DefaultValuePipe` one if we want to add more options to them because their `constructor` has a `private` member

![image](https://user-images.githubusercontent.com/13461315/161886053-221ad6a8-db99-4691-8364-5d5b986fd05f.png)

I don't know if the usage of `private` was intentional tho.

## What is the new behavior?

Now we can write a custom pipe that inherit from `ParseArrayPipe` like so:

```ts
interface MyParseArrayOptions extends ParseArrayOptions {
  minItems?: number;
}

@Injectable()
class MyParseArrayPipe extends ParseArrayPipe {
  constructor(@Optional() protected readonly options: MyParseArrayOptions = {}) {
    super(options)
  }
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
