### PR TITLE
fix(microservices): `getOptionsProp` doesn't ignore a non-empty value

### DIFF
--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -130,7 +130,7 @@ export abstract class ClientProxy {
     T extends ClientOptions['options'],
     K extends keyof T,
   >(obj: T, prop: K, defaultValue: T[K] = undefined) {
-    return (obj && obj[prop]) || defaultValue;
+    return (obj && obj[prop]) ?? defaultValue;
   }
 
   protected normalizePattern(pattern: MsPattern): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`ClientProxy.getOptionsProp` returns undefined instead of non-empty value (0, an empty string, etc)

Issue Number: N/A


## What is the new behavior?

`ClientProxy.getOptionsProp` returns a non-empty value (0, an empty string, etc)

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information