### PR TITLE
feat(core)!: throw an exception instead of logging due to module import misusage

### DIFF
--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -121,11 +121,11 @@ export const USING_INVALID_CLASS_AS_A_MODULE_MESSAGE = (
   metatypeUsedAsAModule: Type | ForwardReference,
   scope: any[],
 ) => {
-  const metatypeName = getInstanceName(metatypeUsedAsAModule) || 'found';
+  const metatypeNameQuote =
+    `"${getInstanceName(metatypeUsedAsAModule)}"` || 'that class';
 
-  // TODO(v9): Edit the message below:
-  return `In the next major version, Nest will not allow classes annotated with @Injectable(), @Catch(), and @Controller() decorators to appear in the "imports" array of a module.
-Please remove "${metatypeName}" (including forwarded occurrences, if any) from all of the "imports" arrays.
+  return `Classes annotated with @Injectable(), @Catch(), and @Controller() decorators must not appear in the "imports" array of a module.
+Please remove ${metatypeNameQuote} (including forwarded occurrences, if any) from all of the "imports" arrays.
 
 Scope [${stringifyScope(scope)}]
 `;

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -2,7 +2,6 @@ import {
   DynamicModule,
   flatten,
   ForwardReference,
-  Logger,
   Provider,
 } from '@nestjs/common';
 import {
@@ -59,7 +58,6 @@ interface ApplicationProviderWrapper {
 }
 
 export class DependenciesScanner {
-  private readonly logger = new Logger(DependenciesScanner.name);
   private readonly applicationProvidersApplyMap: ApplicationProviderWrapper[] =
     [];
 
@@ -151,10 +149,7 @@ export class DependenciesScanner {
       this.isController(moduleToAdd) ||
       this.isExceptionFilter(moduleToAdd)
     ) {
-      // TODO(v9): Throw the exception instead of printing a warning
-      this.logger.warn(
-        new InvalidClassModuleException(moduleDefinition, scope).message,
-      );
+      throw new InvalidClassModuleException(moduleDefinition, scope);
     }
 
     return this.container.addModule(moduleToAdd, scope);

--- a/packages/core/test/scanner.spec.ts
+++ b/packages/core/test/scanner.spec.ts
@@ -9,6 +9,7 @@ import { Scope } from '../../common/interfaces';
 import { ApplicationConfig } from '../application-config';
 import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR, APP_PIPE } from '../constants';
 import { InvalidModuleException } from '../errors/exceptions/invalid-module.exception';
+import { InvalidClassModuleException } from '../errors/exceptions/invalid-class-module.exception';
 import { UndefinedModuleException } from '../errors/exceptions/undefined-module.exception';
 import { NestContainer } from '../injector/container';
 import { InstanceWrapper } from '../injector/instance-wrapper';
@@ -165,16 +166,6 @@ describe('DependenciesScanner', () => {
   });
 
   describe('insertModule', () => {
-    let LoggerWarnSpy: sinon.SinonSpy;
-
-    beforeEach(() => {
-      LoggerWarnSpy = sinon.stub(Logger.prototype, 'warn');
-    });
-
-    afterEach(() => {
-      LoggerWarnSpy.restore();
-    });
-
     it('should call forwardRef() when forwardRef property exists', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
@@ -183,26 +174,26 @@ describe('DependenciesScanner', () => {
 
       expect(module.forwardRef.called).to.be.true;
     });
-    it('should logs an warning when passing a class annotated with `@Injectable()` decorator', () => {
+    it('should throw "InvalidClassModuleException" exception when suppling a class annotated with `@Injectable()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      scanner.insertModule(TestComponent, []);
-
-      expect(LoggerWarnSpy.calledOnce).to.be.true;
+      expect(scanner.insertModule(TestComponent, [])).to.be.rejectedWith(
+        InvalidClassModuleException,
+      );
     });
-    it('should logs an warning when passing a class annotated with `@Controller()` decorator', () => {
+    it('should throw "InvalidClassModuleException" exception when suppling a class annotated with `@Controller()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      scanner.insertModule(TestController, []);
-
-      expect(LoggerWarnSpy.calledOnce).to.be.true;
+      expect(scanner.insertModule(TestController, [])).to.be.rejectedWith(
+        InvalidClassModuleException,
+      );
     });
-    it('should logs an warning when passing a class annotated with `@Catch()` (only) decorator', () => {
+    it('should throw "InvalidClassModuleException" exception when suppling a class annotated with (only) `@Catch()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      scanner.insertModule(TestExceptionFilterWithoutInjectable, []);
-
-      expect(LoggerWarnSpy.calledOnce).to.be.true;
+      expect(
+        scanner.insertModule(TestExceptionFilterWithoutInjectable, []),
+      ).to.be.rejectedWith(InvalidClassModuleException);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

if the `imports` prop of `@Module()` has any class annotated with `@Controller()`, `@Catch()` or `@Injectable()`, we'll get an warning message like the following:

```
[DependenciesScanner] In the next major version, Nest will not allow classes annotated with @Injectable(), @Catch(), and @Controller() decorators to appear in the "imports" array of a module.
Please remove "AppController" (including forwarded occurrences, if any) from all of the "imports" arrays.

Scope [AppModule]
```

![image](https://user-images.githubusercontent.com/13461315/168945823-5b7ca3bc-24d1-4def-bbbd-fd2129db2380.png)

## What is the new behavior?

as this is not allowed in v9, the app now exits with an error:

![image](https://user-images.githubusercontent.com/13461315/168950135-702ce6d7-6ea6-44ea-a4d1-50105da8d5d9.png)


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No
