### PR TITLE
fix(express,fastify): raw body for urlencoded requests

### DIFF
--- a/integration/nest-application/raw-body/e2e/express.spec.ts
+++ b/integration/nest-application/raw-body/e2e/express.spec.ts
@@ -6,7 +6,6 @@ import { ExpressModule } from '../src/express.module';
 
 describe('Raw body (Express Application)', () => {
   let app: NestExpressApplication;
-  const body = '{ "amount":0.0 }';
 
   beforeEach(async () => {
     const moduleFixture = await Test.createTestingModule({
@@ -16,33 +15,63 @@ describe('Raw body (Express Application)', () => {
     app = moduleFixture.createNestApplication<NestExpressApplication>({
       rawBody: true,
     });
-  });
 
-  it('should return exact post body', async () => {
     await app.init();
-    const response = await request(app.getHttpServer())
-      .post('/')
-      .set('Content-Type', 'application/json')
-      .send(body)
-      .expect(201);
-
-    expect(response.body).to.eql({
-      parsed: {
-        amount: 0,
-      },
-      raw: '{ "amount":0.0 }',
-    });
-  });
-
-  it('should work if post body is empty', async () => {
-    await app.init();
-    await request(app.getHttpServer())
-      .post('/')
-      .set('Content-Type', 'application/json')
-      .expect(201);
   });
 
   afterEach(async () => {
     await app.close();
+  });
+
+  describe('application/json', () => {
+    const body = '{ "amount":0.0 }';
+
+    it('should return exact post body', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send(body)
+        .expect(201);
+
+      expect(response.body).to.eql({
+        parsed: {
+          amount: 0,
+        },
+        raw: body,
+      });
+    });
+
+    it('should work if post body is empty', async () => {
+      await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .expect(201);
+    });
+  });
+
+  describe('application/x-www-form-urlencoded', () => {
+    const body = 'content=this is a post\'s content by "Nest"';
+
+    it('should return exact post body', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(body)
+        .expect(201);
+
+      expect(response.body).to.eql({
+        parsed: {
+          content: 'this is a post\'s content by "Nest"',
+        },
+        raw: body,
+      });
+    });
+
+    it('should work if post body is empty', async () => {
+      await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .expect(201);
+    });
   });
 });

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -25,6 +25,7 @@ import { RouterMethodFactory } from '@nestjs/core/helpers/router-method-factory'
 import {
   json as bodyParserJson,
   OptionsJson,
+  OptionsUrlencoded,
   urlencoded as bodyParserUrlencoded,
 } from 'body-parser';
 import * as cors from 'cors';
@@ -32,6 +33,7 @@ import * as express from 'express';
 import * as http from 'http';
 import * as https from 'https';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
+import { getBodyParserOptions } from './utils/get-body-parser-options.util';
 
 type VersionedRoute = <
   TRequest extends Record<string, any> = any,
@@ -194,21 +196,15 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
-    let bodyParserJsonOptions: OptionsJson | undefined;
-    if (rawBody === true) {
-      bodyParserJsonOptions = {
-        verify: (req: RawBodyRequest<http.IncomingMessage>, _res, buffer) => {
-          if (Buffer.isBuffer(buffer)) {
-            req.rawBody = buffer;
-          }
-          return true;
-        },
-      };
-    }
+    const bodyParserJsonOptions = getBodyParserOptions<OptionsJson>(rawBody);
+    const bodyParserUrlencodedOptions = getBodyParserOptions<OptionsUrlencoded>(
+      rawBody,
+      { extended: true },
+    );
 
     const parserMiddleware = {
       jsonParser: bodyParserJson(bodyParserJsonOptions),
-      urlencodedParser: bodyParserUrlencoded({ extended: true }),
+      urlencodedParser: bodyParserUrlencoded(bodyParserUrlencodedOptions),
     };
     Object.keys(parserMiddleware)
       .filter(parser => !this.isMiddlewareApplied(parser))

--- a/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
+++ b/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
@@ -1,0 +1,30 @@
+import type { RawBodyRequest } from '@nestjs/common';
+import type { Options } from 'body-parser';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+const rawBodyParser = (
+  req: RawBodyRequest<IncomingMessage>,
+  _res: ServerResponse,
+  buffer: Buffer,
+) => {
+  if (Buffer.isBuffer(buffer)) {
+    req.rawBody = buffer;
+  }
+  return true;
+};
+
+export function getBodyParserOptions<ParserOptions extends Options>(
+  rawBody: boolean,
+  options?: ParserOptions | undefined,
+): ParserOptions {
+  let parserOptions: ParserOptions = options ?? ({} as ParserOptions);
+
+  if (rawBody === true) {
+    parserOptions = {
+      ...parserOptions,
+      verify: rawBodyParser,
+    };
+  }
+
+  return parserOptions;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9901 


## What is the new behavior?

Registers raw body for `application/x-www-form-urlencoded` requests.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`@fastify/formbody` did not allow any customization in the parsing process. Looking at the source code of that package, shows that it is incredibly small. In order to add `req.rawBody`, most of the code had to be duplicated. So I made the choice to remove registration `fastify/formbody`, and handle the content type ourselves in the exact same way. Only difference: the `req.rawBody` also gets assigned if the option was set.

Keen eyes will also notice that I've added support for `bodyLimit` when registering these content parsers. The previous code (of mine) was missing this.

## Other information

**Question**:
We do not use `@fastify/formbody` anywere after these changes. Should I remove it from `package.json` and `package-lock.json`?