### PR TITLE
feat(core,common): add helpers messages to REPL built-in functions

### DIFF
--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -5,6 +5,7 @@ const colorIfAllowed = (colorFn: ColorTextFn) => (text: string) =>
   isColorAllowed() ? colorFn(text) : text;
 
 export const clc = {
+  bold: colorIfAllowed((text: string) => `\x1B[1m${text}\x1B[0m`),
   green: colorIfAllowed((text: string) => `\x1B[32m${text}\x1B[39m`),
   yellow: colorIfAllowed((text: string) => `\x1B[33m${text}\x1B[39m`),
   red: colorIfAllowed((text: string) => `\x1B[31m${text}\x1B[39m`),

--- a/packages/core/repl/native-functions.ts
+++ b/packages/core/repl/native-functions.ts
@@ -1,0 +1,129 @@
+import { DynamicModule, INestApplicationContext, Type } from '@nestjs/common';
+import { clc } from '@nestjs/common/utils/cli-colors.util';
+import { MetadataScanner } from '../metadata-scanner';
+import { ReplFunction } from './repl-function';
+import type { ModuleDebugEntry } from './repl-context';
+import type { ReplFnDefinition } from './repl.interfaces';
+
+export class GetReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'get',
+    signature: '(token: InjectionToken) => any',
+    description:
+      'Retrieves an instance of either injectable or controller, otherwise, throws exception.',
+    aliases: ['$'],
+  };
+
+  action(token: string | symbol | Function | Type<any>): any {
+    this.ctx.app.get(token);
+  }
+}
+
+export class ResolveReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'resolve',
+    description:
+      'Resolves transient or request-scoped instance of either injectable or controller, otherwise, throws exception',
+    signature: '(token: InjectionToken, contextId: any) => Promise<any>',
+  };
+
+  action(
+    token: string | symbol | Function | Type<any>,
+    contextId: any,
+  ): Promise<any> {
+    return this.ctx.app.resolve(token, contextId);
+  }
+}
+
+export class SelectReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'select',
+    description:
+      'Allows navigating through the modules tree, for example, to pull out a specific instance from the selected module.',
+    signature: '(token: DynamicModule | ClassRef) => INestApplicationContext',
+  };
+
+  action(token: DynamicModule | Type<unknown>): INestApplicationContext {
+    return this.ctx.app.select(token);
+  }
+}
+
+export class DebugReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'debug',
+    description: '',
+    signature: '(moduleCls?: ClassRef | string) => void',
+  };
+
+  action(moduleCls?: Type<unknown> | string): void {
+    this.ctx.writeToStdout('\n');
+
+    if (moduleCls) {
+      const token =
+        typeof moduleCls === 'function' ? moduleCls.name : moduleCls;
+      const moduleEntry = this.ctx.debugRegistry[token];
+      if (!moduleEntry) {
+        return this.logger.error(
+          `"${token}" has not been found in the modules registry`,
+        );
+      }
+      this.printCtrlsAndProviders(token, moduleEntry);
+    } else {
+      Object.keys(this.ctx.debugRegistry).forEach(moduleKey => {
+        this.printCtrlsAndProviders(
+          moduleKey,
+          this.ctx.debugRegistry[moduleKey],
+        );
+      });
+    }
+    this.ctx.writeToStdout('\n');
+  }
+
+  private printCtrlsAndProviders(
+    moduleName: string,
+    moduleDebugEntry: ModuleDebugEntry,
+  ) {
+    const printCollection = (collection: keyof ModuleDebugEntry) => {
+      const collectionEntries = Object.keys(moduleDebugEntry[collection]);
+      if (collectionEntries.length <= 0) {
+        return;
+      }
+      this.ctx.writeToStdout(` ${clc.yellow(`- ${collection}`)}: \n`);
+      collectionEntries.forEach(provider =>
+        this.ctx.writeToStdout(`  ${clc.green('◻')} ${provider}\n`),
+      );
+    };
+
+    this.ctx.writeToStdout(`${clc.green(moduleName)}: \n`);
+    printCollection('controllers');
+    printCollection('providers');
+  }
+}
+
+export class MethodsReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'methods',
+    description: 'Display all public methods available on a given provider.',
+    signature: '(token: ClassRef | string) => void',
+  };
+
+  private readonly metadataScanner = new MetadataScanner();
+
+  action(token: Type<unknown> | string): void {
+    const proto =
+      typeof token !== 'function'
+        ? Object.getPrototypeOf(this.ctx.app.get(token))
+        : token?.prototype;
+
+    const methods = new Set(
+      this.metadataScanner.getAllFilteredMethodNames(proto),
+    );
+
+    this.ctx.writeToStdout('\n');
+    this.ctx.writeToStdout(`${clc.green('Methods')}: \n`);
+    methods.forEach(methodName =>
+      this.ctx.writeToStdout(` ${clc.yellow('◻')} ${methodName}\n`),
+    );
+    this.ctx.writeToStdout('\n');
+  }
+}

--- a/packages/core/repl/native-functions.ts
+++ b/packages/core/repl/native-functions.ts
@@ -5,6 +5,33 @@ import { ReplFunction } from './repl-function';
 import type { ModuleDebugEntry } from './repl-context';
 import type { ReplFnDefinition } from './repl.interfaces';
 
+export class HelpReplFn extends ReplFunction {
+  public fnDefinition: ReplFnDefinition = {
+    name: 'help',
+    signature: '() => void',
+    description: 'Display all available REPL native functions.',
+  };
+
+  action(): void {
+    const buildHelpMessage = ({ name, description }: ReplFnDefinition) =>
+      clc.cyanBright(name) +
+      (description ? ` ${clc.bold('-')} ${description}` : '');
+
+    const sortedNativeFunctions = this.ctx.nativeFunctions
+      .map(nativeFunction => nativeFunction.fnDefinition)
+      .sort((a, b) => (a.name < b.name ? -1 : 1));
+
+    this.ctx.writeToStdout(
+      `You can call ${clc.bold(
+        '.help',
+      )} on any function listed below (e.g.: ${clc.bold('help.help')}):\n\n` +
+        sortedNativeFunctions.map(buildHelpMessage).join('\n') +
+        // Without the following LF the last item won't be displayed
+        '\n',
+    );
+  }
+}
+
 export class GetReplFn extends ReplFunction {
   public fnDefinition: ReplFnDefinition = {
     name: 'get',

--- a/packages/core/repl/repl-context.ts
+++ b/packages/core/repl/repl-context.ts
@@ -6,6 +6,7 @@ import { Module } from '../injector/module';
 import {
   DebugReplFn,
   GetReplFn,
+  HelpReplFn,
   MethodsReplFn,
   ResolveReplFn,
   SelectReplFn,
@@ -95,6 +96,7 @@ export class ReplContext {
     nativeFunctionsClassRefs: ReplFunctionClass[],
   ): void {
     const builtInFunctionsClassRefs: ReplFunctionClass[] = [
+      HelpReplFn,
       GetReplFn,
       ResolveReplFn,
       SelectReplFn,

--- a/packages/core/repl/repl-function.ts
+++ b/packages/core/repl/repl-function.ts
@@ -1,0 +1,36 @@
+import { Logger } from '@nestjs/common';
+import { clc } from '@nestjs/common/utils/cli-colors.util';
+import { ReplContext } from './repl-context';
+import type { ReplFnDefinition } from './repl.interfaces';
+
+export abstract class ReplFunction<
+  ActionParams extends Array<unknown> = Array<unknown>,
+  ActionReturn = any,
+> {
+  /** Metadata that describes the built-in function itself. */
+  public abstract fnDefinition: ReplFnDefinition;
+
+  protected readonly logger: Logger;
+
+  constructor(protected readonly ctx: ReplContext) {
+    this.logger = ctx.logger;
+  }
+
+  /**
+   * Method called when the function is invoked from the REPL by the user.
+   */
+  abstract action(...args: ActionParams): ActionReturn;
+
+  /**
+   * @returns A message displayed by calling `<fnName>.help`
+   */
+  public makeHelpMessage(): string {
+    const { description, name, signature } = this.fnDefinition;
+
+    const fnSignatureWithName = `${name}${signature}`;
+
+    return `${clc.yellow(description)}\n${clc.magentaBright(
+      'Interface:',
+    )} ${clc.bold(fnSignatureWithName)}\n`;
+  }
+}

--- a/packages/core/repl/repl.interfaces.ts
+++ b/packages/core/repl/repl.interfaces.ts
@@ -1,0 +1,21 @@
+import type { ReplContext } from './repl-context';
+import type { ReplFunction } from './repl-function';
+
+export type ReplFnDefinition = {
+  /** Function's name. Note that this should be a valid JavaScript function name. */
+  name: string;
+
+  /** Alternative names to the function. */
+  aliases?: ReplFnDefinition['name'][];
+
+  /** Function's description to display when `<function>.help` is entered. */
+  description: string;
+
+  /**
+   * Function's signature following TypeScript _function type expression_ syntax.
+   * @example '(token: InjectionToken) => any'
+   */
+  signature: string;
+};
+
+export type ReplFunctionClass = new (replContext: ReplContext) => ReplFunction;

--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -3,7 +3,54 @@ import * as _repl from 'repl';
 import { NestFactory } from '../nest-factory';
 import { REPL_INITIALIZED_MESSAGE } from './constants';
 import { ReplContext } from './repl-context';
+import { ReplFunction } from './repl-function';
 import { ReplLogger } from './repl-logger';
+import { ReplFunctionClass } from './repl.interfaces';
+
+function loadNativeFunctionsIntoContext(
+  replServerContext: _repl.REPLServer['context'],
+  replContext: ReplContext,
+) {
+  const registerFunction = (
+    nativeFunction: InstanceType<ReplFunctionClass>,
+  ): void => {
+    // Bind the method to REPL's context:
+    replServerContext[nativeFunction.fnDefinition.name] =
+      nativeFunction.action.bind(nativeFunction);
+
+    // Load the help trigger as a `help` getter on each native function:
+    const functionBoundRef: ReplFunction['action'] =
+      replServerContext[nativeFunction.fnDefinition.name];
+    Object.defineProperty(functionBoundRef, 'help', {
+      enumerable: false,
+      configurable: false,
+      get: () =>
+        // Dynamically builds the help message as will unlikely to be called
+        // several times.
+        replContext.writeToStdout(nativeFunction.makeHelpMessage()),
+    });
+  };
+
+  const aliasesNativeFunctions = replContext.nativeFunctions
+    .filter(nativeFunction => nativeFunction.fnDefinition.aliases)
+    .flatMap(nativeFunction =>
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      nativeFunction.fnDefinition.aliases!.map(aliasFnName => {
+        const aliasNativeFunction: InstanceType<ReplFunctionClass> =
+          Object.create(nativeFunction);
+        aliasNativeFunction.fnDefinition = {
+          name: aliasFnName,
+          description: aliasNativeFunction.fnDefinition.description,
+          signature: aliasNativeFunction.fnDefinition.signature,
+        };
+
+        return aliasNativeFunction;
+      }),
+    );
+
+  replContext.nativeFunctions.push(...aliasesNativeFunctions);
+  replContext.nativeFunctions.forEach(registerFunction);
+}
 
 export async function repl(module: Type) {
   const app = await NestFactory.create(module, {
@@ -20,12 +67,7 @@ export async function repl(module: Type) {
     ignoreUndefined: true,
   });
 
-  replServer.context.$ = replContext.$.bind(replContext);
-  replServer.context.get = replContext.get.bind(replContext);
-  replServer.context.resolve = replContext.resolve.bind(replContext);
-  replServer.context.select = replContext.select.bind(replContext);
-  replServer.context.debug = replContext.debug.bind(replContext);
-  replServer.context.methods = replContext.methods.bind(replContext);
+  loadNativeFunctionsIntoContext(replServer.context, replContext);
 
   return replServer;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

same as PR #9692 but with other interface regarding REPL built-in functions

https://user-images.githubusercontent.com/13461315/171105709-0b7b7f48-0baa-46e9-af5c-1a7ddb222cca.mp4


## What is the differences between them?

1. `ReplContext` is much cleaner. It doesn't have to deal with those built-in functions
3. no decorators (ie., no reflection)
2. Every built-in function will live in their own class and aren't aware (directly) of the others functions
5. To define our own 'built-in functions' we just need to implement classes that `extends ReplFunction`, and then we could pass a list of those class references to the main `repl` function _(if we implement such feature in the feature)_. As of now, they will live along the native ones (`help`, `debug`, etc)

for instance, the `get` native function looks like this:

```ts
class GetReplFn extends ReplFunction {
  // metadata that describes the function itself
  public fnDefinition: ReplFnDefinition = {
    name: 'get',
    signature: '(token: InjectionToken) => any',
    description:
      'Retrieves an instance of either injectable or controller, otherwise, throws exception.',
    // Optional list of aliases
    aliases: ['$'],
  };

  // The function to execute under the name `get`
  action(token: string | symbol | Function | Type<any>): any {
    this.ctx.app.get(token);
  }
}
```

#### pros

- from nestjs user POV, I feel this API is much easier to follow and extend as there's no much magic happing. Users could write functions factories to build their classes easily

#### cons

- we could have naming collision (that I didn't handle in this PR)
- as the name is just an string, users could invalid function names

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
