### PR TITLE
fix(microservices): Update LogEntry in external kafka interface

### DIFF
--- a/packages/microservices/external/kafka.interface.ts
+++ b/packages/microservices/external/kafka.interface.ts
@@ -563,7 +563,7 @@ export interface LogEntry {
 }
 
 export interface LoggerEntryContent {
-  readonly timestamp: Date;
+  readonly timestamp: string;
   readonly message: string;
   [key: string]: any;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Current interface is from version 1.15.0 of kafkajs or earlier, which resulted in a typescript error in my project
Starting version 1.16.0 of kafkajs this field is changed from type Date to string

```
Type 'import("<path>/node_modules/@nestjs/microservices/external/kafka.interface").LogEntry' is not assignable to type 'import("<path>/node_modules/kafkajs/types/index").LogEntry'.
          The types of 'log.timestamp' are incompatible between these types.
            Type 'Date' is not assignable to type 'string'.
```
Issue Number: N/A


## What is the new behavior?
Interface has been updated and the problem doesn't occur anymore
[Link to new interface in kafka](https://github.com/tulios/kafkajs/blob/v1.16.0/types/index.d.ts#L534)
Tested on kafkajs version v1.16.0

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

Possible breaking change for apps using older Kafka versions <=1.15.0