### PR TITLE
fix: prevent handle leak in default e2e test

### DIFF
--- a/sample/30-event-emitter/test/app.e2e-spec.ts
+++ b/sample/30-event-emitter/test/app.e2e-spec.ts
@@ -22,5 +22,5 @@ describe('AppController (e2e)', () => {
       .expect('Hello World!');
   });
   
-  afterEach(async() => await app.close())
+  afterEach(async() => await app.close());
 });

--- a/sample/30-event-emitter/test/app.e2e-spec.ts
+++ b/sample/30-event-emitter/test/app.e2e-spec.ts
@@ -6,7 +6,6 @@ import { AppModule } from './../src/app.module';
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
-  afterAll(async() => await app.close())
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
@@ -22,4 +21,6 @@ describe('AppController (e2e)', () => {
       .expect(200)
       .expect('Hello World!');
   });
+  
+  afterEach(async() => await app.close())
 });

--- a/sample/30-event-emitter/test/app.e2e-spec.ts
+++ b/sample/30-event-emitter/test/app.e2e-spec.ts
@@ -22,5 +22,5 @@ describe('AppController (e2e)', () => {
       .expect('Hello World!');
   });
   
-  afterEach(async() => await app.close());
+  afterEach(() => app.close());
 });

--- a/sample/30-event-emitter/test/app.e2e-spec.ts
+++ b/sample/30-event-emitter/test/app.e2e-spec.ts
@@ -6,6 +6,7 @@ import { AppModule } from './../src/app.module';
 describe('AppController (e2e)', () => {
   let app: INestApplication;
 
+  afterAll(async() => await app.close())
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After the test is run, jest will hang telling
```
Jest did not exit one second after the test run has completed.

This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.
```

## What is the new behavior?

It closes the app so the Jest can exit.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
