### PR TITLE
chore(core): added types on the  methods abstract in http-adapter

### DIFF
--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -100,18 +100,18 @@ export abstract class AbstractHttpAdapter<
   abstract initHttpServer(options: NestApplicationOptions);
   abstract useStaticAssets(...args: any[]);
   abstract setViewEngine(engine: string);
-  abstract getRequestHostname(request);
-  abstract getRequestMethod(request);
-  abstract getRequestUrl(request);
-  abstract status(response, statusCode: number);
-  abstract reply(response, body: any, statusCode?: number);
-  abstract end(response, message?: string);
-  abstract render(response, view: string, options: any);
-  abstract redirect(response, statusCode: number, url: string);
+  abstract getRequestHostname(request: any);
+  abstract getRequestMethod(request: any);
+  abstract getRequestUrl(request: any);
+  abstract status(response: any, statusCode: number);
+  abstract reply(response: any, body: any, statusCode?: number);
+  abstract end(response: any, message?: string);
+  abstract render(response: any, view: string, options: any);
+  abstract redirect(response: any, statusCode: number, url: string);
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
-  abstract isHeadersSent(response);
-  abstract setHeader(response, name: string, value: string);
+  abstract isHeadersSent(response: any);
+  abstract setHeader(response: any, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
   abstract enableCors(
     options: CorsOptions | CorsOptionsDelegate<TRequest>,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
I noticed that types were missing in some abstract methods. (see screenshot)

<img width="934" alt="screenshot" src="https://user-images.githubusercontent.com/11542387/187025681-ff07775e-5f0b-4f69-b5fb-01a2fdfc5e1c.png">


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I used `any` as the type, also since typescript if it does not find the type by default sets `any`, I preferred to use that at the moment. 
