### PR TITLE
refactor(core): early return on rejection on `getUrl`

### DIFF
--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -299,6 +299,7 @@ export class NestApplication
       if (!this.isListening) {
         this.logger.error(MESSAGES.CALL_LISTEN_FIRST);
         reject(MESSAGES.CALL_LISTEN_FIRST);
+        return;
       }
       const address = this.httpServer.address();
       resolve(this.formatAddress(address));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In `#getUrl()` we basically have the following flow when calling it before `#listen()`

```js
function getUrl() {
  return new Promise((resolve, reject) => {
    if (true) {
      reject('something went wrong')
      console.log('-----------') // this will be evaluated
    }
    // and so the following
    resolve('useless evaluation')
  })
}

getUrl()
 .then(() => console.log('not called'))
 .catch(() => console.error('called'))
```

```bash
$ node sample.js 
-----------
called
```

## What is the new behavior?

We don't have to call `resolve()` nor `formatAddress()` as they won't be used in the end.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
