### PR TITLE
feat(common): more verbose tsc error  message on wrong provider declaration

### DIFF
--- a/packages/common/interfaces/modules/provider.interface.ts
+++ b/packages/common/interfaces/modules/provider.interface.ts
@@ -51,7 +51,7 @@ export interface ClassProvider<T = any> {
    *
    * @see [Use factory](https://docs.nestjs.com/fundamentals/custom-providers#factory-providers-usefactory)
    */
-  inject?: never;
+  inject?: 'The `inject` option is only for factory providers!';
   /**
    * Flags provider as durable. This flag can be used in combination with custom context id
    * factory strategy to construct lazy DI subtrees.
@@ -90,7 +90,7 @@ export interface ValueProvider<T = any> {
    *
    * @see [Use factory](https://docs.nestjs.com/fundamentals/custom-providers#factory-providers-usefactory)
    */
-  inject?: never;
+  inject?: 'The `inject` option is only for factory providers!';
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

having the follow custom provider:

```ts
{
  provide: '',
  useClass: class {},
  inject: [],
}
```

triggers the TSC error:

![image](https://user-images.githubusercontent.com/13461315/184508992-bdc858f9-42cc-4d6e-9052-335a433090ec.png)

![image](https://user-images.githubusercontent.com/13461315/184509004-8bf67f73-4e0a-486e-8fe8-6cf1e2682179.png)

which isn't that friendly for beginners on TS

## What is the new behavior?

![image](https://user-images.githubusercontent.com/13461315/184509047-1d8b0387-9ea0-4be0-b319-93d2064a6430.png)

![image](https://user-images.githubusercontent.com/13461315/184509071-af52aab2-48f0-496d-ad1d-8417047f56dd.png)

![image](https://user-images.githubusercontent.com/13461315/184509087-8511e883-e4ee-4913-87ea-745ef7eeb7e6.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

I know that this kind of usage looks hacky and isn't common but I believe it is less cryptic (or maybe is not) :p

Inspired by the video [CUSTOM ERRORS in TypeScript? - Advanced TypeScript](https://www.youtube.com/watch?v=7BnoNWu2y3Y)