### PR TITLE
Fix/10017 parse file pipe builder

### DIFF
--- a/packages/common/pipes/file/parse-file-options.interface.ts
+++ b/packages/common/pipes/file/parse-file-options.interface.ts
@@ -5,5 +5,9 @@ export interface ParseFileOptions {
   validators?: FileValidator[];
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (error: string) => any;
+
+  /**
+   * Defines if file parameter is optional. Default is false.
+   */
   fileIsOptional?: boolean;
 }

--- a/packages/common/pipes/file/parse-file-options.interface.ts
+++ b/packages/common/pipes/file/parse-file-options.interface.ts
@@ -5,4 +5,5 @@ export interface ParseFileOptions {
   validators?: FileValidator[];
   errorHttpStatusCode?: ErrorHttpStatusCode;
   exceptionFactory?: (error: string) => any;
+  fileIsOptional?: boolean;
 }

--- a/packages/common/pipes/file/parse-file-options.interface.ts
+++ b/packages/common/pipes/file/parse-file-options.interface.ts
@@ -7,7 +7,8 @@ export interface ParseFileOptions {
   exceptionFactory?: (error: string) => any;
 
   /**
-   * Defines if file parameter is optional. Default is false.
+   * Defines if file parameter is required.
+   * @default true
    */
-  fileIsOptional?: boolean;
+  fileIsRequired?: boolean;
 }

--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -1,9 +1,10 @@
+import { isUndefined } from '../../utils/shared.utils';
 import { Injectable, Optional } from '../../decorators/core';
 import { HttpStatus } from '../../enums';
-import { HttpErrorByCode } from '../../utils/http-error-by-code.util';
 import { PipeTransform } from '../../interfaces/features/pipe-transform.interface';
-import { ParseFileOptions } from './parse-file-options.interface';
+import { HttpErrorByCode } from '../../utils/http-error-by-code.util';
 import { FileValidator } from './file-validator.interface';
+import { ParseFileOptions } from './parse-file-options.interface';
 
 /**
  * Defines the built-in ParseFile Pipe. This pipe can be used to validate incoming files
@@ -35,6 +36,10 @@ export class ParseFilePipe implements PipeTransform<any> {
   }
 
   async transform(value: any): Promise<any> {
+    if (isUndefined(value)) {
+      return value;
+    }
+
     if (this.validators.length) {
       await this.validate(value);
     }

--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -20,12 +20,14 @@ import { ParseFileOptions } from './parse-file-options.interface';
 export class ParseFilePipe implements PipeTransform<any> {
   protected exceptionFactory: (error: string) => any;
   private readonly validators: FileValidator[];
+  private readonly fileIsOptional: boolean;
 
   constructor(@Optional() options: ParseFileOptions = {}) {
     const {
       exceptionFactory,
       errorHttpStatusCode = HttpStatus.BAD_REQUEST,
       validators = [],
+      fileIsOptional,
     } = options;
 
     this.exceptionFactory =
@@ -33,11 +35,16 @@ export class ParseFilePipe implements PipeTransform<any> {
       (error => new HttpErrorByCode[errorHttpStatusCode](error));
 
     this.validators = validators;
+    this.fileIsOptional = fileIsOptional ?? false;
   }
 
   async transform(value: any): Promise<any> {
     if (isUndefined(value)) {
-      return value;
+      if (this.fileIsOptional) {
+        return value;
+      }
+
+      throw this.exceptionFactory('File is required');
     }
 
     if (this.validators.length) {

--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -20,14 +20,14 @@ import { ParseFileOptions } from './parse-file-options.interface';
 export class ParseFilePipe implements PipeTransform<any> {
   protected exceptionFactory: (error: string) => any;
   private readonly validators: FileValidator[];
-  private readonly fileIsOptional: boolean;
+  private readonly fileIsRequired: boolean;
 
   constructor(@Optional() options: ParseFileOptions = {}) {
     const {
       exceptionFactory,
       errorHttpStatusCode = HttpStatus.BAD_REQUEST,
       validators = [],
-      fileIsOptional,
+      fileIsRequired,
     } = options;
 
     this.exceptionFactory =
@@ -35,16 +35,16 @@ export class ParseFilePipe implements PipeTransform<any> {
       (error => new HttpErrorByCode[errorHttpStatusCode](error));
 
     this.validators = validators;
-    this.fileIsOptional = fileIsOptional ?? false;
+    this.fileIsRequired = fileIsRequired ?? true;
   }
 
   async transform(value: any): Promise<any> {
     if (isUndefined(value)) {
-      if (this.fileIsOptional) {
-        return value;
+      if (this.fileIsRequired) {
+        throw this.exceptionFactory('File is required');
       }
 
-      throw this.exceptionFactory('File is required');
+      return value;
     }
 
     if (this.validators.length) {

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -133,5 +133,22 @@ describe('ParseFilePipe', () => {
         );
       });
     });
+
+    describe('when file is not optional', () => {
+      beforeEach(() => {
+        parseFilePipe = new ParseFilePipe({
+          validators: [new AlwaysInvalidValidator({})],
+          fileIsOptional: false,
+        });
+      });
+
+      it('should throw an error if no file is provided', async () => {
+        const requestFile = undefined;
+
+        await expect(parseFilePipe.transform(requestFile)).to.be.rejectedWith(
+          BadRequestException,
+        );
+      });
+    });
   });
 });

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -117,7 +117,7 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when isFileOptional is true', () => {
+    describe('when fileIsOptional is true', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],
@@ -134,7 +134,7 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when isFileOptional is false', () => {
+    describe('when fileIsOptional is false', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],
@@ -151,7 +151,7 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when isFileOptional is not explicitly provided', () => {
+    describe('when fileIsOptional is not explicitly provided', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -117,11 +117,11 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when fileIsOptional is true', () => {
+    describe('when fileIsRequired is false', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
-          validators: [new AlwaysInvalidValidator({})],
-          fileIsOptional: true,
+          validators: [],
+          fileIsRequired: false,
         });
       });
 
@@ -134,11 +134,11 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when fileIsOptional is false', () => {
+    describe('when fileIsRequired is true', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
-          validators: [new AlwaysInvalidValidator({})],
-          fileIsOptional: false,
+          validators: [],
+          fileIsRequired: true,
         });
       });
 
@@ -149,9 +149,19 @@ describe('ParseFilePipe', () => {
           BadRequestException,
         );
       });
+
+      it('should pass validation if a file is provided', async () => {
+        const requestFile = {
+          path: 'some-path',
+        };
+
+        await expect(parseFilePipe.transform(requestFile)).to.eventually.eql(
+          requestFile,
+        );
+      });
     });
 
-    describe('when fileIsOptional is not explicitly provided', () => {
+    describe('when fileIsRequired is not explicitly provided', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -116,5 +116,22 @@ describe('ParseFilePipe', () => {
         });
       });
     });
+
+    describe('when file is optional', () => {
+      beforeEach(() => {
+        parseFilePipe = new ParseFilePipe({
+          validators: [new AlwaysInvalidValidator({})],
+          fileIsOptional: true,
+        });
+      });
+
+      it('should pass validation if no file is provided', async () => {
+        const requestFile = undefined;
+
+        await expect(parseFilePipe.transform(requestFile)).to.eventually.eql(
+          requestFile,
+        );
+      });
+    });
   });
 });

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -117,7 +117,7 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when file is optional', () => {
+    describe('when isFileOptional is true', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],
@@ -134,11 +134,27 @@ describe('ParseFilePipe', () => {
       });
     });
 
-    describe('when file is not optional', () => {
+    describe('when isFileOptional is false', () => {
       beforeEach(() => {
         parseFilePipe = new ParseFilePipe({
           validators: [new AlwaysInvalidValidator({})],
           fileIsOptional: false,
+        });
+      });
+
+      it('should throw an error if no file is provided', async () => {
+        const requestFile = undefined;
+
+        await expect(parseFilePipe.transform(requestFile)).to.be.rejectedWith(
+          BadRequestException,
+        );
+      });
+    });
+
+    describe('when isFileOptional is not explicitly provided', () => {
+      beforeEach(() => {
+        parseFilePipe = new ParseFilePipe({
+          validators: [new AlwaysInvalidValidator({})],
         });
       });
 

--- a/sample/29-file-upload/e2e/app/app.e2e-spec.ts
+++ b/sample/29-file-upload/e2e/app/app.e2e-spec.ts
@@ -51,6 +51,13 @@ describe('E2E FileTest', () => {
       .expect(400);
   });
 
+  it('should throw when file is required but no file is uploaded', async () => {
+    return request(app.getHttpServer())
+      .post('/file/fail-validation')
+      .send()
+      .expect(400);
+  });
+
   it('should allow for optional file uploads with validation enabled (fixes #10017)', () => {
     return request(app.getHttpServer())
       .post('/file/pass-validation')

--- a/sample/29-file-upload/e2e/app/app.e2e-spec.ts
+++ b/sample/29-file-upload/e2e/app/app.e2e-spec.ts
@@ -51,6 +51,12 @@ describe('E2E FileTest', () => {
       .expect(400);
   });
 
+  it('should allow for optional file uploads with validation enabled (fixes #10017)', () => {
+    return request(app.getHttpServer())
+      .post('/file/pass-validation')
+      .expect(201);
+  });
+
   afterAll(async () => {
     await app.close();
   });

--- a/sample/29-file-upload/e2e/app/app.e2e-spec.ts
+++ b/sample/29-file-upload/e2e/app/app.e2e-spec.ts
@@ -54,7 +54,6 @@ describe('E2E FileTest', () => {
   it('should throw when file is required but no file is uploaded', async () => {
     return request(app.getHttpServer())
       .post('/file/fail-validation')
-      .send()
       .expect(400);
   });
 

--- a/sample/29-file-upload/src/app.controller.ts
+++ b/sample/29-file-upload/src/app.controller.ts
@@ -43,7 +43,7 @@ export class AppController {
           fileType: 'json',
         })
         .build({
-          fileIsOptional: true,
+          fileIsRequired: false,
         }),
     )
     file?: Express.Multer.File,

--- a/sample/29-file-upload/src/app.controller.ts
+++ b/sample/29-file-upload/src/app.controller.ts
@@ -42,13 +42,15 @@ export class AppController {
         .addFileTypeValidator({
           fileType: 'json',
         })
-        .build(),
+        .build({
+          fileIsOptional: true,
+        }),
     )
-    file: Express.Multer.File,
+    file?: Express.Multer.File,
   ) {
     return {
       body,
-      file: file.buffer.toString(),
+      file: file?.buffer.toString(),
     };
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #10017


## What is the new behavior?

Now we can specify if a given `file` parameter is required in the `ParseFilePipeBuilder` or in the `ParseFilePipe`:
```ts
@UploadedFile(
  new ParseFilePipeBuilder()
    .addFileTypeValidator({
      fileType: 'json',
    })
    .build({
      fileIsRequired: false,
    }),
)
file?: Express.Multer.File,
``` 

With that, when a file is explicitly set to be optional, the ParseFileValidator won't throw an error. On the other hand, when the file is required (default behavior), it will now throw a 400 error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information