### PR TITLE
fix: support cache manager v4 and v5

### DIFF
--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -17,20 +17,27 @@ export function createCacheManager(): Provider {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const cmVersion = require('cache-manager/package.json').version;
+      const cmMajor = cmVersion.split('.')[0];
+      const cachingFactory = (
+        store: CacheManagerOptions['store'],
+        options: Omit<CacheManagerOptions, 'store'>,
+      ): Record<string, any> => {
+        if (cmMajor < 5) {
+          return cacheManager.caching({
+            ...defaultCacheOptions,
+            ...{ ...options, store },
+          });
+        }
+        return cacheManager.caching(store ?? 'memory', options);
+      };
 
       return Array.isArray(options)
         ? cacheManager.multiCaching(
-            options.map(store =>
-              cacheManager.caching({
-                ...defaultCacheOptions,
-                ...(store || {}),
-              }),
-            ),
+            options.map(option => cachingFactory(options.store, option)),
           )
-        : cacheManager.caching({
-            ...defaultCacheOptions,
-            ...(options || {}),
-          });
+        : cachingFactory(options.store, options);
     },
     inject: [MODULE_OPTIONS_TOKEN],
   };

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -19,12 +19,12 @@ export function createCacheManager(): Provider {
       );
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const cmVersion = require('cache-manager/package.json').version;
-      const cmMajor = cmVersion.split('.')[0];
+      const cacheManagerMajor = cacheManagerVersion.split('.')[0];
       const cachingFactory = (
         store: CacheManagerOptions['store'],
         options: Omit<CacheManagerOptions, 'store'>,
       ): Record<string, any> => {
-        if (cmMajor < 5) {
+        if (cacheManagerMajor < 5) {
           return cacheManager.caching({
             ...defaultCacheOptions,
             ...{ ...options, store },

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -18,7 +18,7 @@ export function createCacheManager(): Provider {
         require('cache-manager'),
       );
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const cmVersion = require('cache-manager/package.json').version;
+      const cacheManagerVersion = require('cache-manager/package.json').version;
       const cacheManagerMajor = cacheManagerVersion.split('.')[0];
       const cachingFactory = (
         store: CacheManagerOptions['store'],

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -30,7 +30,10 @@ export function createCacheManager(): Provider {
             ...{ ...options, store },
           });
         }
-        return cacheManager.caching(store ?? 'memory', options);
+        return cacheManager.caching(store ?? 'memory', {
+          ...defaultCacheOptions,
+          ...options,
+        });
       };
 
       return Array.isArray(options)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -22,7 +22,7 @@
     "uuid": "9.0.0"
   },
   "peerDependencies": {
-    "cache-manager": "<=4",
+    "cache-manager": "<=5",
     "class-transformer": "*",
     "class-validator": "*",
     "reflect-metadata": "^0.1.12",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently with `cache-manager@5` there is an error about `get is not a function` on the store.

Issue Number: https://github.com/nestjs/docs.nestjs.com/pull/2487
https://github.com/node-cache-manager/node-cache-manager/issues/210

## What is the new behavior?

With the new `cachingFactory` we can support either v4 or v5 and use the proper `caching` method. I've tested v5 locally with success and the current tests still pass, confirming that v4 is unaffected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If we'd rather just wait for Nest 10 to upgrade to cache-manager v5 that's fine too. Just giving us the option :smile_cat: