### PR TITLE
fix(microservices): prevent kafka parser from modifying received message

### DIFF
--- a/packages/microservices/helpers/kafka-parser.ts
+++ b/packages/microservices/helpers/kafka-parser.ts
@@ -9,7 +9,7 @@ export class KafkaParser {
   }
 
   public parse<T = any>(data: any): T {
-    // Duplicate the object to not modify the original one (would break KafkaJS retries)
+    // Clone object to as modifying the original one would break KafkaJS retries
     const result = {
       ...data,
       headers: { ...data.headers },

--- a/packages/microservices/helpers/kafka-parser.ts
+++ b/packages/microservices/helpers/kafka-parser.ts
@@ -9,22 +9,28 @@ export class KafkaParser {
   }
 
   public parse<T = any>(data: any): T {
+    // Duplicate the object to not modify the original one (would break KafkaJS retries)
+    const result = {
+      ...data,
+      headers: { ...data.headers },
+    };
+
     if (!this.keepBinary) {
-      data.value = this.decode(data.value);
+      result.value = this.decode(data.value);
     }
 
     if (!isNil(data.key)) {
-      data.key = this.decode(data.key);
+      result.key = this.decode(data.key);
     }
     if (!isNil(data.headers)) {
       const decodeHeaderByKey = (key: string) => {
-        data.headers[key] = this.decode(data.headers[key]);
+        result.headers[key] = this.decode(data.headers[key]);
       };
       Object.keys(data.headers).forEach(decodeHeaderByKey);
     } else {
-      data.headers = {};
+      result.headers = {};
     }
-    return data;
+    return result;
   }
 
   public decode(value: Buffer): object | string | null | Buffer {

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -76,7 +76,7 @@ describe('ClientKafka', () => {
       message,
       {
         size: 0,
-        value: { test: true },
+        value: Buffer.from(JSON.stringify({ test: true })),
       },
     ),
     heartbeat,
@@ -488,7 +488,7 @@ describe('ClientKafka', () => {
         expect(
           callback.calledWith({
             isDisposed: true,
-            response: payloadDisposed.message.value,
+            response: deserializedPayloadDisposed.message.value,
             err: undefined,
           }),
         ).to.be.true;

--- a/packages/microservices/test/helpers/kafka-parser.spec.ts
+++ b/packages/microservices/test/helpers/kafka-parser.spec.ts
@@ -126,5 +126,35 @@ describe('KafkaParser', () => {
         },
       });
     });
+
+    it('parse message multiple times (simulate retry)', () => {
+      const message = {
+        headers: {
+          [KafkaHeaders.CORRELATION_ID]: Buffer.from('correlation-id'),
+        },
+        value: Buffer.from(JSON.stringify({ prop: 'value' })),
+        key: Buffer.from('1'),
+      };
+      const expectedParsedMessage = {
+        key: '1',
+        value: {
+          prop: 'value',
+        },
+        headers: {
+          [KafkaHeaders.CORRELATION_ID]: 'correlation-id',
+        },
+      };
+      expect(kafkaParser.parse(message)).to.deep.eq(expectedParsedMessage);
+      // Parse message again and verify it still works correctly
+      expect(kafkaParser.parse(message)).to.deep.eq(expectedParsedMessage);
+      // Verify message was not modified
+      expect(message).to.deep.eq({
+        headers: {
+          [KafkaHeaders.CORRELATION_ID]: Buffer.from('correlation-id'),
+        },
+        value: Buffer.from(JSON.stringify({ prop: 'value' })),
+        key: Buffer.from('1'),
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Kafka parser modifies messages during parsing. If a message handler fails and message is retried by KafkaJS, then the already parsed message is parsed again and the value ends up being the string `'[object Object]'`. 

Issue Number: 9956


## What is the new behavior?
Kafka parser duplicates message objects and puts parsed data into these newly created objects. So retries are executed with the same data.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

fix: #9956 