### PR TITLE
fix(microservices): allow `postfixId` on `KafkaOptions` to be an empty string

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -62,7 +62,7 @@ export class ClientKafka extends ClientProxy {
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
-      this.getOptionsProp(this.options, 'postfixId') || '-client';
+      this.getOptionsProp(this.options, 'postfixId') ?? '-client';
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -194,6 +194,9 @@ export interface KafkaParserConfig {
 export interface KafkaOptions {
   transport?: Transport.KAFKA;
   options?: {
+    /**
+     * Defaults to `"-server"` on server side and `"-client"` on client side.
+     */
     postfixId?: string;
     client?: KafkaConfig;
     consumer?: ConsumerConfig;

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -53,7 +53,7 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
-      this.getOptionsProp(this.options, 'postfixId') || '-server';
+      this.getOptionsProp(this.options, 'postfixId') ?? '-server';
 
     this.brokers = clientOptions.brokers || [KAFKA_DEFAULT_BROKER];
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #9677 

## What is the new behavior?

empty strings on `postfixId` option on `KafkaServer` and `KafkaClient`'s `constructor` are allowed now

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

as we're changing the behavior of a public API (`ClientsModule.register`)