### PR TITLE
fix: use pipeline over stream.pipe

### DIFF
--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -65,4 +65,7 @@ describe('Express FileSend', () => {
         expect(res.text).to.be.eq(readmeString);
       });
   });
+  it('should return an error if the file does not exist', async () => {
+    return request(app.getHttpServer()).get('/file/not/exist').expect(400);
+  });
 });

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -31,4 +31,9 @@ export class AppController {
   getFileWithHeaders(): StreamableFile {
     return this.appService.getFileWithHeaders();
   }
+
+  @Get('file/not/exist')
+  getNonExistantFile(): StreamableFile {
+    return this.appService.getFileThatDoesNotExist();
+  }
 }

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -35,4 +35,8 @@ export class AppService {
       },
     );
   }
+
+  getFileThatDoesNotExist(): StreamableFile {
+    return new StreamableFile(createReadStream('does-not-exist.txt'));
+  }
 }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -11,11 +11,13 @@ export interface StreamableHandlerResponse {
 export class StreamableFile {
   private readonly stream: Readable;
 
-  protected handler: (err: Error, response: StreamableHandlerResponse) => void =
-    (err: Error, res) => {
-      res.statusCode = 400;
-      res.send(err.message);
-    };
+  protected handleError: (
+    err: Error,
+    response: StreamableHandlerResponse,
+  ) => void = (err: Error, res) => {
+    res.statusCode = 400;
+    res.send(err.message);
+  };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);
   constructor(readable: Readable, options?: StreamableFileOptions);
@@ -54,13 +56,13 @@ export class StreamableFile {
     err: Error,
     response: StreamableHandlerResponse,
   ) => void {
-    return this.handler;
+    return this.handleError;
   }
 
   setErrorHandler(
     handler: (err: Error, response: StreamableHandlerResponse) => void,
   ) {
-    this.handler = handler;
+    this.handleError = handler;
     return this;
   }
 }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -3,8 +3,21 @@ import { types } from 'util';
 import { isFunction } from '../utils/shared.utils';
 import { StreamableFileOptions } from './streamable-options.interface';
 
+interface StreamableHandlerResponse {
+  statusCode: number;
+  send: (msg: string) => void;
+}
+
 export class StreamableFile {
   private readonly stream: Readable;
+
+  private handler: (err: Error, response: StreamableHandlerResponse) => void = (
+    err: Error,
+    res,
+  ) => {
+    res.statusCode = 400;
+    res.send(err.message);
+  };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);
   constructor(readable: Readable, options?: StreamableFileOptions);
@@ -37,5 +50,19 @@ export class StreamableFile {
       disposition,
       length,
     };
+  }
+
+  get errorHandler(): (
+    err: Error,
+    response: StreamableHandlerResponse,
+  ) => void {
+    return this.handler;
+  }
+
+  setErrorHandler(
+    handler: (err: Error, response: StreamableHandlerResponse) => void,
+  ) {
+    this.handler = handler;
+    return this;
   }
 }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -3,7 +3,7 @@ import { types } from 'util';
 import { isFunction } from '../utils/shared.utils';
 import { StreamableFileOptions } from './streamable-options.interface';
 
-interface StreamableHandlerResponse {
+export interface StreamableHandlerResponse {
   statusCode: number;
   send: (msg: string) => void;
 }
@@ -11,13 +11,11 @@ interface StreamableHandlerResponse {
 export class StreamableFile {
   private readonly stream: Readable;
 
-  private handler: (err: Error, response: StreamableHandlerResponse) => void = (
-    err: Error,
-    res,
-  ) => {
-    res.statusCode = 400;
-    res.send(err.message);
-  };
+  protected handler: (err: Error, response: StreamableHandlerResponse) => void =
+    (err: Error, res) => {
+      res.statusCode = 400;
+      res.send(err.message);
+    };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);
   constructor(readable: Readable, options?: StreamableFileOptions);

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -48,6 +48,7 @@ type VersionedRoute = <
 
 export class ExpressAdapter extends AbstractHttpAdapter {
   private readonly routerMethodFactory = new RouterMethodFactory();
+  private readonly logger = new Logger(ExpressAdapter.name);
 
   constructor(instance?: any) {
     super(instance || express());
@@ -87,7 +88,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
         response,
         (err: Error) => {
           if (err) {
-            new Logger('ExpressAdapter').error(err.message, err.stack);
+            this.logger.error(err.message, err.stack);
           }
         },
       );

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -81,7 +81,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
         response.setHeader('Content-Length', streamHeaders.length);
       }
       return pipeline(
-        body.getStream().on('error', (err: Error) => {
+        body.getStream().once('error', (err: Error) => {
           body.errorHandler(err, response);
         }),
         response,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If a request is cancelled during a `StreamableFile` response, then the stream is not properly closed which can lead to memory leaks and possible server failures if enough of them occur

Issue Number: #9759


## What is the new behavior?

`pipeline` ends up destroying streams used if there is an error in one of
the streams. Due to this, there's no chance of a memory leak from errored out
streams. There's also now an addition of adding an error handler to the
`StreamableFile` so that stream errors by default return a 400 and can be
customized to return an error message however a developer would like. These
only effect the express adapter because of how Fastify already internally
handles streams.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information

fix: #9759