### PR TITLE
refactor(core): replace our own 1-level flatten by the native one

### DIFF
--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -546,7 +546,7 @@ export class DependenciesScanner {
   }
 
   private flatten<T = any>(arr: T[][]): T[] {
-    return arr.reduce((a: T[], b: T[]) => a.concat(b), []);
+    return arr.flat(1);
   }
 
   private isRequestOrTransient(scope: Scope): boolean {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the new behavior?

node12 has `Array.prototype.flat` method. See https://node.green/#ES2019-features-Array-prototype--flat--flatMap--Array-prototype-flat

thus we don't need to write this logic anymore.

I didn't changed the `flatten` on `@nestjs/common` because it is being used by other nestjs packages that didn't bumped their major version (ie., they still supports node10, I guess)

<details>

![image](https://user-images.githubusercontent.com/13461315/178125629-5163da42-cfd4-4f56-8ce0-b936a3100e42.png)

</details>

https://github.com/nestjs/nest/blob/34cb6001c30b3e2d2a9570bc87c6bd78a8c49524/packages/common/decorators/core/dependencies.decorator.ts#L3-L8

the above could be written like this: `arr.flat(Infinity)`

---

Also, I've looked at every JS feature that was added in node12 (taking this table https://node.green) to see if there is something that we could update in this repo. Didn't find other feature tho.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
