### PR TITLE
fix(platform): shutdown hooks not firing caused by open http connections

### DIFF
--- a/integration/nest-application/sse/e2e/express.spec.ts
+++ b/integration/nest-application/sse/e2e/express.spec.ts
@@ -1,0 +1,79 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as EventSource from 'eventsource';
+import { AppModule } from '../src/app.module';
+
+describe('Sse (Express Application)', () => {
+  let app: NestExpressApplication;
+  let eventSource: EventSource;
+
+  describe('without forceCloseConnections', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestExpressApplication>();
+
+      await app.listen(3000);
+      const url = await app.getUrl();
+
+      eventSource = new EventSource(url + '/sse', {
+        headers: { connection: 'keep-alive' },
+      });
+    });
+
+    // The order of actions is very important here. When not using `forceCloseConnections`,
+    // the SSe eventsource should close the connections in order to signal the server that
+    // the keep-alive connection can be ended.
+    afterEach(async () => {
+      eventSource.close();
+
+      await app.close();
+    });
+
+    it('receives events from server', done => {
+      eventSource.addEventListener('message', event => {
+        expect(JSON.parse(event.data)).to.eql({
+          hello: 'world',
+        });
+        done();
+      });
+    });
+  });
+
+  describe('with forceCloseConnections', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestExpressApplication>({
+        forceCloseConnections: true,
+      });
+
+      await app.listen(3000);
+      const url = await app.getUrl();
+
+      eventSource = new EventSource(url + '/sse', {
+        headers: { connection: 'keep-alive' },
+      });
+    });
+
+    afterEach(async () => {
+      await app.close();
+
+      eventSource.close();
+    });
+
+    it('receives events from server', done => {
+      eventSource.addEventListener('message', event => {
+        expect(JSON.parse(event.data)).to.eql({
+          hello: 'world',
+        });
+        done();
+      });
+    });
+  });
+});

--- a/integration/nest-application/sse/e2e/fastify.spec.ts
+++ b/integration/nest-application/sse/e2e/fastify.spec.ts
@@ -1,0 +1,86 @@
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as EventSource from 'eventsource';
+import { AppModule } from '../src/app.module';
+
+describe('Sse (Fastify Application)', () => {
+  let app: NestFastifyApplication;
+  let eventSource: EventSource;
+
+  describe('without forceCloseConnections', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter(),
+      );
+
+      await app.listen(3000);
+      const url = await app.getUrl();
+
+      eventSource = new EventSource(url + '/sse', {
+        headers: { connection: 'keep-alive' },
+      });
+    });
+
+    // The order of actions is very important here. When not using `forceCloseConnections`,
+    // the SSe eventsource should close the connections in order to signal the server that
+    // the keep-alive connection can be ended.
+    afterEach(async () => {
+      eventSource.close();
+
+      await app.close();
+    });
+
+    it('receives events from server', done => {
+      eventSource.addEventListener('message', event => {
+        expect(JSON.parse(event.data)).to.eql({
+          hello: 'world',
+        });
+        done();
+      });
+    });
+  });
+
+  describe('with forceCloseConnections', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter({
+          forceCloseConnections: true,
+        }),
+      );
+
+      await app.listen(3000);
+      const url = await app.getUrl();
+
+      eventSource = new EventSource(url + '/sse', {
+        headers: { connection: 'keep-alive' },
+      });
+    });
+
+    afterEach(async () => {
+      await app.close();
+
+      eventSource.close();
+    });
+
+    it('receives events from server', done => {
+      eventSource.addEventListener('message', event => {
+        expect(JSON.parse(event.data)).to.eql({
+          hello: 'world',
+        });
+        done();
+      });
+    });
+  });
+});

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, MessageEvent, Sse } from '@nestjs/common';
+import { interval, map, Observable } from 'rxjs';
+
+@Controller()
+export class AppController {
+  @Sse('sse')
+  sse(): Observable<MessageEvent> {
+    return interval(1000).pipe(
+      map(_ => ({ data: { hello: 'world' } } as MessageEvent)),
+    );
+  }
+}

--- a/integration/nest-application/sse/src/app.module.ts
+++ b/integration/nest-application/sse/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/integration/nest-application/sse/tsconfig.json
+++ b/integration/nest-application/sse/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "lib": ["dom"],
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/common/interfaces/nest-application-options.interface.ts
+++ b/packages/common/interfaces/nest-application-options.interface.ts
@@ -25,4 +25,9 @@ export interface NestApplicationOptions extends NestApplicationContextOptions {
    * Whether to register the raw request body on the request. Use `req.rawBody`.
    */
   rawBody?: boolean;
+  /**
+   * Force close open HTTP connections. Useful if restarting your application hangs due to
+   * keep-alive connections in the HTTP adapter.
+   */
+  forceCloseConnections?: boolean;
 }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -209,7 +209,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       this.httpServer = http.createServer(this.getInstance());
     }
 
-    if (options?.forceCloseConnections === true) {
+    if (options?.forceCloseConnections) {
       this.trackOpenConnections();
     }
   }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -205,11 +205,13 @@ export class ExpressAdapter extends AbstractHttpAdapter {
         options.httpsOptions,
         this.getInstance(),
       );
-      this.trackOpenConnections();
-      return;
+    } else {
+      this.httpServer = http.createServer(this.getInstance());
     }
-    this.httpServer = http.createServer(this.getInstance());
-    this.trackOpenConnections();
+
+    if (options?.forceCloseConnections === true) {
+      this.trackOpenConnections();
+    }
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {

--- a/sample/28-sse/src/main.ts
+++ b/sample/28-sse/src/main.ts
@@ -2,7 +2,10 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, {
+    forceCloseConnections: true,
+  });
+  app.enableShutdownHooks();
   await app.listen(3000);
   console.log(`Application is running on: ${await app.getUrl()}`);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #9517 

When using long living HTTP connections (like SSE/Keep-Alive connecitons), in conjuction with `app.enableShutdownHooks()` exposed a flaw. When there are keep alive connections in our HTTP server, they would never get closed. This would cause our HTTP adapter to endlessly wait on them until a second restart.

Because the shutdown hooks would halt at `httpAdapter.close()`, the rest of the application shutdown logic would also never run.

## What is the new behavior?

We keep track of open connections in our Express adapter. When `httpAdapter.close()` is called, we iterate these open connections and close them.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

On that note: this fix is superfluous for Fastify. Fastify has the [`forceCloseConnections`](https://github.com/fastify/fastify/blob/a46aead95e1ce2de3928d376a39f79c9d1d5d2ca/docs/Reference/Server.md#forcecloseconnections)