### PR TITLE
feat(core,common): add helpers messages to REPL built-in functions

### DIFF
--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -5,6 +5,7 @@ const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 
 export const clc = {
+  bold: colorIfAllowed((text: string) => `\x1B[1m${text}\x1B[0m`),
   green: colorIfAllowed((text: string) => `\x1B[32m${text}\x1B[39m`),
   yellow: colorIfAllowed((text: string) => `\x1B[33m${text}\x1B[39m`),
   red: colorIfAllowed((text: string) => `\x1B[31m${text}\x1B[39m`),

--- a/packages/core/repl/constants.ts
+++ b/packages/core/repl/constants.ts
@@ -1,1 +1,7 @@
 export const REPL_INITIALIZED_MESSAGE = 'REPL initialized';
+
+/**
+ * NestJS core REPL metadata's identifier.
+ * The metadata itself will have the shape of `ReplMetadata` interface.
+ */
+export const REPL_METADATA_KEY = 'repl:metadata';

--- a/packages/core/repl/repl-fn.decorator.ts
+++ b/packages/core/repl/repl-fn.decorator.ts
@@ -1,0 +1,81 @@
+import { isSymbol, isUndefined } from '@nestjs/common/utils/shared.utils';
+import { REPL_METADATA_KEY } from './constants';
+import type {
+  ReplMetadata,
+  ReplNativeFunctionMetadata,
+} from './repl.interfaces';
+
+type ReplFnDefinition = {
+  /** Function's description to display when `<function>.help` is entered. */
+  fnDescription: string;
+
+  /**
+   * Function's signature following TypeScript _function type expression_ syntax.
+   * @example '(token: InjectionToken) => any'
+   */
+  fnSignature: ReplNativeFunctionMetadata['signature'];
+};
+
+type ReplFnAliasDefinition = {
+  /**
+   * When the function is just an alias to another one that was registered
+   * already. Note that the function with the name passed to `aliasOf` should
+   * appear before this one on class methods's definition.
+   */
+  aliasOf: string;
+};
+
+export const makeReplFnOpt = (
+  description: string,
+  signature: string,
+): { fnDescription: string; fnSignature: string } => ({
+  fnDescription: description,
+  fnSignature: signature,
+});
+
+export function ReplFn(replFnOpts: ReplFnAliasDefinition): MethodDecorator;
+export function ReplFn(replFnOpts: ReplFnDefinition): MethodDecorator;
+export function ReplFn(
+  replFnOpts: ReplFnDefinition | ReplFnAliasDefinition,
+): MethodDecorator {
+  return (property: Object, methodName: string | symbol) => {
+    // As we are using class's properties as the name of the global function to
+    // avoid naming clashes, we won't allow symbols.
+    if (isSymbol(methodName)) {
+      return;
+    }
+
+    const ClassRef = property.constructor;
+    const replMetadata: ReplMetadata = Reflect.getMetadata(
+      REPL_METADATA_KEY,
+      ClassRef,
+    ) || { nativeFunctions: [] };
+
+    if ('aliasOf' in replFnOpts) {
+      if (replFnOpts.aliasOf) {
+        const nativeFunction = replMetadata.nativeFunctions.find(
+          ({ name }) => name === replFnOpts.aliasOf,
+        );
+
+        // If the native function was registered
+        if (!isUndefined(nativeFunction)) {
+          replMetadata.nativeFunctions.push({
+            name: methodName,
+            description: nativeFunction.description,
+            signature: nativeFunction.signature,
+          });
+          Reflect.defineMetadata(REPL_METADATA_KEY, replMetadata, ClassRef);
+        }
+      }
+
+      return;
+    }
+
+    replMetadata.nativeFunctions.push({
+      name: methodName,
+      description: replFnOpts.fnDescription,
+      signature: replFnOpts.fnSignature,
+    });
+    Reflect.defineMetadata(REPL_METADATA_KEY, replMetadata, ClassRef);
+  };
+}

--- a/packages/core/repl/repl.interfaces.ts
+++ b/packages/core/repl/repl.interfaces.ts
@@ -1,0 +1,25 @@
+/**
+ * Metadata of bult-in functions that will be available on the global context of
+ * the NestJS Read-Eval-Print-Loop (REPL).
+ */
+export interface ReplNativeFunctionMetadata {
+  /** Function's name. */
+  name: string;
+
+  /** Function's description to display when `<function>.help` is entered. */
+  description: string;
+
+  /**
+   * Function's signature following TypeScript _function type expression_ syntax,
+   * to display when `<function>.help` is entered along with function's description.
+   * @example '(token: InjectionToken) => any'
+   */
+  signature: string;
+}
+
+/**
+ * Metadata attached to REPL context class.
+ */
+export interface ReplMetadata {
+  nativeFunctions: ReplNativeFunctionMetadata[];
+}

--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -1,9 +1,50 @@
 import { Logger, Type } from '@nestjs/common';
+import { clc } from '@nestjs/common/utils/cli-colors.util';
 import * as _repl from 'repl';
 import { NestFactory } from '../nest-factory';
-import { REPL_INITIALIZED_MESSAGE } from './constants';
-import { ReplContext } from './repl-context';
+import { REPL_INITIALIZED_MESSAGE, REPL_METADATA_KEY } from './constants';
+import { ReplContext as CoreReplContext, ReplContext } from './repl-context';
 import { ReplLogger } from './repl-logger';
+import { ReplMetadata } from './repl.interfaces';
+
+/** Utility to build help messages for NestJS REPL native functions. */
+const makeHelpMessage = (
+  description: string,
+  fnSignatureWithName: string,
+): string =>
+  `${clc.yellow(description)}\n${clc.magentaBright('Interface:')} ${clc.bold(
+    fnSignatureWithName,
+  )}\n`;
+
+function loadNativeFunctionsOnContext(
+  replServerContext: _repl.REPLServer['context'],
+  replContext: ReplContext,
+  replMetadata: ReplMetadata,
+) {
+  replMetadata.nativeFunctions.forEach(nativeFunction => {
+    const functionRef: Function = replContext[nativeFunction.name];
+    if (!functionRef) return;
+
+    // Bind the method to REPL's context:
+    const functionBoundRef = (replServerContext[nativeFunction.name] =
+      functionRef.bind(replContext));
+
+    // Load the help trigger as a `help` getter on each native function:
+    Object.defineProperty(functionBoundRef, 'help', {
+      enumerable: false,
+      configurable: false,
+      get: () => {
+        // Lazy building the help message as will unlikely to be called often,
+        // and we can keep the closure context smaller just for this task.
+        const helpMessage = makeHelpMessage(
+          nativeFunction.description,
+          `${nativeFunction.name}${nativeFunction.signature}`,
+        );
+        replContext.writeToStdout(helpMessage);
+      },
+    });
+  });
+}
 
 export async function repl(module: Type) {
   const app = await NestFactory.create(module, {
@@ -12,6 +53,7 @@ export async function repl(module: Type) {
   });
   await app.init();
 
+  const ReplContext = CoreReplContext;
   const replContext = new ReplContext(app);
   Logger.log(REPL_INITIALIZED_MESSAGE);
 
@@ -20,12 +62,11 @@ export async function repl(module: Type) {
     ignoreUndefined: true,
   });
 
-  replServer.context.$ = replContext.$.bind(replContext);
-  replServer.context.get = replContext.get.bind(replContext);
-  replServer.context.resolve = replContext.resolve.bind(replContext);
-  replServer.context.select = replContext.select.bind(replContext);
-  replServer.context.debug = replContext.debug.bind(replContext);
-  replServer.context.methods = replContext.methods.bind(replContext);
+  const replMetadata: ReplMetadata = Reflect.getMetadata(
+    REPL_METADATA_KEY,
+    ReplContext,
+  );
+  loadNativeFunctionsOnContext(replServer.context, replContext, replMetadata);
 
   return replServer;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

No built-in helpers on current version of REPL feature (that will be added on #9684).

No way to find out what are the functions available to use for the NestJS app

## What is the new behavior?

Users can call `help()` to view all the available 'native functions' (in an alphabetical order). I call them _functions_ because _commands_ are those displayed when we type `.help` (and registed by [`replServer.defineCommand`](https://nodejs.org/api/repl.html#replserverdefinecommandkeyword-cmd))

Users can type `<function>.help` (eg: `methods.help`) if they want to find out what a 'native function' could do (their description and function's signature, which follows the [TS function type expression](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-type-expressions))

Note that aliases should appear after the original function due to how `@ReplFn()` is evaluated. Supporting the out-of-order definition for function aliases looks trickier but it's feasiable.

Demo:

https://user-images.githubusercontent.com/13461315/171057054-031ffc8a-3735-43bd-8e0d-6e5e6451bd9b.mp4

(up-to-date version of `help()` output:)

![image](https://user-images.githubusercontent.com/13461315/171065315-bd204767-c580-4434-a0cc-e9df3ef00439.png)


Also, `delete <function>.help` or `<function>.help = () => {}` won't take any effect on the original `help` getter.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other

The only issue with in-repl docs is that the typings could be vague (for instance, `ClassRef` isn't a valid type from `@nestjs` but I feel it's better than `Type` for those who don't know `Type`). But at same time, having then right on in the REPL will improve DX

We can call `<function>.help()` but we would get an `Uncaught TypeError` because `help` is not a function. I don't know how to prevent that error while allowing both `.help` and `.help()` usages.
