### PR TITLE
feat(common): improve extensibility on few built-in pipes

### DIFF
--- a/packages/common/pipes/parse-bool.pipe.ts
+++ b/packages/common/pipes/parse-bool.pipe.ts
@@ -48,14 +48,32 @@ export class ParseBoolPipe
     value: string | boolean,
     metadata: ArgumentMetadata,
   ): Promise<boolean> {
-    if (value === true || value === 'true') {
+    if (this.isTrue(value)) {
       return true;
     }
-    if (value === false || value === 'false') {
+    if (this.isFalse(value)) {
       return false;
     }
     throw this.exceptionFactory(
       'Validation failed (boolean string is expected)',
     );
+  }
+
+  /**
+   * @param value currently processed route argument
+   * @returns `true` if `value` is said 'true', ie., if it is equal to the boolean
+   * `true` or the string `"true"`
+   */
+  protected isTrue(value: string | boolean): boolean {
+    return value === true || value === 'true';
+  }
+
+  /**
+   * @param value currently processed route argument
+   * @returns `true` if `value` is said 'false', ie., if it is equal to the boolean
+   * `false` or the string `"false"`
+   */
+  protected isFalse(value: string | boolean): boolean {
+    return value === false || value === 'false';
   }
 }

--- a/packages/common/pipes/parse-float.pipe.ts
+++ b/packages/common/pipes/parse-float.pipe.ts
@@ -39,15 +39,23 @@ export class ParseFloatPipe implements PipeTransform<string> {
    * @param metadata contains metadata about the currently processed route argument
    */
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
-    const isNumeric =
-      ['string', 'number'].includes(typeof value) &&
-      !isNaN(parseFloat(value)) &&
-      isFinite(value as any);
-    if (!isNumeric) {
+    if (!this.isNumeric(value)) {
       throw this.exceptionFactory(
         'Validation failed (numeric string is expected)',
       );
     }
     return parseFloat(value);
+  }
+
+  /**
+   * @param value currently processed route argument
+   * @returns `true` if `value` is a valid float number
+   */
+  protected isNumeric(value: string): boolean {
+    return (
+      ['string', 'number'].includes(typeof value) &&
+      !isNaN(parseFloat(value)) &&
+      isFinite(value as any)
+    );
   }
 }

--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -44,15 +44,23 @@ export class ParseIntPipe implements PipeTransform<string> {
    * @param metadata contains metadata about the currently processed route argument
    */
   async transform(value: string, metadata: ArgumentMetadata): Promise<number> {
-    const isNumeric =
-      ['string', 'number'].includes(typeof value) &&
-      /^-?\d+$/.test(value) &&
-      isFinite(value as any);
-    if (!isNumeric) {
+    if (!this.isNumeric(value)) {
       throw this.exceptionFactory(
         'Validation failed (numeric string is expected)',
       );
     }
     return parseInt(value, 10);
+  }
+
+  /**
+   * @param value currently processed route argument
+   * @returns `true` if `value` is a valid integer number
+   */
+  protected isNumeric(value: string): boolean {
+    return (
+      ['string', 'number'].includes(typeof value) &&
+      /^-?\d+$/.test(value) &&
+      isFinite(value as any)
+    );
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The built-in `ParseEnumPipe` has a protected method (`isEnum`) that would help devs on considering if a value is a valid enum, see:

https://github.com/nestjs/nest/blob/85bda838f7da649877c6973d34ed672ca286dba4/packages/common/pipes/parse-enum.pipe.ts#L51-L63


but `ParseBoolPipe`, `ParseFloatPipe` and `ParseIntPipe` doesn't has such capability

## What is the new behavior?

By implemeting the [Template Method](https://refactoring.guru/design-patterns/template-method) pattern, when extending some of those pipes listed above, one could define how they want to evaluate some value as a valid value to proceed the transformation.

For instance, currently, `ParseBoolPipe` will transform `"true"` to `true`, but what if we want to treat `"1"` as `true` as well? we would have to write our own pipe or write some normalization logic in the `transform` method.  
Now we could easily extend the built-in pipe like this:

```ts
class MyParseBoolPipe extends ParseBoolPipe {
   protected isTrue(value: string | boolean): boolean {
      return value === '1' || super.isTrue(value)
   }
}
```

To summary, this PR adds `ParseBoolPipe#isTrue`, `ParseBoolPipe#isFalse`, `ParseFloat#isNumeric` and `ParseInt#isNumeric`. All returns `boolean`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

I'm not 100% sure on this because devs could have extended some of that pipes and write a method on them that will override the newly added methods, which can lead to unexpected behavior (I guess?)