### PR TITLE
feat(core): middleware runs once for matching route

### DIFF
--- a/integration/hello-world/e2e/middleware-run-match-route.ts
+++ b/integration/hello-world/e2e/middleware-run-match-route.ts
@@ -1,0 +1,103 @@
+import {
+  Controller,
+  Get,
+  INestApplication,
+  Injectable,
+  MiddlewareConsumer,
+  NestMiddleware,
+  Module,
+} from '@nestjs/common';
+import { Test } from '../../../packages/testing';
+import * as request from 'supertest';
+import { expect } from 'chai';
+
+/**
+ * Number of times that the middleware was executed.
+ */
+let triggerCounter = 0;
+@Injectable()
+class Middleware implements NestMiddleware {
+  use(req, res, next) {
+    triggerCounter++;
+    next();
+  }
+}
+
+@Controller()
+class TestController {
+  @Get('/test')
+  testA() {}
+
+  @Get('/:id')
+  testB() {}
+
+  @Get('/static/route')
+  testC() {}
+
+  @Get('/:id/:nested')
+  testD() {}
+}
+
+@Module({
+  controllers: [TestController],
+})
+class TestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(Middleware).forRoutes(TestController);
+  }
+}
+
+describe('Middleware (run on route match)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    triggerCounter = 0;
+    app = (
+      await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile()
+    ).createNestApplication();
+
+    await app.init();
+  });
+
+  it(`forRoutes(TestController) should execute middleware once when request url is equal match`, () => {
+    return request(app.getHttpServer())
+      .get('/test')
+      .expect(200)
+      .then(() => {
+        expect(triggerCounter).to.be.eq(1);
+      });
+  });
+
+  it(`forRoutes(TestController) should execute middleware once when request url is not equal match`, () => {
+    return request(app.getHttpServer())
+      .get('/1')
+      .expect(200)
+      .then(() => {
+        expect(triggerCounter).to.be.eq(1);
+      });
+  });
+
+  it(`forRoutes(TestController) should execute middleware once when request url is not of nested params`, () => {
+    return request(app.getHttpServer())
+      .get('/static/route')
+      .expect(200)
+      .then(() => {
+        expect(triggerCounter).to.be.eq(1);
+      });
+  });
+
+  it(`forRoutes(TestController) should execute middleware once when request url is of nested params`, () => {
+    return request(app.getHttpServer())
+      .get('/1/abc')
+      .expect(200)
+      .then(() => {
+        expect(triggerCounter).to.be.eq(1);
+      });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -88,7 +88,7 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
       const regexMatchParams = /(:[^\/]*)/g;
       const wildcard = '([^/]*)';
       const routesWithRegex = routes
-        .filter(route => route.path.indexOf(':') >= 0)
+        .filter(route => route.path.includes(':'))
         .map(route => ({
           path: route.path,
           regex: new RegExp(
@@ -97,9 +97,11 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
           ),
         }));
       return routes.filter(route => {
-        const routeMatch = routesWithRegex.find(
-          v => route.path !== v.path && route.path.match(v.regex),
-        );
+        const isOverlapped = (v: { path: string; regex: RegExp }) => {
+          return route.path !== v.path && route.path.match(v.regex);
+        };
+        const routeMatch = routesWithRegex.find(isOverlapped);
+
         if (routeMatch === undefined) return route;
       });
     }

--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -102,7 +102,9 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
         };
         const routeMatch = routesWithRegex.find(isOverlapped);
 
-        if (routeMatch === undefined) return route;
+        if (routeMatch === undefined) {
+         return route;
+        }
       });
     }
   };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, routes that has dynamic params can trigger a middleware multiple times for a single request if matches another static route inside the controller.

Issue Number: [#1628](https://github.com/nestjs/nest/issues/1628)


## What is the new behavior?
Routes will only trigger the middleware for the exact path match.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information