### PR TITLE
fix(common): stringify arrays on printing with console-logger

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -220,7 +220,7 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {
-    return isPlainObject(message)
+    return isPlainObject(message) || Array.isArray(message)
       ? `${this.colorize('Object:', logLevel)}\n${JSON.stringify(
           message,
           (key, value) =>

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -576,5 +576,54 @@ describe('Logger', () => {
         `Prefix: ~~~test~~~`,
       );
     });
+
+    it('should stringify messages', () => {
+      class CustomConsoleLogger extends ConsoleLogger {
+        protected colorize(message: string, _: LogLevel): string {
+          return message;
+        }
+      }
+
+      const consoleLogger = new CustomConsoleLogger();
+      const consoleLoggerSpy = sinon.spy(
+        consoleLogger,
+        'stringifyMessage' as keyof ConsoleLogger,
+      );
+      consoleLogger.debug(
+        'str1',
+        { key: 'str2' },
+        ['str3'],
+        [{ key: 'str4' }],
+        null,
+        1,
+      );
+
+      expect(consoleLoggerSpy.getCall(0).returnValue).to.equal('str1');
+      expect(consoleLoggerSpy.getCall(1).returnValue).to.equal(
+        `Object:
+{
+  "key": "str2"
+}
+`,
+      );
+      expect(consoleLoggerSpy.getCall(2).returnValue).to.equal(
+        `Object:
+[
+  "str3"
+]
+`,
+      );
+      expect(consoleLoggerSpy.getCall(3).returnValue).to.equal(
+        `Object:
+[
+  {
+    "key": "str4"
+  }
+]
+`,
+      );
+      expect(consoleLoggerSpy.getCall(4).returnValue).to.equal(null);
+      expect(consoleLoggerSpy.getCall(5).returnValue).to.equal(1);
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #10280


## What is the new behavior?

ConsoleLogger prints arrays as json like objects.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information