### PR TITLE
docs(websockets): update GatewayMetadata maxHttpBufferSize default value to 1 MB

### DIFF
--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -51,7 +51,7 @@ export interface GatewayMetadata {
   upgradeTimeout?: number;
   /**
    * How many bytes or characters a message can be, before closing the session (to avoid DoS).
-   * @default 1e5 (100 KB)
+   * @default 1e6 (1 MB)
    */
   maxHttpBufferSize?: number;
   /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default value for maxHttpBufferSize property of GatewayMetadata interface is set to 1e5 (100 KB).

Issue Number: N/A


## What is the new behavior?
The actual default value for maxHttpBufferSize property is 1e6 (1 MB). <a href="https://github.com/socketio/engine.io#methods-1">SocketIO docs</a>

<img width="442" alt="1" src="https://user-images.githubusercontent.com/78868247/177848790-6ca45165-eae2-413e-a6b0-b211e59f79e5.png">



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information