### PR TITLE
fix(microservice): grpc-client serialize error

### DIFF
--- a/integration/microservices/e2e/sum-grpc.spec.ts
+++ b/integration/microservices/e2e/sum-grpc.spec.ts
@@ -60,6 +60,18 @@ describe('GRPC transport', () => {
       .expect(200, { result: 15 });
   });
 
+  it(`GRPC Receiving serialized Error`, async () => {
+    await request(server)
+      .post('/error?client=standard')
+      .expect(200)
+      .expect('false');
+
+    await request(server)
+      .post('/error?client=custom')
+      .expect(200)
+      .expect('true');
+  });
+
   it(`GRPC Sending and Receiving HTTP POST (multiple proto)`, async () => {
     await request(server)
       .post('/multi/sum')

--- a/integration/microservices/src/grpc/math.proto
+++ b/integration/microservices/src/grpc/math.proto
@@ -6,6 +6,7 @@ service Math {
   rpc Sum (RequestSum) returns (SumResult);
   rpc SumStream(stream RequestSum) returns(stream SumResult);
   rpc SumStreamPass(stream RequestSum) returns(stream SumResult);
+  rpc Divide (RequestDivide) returns (DivideResult);
 }
 
 message SumResult {
@@ -14,4 +15,13 @@ message SumResult {
 
 message RequestSum {
   repeated int32 data = 1;
+}
+
+message RequestDivide {
+  int32 dividend = 1;
+  int32 divisor = 2 ;
+}
+
+message DivideResult {
+  int32 result = 1;
 }

--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -174,7 +174,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
               return;
             }
           }
-          observer.error(error);
+          observer.error(this.serializeError(error));
         });
         call.on('end', () => {
           if (upstreamSubscription) {
@@ -216,7 +216,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
           const callArgs = [
             (error: unknown, data: unknown) => {
               if (error) {
-                return observer.error(error);
+                return observer.error(this.serializeError(error));
               }
               observer.next(data);
               observer.complete();
@@ -243,7 +243,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
       return new Observable(observer => {
         client[methodName](...args, (error: any, data: any) => {
           if (error) {
-            return observer.error(error);
+            return observer.error(this.serializeError(error));
           }
           observer.next(data);
           observer.complete();


### PR DESCRIPTION
closes #10104

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number:  [#10104](https://github.com/nestjs/nest/issues/10104)


## What is the new behavior?
`this.serializeError(error)` is called before returning an error in `client-grpc.ts`,
this matches the behavior to the the rest of `ClientProxy` implementations

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I didn't find any test cases for error handling, please refer me to any if i missed it.
Added a basic test to make sure old behavior is not affected when `serializeError` is not overridden