### PR TITLE
fix(common): fix cache-manager v5 type compatibility

### DIFF
--- a/packages/common/cache/interfaces/cache-manager.interface.ts
+++ b/packages/common/cache/interfaces/cache-manager.interface.ts
@@ -18,7 +18,7 @@ export interface CacheStore {
   set<T>(
     key: string,
     value: T,
-    options?: CacheStoreSetOptions<T>,
+    options?: CacheStoreSetOptions<T> | number,
   ): Promise<void> | void;
   /**
    * Retrieve a key/value pair from the cache.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Registering stores that implement new `CacheStore` interface ([here](https://github.com/node-cache-manager/node-cache-manager/blob/master/src/caching.ts#L36)) from new `cache-manager` module leads to typescript error for type mismatch.

Issue Number: N/A


## What is the new behavior?
It no longer gives error because of updated `CacheStore` interface in nest cache module. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
