### PR TITLE
fix(microservices): pass options to rmq deserialize

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
+import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { EventEmitter } from 'events';
 import { EmptyError, fromEvent, lastValueFrom, merge, Observable } from 'rxjs';
 import { first, map, retryWhen, scan, share, switchMap } from 'rxjs/operators';
@@ -186,11 +187,20 @@ export class ClientRMQ extends ClientProxy {
 
   public async handleMessage(
     packet: unknown,
+    callback: (packet: WritePacket) => any,
+  );
+  public async handleMessage(
+    packet: unknown,
     options: Record<string, unknown>,
     callback: (packet: WritePacket) => any,
+  );
+  public async handleMessage(
+    packet: unknown,
+    options: Record<string, unknown> | ((packet: WritePacket) => any),
+    callback?: (packet: WritePacket) => any,
   ) {
-    if (typeof options === 'function') {
-      callback = options;
+    if (isFunction(options)) {
+      callback = options as (packet: WritePacket) => any;
       options = undefined;
     }
 

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -11,12 +11,12 @@ import {
   DISCONNECTED_RMQ_MESSAGE,
   NO_MESSAGE_HANDLER,
   RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT,
+  RQM_DEFAULT_NO_ASSERT,
   RQM_DEFAULT_NOACK,
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
   RQM_DEFAULT_URL,
-  RQM_DEFAULT_NO_ASSERT,
 } from '../constants';
 import { RmqContext } from '../ctx-host';
 import { Transport } from '../enums';
@@ -142,7 +142,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     }
     const { content, properties } = message;
     const rawMessage = JSON.parse(content.toString());
-    const packet = await this.deserializer.deserialize(rawMessage);
+    const packet = await this.deserializer.deserialize(rawMessage, properties);
     const pattern = isString(packet.pattern)
       ? packet.pattern
       : JSON.stringify(packet.pattern);

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -290,7 +290,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: false,
         };
-        await client.handleMessage(packet, callback);
+        await client.handleMessage(packet, undefined, callback);
         expect(
           callback.calledWith({
             err: packet.err,
@@ -311,7 +311,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: true,
         };
-        await client.handleMessage(packet, callback);
+        await client.handleMessage(packet, undefined, callback);
         expect(
           callback.calledWith({
             err: undefined,
@@ -333,7 +333,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: false,
         };
-        await client.handleMessage(packet, callback);
+        await client.handleMessage(packet, undefined, callback);
         expect(
           callback.calledWith({
             err: undefined,

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -311,7 +311,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: true,
         };
-        await client.handleMessage(packet, undefined, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: undefined,
@@ -333,7 +333,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: false,
         };
-        await client.handleMessage(packet, undefined, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: undefined,

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -290,7 +290,7 @@ describe('ClientRMQ', function () {
           response: 'test',
           isDisposed: false,
         };
-        await client.handleMessage(packet, undefined, callback);
+        await client.handleMessage(packet, callback);
         expect(
           callback.calledWith({
             err: packet.err,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`RmqRecordDeserializer#deserialize` always got an `undefined` as options, cannot pair of `RmqRecordSerializer#serialize`
Issue Number: N/A


## What is the new behavior?
Pass Rmq Message properties as options, just like what `serialize` does

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information