### PR TITLE
fix(core): allow importing providers from global modules in lazy modules

### DIFF
--- a/integration/lazy-modules/e2e/lazy-import-global-modules.spec.ts
+++ b/integration/lazy-modules/e2e/lazy-import-global-modules.spec.ts
@@ -1,0 +1,29 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as chai from 'chai';
+import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
+import { AppModule } from '../src/app.module';
+chai.use(chaiAsPromised);
+
+describe('Lazy imports', () => {
+  let server;
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpAdapter().getInstance();
+  });
+
+  it(`Should allow imports of global modules`, async () => {
+    await expect(app.init()).to.eventually.be.fulfilled;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/integration/lazy-modules/e2e/lazy-import-global-modules.spec.ts
+++ b/integration/lazy-modules/e2e/lazy-import-global-modules.spec.ts
@@ -19,7 +19,7 @@ describe('Lazy imports', () => {
     server = app.getHttpAdapter().getInstance();
   });
 
-  it(`Should allow imports of global modules`, async () => {
+  it(`should allow imports of global modules`, async () => {
     await expect(app.init()).to.eventually.be.fulfilled;
   });
 

--- a/integration/lazy-modules/src/app.module.ts
+++ b/integration/lazy-modules/src/app.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { LazyModuleLoader } from '@nestjs/core';
+import { EagerModule } from './eager.module';
+import { GlobalModule } from './global.module';
+import { LazyModule } from './lazy.module';
+
+@Module({
+  imports: [GlobalModule, EagerModule],
+})
+export class AppModule {
+  constructor(public loader: LazyModuleLoader) {}
+
+  async onApplicationBootstrap() {
+    await this.loader.load(() => LazyModule);
+  }
+}

--- a/integration/lazy-modules/src/eager.module.ts
+++ b/integration/lazy-modules/src/eager.module.ts
@@ -1,0 +1,12 @@
+import { Module, Injectable } from '@nestjs/common';
+import { GlobalService } from './global.module';
+
+@Injectable()
+export class EagerService {
+  constructor(public globalService: GlobalService) {}
+}
+
+@Module({
+  providers: [EagerService],
+})
+export class EagerModule {}

--- a/integration/lazy-modules/src/global.module.ts
+++ b/integration/lazy-modules/src/global.module.ts
@@ -1,0 +1,13 @@
+import { Module, Injectable, Global } from '@nestjs/common';
+
+@Injectable()
+export class GlobalService {
+  constructor() {}
+}
+
+@Global()
+@Module({
+  providers: [GlobalService],
+  exports: [GlobalService],
+})
+export class GlobalModule {}

--- a/integration/lazy-modules/src/lazy.module.ts
+++ b/integration/lazy-modules/src/lazy.module.ts
@@ -1,0 +1,12 @@
+import { Module, Injectable } from '@nestjs/common';
+import { GlobalService } from './global.module';
+
+@Injectable()
+export class LazyService {
+  constructor(public globalService: GlobalService) {}
+}
+
+@Module({
+  providers: [LazyService],
+})
+export class LazyModule {}

--- a/integration/lazy-modules/src/main.ts
+++ b/integration/lazy-modules/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+bootstrap();

--- a/packages/core/injector/lazy-module-loader.ts
+++ b/packages/core/injector/lazy-module-loader.ts
@@ -21,9 +21,10 @@ export class LazyModuleLoader {
       | DynamicModule,
   ): Promise<ModuleRef> {
     const moduleClassOrDynamicDefinition = await loaderFn();
-    const moduleInstances = await this.dependenciesScanner.scanForModules(
-      moduleClassOrDynamicDefinition,
-    );
+    const moduleInstances =
+      await this.dependenciesScanner.scanForModulesForLazyModules(
+        moduleClassOrDynamicDefinition,
+      );
     if (moduleInstances.length === 0) {
       // The module has been loaded already. In this case, we must
       // retrieve a module reference from the existing container.

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -77,6 +77,18 @@ export class DependenciesScanner {
     this.container.bindGlobalScope();
   }
 
+  public async scanForModulesForLazyModules(
+    moduleDefinition: Type<unknown> | DynamicModule,
+  ): Promise<Module[]> {
+    const modules = await this.scanForModules(moduleDefinition);
+    // We need to bind global scope to the lazy module because the bind phase happens before it was created
+    // The only one we need to bind is the actual module we are scanning the dependencies for,
+    // this modules is the first element in the modules list comming from the scan
+    this.container.bindGlobalsToImports(modules[0]);
+
+    return modules;
+  }
+
   public async scanForModules(
     moduleDefinition:
       | ForwardReference


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [9622](https://github.com/nestjs/nest/issues/9622)


## What is the new behavior?

Imports of global modules in lazy imported modules is now possible.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Implementation of the solution proposed by [dsullivan](https://github.com/dsullivan) comment in the issue.

Not sure if my test is the correct one to do, I'll be happy to update it if needed.