### PR TITLE
fix(sample): id param is string type

### DIFF
--- a/sample/31-graphql-federation-code-first/posts-application/src/posts/posts.resolver.ts
+++ b/sample/31-graphql-federation-code-first/posts-application/src/posts/posts.resolver.ts
@@ -9,13 +9,14 @@ import {
 import { Post } from './models/post.model';
 import { User } from './models/user.model';
 import { PostsService } from './posts.service';
+import { ParseIntPipe } from '@nestjs/common';
 
 @Resolver((of) => Post)
 export class PostsResolver {
   constructor(private readonly postsService: PostsService) {}
 
   @Query((returns) => Post)
-  post(@Args({ name: 'id', type: () => ID }) id: number): Post {
+  post(@Args({ name: 'id', type: () => ID }, ParseIntPipe) id: number): Post {
     return this.postsService.findOne(id);
   }
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Fix sample

## What is the current behavior?
graphql federation sample does not work when query

```
{
  post(id: 1) {
    id
    user {
      name
    }
  }
}
```


## What is the new behavior?

graphql federation works

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No