### PR TITLE
feat(core): add aop module 

### DIFF
--- a/packages/core/aop/Aspect.ts
+++ b/packages/core/aop/Aspect.ts
@@ -1,0 +1,9 @@
+import { applyDecorators, Injectable } from '@nestjs/common';
+
+export const ASPECT = Symbol('ASPECT_CLASS');
+
+export function Aspect() {
+  return applyDecorators((target: any) => {
+    Reflect.defineMetadata(ASPECT, 'ASPECT_CLASS', target);
+  }, Injectable);
+}

--- a/packages/core/aop/Aspect.ts
+++ b/packages/core/aop/Aspect.ts
@@ -2,6 +2,11 @@ import { applyDecorators, Injectable } from '@nestjs/common';
 
 export const ASPECT = Symbol('ASPECT_CLASS');
 
+/**
+ * Decorator for locating the LazyDecorator implementation in the Provider list.
+ *
+ * @constructor
+ */
 export function Aspect() {
   return applyDecorators((target: any) => {
     Reflect.defineMetadata(ASPECT, 'ASPECT_CLASS', target);

--- a/packages/core/aop/aop.module.ts
+++ b/packages/core/aop/aop.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AutoAspectExecutor } from './auto-aspect-executor';
+import { DiscoveryModule } from '../discovery';
+
+@Module({
+  imports: [DiscoveryModule],
+  providers: [AutoAspectExecutor],
+})
+export class AopModule {}

--- a/packages/core/aop/auto-aspect-executor.ts
+++ b/packages/core/aop/auto-aspect-executor.ts
@@ -1,8 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import is from '@sindresorhus/is';
 
 import { ASPECT } from './Aspect';
-import { LazyDecorator } from './lazy-decorator';
+import { LazyDecorator } from './lazy-decorator.interface';
 import { DiscoveryService } from '../discovery';
 import { MetadataScanner } from '../metadata-scanner';
 import { Reflector } from '../services';
@@ -59,13 +58,11 @@ export class AutoAspectExecutor implements OnModuleInit {
 
         const aspect = reflector.get<string>(ASPECT, metatype);
 
-        if (!is.nonEmptyString(aspect)) {
+        if (!aspect) {
           return false;
         }
 
-        return (
-          !is.nullOrUndefined(instance.wrap) && is.boundFunction(instance.wrap)
-        );
+        return instance.wrap && typeof instance.wrap === 'function';
       })
       .map(({ instance }) => instance);
   }

--- a/packages/core/aop/auto-aspect-executor.ts
+++ b/packages/core/aop/auto-aspect-executor.ts
@@ -1,0 +1,72 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import is from '@sindresorhus/is';
+
+import { ASPECT } from './Aspect';
+import { LazyDecorator } from './lazy-decorator';
+import { DiscoveryService } from '../discovery';
+import { MetadataScanner } from '../metadata-scanner';
+import { Reflector } from '../services';
+
+@Injectable()
+export class AutoAspectExecutor implements OnModuleInit {
+  constructor(
+    private readonly discoveryService: DiscoveryService,
+    private readonly metadataScanner: MetadataScanner,
+    private readonly reflector: Reflector,
+  ) {}
+
+  onModuleInit() {
+    const providers = this.discoveryService.getProviders();
+
+    const lazyDecorators = this.lookupLazyDecorators(providers);
+
+    if (lazyDecorators.length === 0) {
+      return;
+    }
+
+    [...providers, ...this.discoveryService.getControllers()]
+      .filter(wrapper => wrapper.isDependencyTreeStatic())
+      .filter(({ instance }) => instance && Object.getPrototypeOf(instance))
+      .forEach(({ instance }) => {
+        this.metadataScanner.scanFromPrototype(
+          instance,
+          Object.getPrototypeOf(instance),
+          methodName =>
+            lazyDecorators.forEach(lazyDecorator => {
+              const wrappedMethod = lazyDecorator.wrap(
+                this.reflector,
+                instance,
+                methodName,
+              );
+
+              if (wrappedMethod) {
+                instance[methodName] = wrappedMethod;
+              }
+            }),
+        );
+      });
+  }
+
+  private lookupLazyDecorators(providers: any[]): LazyDecorator[] {
+    const { reflector } = this;
+
+    return providers
+      .filter(wrapper => wrapper.isDependencyTreeStatic())
+      .filter(({ instance, metatype }) => {
+        if (!instance || !metatype) {
+          return false;
+        }
+
+        const aspect = reflector.get<string>(ASPECT, metatype);
+
+        if (!is.nonEmptyString(aspect)) {
+          return false;
+        }
+
+        return (
+          !is.nullOrUndefined(instance.wrap) && is.boundFunction(instance.wrap)
+        );
+      })
+      .map(({ instance }) => instance);
+  }
+}

--- a/packages/core/aop/index.ts
+++ b/packages/core/aop/index.ts
@@ -1,0 +1,3 @@
+export * from './aop.module';
+export * from './Aspect';
+export * from './lazy-decorator';

--- a/packages/core/aop/index.ts
+++ b/packages/core/aop/index.ts
@@ -1,3 +1,3 @@
 export * from './aop.module';
 export * from './Aspect';
-export * from './lazy-decorator';
+export * from './lazy-decorator.interface';

--- a/packages/core/aop/lazy-decorator.interface.ts
+++ b/packages/core/aop/lazy-decorator.interface.ts
@@ -2,6 +2,13 @@ import { Reflector } from '../services';
 
 export type Decorator = (...args: any) => unknown | Promise<unknown>;
 
+/**
+ * When OnModuleInithook is invoked, it is responsible for enclosing certain functions of the Provider and Controller in the Nest IOC.
+ *
+ * Lazy Decorator is basically one of the Providers in Nest IOC, so DI is possible.
+ *
+ * For example, CashManager can also inject, so you can apply cache to Provider.
+ */
 export interface LazyDecorator {
   wrap(
     reflector: Reflector,

--- a/packages/core/aop/lazy-decorator.interface.ts
+++ b/packages/core/aop/lazy-decorator.interface.ts
@@ -2,9 +2,6 @@ import { Reflector } from '../services';
 
 export type Decorator = (...args: any) => unknown | Promise<unknown>;
 
-/**
- * Aspect 선언시 구현이 필요합니다.
- */
 export interface LazyDecorator {
   wrap(
     reflector: Reflector,

--- a/packages/core/aop/lazy-decorator.ts
+++ b/packages/core/aop/lazy-decorator.ts
@@ -1,0 +1,14 @@
+import { Reflector } from '../services';
+
+export type Decorator = (...args: any) => unknown | Promise<unknown>;
+
+/**
+ * Aspect 선언시 구현이 필요합니다.
+ */
+export interface LazyDecorator {
+  wrap(
+    reflector: Reflector,
+    instance: any,
+    methodName: string,
+  ): Decorator | undefined;
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -20,3 +20,4 @@ export * from './nest-application-context';
 export { NestFactory } from './nest-factory';
 export * from './router';
 export * from './services';
+export * from './aop';

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -167,8 +167,8 @@ export class NestApplication
     useBodyParser && this.registerParserMiddleware();
 
     await this.registerModules();
-    await this.registerRouter();
     await this.callInitHook();
+    await this.registerRouter();
     await this.registerRouterHooks();
     await this.callBootstrapHook();
 

--- a/packages/core/test/aop/auto-aspect-executor.spec.ts
+++ b/packages/core/test/aop/auto-aspect-executor.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import { ASPECT, Aspect, Decorator, LazyDecorator } from '../../aop';
+import { Aspect, Decorator, LazyDecorator } from '../../aop';
 import { Reflector } from '../../services';
-import { Controller, Logger, Scope, SetMetadata } from '@nestjs/common';
+import { Controller, Logger, SetMetadata } from '@nestjs/common';
 import { Module as ModuleDecorator } from '../../../common/decorators/modules/module.decorator';
 import { DiscoveryService } from '../../discovery';
 import { AutoAspectExecutor } from '../../aop/auto-aspect-executor';

--- a/packages/core/test/aop/auto-aspect-executor.spec.ts
+++ b/packages/core/test/aop/auto-aspect-executor.spec.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { ASPECT, Aspect, Decorator, LazyDecorator } from '../../aop';
+import { Reflector } from '../../services';
+import { Controller, Logger, Scope, SetMetadata } from '@nestjs/common';
+import { Module as ModuleDecorator } from '../../../common/decorators/modules/module.decorator';
+import { DiscoveryService } from '../../discovery';
+import { AutoAspectExecutor } from '../../aop/auto-aspect-executor';
+import { ModulesContainer } from '../../injector';
+import { MetadataScanner } from '../../metadata-scanner';
+import * as sinon from 'sinon';
+import { InstanceWrapper } from '../../injector/instance-wrapper';
+
+describe('AutoAspectExecutor', () => {
+  const key = 'logging';
+  const Log = () => SetMetadata('logging', true);
+
+  @Aspect()
+  class LogLazyDecorator implements LazyDecorator {
+    constructor(private readonly logger: Logger) {}
+
+    wrap(
+      reflector: Reflector,
+      instance: any,
+      methodName: string,
+    ): Decorator | undefined {
+      const methodRef = instance[methodName];
+
+      const shouldWrap = reflector.get(key, methodRef);
+
+      if (!shouldWrap) {
+        return;
+      }
+
+      return (...args: any[]) => {
+        this.logger.log(`${methodName} <= ${args}`);
+
+        const result = methodRef.call(instance, ...args);
+
+        this.logger.log(`${methodName} => ${result}`);
+
+        return result;
+      };
+    }
+  }
+
+  @ModuleDecorator({})
+  class TestModule {}
+
+  class TestService {
+    @Log()
+    hello(name: string) {
+      return `hello ${name}`;
+    }
+  }
+
+  @Controller()
+  class TestController {
+    @Log()
+    hello(name: string) {
+      return `hello ${name}`;
+    }
+  }
+
+  it('should called log method', async () => {
+    const logger = new Logger();
+    const logSpy = sinon.spy(logger, 'log');
+
+    const logLazyDecorator = new LogLazyDecorator(logger);
+    const testController = new TestController();
+
+    const testService = new TestService();
+    const discoveryService = new DiscoveryService(new ModulesContainer());
+
+    const getProvidersStub = sinon.stub(discoveryService, 'getProviders');
+    const getControllersStub = sinon.stub(discoveryService, 'getControllers');
+
+    getProvidersStub.returns([
+      new InstanceWrapper({
+        instance: testService,
+        metatype: TestService,
+      }),
+      new InstanceWrapper({
+        instance: logLazyDecorator,
+        metatype: LogLazyDecorator,
+      }),
+    ]);
+    const autoAspectExecutor = new AutoAspectExecutor(
+      discoveryService,
+      new MetadataScanner(),
+      new Reflector(),
+    );
+
+    getControllersStub.returns([
+      new InstanceWrapper({
+        instance: testController,
+        metatype: TestController,
+      }),
+    ]);
+
+    autoAspectExecutor.onModuleInit();
+
+    testService.hello('kys');
+    expect(logSpy.calledTwice).to.be.true;
+
+    logSpy.resetHistory();
+
+    testController.hello('kys');
+    expect(logSpy.calledTwice).to.be.true;
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This PR can be applied AOP with the same code to Provider and Controller. In addition, certain instances in Nest IoC containers can be injected with DI into the Provider and wrapped with a decorator.

I wanted to apply the AOP pattern to the Provider using the instances in the Nest IoC container like the Interceptor of the Controller.

While I was thinking about it, I realized that if I use DiscoverModule, I can apply the decorator to a specific function for the instance I wanted during Nest LifeCycle.

The basic concept is to cover the decorator while touring the controllers and providers registered in the Nest IoC container at the time of OnModuleInithook.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
