### PR TITLE
fix: update factory to account for old v4 syntax for cache stores

### DIFF
--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -13,24 +13,30 @@ import { CacheManagerOptions } from './interfaces/cache-manager.interface';
 export function createCacheManager(): Provider {
   return {
     provide: CACHE_MANAGER,
-    useFactory: (options: CacheManagerOptions) => {
+    useFactory: async (options: CacheManagerOptions) => {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const cacheManagerVersion = require('cache-manager/package.json').version;
       const cacheManagerMajor = cacheManagerVersion.split('.')[0];
-      const cachingFactory = (
+      const cachingFactory = async (
         store: CacheManagerOptions['store'],
         options: Omit<CacheManagerOptions, 'store'>,
-      ): Record<string, any> => {
+      ): Promise<Record<string, any>> => {
         if (cacheManagerMajor < 5) {
           return cacheManager.caching({
             ...defaultCacheOptions,
             ...{ ...options, store },
           });
         }
-        return cacheManager.caching(store ?? 'memory', {
+        let cache: string | Function = 'memory';
+        if (typeof store === 'object' && 'create' in store) {
+          cache = store.create;
+        } else if (typeof store === 'function') {
+          cache = store;
+        }
+        return cacheManager.caching(cache, {
           ...defaultCacheOptions,
           ...options,
         });
@@ -38,7 +44,9 @@ export function createCacheManager(): Provider {
 
       return Array.isArray(options)
         ? cacheManager.multiCaching(
-            options.map(option => cachingFactory(options.store, option)),
+            await Promise.all(
+              options.map(option => cachingFactory(option.store, option)),
+            ),
           )
         : cachingFactory(options.store, options);
     },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

E2E tests failed using cache-manager v5 due to a difference in cache factory type and a need to `await` an async method

Issue Number: 10348


## What is the new behavior?

The new cache-manager 5 and cache-manager 4 are both supported, with integration tests passing

<details>

<summary>Tests with v5</summary>

```
nest at   on  fix/cache-v5 [ ] is  v9.1.2 via  v16.17.1 with 
❯ npx mocha integration/cache/e2e/*.spec.ts --reporter=spec


  Async Register
    ✔ should be defined
    ✔ should return empty
    ✔ should return data

  Caching Multi Store
    ✔ should return empty
    ✔ should return data


  5 passing (167ms)


nest at   on  fix/cache-v5 [ ] is  v9.1.2 via  v16.17.1 with  took 2s
❯ npm ls cache-manager
@nestjs/core@9.1.2 ~/
└── cache-manager@5.0.0
```

</details>

<details>

<summary>Tests with v4</summary>

```
nest at   on  fix/cache-v5 [  ] is  v9.1.2 via  v16.17.1 with 
❯ npx mocha integration/cache/e2e/*.spec.ts --reporter=spec


  Async Register
    ✔ should be defined
    ✔ should return empty
    ✔ should return data

  Caching Multi Store
    ✔ should return empty
    ✔ should return data


  5 passing (178ms)


nest at   on  fix/cache-v5 [  ] is  v9.1.2 via  v16.17.1 with  took 3s
❯ npm ls cache-manager
@nestjs/core@9.1.2 ~/
└── cache-manager@4.1.0
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information