### PR TITLE
Cache TTL is in milliseconds instead of seconds

### DIFF
--- a/packages/common/cache/default-options.ts
+++ b/packages/common/cache/default-options.ts
@@ -1,5 +1,5 @@
 export const defaultCacheOptions = {
-  ttl: 5,
+  ttl: 5000,
   max: 100,
   store: 'memory',
 };

--- a/packages/common/cache/interfaces/cache-manager.interface.ts
+++ b/packages/common/cache/interfaces/cache-manager.interface.ts
@@ -36,7 +36,7 @@ export interface CacheStore {
 
 export interface CacheStoreSetOptions<T> {
   /**
-   * Time to live - amount of time in seconds that a response is cached before it
+   * Time to live - amount of time in milliseconds that a response is cached before it
    * is deleted. Defaults based on your cache manager settings.
    */
   ttl?: ((value: T) => number) | number;
@@ -70,7 +70,7 @@ export interface CacheManagerOptions {
    */
   store?: string | CacheStoreFactory | CacheStore;
   /**
-   * Time to live - amount of time in seconds that a response is cached before it
+   * Time to live - amount of time in milliseconds that a response is cached before it
    * is deleted. Subsequent request will call through the route handler and refresh
    * the cache.  Defaults to 5 seconds.
    */


### PR DESCRIPTION
The cache-manager package uses the lru-cache package [for its in-memory cache](https://github.com/node-cache-manager/node-cache-manager/blob/master/src/stores/memory.ts#L42) which expects the [TTL to be in milliseconds](https://github.com/isaacs/node-lru-cache/blob/fd370b8bcb74b7e18824c87bd03ab6942f4c8f97/README.md?plain=1#L59).

PR for docs: https://github.com/nestjs/docs.nestjs.com/pull/2492