### PR TITLE
feat(common): Add error chaining support to http exception

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -44,6 +44,8 @@ export class HttpException extends Error {
     this.initCause();
   }
 
+  public cause: Error | undefined;
+
   /**
    * Configures error chaining support
    *
@@ -53,7 +55,6 @@ export class HttpException extends Error {
    */
   public initCause() {
     if (this.response instanceof Error) {
-      // @ts-ignore
       this.cause = this.response;
     }
   }

--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -41,6 +41,21 @@ export class HttpException extends Error {
     super();
     this.initMessage();
     this.initName();
+    this.initCause();
+  }
+
+  /**
+   * Configures error chaining support
+   *
+   * See:
+   * - https://nodejs.org/en/blog/release/v16.9.0/#error-cause
+   * - https://github.com/microsoft/TypeScript/issues/45167
+   */
+  public initCause() {
+    if (this.response instanceof Error) {
+      // @ts-ignore
+      this.cause = this.response;
+    }
   }
 
   public initMessage() {

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -135,7 +135,6 @@ describe('HttpException', () => {
       const message = new Error('Some Error');
       const error = new HttpException(message, 400);
       expect(`${error}`).to.be.eql(`HttpException: ${message.message}`);
-      // @ts-ignore
       const { cause } = error;
 
       expect(cause).to.be.eql(message);

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -129,4 +129,16 @@ describe('HttpException', () => {
       });
     });
   });
+
+  describe('initCause', () => {
+    it('configures a cause when message is an instance of error', () => {
+      const message = new Error('Some Error');
+      const error = new HttpException(message, 400);
+      expect(`${error}`).to.be.eql(`HttpException: ${message.message}`);
+      // @ts-ignore
+      const { cause } = error;
+
+      expect(cause).to.be.eql(message);
+    });
+  });
 });


### PR DESCRIPTION
Adds the ability to configure the cause of an error when passing an error object to http exception.

I would love to see HTTP Exception change over time to be more flexible, such as having both a custom message and a cause, but for now this fits my needs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
   - Don't think this needs docs, since this is a side effect of passing an error, and not really a decision the user needs to make.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
You can't set the `cause` of an error object.

Issue Number: N/A


## What is the new behavior?
It is now possible to set the cause of an HTTP Exception based error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Documentation
- https://nodejs.org/en/blog/release/v16.9.0/#error-cause
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#rethrowing_an_error_with_a_cause
- https://github.com/microsoft/TypeScript/issues/45167