### PR TITLE
fix(core): when debug-repl has duplicated providers

### DIFF
--- a/integration/repl/e2e/repl.spec.ts
+++ b/integration/repl/e2e/repl.spec.ts
@@ -52,7 +52,7 @@ ${PROMPT}`,
 ${PROMPT}`);
 
     outputText = '';
-    server.emit('line', 'get(UsersRepository)');
+    server.emit('line', 'get("UsersRepository")');
 
     expect(outputText).to.equal(`UsersRepository {}
 ${PROMPT}`);
@@ -81,7 +81,7 @@ ${PROMPT}`,
 ${PROMPT}`);
 
     outputText = '';
-    server.emit('line', '$(UsersRepository)');
+    server.emit('line', '$("UsersRepository")');
 
     expect(outputText).to.equal(`UsersRepository {}
 ${PROMPT}`);
@@ -104,7 +104,7 @@ UsersModule:
   ◻ UsersController
  - providers:
   ◻ UsersService
-  ◻ UsersRepository
+  ◻ "UsersRepository"
 
 ${PROMPT}`,
     );
@@ -118,7 +118,7 @@ ${PROMPT}`,
       outputText += text;
       return true;
     });
-    server.emit('line', 'methods(UsersRepository)');
+    server.emit('line', 'methods("UsersRepository")');
 
     expect(outputText).to.equal(
       `

--- a/packages/core/repl/repl-context.ts
+++ b/packages/core/repl/repl-context.ts
@@ -109,7 +109,7 @@ export class ReplContext {
       ? typeof token === 'function'
         ? token.name
         : token?.toString()
-      : token;
+      : `"${token}"`;
   }
 
   private addNativeFunction(

--- a/packages/core/repl/repl-context.ts
+++ b/packages/core/repl/repl-context.ts
@@ -80,21 +80,24 @@ export class ReplContext {
       const stringifiedToken = this.stringifyToken(token);
       if (
         stringifiedToken === ApplicationConfig.name ||
-        stringifiedToken === moduleRef.metatype.name ||
-        this.globalScope[stringifiedToken]
+        stringifiedToken === moduleRef.metatype.name
       ) {
         return;
       }
-      // For in REPL auto-complete functionality
-      Object.defineProperty(this.globalScope, stringifiedToken, {
-        value: token,
-        configurable: false,
-        enumerable: true,
-      });
+
+      if (!this.globalScope[stringifiedToken]) {
+        // For in REPL auto-complete functionality
+        Object.defineProperty(this.globalScope, stringifiedToken, {
+          value: token,
+          configurable: false,
+          enumerable: true,
+        });
+      }
 
       if (stringifiedToken === ModuleRef.name) {
         return;
       }
+
       moduleDebugEntry[stringifiedToken] = token;
     });
 

--- a/packages/core/test/repl/native-functions/debug-repl-fn.spec.ts
+++ b/packages/core/test/repl/native-functions/debug-repl-fn.spec.ts
@@ -24,9 +24,15 @@ describe('DebugReplFn', () => {
     container.addController(class ControllerA {}, aModuleRef.token);
     container.addProvider(class ProviderA1 {}, aModuleRef.token);
     container.addProvider(class ProviderA2 {}, aModuleRef.token);
+    container.addProvider(class SharedProvider {}, aModuleRef.token);
+    container.addProvider(
+      { provide: 'StringToken', useValue: 123 },
+      aModuleRef.token,
+    );
 
     container.addProvider(class ProviderB1 {}, bModuleRef.token);
     container.addProvider(class ProviderB2 {}, bModuleRef.token);
+    container.addProvider(class SharedProvider {}, bModuleRef.token);
 
     mockApp = {
       container,
@@ -68,10 +74,13 @@ ModuleA:
  - providers:
   ◻ ProviderA1
   ◻ ProviderA2
+  ◻ SharedProvider
+  ◻ "StringToken"
 ModuleB:
  - providers:
   ◻ ProviderB1
   ◻ ProviderB2
+  ◻ SharedProvider
 
 `);
     });
@@ -93,6 +102,8 @@ ModuleA:
  - providers:
   ◻ ProviderA1
   ◻ ProviderA2
+  ◻ SharedProvider
+  ◻ "StringToken"
 
 `);
       });
@@ -114,6 +125,8 @@ ModuleA:
  - providers:
   ◻ ProviderA1
   ◻ ProviderA2
+  ◻ SharedProvider
+  ◻ "StringToken"
 
 `);
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #9893 + one minor feature

![image](https://user-images.githubusercontent.com/13461315/183255241-5bc8b016-5d8a-4f6a-b3e7-ccb38e3ec0f4.png)

(see the code below)


## What is the new behavior?

Now the `debug()` function will

- display string tokens with double quotes, so we could easily distinguish between classes references, which also means that `$("Foo")` and `$(Foo)` aren't treated alike anymore. So we could have both providers (`class Foo {}` and `{ provide: "Foo", ... }`)
- display all those providers registered in the module properly

<details>
<summary>full code + demo</summary>

![image](https://user-images.githubusercontent.com/13461315/183255055-371304f8-9acf-440a-a165-4366b372d385.png)

</details>

I'm not sure if treating string tokens in the same way as class references was intentional but I believe this decreases the flexiblity of the REPL

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No(?)
