### PR TITLE
feat(microservices): Add producer reference to KafkaContext

### DIFF
--- a/packages/microservices/ctx-host/kafka.context.ts
+++ b/packages/microservices/ctx-host/kafka.context.ts
@@ -1,4 +1,4 @@
-import { Consumer, KafkaMessage } from '../external/kafka.interface';
+import { Consumer, KafkaMessage, Producer } from '../external/kafka.interface';
 import { BaseRpcContext } from './base-rpc.context';
 
 type KafkaContextArgs = [
@@ -7,6 +7,7 @@ type KafkaContextArgs = [
   topic: string,
   consumer: Consumer,
   heartbeat: () => Promise<void>,
+  producer: Producer,
 ];
 
 export class KafkaContext extends BaseRpcContext<KafkaContextArgs> {
@@ -47,5 +48,12 @@ export class KafkaContext extends BaseRpcContext<KafkaContextArgs> {
    */
   getHeartbeat() {
     return this.args[4];
+  }
+
+  /**
+   * Returns the Kafka producer reference,
+   */
+  getProducer() {
+    return this.args[5];
   }
 }

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -168,6 +168,7 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
       payload.topic,
       this.consumer,
       payload.heartbeat,
+      this.producer,
     ]);
     const handler = this.getHandlerByPattern(packet.pattern);
     // if the correlation id or reply topic is not set

--- a/packages/microservices/test/ctx-host/kafka.context.spec.ts
+++ b/packages/microservices/test/ctx-host/kafka.context.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import { KafkaContext } from '../../ctx-host';
-import { Consumer, KafkaMessage } from '../../external/kafka.interface';
+import {
+  Consumer,
+  KafkaMessage,
+  Producer,
+} from '../../external/kafka.interface';
 
 describe('KafkaContext', () => {
   const args = [
@@ -9,12 +13,20 @@ describe('KafkaContext', () => {
     undefined,
     { test: 'consumer' },
     () => {},
+    { test: 'producer' },
   ];
   let context: KafkaContext;
 
   beforeEach(() => {
     context = new KafkaContext(
-      args as [KafkaMessage, number, string, Consumer, () => Promise<void>],
+      args as [
+        KafkaMessage,
+        number,
+        string,
+        Consumer,
+        () => Promise<void>,
+        Producer,
+      ],
     );
   });
   describe('getTopic', () => {
@@ -40,6 +52,11 @@ describe('KafkaContext', () => {
   describe('getHeartbeat', () => {
     it('should return heartbeat callback', () => {
       expect(context.getHeartbeat()).to.be.eql(args[4]);
+    });
+  });
+  describe('getProducer', () => {
+    it('should return producer instance', () => {
+      expect(context.getProducer()).to.deep.eq({ test: 'producer' });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Kafka producer is not exposed in `KafkaContext`

Issue Number:  #10263 


## What is the new behavior?
Kafka producer is exposed in `KafkaContext` under `getProducer()`
Closes #10263 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

In order not to introduce a braking change, I added the producer as the last argument of `KafkaContextArgs`. It would look better if it were immediately after `consumer`.

## Other information
Btw, I noticed that all Kafka related integration tests are skipped for being "flaky", therefore I didn't add one. Is this something that can be worked on to make them reliable?