### PR TITLE
feat(common): make `transformDefinition` optional

### DIFF
--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -97,7 +97,7 @@ export class ConfigurableModuleBuilder<
     transformDefinition: (
       definition: DynamicModule,
       extras: ExtraModuleDefinitionOptions,
-    ) => DynamicModule,
+    ) => DynamicModule = def => def,
   ) {
     const builder = new ConfigurableModuleBuilder<
       ModuleOptions,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?
More clean way
```ts
export const {
  ConfigurableModuleClass,
  MODULE_OPTIONS_TOKEN,
  OPTIONS_TYPE,
  ASYNC_OPTIONS_TYPE,
}
  = new ConfigurableModuleBuilder<MyOptions>().setExtras(
    {
      isGlobal: false,
    },
    // definition => definition, // we don't need this function if this PR is accepted
  ).build()

/**
 * This module is only for generating options
 */
@Module({
  exports: [MODULE_OPTIONS_TOKEN],
})
export class HttpBaseModule extends ConfigurableModuleClass {
}

@Module({})
export class HttpModule {
  private static innerRegister(baseModule: DynamicModule, isGlobal = false): DynamicModule {
    return {
        module: HttpModule,
        global: isGlobal,
        providers: [Xxx], // this provider will consume MODULE_OPTIONS_TOKEN
        imports: [baseModule],
        exports: [baseModule],
    }
  }
  static register(options: typeof OPTIONS_TYPE): DynamicModule {
    const baseModule = HttpBaseModule.register(options)
    return this.innerRegister(baseModule, options.isGlobal)
  }

  static registerAsync(options: typeof ASYNC_OPTIONS_TYPE): DynamicModule {
    const baseModule = HttpBaseModule.registerAsync(options)
    return this.innerRegister(baseModule, options.isGlobal)
  }
}
````


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information