### PR TITLE
chore: cover `integration` dir on lint-staged config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 packages/**/*.d.ts
 packages/**/*.js
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean": "gulp clean:bundle",
     "codechecks:benchmarks": "codechecks ./tools/benchmarks/check-benchmarks.ts",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "format": "prettier \"**/*.ts\" --ignore-path ./.prettierignore --write && git status",
+    "format": "prettier \"**/*.ts\" \"packages/**/*.json\" --ignore-path ./.prettierignore --write && git status",
     "postinstall": "opencollective",
     "test": "nyc mocha packages/**/*.spec.ts --reporter spec",
     "test:integration": "mocha \"integration/*/{,!(node_modules)/**/}/*.spec.ts\" --reporter spec",
@@ -44,7 +44,10 @@
     "prepare": "husky install"
   },
   "lint-staged": {
-    "packages/**/*.{ts,json}": [
+    "**/*.ts": [
+      "prettier --ignore-path ./.prettierignore --write"
+    ],
+    "packages/**/*.json": [
       "prettier --ignore-path ./.prettierignore --write"
     ]
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

there's a mismatch between the `format` npm-script and the files that lint-staged will watch against

https://github.com/nestjs/nest/blob/f765e2c8c9e3f0d1d1426e962dcab380bb960d85/package.json#L26

https://github.com/nestjs/nest/blob/f765e2c8c9e3f0d1d1426e962dcab380bb960d85/package.json#L47

## What is the new behavior?

now both are following the same patterns

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
