### PR TITLE
chore(common): only allow cache-manager version <=4

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,7 +22,7 @@
     "uuid": "9.0.0"
   },
   "peerDependencies": {
-    "cache-manager": "*",
+    "cache-manager": "<=4",
     "class-transformer": "*",
     "class-validator": "*",
     "reflect-metadata": "^0.1.12",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`cache-manager` v5 introduces breaking changes that now are leading to an error described here: https://github.com/node-cache-manager/node-cache-manager/issues/210 But `@nestjs/common@9.1.2` doesn't covers that at package installation time

## What is the new behavior?

Now we'll get an peer dep version mismatch on installing `cache-manager@5` due to the semver range constraint. Note that I didn't tested older version of `cache-manager` so I can't tell for sure if the range `<=4` is correct.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Read this comment made by Jay: https://github.com/node-cache-manager/node-cache-manager/issues/210#issuecomment-1264848047