### PR TITLE
Revert "Revert "fix: update factory to account for old v4 syntax for cache stores""

### DIFF
--- a/integration/cache/src/async-register/config/cache.config.ts
+++ b/integration/cache/src/async-register/config/cache.config.ts
@@ -7,7 +7,7 @@ import {
 @Injectable()
 export class CacheConfig implements CacheOptionsFactory {
   createCacheOptions(): CacheModuleOptions {
-    const ttl = 10;
+    const ttl = 100;
 
     return { ttl };
   }

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -13,24 +13,30 @@ import { CacheManagerOptions } from './interfaces/cache-manager.interface';
 export function createCacheManager(): Provider {
   return {
     provide: CACHE_MANAGER,
-    useFactory: (options: CacheManagerOptions) => {
+    useFactory: async (options: CacheManagerOptions) => {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const cacheManagerVersion = require('cache-manager/package.json').version;
       const cacheManagerMajor = cacheManagerVersion.split('.')[0];
-      const cachingFactory = (
+      const cachingFactory = async (
         store: CacheManagerOptions['store'],
         options: Omit<CacheManagerOptions, 'store'>,
-      ): Record<string, any> => {
+      ): Promise<Record<string, any>> => {
         if (cacheManagerMajor < 5) {
           return cacheManager.caching({
             ...defaultCacheOptions,
             ...{ ...options, store },
           });
         }
-        return cacheManager.caching(store ?? 'memory', {
+        let cache: string | Function = 'memory';
+        if (typeof store === 'object' && 'create' in store) {
+          cache = store.create;
+        } else if (typeof store === 'function') {
+          cache = store;
+        }
+        return cacheManager.caching(cache, {
           ...defaultCacheOptions,
           ...options,
         });
@@ -38,7 +44,9 @@ export function createCacheManager(): Provider {
 
       return Array.isArray(options)
         ? cacheManager.multiCaching(
-            options.map(option => cachingFactory(options.store, option)),
+            await Promise.all(
+              options.map(option => cachingFactory(option.store, option)),
+            ),
           )
         : cachingFactory(options.store, options);
     },

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -17,14 +17,12 @@ export function createCacheManager(): Provider {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
-      console.log(Object.keys(cacheManager));
-      const cacheManagerIsv5 = 'memoryStore' in Object.keys(cacheManager);
-      console.log(cacheManagerIsv5);
+      const cacheManagerIsv5OrGreater = 'memoryStore' in cacheManager;
       const cachingFactory = async (
         store: CacheManagerOptions['store'],
         options: Omit<CacheManagerOptions, 'store'>,
       ): Promise<Record<string, any>> => {
-        if (cacheManagerIsv5) {
+        if (!cacheManagerIsv5OrGreater) {
           return cacheManager.caching({
             ...defaultCacheOptions,
             ...{ ...options, store },

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -31,6 +31,7 @@ export function createCacheManager(): Provider {
           });
         }
         let cache: string | Function = 'memory';
+        defaultCacheOptions.ttl *= 1000;
         if (typeof store === 'object' && 'create' in store) {
           cache = store.create;
         } else if (typeof store === 'function') {

--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -17,14 +17,14 @@ export function createCacheManager(): Provider {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const cacheManagerVersion = require('cache-manager/package.json').version;
-      const cacheManagerMajor = cacheManagerVersion.split('.')[0];
+      console.log(Object.keys(cacheManager));
+      const cacheManagerIsv5 = 'memoryStore' in Object.keys(cacheManager);
+      console.log(cacheManagerIsv5);
       const cachingFactory = async (
         store: CacheManagerOptions['store'],
         options: Omit<CacheManagerOptions, 'store'>,
       ): Promise<Record<string, any>> => {
-        if (cacheManagerMajor < 5) {
+        if (cacheManagerIsv5) {
           return cacheManager.caching({
             ...defaultCacheOptions,
             ...{ ...options, store },

--- a/packages/common/cache/interfaces/cache-manager.interface.ts
+++ b/packages/common/cache/interfaces/cache-manager.interface.ts
@@ -70,9 +70,10 @@ export interface CacheManagerOptions {
    */
   store?: string | CacheStoreFactory | CacheStore;
   /**
-   * Time to live - amount of time in seconds that a response is cached before it
+   * Time to live - amount of time that a response is cached before it
    * is deleted. Subsequent request will call through the route handler and refresh
-   * the cache.  Defaults to 5 seconds.
+   * the cache.  Defaults to 5 seconds. In `cache-manager@^4` this value is in seconds.
+   * In `cache-manager@^5` this value is in milliseconds.
    */
   ttl?: number;
   /**


### PR DESCRIPTION
This reverts commit 530af92.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Reverting a revert, I know, always fun! The flakiness of the tests came from how v5 uses milliseconds whereas v4 uses seconds to the `ttl`. This caused our tests to not pass because the HTTP calls weren't _quite_ fast enough all of the time. 

## What is the new behavior?

I updated the timing of the tests to be 100seconds or 100 milliseconds depending on the cache-manager version and that seems to have stabilized the test. The other option we have here would be to automatically multiply the `ttl` given to the `CacheModule.register/Async()` by `1000` to convert the `ms` to `s`. This would make other user's transition from v4 to v5 smoother, however, if someone were to put in a seconds value already then we've taken it from seconds to a large number of minutes, which would cause the cache to work incorrectly for their use case. It's a tricky one to be sure. Happy to go with either approach though.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

If _anything_ is a breaking change it's that the `ttl` is now in milliseconds instead of seconds like it was in v4, but that's a difference of that package and not with out implementation.


## Other information

We should update the `@nestjs/cli`'s default webpack to include `cache-manager/package.json` in the excluded packages

[cache-manager@^4 ttl](https://github.com/node-cache-manager/node-cache-manager/blob/199eb068766984d2e100ba9751cece14a14beec6/lib/stores/memory.js#L36)
[cache-manager@^5 ttl](https://github.com/node-cache-manager/node-cache-manager/blob/4c2396af6e24741b909a1753f1a43a5c16d8df5c/src/stores/memory.ts#L39)