### PR TITLE
fix(testing): disable logs when `logger` is `false` on `TestingModule`

### DIFF
--- a/packages/testing/testing-module.ts
+++ b/packages/testing/testing-module.ts
@@ -9,6 +9,7 @@ import {
 import { NestMicroserviceOptions } from '@nestjs/common/interfaces/microservices/nest-microservice-options.interface';
 import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
+import { isUndefined } from '@nestjs/common/utils/shared.utils';
 import {
   AbstractHttpAdapter,
   NestApplication,
@@ -72,7 +73,7 @@ export class TestingModule extends NestApplicationContext {
   }
 
   private applyLogger(options: NestApplicationContextOptions | undefined) {
-    if (!options || !options.logger) {
+    if (!options || isUndefined(options.logger)) {
       return;
     }
     Logger.overrideLogger(options.logger);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when creating a testing app with `Test.createTestingModule` and `createNestApplication()`, if we pass `false` to `logger` option, the logs aren't disable as stated in the `NestApplicationContextOptions` docs:

https://github.com/nestjs/nest/blob/df2dab4fccc5e9a32e2305929e09c7392b3daf78/packages/common/interfaces/nest-application-context-options.interface.ts#L6-L10

and is pretty easy to understand why:

https://github.com/nestjs/nest/blob/6aeb3258ac55f442913cf447d7e64ef83eb5496f/packages/testing/testing-module.ts#L74-L78

as L78 above is never called, there's no way to disable logs easily. Which isn't the same as the `NestFactory` version one:

https://github.com/nestjs/nest/blob/6f5986d19e43da92801ac3f7d59cab9554741550/packages/core/nest-factory.ts#L232-L246

you can see that L239 above will evaluate to true when `options.logger === false`, which ends up with `Logger.overrideLogger(false)`

## What is the new behavior?

now we can disable logs in the following usage:

```ts
const module = await Test.createTestingModule({
  imports: [],
}).compile()

const appExpress = module.createNestApplication(new ExpressAdapter(), {
  logger: false,
})
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

