### PR TITLE
fix(common): cache-manager v5 compatibility for multiCaching

### DIFF
--- a/packages/common/cache/cache.providers.ts
+++ b/packages/common/cache/cache.providers.ts
@@ -13,7 +13,7 @@ import { CacheManagerOptions } from './interfaces/cache-manager.interface';
 export function createCacheManager(): Provider {
   return {
     provide: CACHE_MANAGER,
-    useFactory: (options: CacheManagerOptions) => {
+    useFactory: async (options: CacheManagerOptions) => {
       const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
         require('cache-manager'),
       );
@@ -37,9 +37,9 @@ export function createCacheManager(): Provider {
       };
 
       return Array.isArray(options)
-        ? cacheManager.multiCaching(
-            options.map(option => cachingFactory(options.store, option)),
-          )
+        ? cacheManager.multiCaching(await Promise.all(
+            options.map(option => cachingFactory(option.store, option)),
+          ))
         : cachingFactory(options.store, options);
     },
     inject: [MODULE_OPTIONS_TOKEN],


### PR DESCRIPTION
While cacheManager.caching in v4 returned synchronously  (https://www.npmjs.com/package/cache-manager/v/4.1.0#user-content-usage-examples) in v5 it returns asynchronously
https://www.npmjs.com/package/cache-manager/v/5.1.1#user-content-usage-examples

By using await Promise.all we can handle both cases and pass resolved cache to multiCaching

This commit also fixes a typo that causes a functional bug. When options is an array, each option will have a store, but not the options array itself

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Multi store caching is broken (example repo: https://github.com/nestjs/nest/blob/master/integration/cache/src/multi-store/multi-store.module.ts )

Issue Number: N/A

## What is the new behavior?
Multi store caching is fixed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information