### PR TITLE
fix(): individual test run

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,7 +1,0 @@
-module.exports = {
-  mochaHooks: {
-    beforeAll: function() {
-      require('reflect-metadata');
-    }
-  }
-};

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "format": "prettier \"**/*.ts\" --ignore-path ./.prettierignore --write && git status",
     "postinstall": "opencollective",
-    "test": "nyc --require ts-node/register mocha packages/**/*.spec.ts --reporter spec --require 'node_modules/reflect-metadata/Reflect.js' --exit",
-    "test:integration": "mocha \"integration/*/{,!(node_modules)/**/}/*.spec.ts\" --reporter spec --require ts-node/register --require 'node_modules/reflect-metadata/Reflect.js' --exit",
+    "test": "nyc mocha packages/**/*.spec.ts --reporter spec",
+    "test:integration": "mocha \"integration/*/{,!(node_modules)/**/}/*.spec.ts\" --reporter spec",
     "test:docker:up": "docker-compose -f integration/docker-compose.yml up -d",
     "test:docker:down": "docker-compose -f integration/docker-compose.yml down",
     "lint": "concurrently 'npm run lint:packages' 'npm run lint:integration' 'npm run lint:spec'",
@@ -225,5 +225,9 @@
     ],
     "sourceMap": true,
     "instrument": true
+  },
+  "mocha": {
+    "require": ["ts-node/register", "node_modules/reflect-metadata/Reflect.js", "rootHook.ts"],
+    "exit": true
   }
 }

--- a/rootHook.ts
+++ b/rootHook.ts
@@ -1,0 +1,7 @@
+export const mochaHooks = (): Mocha.RootHookObject => {
+  return {
+    async beforeAll(this: Mocha.Context) {
+      await import('reflect-metadata');
+    }
+  };
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: This diff fixes the individual test run as described:

Before this diff, running the test `./node_modules/.bin/mocha packages/common/test/decorators/set-metadata.decorator.spec.ts --reporter spec --require 'node_modules/reflect-metadata/Reflect.js' --exit`, produced error
```
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/saurabh/Desktop/Project-Repos/nest/packages/common/test/decorators/set-metadata.decorator.spec.ts
    at Loader.defaultGetFormat [as _getFormat] (internal/modules/esm/get_format.js:71:15)
    at Loader.getFormat (internal/modules/esm/loader.js:104:42)
    at Loader.getModuleJob (internal/modules/esm/loader.js:242:31)
    at async Loader.import (internal/modules/esm/loader.js:176:17)
    at async formattedImport (/Users/saurabh/Desktop/Project-Repos/nest/node_modules/mocha/lib/nodejs/esm-utils.js:7:14)
    at async Object.exports.requireOrImport (/Users/saurabh/Desktop/Project-Repos/nest/node_modules/mocha/lib/nodejs/esm-utils.js:48:32)
    at async Object.exports.loadFilesAsync (/Users/saurabh/Desktop/Project-Repos/nest/node_modules/mocha/lib/nodejs/esm-utils.js:103:20)
    at async singleRun (/Users/saurabh/Desktop/Project-Repos/nest/node_modules/mocha/lib/cli/run-helpers.js:125:3)
    at async Object.exports.handler (/Users/saurabh/Desktop/Project-Repos/nest/node_modules/mocha/lib/cli/run.js:374:5)
```

After this diff, running the (updated short command) test `./node_modules/.bin/mocha packages/common/test/decorators/set-metadata.decorator.spec.ts --reporter spec` produces output
```


  @SetMetadata
    ✔ should enhance class with expected metadata
    ✔ should enhance method with expected metadata


  2 passing (10ms)


```

## What is the current behavior?
Command
```
./node_modules/.bin/mocha packages/common/test/decorators/set-metadata.decorator.spec.ts --reporter spec --require 'node_modules/reflect-metadata/Reflect.js' --exit
```
exits with error

## What is the new behavior?
Command
```
./node_modules/.bin/mocha packages/common/test/decorators/set-metadata.decorator.spec.ts --reporter spec
```
passes without any errors

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information