### PR TITLE
Support multiple file upload validation

### DIFF
--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from '../../utils/shared.utils';
+import { isEmpty, isUndefined } from '../../utils/shared.utils';
 import { Injectable, Optional } from '../../decorators/core';
 import { HttpStatus } from '../../enums';
 import { PipeTransform } from '../../interfaces/features/pipe-transform.interface';
@@ -39,7 +39,7 @@ export class ParseFilePipe implements PipeTransform<any> {
   }
 
   async transform(value: any): Promise<any> {
-    if (isUndefined(value)) {
+    if (isUndefined(value) || (Array.isArray(value) && isEmpty(value))) {
       if (this.fileIsRequired) {
         throw this.exceptionFactory('File is required');
       }
@@ -48,7 +48,11 @@ export class ParseFilePipe implements PipeTransform<any> {
     }
 
     if (this.validators.length) {
-      await this.validate(value);
+      if (Array.isArray(value)) {
+        await Promise.all(value.map((v) => this.validate(v)));
+      } else {
+        await this.validate(value);
+      }
     }
     return value;
   }

--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -48,7 +48,7 @@ export class ParseFilePipe implements PipeTransform<any> {
     }
 
     if (this.validators.length) {
-      this.validateAllFrom(value)
+      this.validateAllFrom(value);
     }
     return value;
   }
@@ -63,17 +63,17 @@ export class ParseFilePipe implements PipeTransform<any> {
 
   private async validateAllFrom(value: any) {
     if (Array.isArray(value)) {
-      await this.validateFiles(value)
+      await this.validateFiles(value);
     } else if (isObject(value)) {
-      const files = [].concat(...Object.values(value))
-      await this.validateFiles(files)
+      const files = [].concat(...Object.values(value));
+      await this.validateFiles(files);
     } else {
       await this.validate(value);
     }
   }
 
   private validateFiles(files: any[]): Promise<any[]> {
-    return Promise.all(files.map(f => this.validate(f)))
+    return Promise.all(files.map(f => this.validate(f)));
   } 
 
   private async validateOrThrow(file: any, validator: FileValidator) {
@@ -86,9 +86,9 @@ export class ParseFilePipe implements PipeTransform<any> {
   }
 
   private thereAreNoFilesIn(value: any): boolean {
-    const isEmptyArray = (Array.isArray(value) && isEmpty(value))
-    const isEmptyObject = isObject(value) && isEmpty(Object.keys(value))
-    return isUndefined(value) || isEmptyArray || isEmptyObject
+    const isEmptyArray = (Array.isArray(value) && isEmpty(value));
+    const isEmptyObject = isObject(value) && isEmpty(Object.keys(value));
+    return isUndefined(value) || isEmptyArray || isEmptyObject;
   }
 
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently file validation via the `ParseFilePipe` only works when validating a single file. When using an array of files it always throws an error.

Issue Number: N/A


## What is the new behavior?

Single file validation continues to work unchanged, but now when uploading multiple files:
1. `fileIsRequired` works 
2. Each file in the array is validated


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information