### PR TITLE
feat(core): add option to disable logs on `LazyModuleLoader#load`

### DIFF
--- a/packages/core/injector/instance-loader.ts
+++ b/packages/core/injector/instance-loader.ts
@@ -11,10 +11,14 @@ export class InstanceLoader {
   protected readonly injector = new Injector();
   constructor(
     protected readonly container: NestContainer,
-    private readonly logger = new Logger(InstanceLoader.name, {
+    private logger = new Logger(InstanceLoader.name, {
       timestamp: true,
     }),
   ) {}
+
+  public setLogger(logger: Logger) {
+    this.logger = logger;
+  }
 
   public async createInstancesOfDependencies(
     modules: Map<string, Module> = this.container.getModules(),

--- a/packages/core/injector/lazy-module-loader-options.interface.ts
+++ b/packages/core/injector/lazy-module-loader-options.interface.ts
@@ -1,0 +1,3 @@
+export interface LazyModuleLoaderLoadOptions {
+  disableLogs?: boolean;
+}

--- a/packages/core/injector/lazy-module-loader-options.interface.ts
+++ b/packages/core/injector/lazy-module-loader-options.interface.ts
@@ -1,3 +1,6 @@
 export interface LazyModuleLoaderLoadOptions {
-  disableLogs?: boolean;
+  /** 
+   * If `false`, no logs will be generated when loading some module lazily.
+   */
+  logger?: boolean;
 }

--- a/packages/core/injector/lazy-module-loader.ts
+++ b/packages/core/injector/lazy-module-loader.ts
@@ -51,7 +51,7 @@ export class LazyModuleLoader {
   }
 
   private registerLoggerConfiguration(loadOpts?: LazyModuleLoaderLoadOptions) {
-    if (loadOpts?.disableLogs) {
+    if (loadOpts?.logger === false) {
       this.instanceLoader.setLogger(new SilentLogger());
     }
   }

--- a/packages/core/injector/lazy-module-loader.ts
+++ b/packages/core/injector/lazy-module-loader.ts
@@ -2,6 +2,8 @@ import { DynamicModule, Type } from '@nestjs/common';
 import { DependenciesScanner } from '../scanner';
 import { ModuleCompiler } from './compiler';
 import { InstanceLoader } from './instance-loader';
+import { SilentLogger } from './silent-logger';
+import { LazyModuleLoaderLoadOptions } from './lazy-module-loader-options.interface';
 import { Module } from './module';
 import { ModuleRef } from './module-ref';
 import { ModulesContainer } from './modules-container';
@@ -19,7 +21,10 @@ export class LazyModuleLoader {
       | Promise<Type<unknown> | DynamicModule>
       | Type<unknown>
       | DynamicModule,
+    loadOpts?: LazyModuleLoaderLoadOptions,
   ): Promise<ModuleRef> {
+    this.registerLoggerConfiguration(loadOpts);
+
     const moduleClassOrDynamicDefinition = await loaderFn();
     const moduleInstances = await this.dependenciesScanner.scanForModules(
       moduleClassOrDynamicDefinition,
@@ -43,6 +48,12 @@ export class LazyModuleLoader {
     );
     const [targetModule] = moduleInstances;
     return this.getTargetModuleRef(targetModule);
+  }
+
+  private registerLoggerConfiguration(loadOpts?: LazyModuleLoaderLoadOptions) {
+    if (loadOpts?.disableLogs) {
+      this.instanceLoader.setLogger(new SilentLogger());
+    }
   }
 
   private createLazyModulesContainer(

--- a/packages/core/injector/silent-logger.ts
+++ b/packages/core/injector/silent-logger.ts
@@ -1,0 +1,12 @@
+import { Logger } from '@nestjs/common';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+export class SilentLogger extends Logger {
+  log = noop;
+  error = noop;
+  warn = noop;
+  debug = noop;
+  verbose = noop;
+  setLogLevels = noop;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #9107 


## What is the new behavior?

```ts
const moduleRef = await this.lazyModuleLoader.load(() => LazyModule, { logger: false });

const moduleRef = await this.lazyModuleLoader.load(() => LazyModule); // logs enabled
```

I choose the name `logger` so we could enhance this feature later on without introducing breaking changes on that signature

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information