### PR TITLE
chore(integration): update mysql image to 8.0.30

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - "9001:9001"
     restart: always
   mysql:
-    image: mysql:8.0.28
+    image: mysql:8.0.30
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: test


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Integration test related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`npm run test:docker:up` fails on M1 Mac with the error below:

```
Pulling mysql (mysql:8.0.28)...
8.0.28: Pulling from library/mysql
ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries
```

This is because 8.0.28 doesn't support arm64 architecture.

## What is the new behavior?

We can run successfully `npm run test:docker:up` on M1 Mac because 8.0.29 and above supports arm64 architecture.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information