### PR TITLE
feat(microservices): enable wildcards in redis microservice patterns

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -90,6 +90,10 @@ export interface RedisOptions {
     port?: number;
     retryAttempts?: number;
     retryDelay?: number;
+    /**
+     * Use `psubscribe`/`pmessage` to enable wildcards in the patterns
+     */
+    wildcards?: boolean;
     serializer?: Serializer;
     deserializer?: Deserializer;
   } & IORedisOptions;

--- a/packages/microservices/server/server-redis.ts
+++ b/packages/microservices/server/server-redis.ts
@@ -1,5 +1,4 @@
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
-import { Observable } from 'rxjs';
 import {
   ERROR_EVENT,
   MESSAGE_EVENT,
@@ -64,13 +63,23 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
   }
 
   public bindEvents(subClient: Redis, pubClient: Redis) {
-    subClient.on(MESSAGE_EVENT, this.getMessageHandler(pubClient).bind(this));
+    subClient.on(
+      this.options.wildcards ? 'pmessage' : MESSAGE_EVENT,
+      this.getMessageHandler(pubClient).bind(this),
+    );
     const subscribePatterns = [...this.messageHandlers.keys()];
     subscribePatterns.forEach(pattern => {
       const { isEventHandler } = this.messageHandlers.get(pattern);
-      subClient.subscribe(
-        isEventHandler ? pattern : this.getRequestPattern(pattern),
-      );
+
+      const channel = isEventHandler
+        ? pattern
+        : this.getRequestPattern(pattern);
+
+      if (this.options.wildcards) {
+        subClient.psubscribe(channel);
+      } else {
+        subClient.subscribe(channel);
+      }
     });
   }
 
@@ -90,18 +99,22 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
   }
 
   public getMessageHandler(pub: Redis) {
-    return async (channel: string, buffer: string | any) =>
-      this.handleMessage(channel, buffer, pub);
+    return this.options.wildcards
+      ? (channel: string, pattern: string, buffer: string | any) =>
+          this.handleMessage(channel, buffer, pub, pattern)
+      : (channel: string, buffer: string | any) =>
+          this.handleMessage(channel, buffer, pub, channel);
   }
 
   public async handleMessage(
     channel: string,
     buffer: string | any,
     pub: Redis,
+    pattern: string,
   ) {
     const rawMessage = this.parseMessage(buffer);
     const packet = await this.deserializer.deserialize(rawMessage, { channel });
-    const redisCtx = new RedisContext([channel]);
+    const redisCtx = new RedisContext([pattern]);
 
     if (isUndefined((packet as IncomingRequest).id)) {
       return this.handleEvent(channel, packet, redisCtx);


### PR DESCRIPTION
The redis microservice now makes use of `psubscribe` and `pmessage` if the `wildcards` option is enabled in the options of the microservice, which makes it possible to use wildcards as specified by the Redis documentation.

Closes #10344

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current setup uses `subscribe` and `message` when listening for patterns in a Redis microservice, while using `psubscribe` and `pmessage` would make it possible to use wildcards in those patterns as prescribed by the Redis documentation.

Issue Number: #10344 


## What is the new behavior?
The change makes it possible to use wildcards in the Redis microservice patterns by enabling the `wildcards` option of the microservice.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information