### PR TITLE
fix(microservices): adds feedback message when RabbitMQ server connection hangs

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -52,3 +52,6 @@ export const MQTT_WILDCARD_ALL = '#';
 export const ECONNREFUSED = 'ECONNREFUSED';
 export const CONN_ERR = 'CONN_ERR';
 export const EADDRINUSE = 'EADDRINUSE';
+
+export const CONNECTION_FAILED_MESSAGE =
+  'Connection to transport failed. Trying to reconnect...';

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -5,8 +5,10 @@ import {
 } from '@nestjs/common/utils/shared.utils';
 import {
   CONNECT_EVENT,
-  DISCONNECTED_RMQ_MESSAGE,
+  CONNECT_FAILED_EVENT,
+  CONNECTION_FAILED_MESSAGE,
   DISCONNECT_EVENT,
+  DISCONNECTED_RMQ_MESSAGE,
   NO_MESSAGE_HANDLER,
   RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT,
   RQM_DEFAULT_NOACK,
@@ -93,6 +95,10 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     });
     this.server.on(DISCONNECT_EVENT, (err: any) => {
       this.logger.error(DISCONNECTED_RMQ_MESSAGE);
+      this.logger.error(err);
+    });
+    this.server.on(CONNECT_FAILED_EVENT, (err: any) => {
+      this.logger.error(CONNECTION_FAILED_MESSAGE);
       this.logger.error(err);
     });
   }

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -52,6 +52,10 @@ describe('ServerRMQ', () => {
       server.listen(callbackSpy);
       expect(onStub.getCall(1).args[0]).to.be.equal('disconnect');
     });
+    it('should bind "connectFailed" event to handler', () => {
+      server.listen(callbackSpy);
+      expect(onStub.getCall(2).args[0]).to.be.equal('connectFailed');
+    });
     describe('when "start" throws an exception', () => {
       it('should call callback with a thrown error as an argument', () => {
         const error = new Error('random error');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9749

If a RabbitMQ connection fails, NestJS keeps trying to reconnect but no log message is dispatched. So, the user thinks the server frozen and it is not doing anything else.

## What is the new behavior?

Upon a failed connection on the RabbitMQ server, I've added an error log to show what happened to the user.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

At first we were considering that #9726 was also impacted by this issue, but it isn't, since this is specific to how RabbitMQ handles failed connection attempts.