### PR TITLE
chore(deps): remove fastify deprecation warning

### DIFF
--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "fastify": "3.29.0",
-    "fastify-cors": "6.1.0",
-    "fastify-formbody": "5.3.0",
+    "@fastify/cors": "7.0.0",
+    "@fastify/formbody": "6.0.1",
     "light-my-request": "5.0.0",
     "middie": "6.1.0",
     "path-to-regexp": "3.2.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe: 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A warning is shown

```
(node:31444) [FST_MODULE_DEP_FASTIFY-FORMBODY] FastifyWarning.fastify-formbody: fastify-formbody has been deprecated. Use @fastify/formbody@6.0.0 instead.
(Use `node --trace-warnings ...` to show where the warning was created)
```

Issue Number: N/A


## What is the new behavior?

The new fastify's plugin major releases contain only the module rename without the warning.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Ref https://github.com/fastify/fastify-formbody/issues/116