### PR TITLE
Use rxjs when checking if the value is an observable

### DIFF
--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -5,9 +5,9 @@ import {
   RequestMethod,
   MessageEvent,
 } from '@nestjs/common';
-import { isFunction, isObject } from '@nestjs/common/utils/shared.utils';
+import { isObject } from '@nestjs/common/utils/shared.utils';
 import { IncomingMessage } from 'http';
-import { EMPTY, lastValueFrom, Observable } from 'rxjs';
+import { EMPTY, lastValueFrom, Observable, isObservable } from 'rxjs';
 import { catchError, debounce, map } from 'rxjs/operators';
 import {
   AdditionalHeaders,
@@ -64,7 +64,7 @@ export class RouterResponseController {
   }
 
   public async transformToResult(resultOrDeferred: any) {
-    if (resultOrDeferred && isFunction(resultOrDeferred.subscribe)) {
+    if (isObservable(resultOrDeferred)) {
       return lastValueFrom(resultOrDeferred);
     }
     return resultOrDeferred;
@@ -152,8 +152,8 @@ export class RouterResponseController {
     });
   }
 
-  private assertObservable(result: any) {
-    if (!isFunction(result.subscribe)) {
+  private assertObservable(value: any) {
+    if (!isObservable(value)) {
       throw new ReferenceError(
         'You must return an Observable stream to use Server-Sent Events (SSE).',
       );

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -71,13 +71,13 @@ describe('RouterResponseController', () => {
   describe('transformToResult', () => {
     describe('when resultOrDeferred', () => {
       describe('is Promise', () => {
-        it('should return Promise', async () => {
+        it('should return Promise that resolves to the value resolved by the input Promise', async () => {
           const value = 100;
           expect(
             await routerResponseController.transformToResult(
               Promise.resolve(value),
             ),
-          ).to.be.eq(100);
+          ).to.be.eq(value);
         });
       });
 
@@ -88,16 +88,25 @@ describe('RouterResponseController', () => {
             await routerResponseController.transformToResult(
               of(1, 2, 3, lastValue),
             ),
-          ).to.be.eq(100);
+          ).to.be.eq(lastValue);
         });
       });
 
-      describe('is value', () => {
-        it('should return Promise', async () => {
+      describe('is an object that has the method `subscribe`', () => {
+        it('should return a Promise that resolves to the input value', async () => {
+          const value = { subscribe() {} };
+          expect(
+            await routerResponseController.transformToResult(value),
+          ).to.equal(value);
+        });
+      });
+
+      describe('is an ordinary value', () => {
+        it('should return a Promise that resolves to the input value', async () => {
           const value = 100;
           expect(
             await routerResponseController.transformToResult(value),
-          ).to.be.eq(100);
+          ).to.be.eq(value);
         });
       });
     });

--- a/packages/websockets/test/web-sockets-controller.spec.ts
+++ b/packages/websockets/test/web-sockets-controller.spec.ts
@@ -345,7 +345,7 @@ describe('WebSocketsController', () => {
                 Promise.resolve(Promise.resolve(value)),
               ),
             ),
-          ).to.be.eq(100);
+          ).to.be.eq(value);
         });
       });
 
@@ -356,18 +356,29 @@ describe('WebSocketsController', () => {
             await lastValueFrom(
               await instance.pickResult(Promise.resolve(of(value))),
             ),
-          ).to.be.eq(100);
+          ).to.be.eq(value);
         });
       });
 
-      describe('is a value', () => {
+      describe('is an object that has the method `subscribe`', () => {
+        it('should return Promise<Observable>', async () => {
+          const value = { subscribe() {} };
+          expect(
+            await lastValueFrom(
+              await instance.pickResult(Promise.resolve(value)),
+            ),
+          ).to.equal(value);
+        });
+      });
+
+      describe('is an ordinary value', () => {
         it('should return Promise<Observable>', async () => {
           const value = 100;
           expect(
             await lastValueFrom(
               await instance.pickResult(Promise.resolve(value)),
             ),
-          ).to.be.eq(100);
+          ).to.be.eq(value);
         });
       });
     });

--- a/packages/websockets/web-sockets-controller.ts
+++ b/packages/websockets/web-sockets-controller.ts
@@ -1,9 +1,14 @@
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { Logger } from '@nestjs/common/services/logger.service';
-import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { ApplicationConfig } from '@nestjs/core/application-config';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
-import { from as fromPromise, Observable, of, Subject } from 'rxjs';
+import {
+  from as fromPromise,
+  Observable,
+  isObservable,
+  of,
+  Subject,
+} from 'rxjs';
 import { distinctUntilChanged, mergeAll } from 'rxjs/operators';
 import { GATEWAY_OPTIONS, PORT_METADATA } from './constants';
 import { WsContextCreator } from './context/ws-context-creator';
@@ -158,7 +163,7 @@ export class WebSocketsController {
     deferredResult: Promise<any>,
   ): Promise<Observable<any>> {
     const result = await deferredResult;
-    if (result && isFunction(result.subscribe)) {
+    if (isObservable(result)) {
       return result;
     }
     if (result instanceof Promise) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Here's the full code: https://gitlab.com/micalevisk/nestjs-observable-issue

If we return a literal object that has the `subscribe` method on it, the application gets stuck

```ts
import { Controller, Get, Req } from '@nestjs/common'
import { of, Observable } from 'rxjs'

@Controller()
export class AppController {
  @Get()
  getHello(): any {
    return { subscribe(){} }
  }
}
```

If we return `req.route` (from Express), we got the following error (and `500` as a response)

```
Error: Route.subscribe() requires a callback function but got a [object Object]
    at Route.<computed> [as subscribe] (/x/node_modules/express/lib/router/route.js:202:15)
    at /x/node_modules/rxjs/src/internal/lastValueFrom.ts:59:12
    at new Promise (<anonymous>)
    at Object.lastValueFrom (/x/node_modules/rxjs/src/internal/lastValueFrom.ts:56:10)
    at RouterResponseController.transformToResult (/x/node_modules/@nestjs/core/router/router-response-controller.js:34:27)
    at /x/node_modules/@nestjs/core/router/router-execution-context.js:174:52
    at /x/node_modules/@nestjs/core/router/router-execution-context.js:47:19
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at /x/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

```ts
import { Controller, Get, Req } from '@nestjs/common'
import { of, Observable } from 'rxjs'
import { Request } from 'express'

@Controller()
export class AppController {
  @Get()
  getHello(@Req() req: Request): string | Observable<string> | Record<string, any> {
    // return 'hello world' // Works
    // return of('hello world') // Works
    return req.route // Errors but should work too as it isn't an Observable
  }
}
```

## What is the new behavior?

Instead of checking if the return of the method has the function `subscribe`, we're using [`isObservable`](https://rxjs.dev/api/index/function/isObservable) from `rxjs` to check if the return is, in fact, a valid observable object

Thus, now with the above code the server will reply with this JSON instead:

```json
{
  "path": "/",
  "stack": [
    {
      "name": "<anonymous>",
      "keys": [],
      "regexp": {
        "fast_star": false,
        "fast_slash": false
      },
      "method": "get"
    }
  ],
  "methods": {
    "get": true
  }
}
```

as expected.

And just `{}` when we return `{ subscribe(){} }`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

There are other places in which `isObservable` is used. See:

<details>

![image](https://user-images.githubusercontent.com/13461315/164834377-bdf89a54-92ae-4840-a709-d51ace6513da.png)

</details>

While others are using `isFunction(value.subscribe)` and I'm unsure if this was intentional. See:

<details>

![image](https://user-images.githubusercontent.com/13461315/164835149-7c0f0dc4-a79c-4aa7-a433-47508bfbe014.png)

</details>

Should we do the same for

https://github.com/nestjs/nest/blob/d9d628d112ff992c8075bae44b826300fd5ca6c8/packages/microservices/client/client-grpc.ts#L211-L212

https://github.com/nestjs/nest/blob/d9d628d112ff992c8075bae44b826300fd5ca6c8/packages/microservices/client/client-grpc.ts#L154-L155

?
