### PR TITLE
feat(core): free port listening

### DIFF
--- a/integration/nest-application/listen/e2e/express.spec.ts
+++ b/integration/nest-application/listen/e2e/express.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as express from 'express';
 import { AppModule } from '../src/app.module';
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, INestFreePortListener } from '@nestjs/common';
 
 describe('Listen (Express Application)', () => {
   let testModule: TestingModule;
@@ -34,6 +34,19 @@ describe('Listen (Express Application)', () => {
       await secondApp.listen(3000);
     } catch (error) {
       expect(error.code).to.equal('EADDRINUSE');
+    }
+  });
+
+  it('should find free port if the it is not available and resolve with httpServer on success', async () => {
+    await app.listen(3000);
+    const secondApp = testModule.createNestApplication<INestFreePortListener>(
+      new ExpressAdapter(express()),
+    );
+    try {
+      const response = await secondApp.listenFreePort({ port: 3000 });
+      expect(response).to.eql(app.getHttpServer());
+    } catch (error) {
+      expect(false).true;
     }
   });
 

--- a/integration/nest-application/listen/e2e/express.spec.ts
+++ b/integration/nest-application/listen/e2e/express.spec.ts
@@ -43,10 +43,18 @@ describe('Listen (Express Application)', () => {
       new ExpressAdapter(express()),
     );
     try {
-      const response = await secondApp.listenFreePort({ port: 3000 });
-      expect(response).to.eql(app.getHttpServer());
+      let currentPort = 3000;
+      await secondApp.listenFreePort({
+        port: 3000,
+        onStart: port => (currentPort = port),
+      });
+
+      expect(currentPort).to.eql(3001);
     } catch (error) {
-      expect(false).true;
+      console.trace(error);
+      expect(error).to.eql(undefined);
+    } finally {
+      await secondApp.close();
     }
   });
 

--- a/integration/nest-application/listen/e2e/fastify.spec.ts
+++ b/integration/nest-application/listen/e2e/fastify.spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, INestFreePortListener } from '@nestjs/common';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
@@ -31,6 +31,21 @@ describe('Listen (Fastify Application)', () => {
       await secondApp.listen(3000);
     } catch (error) {
       expect(error.code).to.equal('EADDRINUSE');
+    }
+
+    await secondApp.close();
+  });
+
+  it('should find free port if the it is not available and resolve with httpServer on success', async () => {
+    await app.listen(3000);
+    const secondApp = testModule.createNestApplication<INestFreePortListener>(
+      new FastifyAdapter(),
+    );
+    try {
+      const response = await secondApp.listenFreePort({ port: 3000 });
+      expect(response).to.eql(app.getHttpServer());
+    } catch (error) {
+      expect(false).true;
     }
 
     await secondApp.close();

--- a/integration/nest-application/listen/e2e/fastify.spec.ts
+++ b/integration/nest-application/listen/e2e/fastify.spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication, INestFreePortListener } from '@nestjs/common';
+import { INestApplication } from '@nestjs/common';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
 import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
@@ -36,20 +36,27 @@ describe('Listen (Fastify Application)', () => {
     await secondApp.close();
   });
 
-  it('should find free port if the it is not available and resolve with httpServer on success', async () => {
-    await app.listen(3000);
-    const secondApp = testModule.createNestApplication<INestFreePortListener>(
-      new FastifyAdapter(),
-    );
-    try {
-      const response = await secondApp.listenFreePort({ port: 3000 });
-      expect(response).to.eql(app.getHttpServer());
-    } catch (error) {
-      expect(false).true;
-    }
-
-    await secondApp.close();
-  });
+  // Add Fastify support in future
+  // it('should find free port if the it is not available and resolve with httpServer on success', async () => {
+  //   await app.listen(4000);
+  //   const secondApp = testModule.createNestApplication<INestFreePortListener>(
+  //     new FastifyAdapter(),
+  //   );
+  //   try {
+  //     let currentPort = 4000;
+  //     await secondApp.listenFreePort({
+  //       port: 4000,
+  //       onStart: port => (currentPort = port),
+  //     });
+  //
+  //     expect(currentPort).to.eql(4001);
+  //   } catch (error) {
+  //     console.trace(error);
+  //     expect(error).to.eql(undefined);
+  //   } finally {
+  //     await secondApp.close();
+  //   }
+  // });
 
   it('should reject if there is an invalid host', async () => {
     try {

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -60,6 +60,8 @@ export {
   WebSocketAdapter,
   WsExceptionFilter,
   WsMessageHandler,
+  INestFreePortListener,
+  INestListenFreePortOptions,
 } from './interfaces';
 export * from './module-utils';
 export * from './pipes';

--- a/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
+++ b/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
@@ -1,0 +1,13 @@
+import { INestApplication } from '../nest-application.interface';
+import { INestListenFreePortOptions } from './nest-listen-free-port-options.interface';
+
+export interface INestFreePortListener extends INestApplication {
+  /**
+   * Starts the application on free port.
+   * If selected port is busy it increments port value and trying again.
+   *
+   * @param {Object} options Server listening options.
+   * @returns {Promise} A Promise that, when resolved, is a reference to the underlying HttpServer.
+   */
+  listenFreePort(options: INestListenFreePortOptions): Promise<any>;
+}

--- a/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
+++ b/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
@@ -1,6 +1,13 @@
 import { INestApplication } from '../nest-application.interface';
 import { INestListenFreePortOptions } from './nest-listen-free-port-options.interface';
 
+/**
+ * INestApplication extension with methods to listen free port.
+ *
+ * @example
+ *   const app = await NestFactory.create<INestFreePortListener>(AppModule);
+ *   await app.listenFreePort({ port: 3000 });
+ */
 export interface INestFreePortListener extends INestApplication {
   /**
    * Starts the application on free port.

--- a/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
+++ b/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
@@ -3,6 +3,8 @@ import { INestListenFreePortOptions } from './nest-listen-free-port-options.inte
 
 /**
  * INestApplication extension with methods to listen free port.
+ * <br>
+ * <b>NOT AVAILABLE for Fastify servers.</b>
  *
  * @example
  *   const app = await NestFactory.create<INestFreePortListener>(AppModule);

--- a/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
+++ b/packages/common/interfaces/extensions/nest-free-port-listener.interface.ts
@@ -9,5 +9,5 @@ export interface INestFreePortListener extends INestApplication {
    * @param {Object} options Server listening options.
    * @returns {Promise} A Promise that, when resolved, is a reference to the underlying HttpServer.
    */
-  listenFreePort(options: INestListenFreePortOptions): Promise<any>;
+  listenFreePort(options?: INestListenFreePortOptions): Promise<any>;
 }

--- a/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
+++ b/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
@@ -1,5 +1,19 @@
 export interface INestListenFreePortOptions {
+  /**
+   * Port.
+   * */
   port: string | number;
+  /**
+   * Callback function that call when port was busy.
+   *
+   * @param {number} port Busy port.
+   * @returns {boolean} Continue finding free port? true - to continue, false - to reject listening with Error.
+   * */
   onSkip: (port: number) => boolean;
-  onStart: (port: number) => boolean;
+  /**
+   * Callback function that call when server starts listening.
+   *
+   * @param {number} port Final selected port.
+   * */
+  onStart: (port: number) => void;
 }

--- a/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
+++ b/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
@@ -1,0 +1,5 @@
+export interface INestListenFreePortOptions {
+  port: string | number;
+  onSkip: (port: number) => boolean;
+  onStart: (port: number) => boolean;
+}

--- a/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
+++ b/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
@@ -5,6 +5,10 @@ export interface INestListenFreePortOptions {
    * */
   port: string | number;
   /**
+   * Hostname.
+   * */
+  hostname: string;
+  /**
    * Callback function that call when port was busy.
    *
    * @param {number} port Busy port.

--- a/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
+++ b/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
@@ -1,4 +1,5 @@
 export interface INestListenFreePortOptions {
+  // TODO make fields readonly
   /**
    * Port.
    * */

--- a/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
+++ b/packages/common/interfaces/extensions/nest-listen-free-port-options.interface.ts
@@ -1,24 +1,23 @@
 export interface INestListenFreePortOptions {
-  // TODO make fields readonly
   /**
    * Port.
    * */
-  port: string | number;
+  port?: string | number;
   /**
    * Hostname.
    * */
-  hostname: string;
+  hostname?: string;
   /**
    * Callback function that call when port was busy.
    *
    * @param {number} port Busy port.
    * @returns {boolean} Continue finding free port? true - to continue, false - to reject listening with Error.
    * */
-  onSkip: (port: number) => boolean;
+  onSkip?: (port: number) => boolean;
   /**
    * Callback function that call when server starts listening.
    *
    * @param {number} port Final selected port.
    * */
-  onStart: (port: number) => void;
+  onStart?: (port: number) => void;
 }

--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -27,3 +27,5 @@ export * from './scope-options.interface';
 export * from './type.interface';
 export * from './version-options.interface';
 export * from './websockets/web-socket-adapter.interface';
+export * from './extensions/nest-free-port-listener.interface';
+export * from './extensions/nest-listen-free-port-options.interface';

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -303,6 +303,12 @@ export class NestApplication
     !this.isInitialized && (await this.init());
 
     return new Promise(async (resolve, reject) => {
+      // Using Fastify app server thinks that port is free, but on 2nd with similar app launch it breaks.
+      // Port checking is independent on httpAdapter. Fastify works in core strange with ports.
+      if (this.httpAdapter.constructor.name === 'FastifyAdapter') {
+        reject('Free port listener is not available for Fastify.');
+      }
+
       let isIncreasing = true;
       let currentPort = parseInt(options?.port.toString()) ?? 3000;
       const firstPort = currentPort;
@@ -504,7 +510,7 @@ export class NestApplication
       });
 
       try {
-        server.listen(port);
+        server.listen(port, '0.0.0.0');
       } catch (err) {
         if (err.code === 'EADDRINUSE') {
           resolve(true);

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -318,8 +318,9 @@ export class NestApplication
 
       // Increment port value while free will not found
       while (await this.isPortBusy(currentPort)) {
-        options?.onSkip?.call(null, currentPort) ||
+        if (options?.onSkip?.call(null, currentPort) === false) {
           reject(new Error('Skip callback rejected'));
+        }
 
         if (currentPort === 65536) {
           isIncreasing = false;

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -342,6 +342,13 @@ export class NestApplication
           this.flushLogs();
         }
 
+        const address = this.httpServer.address();
+        if (address) {
+          this.httpServer.removeListener('error', errorHandler);
+          this.isListening = true;
+          resolve(this.httpServer);
+        }
+
         options?.onStart?.call(null, currentPort);
       });
     });

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -338,6 +338,10 @@ export class NestApplication
       this.httpServer.once('error', errorHandler);
 
       this.httpAdapter.listen(currentPort, () => {
+        if (this.appOptions?.autoFlushLogs ?? true) {
+          this.flushLogs();
+        }
+
         options?.onStart?.call(null, currentPort);
       });
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Default Nest.js application startup.

```ts
  const app = await NestFactory.create(AppModule);
  await app.listen(3000);
```
It will potentially throw EADDRINUSE error (if you launching different servers at the same time with same ports).

## What is the new behavior?
We can run application anyway, even port is busy. Nest.js application will automatically find free port.

```ts
  const app = await NestFactory.create<INestFreePortListener>(AppModule);
  await app.listenFreePort({
    port: 3000,
  });
```

It can be helpful in debugging, when we want just to start a server.

```ts
  const app = await NestFactory.create<INestFreePortListener>(AppModule);
  if (process.env.NODE_ENV === 'development') {
    await app.listenFreePort({
      port: 3000,
    });
  } else {
    await app.listen(3000);
  }
```

All parameters of `.listenFreePort(options)`. All parameters are nullable. Default port is 3000.

```ts
  const app = await NestFactory.create<INestFreePortListener>(AppModule);
  await app.listenFreePort({
    port: 3000,
    hostname: '0.0.0.0',
    onSkip: (port) => {
      console.log(`Port ${port} is busy. Try another one...`);
      return port < 4000; // Set some restriction for port. Return true if we want to continue port skipping.
    },
    onStart: (port) => console.log(`Server listening at http://localhost:${port}`),
  });
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<b>Fastify support not available yet :(</b>