### PR TITLE
feat(microservices): added rabbitmq queue consumer options

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -37,6 +37,7 @@ export const RQM_DEFAULT_QUEUE = 'default';
 export const RQM_DEFAULT_PREFETCH_COUNT = 0;
 export const RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT = false;
 export const RQM_DEFAULT_QUEUE_OPTIONS = {};
+export const RQM_DEFAULT_CONSUMER_OPTIONS = {};
 export const RQM_DEFAULT_NOACK = true;
 export const RQM_DEFAULT_PERSISTENT = false;
 export const RQM_DEFAULT_NO_ASSERT = false;

--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -28,3 +28,11 @@ export interface AmqplibQueueOptions {
   maxLength?: number;
   maxPriority?: number;
 }
+
+export interface AmqplibConsumerOptions {
+  noAck?: boolean;
+  consumerTag?: string,
+  noLocal?: string,
+  exclusive?: string,
+  arguments?: any;
+}

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -174,6 +174,7 @@ export interface RmqOptions {
     queue?: string;
     prefetchCount?: number;
     isGlobalPrefetchCount?: boolean;
+    consumerOptions?: any; // AmqplibConsumerOptions;
     queueOptions?: any; // AmqplibQueueOptions;
     socketOptions?: any; // AmqpConnectionManagerSocketOptions;
     noAck?: boolean;

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -16,6 +16,7 @@ import {
   RQM_DEFAULT_PREFETCH_COUNT,
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
+  RQM_DEFAULT_CONSUMER_OPTIONS,
   RQM_DEFAULT_URL,
 } from '../constants';
 import { RmqContext } from '../ctx-host';
@@ -43,6 +44,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   protected readonly queue: string;
   protected readonly prefetchCount: number;
   protected readonly queueOptions: any;
+  protected readonly consumerOptions: any;
   protected readonly isGlobalPrefetchCount: boolean;
   protected readonly noAssert: boolean;
 
@@ -60,6 +62,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     this.queueOptions =
       this.getOptionsProp(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
+    this.consumerOptions =
+      this.getOptionsProp(this.options, 'consumerOptions') ||
+      RQM_DEFAULT_CONSUMER_OPTIONS;
     this.noAssert =
       this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
 
@@ -152,6 +157,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       (msg: Record<string, any>) => this.handleMessage(msg, channel),
       {
         noAck,
+        ...this.consumerOptions,
       },
     );
     callback();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR introduces a new configuration for RabbitMQ microservices queue.

Adds an option to configure consumer arguments

```typescript
export const RabbitMQQueueNest = {
  name: 'QUEUE_STREAM',
  transport: Transport.RMQ,
  options: {
    urls: [rabbitMqUrl],
    queue: RabbitMqQueues.USUARIOS.name,
    noAck: false,
    prefetchCount: 1000,
    consumerOptions: {
      arguments: {
        'x-stream-offset': '7D',
      },
    },
    queueOptions: {
      durable: true,
      deadLetterExchange: ``,
      deadLetterRoutingKey: RabbitMqQueues.USUARIOS.dlq,
      arguments: {
        'x-queue-type': 'stream',
      },
    },
  },
};

```
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Actually, only `noAck` argument is passed to the consumerOptions, but rabbitmq accept any argument from options that changes the way that rabbitmq consumer works


## What is the new behavior?
This PR enables the possibility to add any argument to the RabbitMQ Consumer

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No


## Other information
This is not a break change, only introduces an new option to rabbitmq queue configuration