### PR TITLE
fix: export cache module options token under easy name

### DIFF
--- a/packages/common/cache/cache.constants.ts
+++ b/packages/common/cache/cache.constants.ts
@@ -1,3 +1,6 @@
+import { MODULE_OPTIONS_TOKEN } from './cache.module-definition';
+
 export const CACHE_MANAGER = 'CACHE_MANAGER';
 export const CACHE_KEY_METADATA = 'cache_module:cache_key';
 export const CACHE_TTL_METADATA = 'cache_module:cache_ttl';
+export const CACHE_MODULE_OPTIONS = MODULE_OPTIONS_TOKEN;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

In Nest v9 now that we use the `ConfigurableModuleBuilder` we no longer expose the `CACHE_MODULE_OPTIONS` token that we used to in v8

## What is the new behavior?
Re-expose the `CACHE_MODULE_OPTIONS` as an alias for `MODULE_OPTIONS_TOKEN` so that the cache module options can be easily overwritten in a test rather than having to `import { MODULE_OPTIONS_TOKEN } from '@nestjs/common/cache/cache.module-definitions'`

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information