### PR TITLE
fix: add a check if the res is destroyed before sending response

### DIFF
--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -75,9 +75,9 @@ describe('Express FileSend', () => {
   });
   it('should allow for the client to end the response and be able to make another', async () => {
     await app.listen(0);
-    const httpOptions = await getHttpBaseOptions(app);
-    await sendCanceledHttpRequest(httpOptions, '/file/slow');
-    const res = await sendHttpRequest(httpOptions, '/file/stream');
+    const url = await getHttpBaseOptions(app);
+    await sendCanceledHttpRequest(new URL('/file/slow', url));
+    const res = await sendHttpRequest(new URL('/file/stream', url));
     expect(res.statusCode).to.be.eq(200);
   }).timeout(5000);
 });

--- a/integration/send-files/e2e/express.spec.ts
+++ b/integration/send-files/e2e/express.spec.ts
@@ -5,10 +5,14 @@ import {
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import { readFileSync } from 'fs';
-import * as http from 'http';
 import { join } from 'path';
 import * as request from 'supertest';
 import { AppModule } from '../src/app.module';
+import {
+  getHttpBaseOptions,
+  sendCanceledHttpRequest,
+  sendHttpRequest,
+} from './utils';
 
 const readme = readFileSync(join(process.cwd(), 'Readme.md'));
 const readmeString = readme.toString();
@@ -71,42 +75,9 @@ describe('Express FileSend', () => {
   });
   it('should allow for the client to end the response and be able to make another', async () => {
     await app.listen(0);
-    const url = await app.getUrl();
-    const [protocol, host, port] = url.replace('[::1]', 'localhost').split(':');
-    const httpOptions = {
-      host: host.replace('//', ''),
-      protocol: `${protocol}:`,
-      port,
-      path: '/file/slow',
-      method: 'GET',
-    };
-    await new Promise<void>(resolve => {
-      const req = http.request(httpOptions, res => {
-        res.on('data', () => {
-          req.destroy();
-        });
-        /* no op */
-        res.on('close', resolve);
-      });
-      req.end();
-    });
-    await new Promise<void>((resolve, reject) => {
-      const req = http.request(
-        { ...httpOptions, path: '/file/stream' },
-        res => {
-          res.on('data', chunk => {
-            /* no op */
-          });
-          res.on('error', err => {
-            reject(err);
-          });
-          res.on('end', () => {
-            expect(res.statusCode).to.be.eq(200);
-            resolve();
-          });
-        },
-      );
-      req.end();
-    });
+    const httpOptions = await getHttpBaseOptions(app);
+    await sendCanceledHttpRequest(httpOptions, '/file/slow');
+    const res = await sendHttpRequest(httpOptions, '/file/stream');
+    expect(res.statusCode).to.be.eq(200);
   }).timeout(5000);
 });

--- a/integration/send-files/e2e/utils.ts
+++ b/integration/send-files/e2e/utils.ts
@@ -1,0 +1,61 @@
+import { INestApplication } from '@nestjs/common';
+import { IncomingMessage, request, RequestOptions } from 'http';
+
+export const getHttpBaseOptions = async (
+  app: INestApplication,
+): Promise<RequestOptions> => {
+  const url = await app.getUrl();
+  // replace IPv6 localhost with IPv4 localhost alias and split URL on : to get the protocol (http), the host (localhost) and the port (random port)
+  const [protocol, host, port] = url.replace('[::1]', 'localhost').split(':');
+  return {
+    // protocol is expected to be http: or https:
+    protocol: `${protocol}:`,
+    // remove the // prefix left over from the split(':')
+    host: host.replace('//', ''),
+    port,
+    method: 'GET',
+  };
+};
+
+export const sendCanceledHttpRequest = async (
+  options: RequestOptions,
+  path: string,
+) => {
+  return new Promise((resolve, reject) => {
+    const req = request({ ...options, path }, res => {
+      // close the request once we get the first response of data
+      res.on('data', () => {
+        req.destroy();
+      });
+      // response is closed, move on to next request and verify it's doable
+      res.on('close', resolve);
+    });
+    // fire the request
+    req.end();
+  });
+};
+
+export const sendHttpRequest = async (
+  options: RequestOptions,
+  path: string,
+) => {
+  return new Promise<IncomingMessage>((resolve, reject) => {
+    const req = request({ ...options, path }, res => {
+      // this makes sure that the response actually starts and is read. We could verify this value against the same
+      // that is in an earlier test, but all we care about in _this_ test is that the status code is 200
+      res.on('data', chunk => {
+        /* no op */
+      });
+      // fail the test if somethin goes wrong
+      res.on('error', err => {
+        reject(err);
+      });
+      // pass the response back so we can verify values in the test
+      res.on('end', () => {
+        resolve(res);
+      });
+    });
+    // fire the request
+    req.end();
+  });
+};

--- a/integration/send-files/e2e/utils.ts
+++ b/integration/send-files/e2e/utils.ts
@@ -1,28 +1,17 @@
 import { INestApplication } from '@nestjs/common';
 import { IncomingMessage, request, RequestOptions } from 'http';
+import { URL } from 'url';
 
 export const getHttpBaseOptions = async (
   app: INestApplication,
-): Promise<RequestOptions> => {
+): Promise<URL> => {
   const url = await app.getUrl();
-  // replace IPv6 localhost with IPv4 localhost alias and split URL on : to get the protocol (http), the host (localhost) and the port (random port)
-  const [protocol, host, port] = url.replace('[::1]', 'localhost').split(':');
-  return {
-    // protocol is expected to be http: or https:
-    protocol: `${protocol}:`,
-    // remove the // prefix left over from the split(':')
-    host: host.replace('//', ''),
-    port,
-    method: 'GET',
-  };
+  return new URL(url);
 };
 
-export const sendCanceledHttpRequest = async (
-  options: RequestOptions,
-  path: string,
-) => {
+export const sendCanceledHttpRequest = async (url: URL) => {
   return new Promise((resolve, reject) => {
-    const req = request({ ...options, path }, res => {
+    const req = request(url, res => {
       // close the request once we get the first response of data
       res.on('data', () => {
         req.destroy();
@@ -35,12 +24,9 @@ export const sendCanceledHttpRequest = async (
   });
 };
 
-export const sendHttpRequest = async (
-  options: RequestOptions,
-  path: string,
-) => {
+export const sendHttpRequest = async (url: URL) => {
   return new Promise<IncomingMessage>((resolve, reject) => {
-    const req = request({ ...options, path }, res => {
+    const req = request(url, res => {
       // this makes sure that the response actually starts and is read. We could verify this value against the same
       // that is in an earlier test, but all we care about in _this_ test is that the status code is 200
       res.on('data', chunk => {

--- a/integration/send-files/e2e/utils.ts
+++ b/integration/send-files/e2e/utils.ts
@@ -30,7 +30,7 @@ export const sendHttpRequest = async (url: URL) => {
       // this makes sure that the response actually starts and is read. We could verify this value against the same
       // that is in an earlier test, but all we care about in _this_ test is that the status code is 200
       res.on('data', chunk => {
-        /* no op */
+        // no op
       });
       // fail the test if somethin goes wrong
       res.on('error', err => {

--- a/integration/send-files/src/app.controller.ts
+++ b/integration/send-files/src/app.controller.ts
@@ -36,4 +36,9 @@ export class AppController {
   getNonExistantFile(): StreamableFile {
     return this.appService.getFileThatDoesNotExist();
   }
+
+  @Get('/file/slow')
+  getSlowFile(): StreamableFile {
+    return this.appService.getSlowStream();
+  }
 }

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -8,6 +8,9 @@ import { NonFile } from './non-file';
 
 @Injectable()
 export class AppService {
+  // `randomBytes` has a max value of 2^31 -1. That's all this is
+  private readonly MAX_BITES = Math.pow(2, 31) - 1;
+
   getReadStream(): StreamableFile {
     return new StreamableFile(
       createReadStream(join(process.cwd(), 'Readme.md')),
@@ -44,7 +47,8 @@ export class AppService {
 
   getSlowStream(): StreamableFile {
     const stream = new Readable();
-    stream.push(Buffer.from(randomBytes(Math.pow(2, 31) - 1)));
+    stream.push(Buffer.from(randomBytes(this.MAX_BITES)));
+    // necessary for a `new Readable()`. Doesn't do anything
     stream._read = () => {};
     return new StreamableFile(stream);
   }

--- a/integration/send-files/src/app.service.ts
+++ b/integration/send-files/src/app.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, StreamableFile } from '@nestjs/common';
+import { randomBytes } from 'crypto';
 import { createReadStream, readFileSync } from 'fs';
 import { join } from 'path';
 import { Observable, of } from 'rxjs';
+import { Readable } from 'stream';
 import { NonFile } from './non-file';
 
 @Injectable()
@@ -38,5 +40,12 @@ export class AppService {
 
   getFileThatDoesNotExist(): StreamableFile {
     return new StreamableFile(createReadStream('does-not-exist.txt'));
+  }
+
+  getSlowStream(): StreamableFile {
+    const stream = new Readable();
+    stream.push(Buffer.from(randomBytes(Math.pow(2, 31) - 1)));
+    stream._read = () => {};
+    return new StreamableFile(stream);
   }
 }

--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -4,6 +4,7 @@ import { isFunction } from '../utils/shared.utils';
 import { StreamableFileOptions } from './streamable-options.interface';
 
 export interface StreamableHandlerResponse {
+  destroyed: boolean;
   statusCode: number;
   send: (msg: string) => void;
 }
@@ -15,8 +16,10 @@ export class StreamableFile {
     err: Error,
     response: StreamableHandlerResponse,
   ) => void = (err: Error, res) => {
-    res.statusCode = 400;
-    res.send(err.message);
+    if (!res.destroyed) {
+      res.statusCode = 400;
+      res.send(err.message);
+    }
   };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If a client currently closes the request before the stream finishes we get an error about not being able to send headers to a response that is already sent. It should be noted that this is express only, fastify does not have this issue

Issue Number: #10105


## What is the new behavior?

In the case of using `curl` or a similar tool on the command line,
or if the client decides to end the request for a streamed file early
without the check we would end up causing a server crash. Now, we will
just not send the response as the client has already decided how to
move on.

## Does this PR introduce a breaking change?
- [X] Yes
- [ ] No

_Technically_ yes due to the fact that the server now no longer dies, but that is the expected case, so I believe this should be fine as a `patch` rather than a `major` bump. The fact that we actually now prevent a crash is the good thing :cat: 


## Other information