### PR TITLE
fix(common): make `ExtraModuleDefinitionOptions` partial in `OPTIONS_TYPE`

### DIFF
--- a/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
+++ b/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
@@ -21,7 +21,9 @@ export type ConfigurableModuleCls<
   new (): any;
 } & Record<
   `${MethodKey}`,
-  (options: ModuleOptions & ExtraModuleDefinitionOptions) => DynamicModule
+  (
+    options: ModuleOptions & Partial<ExtraModuleDefinitionOptions>,
+  ) => DynamicModule
 > &
   Record<
     `${MethodKey}Async`,
@@ -30,6 +32,6 @@ export type ConfigurableModuleCls<
         ModuleOptions,
         FactoryClassMethodKey
       > &
-        ExtraModuleDefinitionOptions,
+        Partial<ExtraModuleDefinitionOptions>,
     ) => DynamicModule
   >;

--- a/packages/common/module-utils/interfaces/configurable-module-host.interface.ts
+++ b/packages/common/module-utils/interfaces/configurable-module-host.interface.ts
@@ -57,7 +57,7 @@ export interface ConfigurableModuleHost<
     ModuleOptions,
     FactoryClassMethodKey
   > &
-    ExtraModuleDefinitionOptions;
+    Partial<ExtraModuleDefinitionOptions>;
   /**
    * Can be used to auto-infer the compound "module options" type (options interface + extra module definition options).
    * Note: this property is not supposed to be used as a value.
@@ -73,5 +73,5 @@ export interface ConfigurableModuleHost<
    * }
    * ```
    */
-  OPTIONS_TYPE: ModuleOptions & ExtraModuleDefinitionOptions;
+  OPTIONS_TYPE: ModuleOptions & Partial<ExtraModuleDefinitionOptions>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the `OPTIONS_TYPE` and `ASYNC_OPTIONS_TYPE` require all fields of `ExtraModuleDefinitionOptions`, but `ExtraModuleDefinitionOptions` has default values which are set in the `setExtras` function.

## What is the new behavior?

the `ExtraModuleDefinitionOptions` in `OPTIONS_TYPE` and `ASYNC_OPTIONS_TYPE` is partial.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
