### PR TITLE
Make metadata optional

### DIFF
--- a/packages/common/decorators/modules/module.decorator.ts
+++ b/packages/common/decorators/modules/module.decorator.ts
@@ -15,7 +15,7 @@ import { validateModuleKeys } from '../../utils/validate-module-keys.util';
  *
  * @publicApi
  */
-export function Module(metadata: ModuleMetadata): ClassDecorator {
+export function Module(metadata: ModuleMetadata = {}): ClassDecorator {
   const propsKeys = Object.keys(metadata);
   validateModuleKeys(propsKeys);
 


### PR DESCRIPTION
Quality of life update for those who use `@Module({})` and would rather `@Module()`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x]  Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`@Module()` requires a parameter

Issue Number: N/A


## What is the new behavior?
`@Module()` will default to `{}` if no parameters given

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information