### PR TITLE
fix(core): prompt respects `NO_COLOR` config

### DIFF
--- a/integration/repl/e2e/repl.spec.ts
+++ b/integration/repl/e2e/repl.spec.ts
@@ -14,7 +14,7 @@ import * as sinon from 'sinon';
 import { AppModule } from '../src/app.module';
 import { UsersModule } from '../src/users/users.module';
 
-const prompt = '\u001b[1G\u001b[0J\u001b[32m>\u001b[0m \u001b[3G';
+const PROMPT = '\u001b[1G\u001b[0J> \u001b[3G';
 
 describe('REPL', () => {
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('REPL', () => {
 
     expect(outputText).to.equal(
       `UsersService { usersRepository: UsersRepository {} }
-${prompt}`,
+${PROMPT}`,
     );
 
     outputText = '';
@@ -52,13 +52,13 @@ ${prompt}`,
 
     expect(outputText).to
       .equal(`\u001b[32m'This action returns all users'\u001b[39m
-${prompt}`);
+${PROMPT}`);
 
     outputText = '';
     server.emit('line', 'get(UsersRepository)');
 
     expect(outputText).to.equal(`UsersRepository {}
-${prompt}`);
+${PROMPT}`);
   });
 
   it('debug()', async () => {
@@ -80,7 +80,7 @@ UsersModule:
   ◻ UsersService
   ◻ UsersRepository
 
-${prompt}`,
+${PROMPT}`,
     );
   });
 
@@ -99,7 +99,7 @@ ${prompt}`,
 Methods:
  ◻ find
 
-${prompt}`,
+${PROMPT}`,
     );
 
     outputText = '';
@@ -114,7 +114,7 @@ Methods:
  ◻ update
  ◻ remove
 
-${prompt}`,
+${PROMPT}`,
     );
   });
 
@@ -135,7 +135,7 @@ ${prompt}`,
 
       expect(outputText).to.equal(`${description}
 Interface: help${signature}
-${prompt}`);
+${PROMPT}`);
     });
 
     it(`Typing "get.help" should print function's description and interface`, async () => {
@@ -154,7 +154,7 @@ ${prompt}`);
 
       expect(outputText).to.equal(`${description}
 Interface: get${signature}
-${prompt}`);
+${PROMPT}`);
     });
 
     it(`Typing "resolve.help" should print function's description and interface`, async () => {
@@ -173,7 +173,7 @@ ${prompt}`);
 
       expect(outputText).to.equal(`${description}
 Interface: resolve${signature}
-${prompt}`);
+${PROMPT}`);
     });
 
     it(`Typing "select.help" should print function's description and interface`, async () => {
@@ -192,7 +192,7 @@ ${prompt}`);
 
       expect(outputText).to.equal(`${description}
 Interface: select${signature}
-${prompt}`);
+${PROMPT}`);
     });
 
     it(`Typing "debug.help" should print function's description and interface`, async () => {
@@ -211,7 +211,7 @@ ${prompt}`);
 
       expect(outputText).to.equal(`${description}
 Interface: debug${signature}
-${prompt}`);
+${PROMPT}`);
     });
 
     it(`Typing "methods.help" should print function's description and interface`, async () => {
@@ -230,7 +230,7 @@ ${prompt}`);
 
       expect(outputText).to.equal(`${description}
 Interface: methods${signature}
-${prompt}`);
+${PROMPT}`);
     });
   });
 });

--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -1,5 +1,6 @@
 import { Logger, Type } from '@nestjs/common';
 import * as _repl from 'repl';
+import { clc } from '@nestjs/common/utils/cli-colors.util';
 import { NestFactory } from '../nest-factory';
 import { REPL_INITIALIZED_MESSAGE } from './constants';
 import { loadNativeFunctionsIntoContext } from './load-native-functions-into-context';
@@ -17,7 +18,7 @@ export async function repl(module: Type) {
   Logger.log(REPL_INITIALIZED_MESSAGE);
 
   const replServer = _repl.start({
-    prompt: '\x1b[32m>\x1b[0m ',
+    prompt: clc.green('> '),
     ignoreUndefined: true,
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

when `NO_COLOR` env. var. is defined, the prompt indicator remains colored

![image](https://user-images.githubusercontent.com/13461315/171489097-acd6cd23-c058-42f2-a40e-05a403678f00.png)

## What is the new behavior?


![image](https://user-images.githubusercontent.com/13461315/171532476-4ab9cd9b-24da-46fb-9f4f-f2dee285ea73.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No