### PR TITLE
feat(common): ConsoleLogger: extract protected formatTimestampDiff

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -246,10 +246,14 @@ export class ConsoleLogger implements LoggerService {
     const includeTimestamp =
       ConsoleLogger.lastTimestampAt && this.options?.timestamp;
     const result = includeTimestamp
-      ? yellow(` +${Date.now() - ConsoleLogger.lastTimestampAt}ms`)
+      ? this.formatTimestampDiff(Date.now() - ConsoleLogger.lastTimestampAt)
       : '';
     ConsoleLogger.lastTimestampAt = Date.now();
     return result;
+  }
+
+  protected formatTimestampDiff(timestampDiff: number) {
+    return yellow(` +${timestampDiff}ms`);
   }
 
   private getContextAndMessagesToPrint(args: unknown[]) {


### PR DESCRIPTION
allow overriding of timestampDiff formating

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently there is no way to override timestampDiff formating by extending ConsoleLogger. This feature is required if we want to extend and create JsonConsoleLogger that emits json without any formating
Related: https://github.com/nestjs/nest/issues/10342

## What is the new behavior?
We can now override contextMessage formating by overriding `formatTimestampDiff` method

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Related: https://github.com/nestjs/nest/pull/10364