### PR TITLE
refactor(repl): use INestApplicationContext instead of full INestApplication

### DIFF
--- a/packages/core/repl/repl-context.ts
+++ b/packages/core/repl/repl-context.ts
@@ -1,4 +1,4 @@
-import { INestApplication, InjectionToken, Logger } from '@nestjs/common';
+import { INestApplicationContext, InjectionToken, Logger } from '@nestjs/common';
 import { ApplicationConfig } from '../application-config';
 import { ModuleRef, NestContainer } from '../injector';
 import { InternalCoreModule } from '../injector/internal-core-module';
@@ -33,7 +33,7 @@ export class ReplContext {
   private readonly container: NestContainer;
 
   constructor(
-    public readonly app: INestApplication,
+    public readonly app: INestApplicationContext,
     nativeFunctionsClassRefs?: ReplFunctionClass[],
   ) {
     this.container = (app as any).container; // Using `any` because `app.container` is not public.

--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -5,9 +5,10 @@ import { assignToObject } from './assign-to-object.util';
 import { REPL_INITIALIZED_MESSAGE } from './constants';
 import { ReplContext } from './repl-context';
 import { ReplLogger } from './repl-logger';
+import { AbstractHttpAdapter } from '../adapters/http-adapter';
 
-export async function repl(module: Type) {
-  const app = await NestFactory.create(module, {
+export async function repl(module: Type, httpAdapter?: AbstractHttpAdapter) {
+  const app = await NestFactory.create(module, httpAdapter, {
     abortOnError: false,
     logger: new ReplLogger(),
   });

--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -7,8 +7,8 @@ import { ReplContext } from './repl-context';
 import { ReplLogger } from './repl-logger';
 import { AbstractHttpAdapter } from '../adapters/http-adapter';
 
-export async function repl(module: Type, httpAdapter?: AbstractHttpAdapter) {
-  const app = await NestFactory.create(module, httpAdapter, {
+export async function repl(module: Type) {
+  const app = await NestFactory.createApplicationContext(module, {
     abortOnError: false,
     logger: new ReplLogger(),
   });


### PR DESCRIPTION
The `ReplContext` only uses the `.container` private property from the NestApplication, which is also available on NestApplicationContext, which doesn't require a httpAdapter.

Closes #10052

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information