### PR TITLE
refactor(platform-express,platform-fastify): disable implicit override

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -39,7 +39,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     super(instance || express());
   }
 
-  public reply(response: any, body: any, statusCode?: number) {
+  public override reply(response: any, body: any, statusCode?: number) {
     if (statusCode) {
       response.status(statusCode);
     }
@@ -71,37 +71,41 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return isObject(body) ? response.json(body) : response.send(String(body));
   }
 
-  public status(response: any, statusCode: number) {
+  public override status(response: any, statusCode: number) {
     return response.status(statusCode);
   }
 
-  public render(response: any, view: string, options: any) {
+  public override render(response: any, view: string, options: any) {
     return response.render(view, options);
   }
 
-  public redirect(response: any, statusCode: number, url: string) {
+  public override redirect(response: any, statusCode: number, url: string) {
     return response.redirect(statusCode, url);
   }
 
-  public setErrorHandler(handler: Function, prefix?: string) {
+  public override setErrorHandler(handler: Function, prefix?: string) {
     return this.use(handler);
   }
 
-  public setNotFoundHandler(handler: Function, prefix?: string) {
+  public override setNotFoundHandler(handler: Function, prefix?: string) {
     return this.use(handler);
   }
 
-  public setHeader(response: any, name: string, value: string) {
+  public override setHeader(response: any, name: string, value: string) {
     return response.set(name, value);
   }
 
-  public listen(port: string | number, callback?: () => void);
-  public listen(port: string | number, hostname: string, callback?: () => void);
-  public listen(port: any, ...args: any[]) {
+  public override listen(port: string | number, callback?: () => void);
+  public override listen(
+    port: string | number,
+    hostname: string,
+    callback?: () => void,
+  );
+  public override listen(port: any, ...args: any[]) {
     return this.httpServer.listen(port, ...args);
   }
 
-  public close() {
+  public override close() {
     if (!this.httpServer) {
       return undefined;
     }
@@ -124,7 +128,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return this.instance.engine(...args);
   }
 
-  public useStaticAssets(path: string, options: ServeStaticOptions) {
+  public override useStaticAssets(path: string, options: ServeStaticOptions) {
     if (options && options.prefix) {
       return this.use(options.prefix, express.static(path, options));
     }
@@ -135,27 +139,27 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return this.set('views', path);
   }
 
-  public setViewEngine(engine: string) {
+  public override setViewEngine(engine: string) {
     return this.set('view engine', engine);
   }
 
-  public getRequestHostname(request: any): string {
+  public override getRequestHostname(request: any): string {
     return request.hostname;
   }
 
-  public getRequestMethod(request: any): string {
+  public override getRequestMethod(request: any): string {
     return request.method;
   }
 
-  public getRequestUrl(request: any): string {
+  public override getRequestUrl(request: any): string {
     return request.originalUrl;
   }
 
-  public enableCors(options: CorsOptions | CorsOptionsDelegate<any>) {
+  public override enableCors(options: CorsOptions | CorsOptionsDelegate<any>) {
     return this.use(cors(options));
   }
 
-  public createMiddlewareFactory(
+  public override createMiddlewareFactory(
     requestMethod: RequestMethod,
   ): (path: string, callback: Function) => any {
     return this.routerMethodFactory
@@ -163,7 +167,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       .bind(this.instance);
   }
 
-  public initHttpServer(options: NestApplicationOptions) {
+  public override initHttpServer(options: NestApplicationOptions) {
     const isHttpsEnabled = options && options.httpsOptions;
     if (isHttpsEnabled) {
       this.httpServer = https.createServer(
@@ -175,7 +179,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     this.httpServer = http.createServer(this.getInstance());
   }
 
-  public registerParserMiddleware() {
+  public override registerParserMiddleware() {
     const parserMiddleware = {
       jsonParser: bodyParserJson(),
       urlencodedParser: bodyParserUrlencoded({ extended: true }),
@@ -190,7 +194,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     return this;
   }
 
-  public getType(): string {
+  public override getType(): string {
     return 'express';
   }
 

--- a/packages/platform-express/tsconfig.json
+++ b/packages/platform-express/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./../tsconfig.base.json",
   "compilerOptions": {
+    "noImplicitOverride": true,
     "baseUrl": "./"
   },
   "include": ["*.ts", "**/*.ts"]

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -100,7 +100,7 @@ export class FastifyAdapter<
     TRawResponse
   > = FastifyInstance<TServer, TRawRequest, TRawResponse>,
 > extends AbstractHttpAdapter<TServer, TRequest, TReply> {
-  protected readonly instance: TInstance;
+  protected override readonly instance: TInstance;
 
   private _isParserRegistered: boolean;
   private isMiddieRegistered: boolean;
@@ -206,48 +206,51 @@ export class FastifyAdapter<
     this.setInstance(instance);
   }
 
-  public async init() {
+  public override async init() {
     if (this.isMiddieRegistered) {
       return;
     }
     await this.registerMiddie();
   }
 
-  public listen(port: string | number, callback?: () => void): void;
-  public listen(
+  public override listen(port: string | number, callback?: () => void): void;
+  public override listen(
     port: string | number,
     hostname: string,
     callback?: () => void,
   ): void;
-  public listen(port: string | number, ...args: any[]): Promise<string> {
+  public override listen(
+    port: string | number,
+    ...args: any[]
+  ): Promise<string> {
     return this.instance.listen(port, ...args);
   }
 
-  public get(...args: any[]) {
+  public override get(...args: any[]) {
     return this.injectConstraintsIfVersioned('get', ...args);
   }
 
-  public post(...args: any[]) {
+  public override post(...args: any[]) {
     return this.injectConstraintsIfVersioned('post', ...args);
   }
 
-  public head(...args: any[]) {
+  public override head(...args: any[]) {
     return this.injectConstraintsIfVersioned('head', ...args);
   }
 
-  public delete(...args: any[]) {
+  public override delete(...args: any[]) {
     return this.injectConstraintsIfVersioned('delete', ...args);
   }
 
-  public put(...args: any[]) {
+  public override put(...args: any[]) {
     return this.injectConstraintsIfVersioned('put', ...args);
   }
 
-  public patch(...args: any[]) {
+  public override patch(...args: any[]) {
     return this.injectConstraintsIfVersioned('patch', ...args);
   }
 
-  public options(...args: any[]) {
+  public override options(...args: any[]) {
     return this.injectConstraintsIfVersioned('options', ...args);
   }
 
@@ -264,7 +267,7 @@ export class FastifyAdapter<
     return versionedRoute;
   }
 
-  public reply(
+  public override reply(
     response: TRawResponse | TReply,
     body: any,
     statusCode?: number,
@@ -313,7 +316,7 @@ export class FastifyAdapter<
     return fastifyReply.send(body);
   }
 
-  public status(response: TRawResponse | TReply, statusCode: number) {
+  public override status(response: TRawResponse | TReply, statusCode: number) {
     if (this.isNativeResponse(response)) {
       response.statusCode = statusCode;
       return response;
@@ -321,7 +324,7 @@ export class FastifyAdapter<
     return (response as TReply).code(statusCode);
   }
 
-  public render(
+  public override render(
     response: TReply & { view: Function },
     view: string,
     options: any,
@@ -329,24 +332,26 @@ export class FastifyAdapter<
     return response && response.view(view, options);
   }
 
-  public redirect(response: TReply, statusCode: number, url: string) {
+  public override redirect(response: TReply, statusCode: number, url: string) {
     const code = statusCode ?? HttpStatus.FOUND;
     return response.status(code).redirect(url);
   }
 
-  public setErrorHandler(handler: Parameters<TInstance['setErrorHandler']>[0]) {
+  public override setErrorHandler(
+    handler: Parameters<TInstance['setErrorHandler']>[0],
+  ) {
     return this.instance.setErrorHandler(handler);
   }
 
-  public setNotFoundHandler(handler: Function) {
+  public override setNotFoundHandler(handler: Function) {
     return this.instance.setNotFoundHandler(handler as any);
   }
 
-  public getHttpServer<T = TServer>(): T {
+  public override getHttpServer<T = TServer>(): T {
     return this.instance.server as unknown as T;
   }
 
-  public getInstance<T = TInstance>(): T {
+  public override getInstance<T = TInstance>(): T {
     return this.instance as unknown as T;
   }
 
@@ -365,7 +370,7 @@ export class FastifyAdapter<
     return this.instance.inject(opts);
   }
 
-  public async close() {
+  public override async close() {
     try {
       return await this.instance.close();
     } catch (err) {
@@ -377,11 +382,11 @@ export class FastifyAdapter<
     }
   }
 
-  public initHttpServer() {
+  public override initHttpServer() {
     this.httpServer = this.instance.server;
   }
 
-  public useStaticAssets(options: FastifyStaticOptions) {
+  public override useStaticAssets(options: FastifyStaticOptions) {
     return this.register(
       loadPackage('fastify-static', 'FastifyAdapter.useStaticAssets()', () =>
         require('fastify-static'),
@@ -390,7 +395,7 @@ export class FastifyAdapter<
     );
   }
 
-  public setViewEngine(options: PointOfViewOptions | string) {
+  public override setViewEngine(options: PointOfViewOptions | string) {
     if (isString(options)) {
       new Logger('FastifyAdapter').error(
         "setViewEngine() doesn't support a string argument.",
@@ -405,29 +410,31 @@ export class FastifyAdapter<
     );
   }
 
-  public setHeader(response: TReply, name: string, value: string) {
+  public override setHeader(response: TReply, name: string, value: string) {
     return response.header(name, value);
   }
 
-  public getRequestHostname(request: TRequest): string {
+  public override getRequestHostname(request: TRequest): string {
     return request.hostname;
   }
 
-  public getRequestMethod(request: TRequest): string {
+  public override getRequestMethod(request: TRequest): string {
     return request.raw ? request.raw.method : request.method;
   }
 
-  public getRequestUrl(request: TRequest): string;
-  public getRequestUrl(request: TRawRequest): string;
-  public getRequestUrl(request: TRequest & TRawRequest): string {
+  public override getRequestUrl(request: TRequest): string;
+  public override getRequestUrl(request: TRawRequest): string;
+  public override getRequestUrl(request: TRequest & TRawRequest): string {
     return this.getRequestOriginalUrl(request.raw || request);
   }
 
-  public enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>) {
+  public override enableCors(
+    options: CorsOptions | CorsOptionsDelegate<TRequest>,
+  ) {
     this.register(import('fastify-cors'), options);
   }
 
-  public registerParserMiddleware() {
+  public override registerParserMiddleware() {
     if (this._isParserRegistered) {
       return;
     }
@@ -435,7 +442,7 @@ export class FastifyAdapter<
     this._isParserRegistered = true;
   }
 
-  public async createMiddlewareFactory(
+  public override async createMiddlewareFactory(
     requestMethod: RequestMethod,
   ): Promise<(path: string, callback: Function) => any> {
     if (!this.isMiddieRegistered) {
@@ -458,7 +465,7 @@ export class FastifyAdapter<
     };
   }
 
-  public getType(): string {
+  public override getType(): string {
     return 'fastify';
   }
 

--- a/packages/platform-fastify/tsconfig.json
+++ b/packages/platform-fastify/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "./../tsconfig.base.json",
   "compilerOptions": {
+    "noImplicitOverride": true,
     "baseUrl": "./"
   },
   "include": ["*.ts", "**/*.ts"]


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Pretty much what is described in [TS docs on `--noImplicitOverride`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-3.html#override-and-the---noimplicitoverride-flag)

![image](https://user-images.githubusercontent.com/13461315/162446323-b4db6bf6-0109-4c21-93c7-e306aa16580e.png)

## What is the new behavior?

Make refactorings less error-prone

![image](https://user-images.githubusercontent.com/13461315/162446488-8d57579a-04c1-47d3-b289-c1f5ebafcc1d.png)

Also, having methods with `override` make it easier to find which ones are specific for each adapter.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Tell me if I add `noImplicitOverride` to `packages/tsconfig.base.json`? Then I'll need to touch several other files

---

btw does the method `applyVersionFilter` should be add as an abstract method on `AbstractHttpAdapter` class?  
I didn't made this change because I believe it will introduces breaking changes for those how are implementing `AbstractHttpAdapter` but I'm unsure.

```bash
$ grep -P 'public (?!override)' express-adapter.ts fastify-adapter.ts
express-adapter.ts:  public set(...args: any[]) {
express-adapter.ts:  public enable(...args: any[]) {
express-adapter.ts:  public disable(...args: any[]) {
express-adapter.ts:  public engine(...args: any[]) {
express-adapter.ts:  public setBaseViewsDir(path: string | string[]) {
express-adapter.ts:  public setLocal(key: string, value: any) {
express-adapter.ts:  public applyVersionFilter(
fastify-adapter.ts:  public applyVersionFilter(
fastify-adapter.ts:  public register<TRegister extends Parameters<TInstance['register']>>(
fastify-adapter.ts:  public inject(): LightMyRequestChain;
fastify-adapter.ts:  public inject(opts: InjectOptions | string): Promise<LightMyRequestResponse>;
fastify-adapter.ts:  public inject(
```