### PR TITLE
draft: fix(common): change configurable module class type to support promise

### DIFF
--- a/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
+++ b/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
@@ -21,7 +21,9 @@ export type ConfigurableModuleCls<
   new (): any;
 } & Record<
   `${MethodKey}`,
-  (options: ModuleOptions & ExtraModuleDefinitionOptions) => DynamicModule
+  (
+    options: ModuleOptions & ExtraModuleDefinitionOptions,
+  ) => DynamicModule | Promise<DynamicModule>
 > &
   Record<
     `${MethodKey}Async`,
@@ -31,5 +33,5 @@ export type ConfigurableModuleCls<
         FactoryClassMethodKey
       > &
         ExtraModuleDefinitionOptions,
-    ) => DynamicModule
+    ) => DynamicModule | Promise<DynamicModule>
   >;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Configurable modules built with the `ConfigurableModuleBuilder` can't have `async` `register` or `registerAsync` methods

Issue Number: #10226

## What is the new behavior?

Configurable modules built with the `ConfigurableModuleBuilder` can have `async` `register` or `registerAsync` methods

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information