### PR TITLE
fix(microservices): Fixed typings for MessageHandler

### DIFF
--- a/packages/microservices/interfaces/message-handler.interface.ts
+++ b/packages/microservices/interfaces/message-handler.interface.ts
@@ -1,8 +1,13 @@
 import { Observable } from 'rxjs';
 
 export interface MessageHandler<TInput = any, TContext = any, TResult = any> {
-  (data: TInput, ctx?: TContext): Promise<Observable<TResult>>;
-  next?: (data: TInput, ctx?: TContext) => Promise<Observable<TResult>>;
+  (data: TInput, ctx?: TContext):
+    | Promise<Observable<TResult>>
+    | Promise<TResult>;
+  next?: (
+    data: TInput,
+    ctx?: TContext,
+  ) => Promise<Observable<TResult>> | Promise<TResult>;
   isEventHandler?: boolean;
   extras?: Record<string, any>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9668 


## What is the new behavior?

MessageHandler return type was changed to `Promise<Observable<TResult>> | Promise<TResult>`

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Since the return type had changed, users may be required to cast type explicitly in the old code.

```ts
let handler: MessageHandler;
...
let result = await messageHandler(data);
// Here we need type casting
(result as Observable<...>).pipe(...);
// Same for next method
result = await messageHandler.next(data);
(result as Observable<...>).pipe(...);
```

## Other information

fixes #9668