### PR TITLE
Fix HTTPException on minifying class names, its not match regex expre…

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -70,7 +70,7 @@ export class HttpException extends Error {
     } else if (this.constructor) {
       this.message = this.constructor.name
         .match(/[A-Z][a-z]+|[0-9]+/g)
-        .join(' ');
+        ?.join(' ') ?? 'Error';
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

```js
"BadRequest".match(/[A-Z][a-z]+|[0-9]+/g).join(' ') // this is ok 
// but on minify 
"t".match(/[A-Z][a-z]+|[0-9]+/g).join(' ') // throws error
// Uncaught TypeError: Cannot read properties of null (reading 'join')
```

Issue Number: N/A


## What is the new behavior?

```js
"t".match(/[A-Z][a-z]+|[0-9]+/g)?.join(' ') ?? "Error" // will give "Error" message
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information