### PR TITLE
feat(microservices): Introduce producerOnlyMode to ClientKafka

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -137,7 +137,9 @@ export class ClientKafka extends ClientProxy {
   }
 
   public async bindTopics(): Promise<void> {
-    if (!this.consumer) throw Error('No consumer initialized');
+    if (!this.consumer) {
+       throw Error('No consumer initialized');
+    }
 
     const consumerSubscribeOptions = this.options.subscribe || {};
     const subscribeTo = async (responsePattern: string) =>

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -52,6 +52,7 @@ export class ClientKafka extends ClientProxy {
   protected brokers: string[] | BrokersFunction;
   protected clientId: string;
   protected groupId: string;
+  protected producerOnlyMode: boolean;
 
   constructor(protected readonly options: KafkaOptions['options']) {
     super();
@@ -62,6 +63,8 @@ export class ClientKafka extends ClientProxy {
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
       this.getOptionsProp(this.options, 'postfixId') || '-client';
+    this.producerOnlyMode =
+      this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 
     this.brokers = clientOptions.brokers || [KAFKA_DEFAULT_BROKER];
 
@@ -100,36 +103,42 @@ export class ClientKafka extends ClientProxy {
     }
     this.client = this.createClient();
 
-    const partitionAssigners = [
-      (config: ConstructorParameters<typeof KafkaReplyPartitionAssigner>[1]) =>
-        new KafkaReplyPartitionAssigner(this, config),
-    ] as any[];
+    if (!this.producerOnlyMode) {
+      const partitionAssigners = [
+        (
+          config: ConstructorParameters<typeof KafkaReplyPartitionAssigner>[1],
+        ) => new KafkaReplyPartitionAssigner(this, config),
+      ] as any[];
 
-    const consumerOptions = Object.assign(
-      {
-        partitionAssigners,
-      },
-      this.options.consumer || {},
-      {
-        groupId: this.groupId,
-      },
-    );
+      const consumerOptions = Object.assign(
+        {
+          partitionAssigners,
+        },
+        this.options.consumer || {},
+        {
+          groupId: this.groupId,
+        },
+      );
+
+      this.consumer = this.client.consumer(consumerOptions);
+      // set member assignments on join and rebalance
+      this.consumer.on(
+        this.consumer.events.GROUP_JOIN,
+        this.setConsumerAssignments.bind(this),
+      );
+      await this.consumer.connect();
+      await this.bindTopics();
+    }
+
     this.producer = this.client.producer(this.options.producer || {});
-    this.consumer = this.client.consumer(consumerOptions);
-
-    // set member assignments on join and rebalance
-    this.consumer.on(
-      this.consumer.events.GROUP_JOIN,
-      this.setConsumerAssignments.bind(this),
-    );
-
     await this.producer.connect();
-    await this.consumer.connect();
-    await this.bindTopics();
+
     return this.producer;
   }
 
   public async bindTopics(): Promise<void> {
+    if (!this.consumer) throw Error('No consumer initialized');
+
     const consumerSubscribeOptions = this.options.subscribe || {};
     const subscribeTo = async (responsePattern: string) =>
       this.consumer.subscribe({

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -204,5 +204,6 @@ export interface KafkaOptions {
     serializer?: Serializer;
     deserializer?: Deserializer;
     parser?: KafkaParserConfig;
+    producerOnlyMode?: boolean;
   };
 }

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -277,47 +277,95 @@ describe('ClientKafka', () => {
     let bindTopicsStub: sinon.SinonStub;
     // let handleErrorsSpy: sinon.SinonSpy;
 
-    beforeEach(() => {
-      consumerAssignmentsStub = sinon.stub(
-        client as any,
-        'consumerAssignments',
-      );
-      bindTopicsStub = sinon
-        .stub(client, 'bindTopics')
-        .callsFake(async () => {});
+    describe('consumer and producer', () => {
+      beforeEach(() => {
+        consumerAssignmentsStub = sinon.stub(
+          client as any,
+          'consumerAssignments',
+        );
+        bindTopicsStub = sinon
+          .stub(client, 'bindTopics')
+          .callsFake(async () => {});
+      });
+
+      it('should expect the connection to be created', async () => {
+        const connection = await client.connect();
+
+        expect(createClientStub.calledOnce).to.be.true;
+        expect(producerStub.calledOnce).to.be.true;
+
+        expect(consumerStub.calledOnce).to.be.true;
+
+        expect(on.calledOnce).to.be.true;
+        expect(client['consumerAssignments']).to.be.empty;
+
+        expect(connect.calledTwice).to.be.true;
+
+        expect(bindTopicsStub.calledOnce).to.be.true;
+        expect(connection).to.deep.equal(producerStub());
+      });
+
+      it('should expect the connection to be reused', async () => {
+        (client as any).client = kafkaClient;
+        await client.connect();
+
+        expect(createClientStub.calledOnce).to.be.false;
+        expect(producerStub.calledOnce).to.be.false;
+        expect(consumerStub.calledOnce).to.be.false;
+
+        expect(on.calledOnce).to.be.false;
+        expect(client['consumerAssignments']).to.be.empty;
+
+        expect(connect.calledTwice).to.be.false;
+
+        expect(bindTopicsStub.calledOnce).to.be.false;
+      });
     });
 
-    it('should expect the connection to be created', async () => {
-      const connection = await client.connect();
+    describe('producer only mode', () => {
+      beforeEach(() => {
+        consumerAssignmentsStub = sinon.stub(
+          client as any,
+          'consumerAssignments',
+        );
+        bindTopicsStub = sinon
+          .stub(client, 'bindTopics')
+          .callsFake(async () => {});
+        client['producerOnlyMode'] = true;
+      });
 
-      expect(createClientStub.calledOnce).to.be.true;
-      expect(producerStub.calledOnce).to.be.true;
+      it('should expect the connection to be created', async () => {
+        const connection = await client.connect();
 
-      expect(consumerStub.calledOnce).to.be.true;
+        expect(createClientStub.calledOnce).to.be.true;
+        expect(producerStub.calledOnce).to.be.true;
 
-      expect(on.calledOnce).to.be.true;
-      expect(client['consumerAssignments']).to.be.empty;
+        expect(consumerStub.calledOnce).to.be.false;
 
-      expect(connect.calledTwice).to.be.true;
+        expect(on.calledOnce).to.be.false;
+        expect(client['consumerAssignments']).to.be.empty;
 
-      expect(bindTopicsStub.calledOnce).to.be.true;
-      expect(connection).to.deep.equal(producerStub());
-    });
+        expect(connect.calledOnce).to.be.true;
 
-    it('should expect the connection to be reused', async () => {
-      (client as any).client = kafkaClient;
-      await client.connect();
+        expect(bindTopicsStub.calledOnce).to.be.false;
+        expect(connection).to.deep.equal(producerStub());
+      });
 
-      expect(createClientStub.calledOnce).to.be.false;
-      expect(producerStub.calledOnce).to.be.false;
-      expect(consumerStub.calledOnce).to.be.false;
+      it('should expect the connection to be reused', async () => {
+        (client as any).client = kafkaClient;
+        await client.connect();
 
-      expect(on.calledOnce).to.be.false;
-      expect(client['consumerAssignments']).to.be.empty;
+        expect(createClientStub.calledOnce).to.be.false;
+        expect(producerStub.calledOnce).to.be.false;
+        expect(consumerStub.calledOnce).to.be.false;
 
-      expect(connect.calledTwice).to.be.false;
+        expect(on.calledOnce).to.be.false;
+        expect(client['consumerAssignments']).to.be.empty;
 
-      expect(bindTopicsStub.calledOnce).to.be.false;
+        expect(connect.calledTwice).to.be.false;
+
+        expect(bindTopicsStub.calledOnce).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
This feature flag enables users to skip the consumer group creation and
rebalancing and allows to only act as a producer on Kafka.

Resolves: #7259

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

PR for nestjs-docs: https://github.com/nestjs/docs.nestjs.com/pull/2280


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
A client will always create a consumer with a default group id on kafka, which leads to rebalancing the consumer group and delaying the application. Even if we don't really want to consume any messages, this requires us to create a new consumer group on Kafka.

Issue Number: #7259


## What is the new behavior?
This change introduces a feature flag to ClientKafka for only using a producer and skipping the consumer group registration

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
kafkajs-docs: https://kafka.js.org/docs/consuming
confluent-docs: https://docs.confluent.io/platform/current/clients/consumer.html#consumer-groups

PR for nestjs-docs: https://github.com/nestjs/docs.nestjs.com/pull/2280