### PR TITLE
chore: improve typings of `.createBody(…)`

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -1,3 +1,7 @@
+import {
+  HttpExceptionBodyMessage,
+  HttpExceptionBody,
+} from '../interfaces/http/http-exception-body.interface';
 import { Logger } from '../services';
 import { isObject, isString } from '../utils/shared.utils';
 
@@ -118,17 +122,42 @@ export class HttpException extends Error {
   }
 
   public static createBody(
-    objectOrErrorMessage: object | string,
-    description?: string,
+    nil: null | '',
+    message: HttpExceptionBodyMessage,
+    statusCode: number,
+  ): HttpExceptionBody;
+
+  public static createBody(
+    message: HttpExceptionBodyMessage,
+    error: string,
+    statusCode: number,
+  ): HttpExceptionBody;
+
+  public static createBody<Body extends Record<string, unknown>>(
+    custom: Body,
+  ): Body;
+
+  public static createBody<Body extends Record<string, unknown>>(
+    arg0: null | HttpExceptionBodyMessage | Body,
+    arg1?: HttpExceptionBodyMessage | string,
     statusCode?: number,
-  ) {
-    if (!objectOrErrorMessage) {
-      return { statusCode, message: description };
+  ): HttpExceptionBody | Body {
+    if (!arg0) {
+      return {
+        message: arg1,
+        statusCode: statusCode,
+      };
     }
-    return isObject(objectOrErrorMessage) &&
-      !Array.isArray(objectOrErrorMessage)
-      ? objectOrErrorMessage
-      : { statusCode, message: objectOrErrorMessage, error: description };
+
+    if (isString(arg0) || Array.isArray(arg0)) {
+      return {
+        message: arg0,
+        error: arg1 as string,
+        statusCode: statusCode,
+      };
+    }
+
+    return arg0;
   }
 
   public static getDescriptionFrom(

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -26,6 +26,8 @@ export {
   FactoryProvider,
   ForwardReference,
   HttpServer,
+  HttpExceptionBody,
+  HttpExceptionBodyMessage,
   INestApplication,
   INestApplicationContext,
   INestMicroservice,

--- a/packages/common/interfaces/http/index.ts
+++ b/packages/common/interfaces/http/index.ts
@@ -1,3 +1,4 @@
+export * from './http-exception-body.interface';
 export * from './http-server.interface';
 export * from './message-event.interface';
 export * from './raw-body-request.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

<img width="727" alt="image" src="https://user-images.githubusercontent.com/59528510/181243307-7fab215a-35ac-471e-bfa3-79b250a0ace4.png">

Issue Number: N/A

## What is the new behavior?

<img width="727" alt="image" src="https://user-images.githubusercontent.com/59528510/181243969-6700baba-31bb-4613-96da-0aca4400220a.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/59528510/181244058-686a7464-deba-4cb9-b032-dac8cb68b8c7.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/59528510/181244238-09a6ae0d-520a-4757-8a5a-2280a9351cc8.png">

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If the first argument is a non-empty string, previously compiler allowed providing it alone:

```ts
HttpException.createBody('some message'); // ✅
```

… which is incorrect, because that would make `.error` and `.statusCode` equal to `undefined` (no second and third arguments provided). This is fixed now: if `.createBody(…)` is called with a single argument, it is expected to be a full custom body:

```ts
HttpException.createBody('some message'); // ❌ Error: Argument of type 'string' is not assignable to parameter of type 'Record<string, unknown>'.
```

## Other information

_(none)_