### PR TITLE
feat(common): ConsoleLogger: extract protected formatContext method

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -185,7 +185,7 @@ export class ConsoleLogger implements LoggerService {
   ) {
     messages.forEach(message => {
       const pidMessage = this.formatPid(process.pid);
-      const contextMessage = context ? yellow(`[${context}] `) : '';
+      const contextMessage = this.formatContext(context);
       const timestampDiff = this.updateAndGetTimestampDiff();
       const formattedLogLevel = logLevel.toUpperCase().padStart(7, ' ');
       const formattedMessage = this.formatMessage(
@@ -203,6 +203,10 @@ export class ConsoleLogger implements LoggerService {
 
   protected formatPid(pid: number) {
     return `[Nest] ${pid}  - `;
+  }
+
+  protected formatContext(context: string): string {
+    return context ? yellow(`[${context}] `) : '';
   }
 
   protected formatMessage(


### PR DESCRIPTION
allow overriding of context formating

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently there is no way to override contextMessage formating by extending ConsoleLogger. This feature is required if we want to extend and create JsonConsoleLogger that emits json without any formating
Related: https://github.com/nestjs/nest/issues/10342


## What is the new behavior?
We can now override contextMessage formating by overriding `formatContext` method

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information