### PR TITLE
refactor(express): improve `applyVersioning` handler selector code

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -35,6 +35,15 @@ import * as http from 'http';
 import * as https from 'https';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
 
+type VersionedRoute = <
+  TRequest extends Record<string, any> = any,
+  TResponse = any,
+>(
+  req: TRequest,
+  res: TResponse,
+  next: () => void,
+) => any;
+
 export class ExpressAdapter extends AbstractHttpAdapter {
   private readonly routerMethodFactory = new RouterMethodFactory();
 
@@ -213,22 +222,30 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     handler: Function,
     version: VersionValue,
     versioningOptions: VersioningOptions,
-  ) {
-    return <TRequest extends Record<string, any> = any, TResponse = any>(
-      req: TRequest,
-      res: TResponse,
-      next: () => void,
-    ) => {
-      if (version === VERSION_NEUTRAL) {
-        return handler(req, res, next);
+  ): VersionedRoute {
+    const callNextHandler: VersionedRoute = (req, res, next) => {
+      if (!next) {
+        throw new InternalServerErrorException(
+          'HTTP adapter does not support filtering on version',
+        );
       }
-      // URL Versioning is done via the path, so the filter continues forward
-      if (versioningOptions.type === VersioningType.URI) {
-        return handler(req, res, next);
-      }
+      return next();
+    };
 
-      // Custom Extractor Versioning Handler
-      if (versioningOptions.type === VersioningType.CUSTOM) {
+    if (
+      version === VERSION_NEUTRAL ||
+      // URL Versioning is done via the path, so the filter continues forward
+      versioningOptions.type === VersioningType.URI
+    ) {
+      const handlerForNoVersioning: VersionedRoute = (req, res, next) =>
+        handler(req, res, next);
+
+      return handlerForNoVersioning;
+    }
+
+    // Custom Extractor Versioning Handler
+    if (versioningOptions.type === VersioningType.CUSTOM) {
+      const handlerForCustomVersioning: VersionedRoute = (req, res, next) => {
         const extractedVersion = versioningOptions.extractor(req);
 
         if (Array.isArray(version)) {
@@ -237,7 +254,9 @@ export class ExpressAdapter extends AbstractHttpAdapter {
             version.filter(v => extractedVersion.includes(v as string)).length
           ) {
             return handler(req, res, next);
-          } else if (
+          }
+
+          if (
             isString(extractedVersion) &&
             version.includes(extractedVersion)
           ) {
@@ -253,17 +272,26 @@ export class ExpressAdapter extends AbstractHttpAdapter {
             extractedVersion.includes(version)
           ) {
             return handler(req, res, next);
-          } else if (
-            isString(extractedVersion) &&
-            version === extractedVersion
-          ) {
+          }
+
+          if (isString(extractedVersion) && version === extractedVersion) {
             return handler(req, res, next);
           }
         }
-      }
 
-      // Media Type (Accept Header) Versioning Handler
-      if (versioningOptions.type === VersioningType.MEDIA_TYPE) {
+        return callNextHandler(req, res, next);
+      };
+
+      return handlerForCustomVersioning;
+    }
+
+    // Media Type (Accept Header) Versioning Handler
+    if (versioningOptions.type === VersioningType.MEDIA_TYPE) {
+      const handlerForMediaTypeVersioning: VersionedRoute = (
+        req,
+        res,
+        next,
+      ) => {
         const MEDIA_TYPE_HEADER = 'Accept';
         const acceptHeaderValue: string | undefined =
           req.headers?.[MEDIA_TYPE_HEADER] ||
@@ -295,9 +323,16 @@ export class ExpressAdapter extends AbstractHttpAdapter {
             }
           }
         }
-      }
-      // Header Versioning Handler
-      else if (versioningOptions.type === VersioningType.HEADER) {
+
+        return callNextHandler(req, res, next);
+      };
+
+      return handlerForMediaTypeVersioning;
+    }
+
+    // Header Versioning Handler
+    if (versioningOptions.type === VersioningType.HEADER) {
+      const handlerForHeaderVersioning: VersionedRoute = (req, res, next) => {
         const customHeaderVersionParameter: string | undefined =
           req.headers?.[versioningOptions.header] ||
           req.headers?.[versioningOptions.header.toLowerCase()];
@@ -320,15 +355,12 @@ export class ExpressAdapter extends AbstractHttpAdapter {
             }
           }
         }
-      }
 
-      if (!next) {
-        throw new InternalServerErrorException(
-          'HTTP adapter does not support filtering on version',
-        );
-      }
-      return next();
-    };
+        return callNextHandler(req, res, next);
+      };
+
+      return handlerForHeaderVersioning;
+    }
   }
 
   private isMiddlewareApplied(name: string): boolean {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The current version of `ExpressAdapter#applyVersionFilter` return a route handler that does too much even tho the versioning type isn't dynamic per handler

![image](https://user-images.githubusercontent.com/13461315/169678822-a484e066-7547-4d00-9471-4a4a27da7b6b.png)

## What is the new behavior?

Now `ExpressAdapter#applyVersionFilter` will evaluate and return a request handler that just deals with one configured versioning type.

Also, the type defs are improved (a bit), to make that method more type-safe.

![image](https://user-images.githubusercontent.com/13461315/169678905-4f8595d0-bc20-4ca4-9298-05430ea4b023.png)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

