### PR TITLE
Fix Content-Type for unexpected errors in Fastify

### DIFF
--- a/integration/hello-world/e2e/exceptions.spec.ts
+++ b/integration/hello-world/e2e/exceptions.spec.ts
@@ -1,10 +1,10 @@
-import { HttpStatus, INestApplication } from '@nestjs/common';
+import { HttpServer, HttpStatus, INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import * as request from 'supertest';
 import { ErrorsController } from '../src/errors/errors.controller';
 
 describe('Error messages', () => {
-  let server;
+  let server: HttpServer;
   let app: INestApplication;
 
   beforeEach(async () => {
@@ -31,6 +31,16 @@ describe('Error messages', () => {
       error: 'Bad Request',
       message: 'Integration test',
     });
+  });
+
+  it(`/GET (InternalServerError despite custom content-type)`, async () => {
+    return request(server)
+      .get('/unexpected-error')
+      .expect(HttpStatus.INTERNAL_SERVER_ERROR)
+      .expect({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
   });
 
   afterEach(async () => {

--- a/integration/hello-world/e2e/exceptions.spec.ts
+++ b/integration/hello-world/e2e/exceptions.spec.ts
@@ -1,49 +1,134 @@
 import { HttpServer, HttpStatus, INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
 import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
 import * as request from 'supertest';
 import { ErrorsController } from '../src/errors/errors.controller';
 
 describe('Error messages', () => {
   let server: HttpServer;
-  let app: INestApplication;
 
-  beforeEach(async () => {
-    const module = await Test.createTestingModule({
-      controllers: [ErrorsController],
-    }).compile();
+  describe('Express', () => {
+    let app: INestApplication;
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        controllers: [ErrorsController],
+      }).compile();
 
-    app = module.createNestApplication();
-    server = app.getHttpServer();
-    await app.init();
-  });
+      app = module.createNestApplication();
+      server = app.getHttpServer();
+      await app.init();
+    });
 
-  it(`/GET`, () => {
-    return request(server).get('/sync').expect(HttpStatus.BAD_REQUEST).expect({
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'Integration test',
+    it(`/GET`, () => {
+      return request(server)
+        .get('/sync')
+        .expect(HttpStatus.BAD_REQUEST)
+        .expect({
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'Integration test',
+        });
+    });
+
+    it(`/GET (Promise/async)`, () => {
+      return request(server)
+        .get('/async')
+        .expect(HttpStatus.BAD_REQUEST)
+        .expect({
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'Integration test',
+        });
+    });
+
+    it(`/GET (InternalServerError despite custom content-type)`, async () => {
+      return request(server)
+        .get('/unexpected-error')
+        .expect(HttpStatus.INTERNAL_SERVER_ERROR)
+        .expect({
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
     });
   });
 
-  it(`/GET (Promise/async)`, () => {
-    return request(server).get('/async').expect(HttpStatus.BAD_REQUEST).expect({
-      statusCode: 400,
-      error: 'Bad Request',
-      message: 'Integration test',
+  describe('Fastify', () => {
+    let app: NestFastifyApplication;
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        controllers: [ErrorsController],
+      }).compile();
+
+      app = module.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter(),
+      );
+      server = app.getHttpServer();
+      await app.init();
     });
-  });
 
-  it(`/GET (InternalServerError despite custom content-type)`, async () => {
-    return request(server)
-      .get('/unexpected-error')
-      .expect(HttpStatus.INTERNAL_SERVER_ERROR)
-      .expect({
-        statusCode: 500,
-        message: 'Internal server error',
-      });
-  });
+    it(`/GET`, async () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/sync',
+        })
+        .then(({ payload, statusCode }) => {
+          expect(statusCode).to.equal(HttpStatus.BAD_REQUEST);
+          expect(payload).to.equal(
+            JSON.stringify({
+              statusCode: 400,
+              error: 'Bad Request',
+              message: 'Integration test',
+            }),
+          );
+        });
+    });
 
-  afterEach(async () => {
-    await app.close();
+    it(`/GET (Promise/async)`, async () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/sync',
+        })
+        .then(({ payload, statusCode }) => {
+          expect(statusCode).to.equal(HttpStatus.BAD_REQUEST);
+          expect(payload).to.equal(
+            JSON.stringify({
+              statusCode: 400,
+              error: 'Bad Request',
+              message: 'Integration test',
+            }),
+          );
+        });
+    });
+
+    it(`/GET (InternalServerError despite custom content-type)`, async () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/unexpected-error',
+        })
+        .then(({ payload, statusCode }) => {
+          expect(statusCode).to.equal(HttpStatus.INTERNAL_SERVER_ERROR);
+          expect(payload).to.equal(
+            JSON.stringify({
+              statusCode: 500,
+              message: 'Internal server error',
+            }),
+          );
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
   });
 });

--- a/integration/hello-world/src/errors/errors.controller.ts
+++ b/integration/hello-world/src/errors/errors.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, Get } from '@nestjs/common';
+import { BadRequestException, Controller, Get, Header } from '@nestjs/common';
 
 @Controller()
 export class ErrorsController {
@@ -10,6 +10,12 @@ export class ErrorsController {
   @Get('async')
   async asynchronous() {
     this.throwError();
+  }
+
+  @Get('unexpected-error')
+  @Header('Content-Type', 'application/pdf')
+  unexpectedError() {
+    throw new Error();
   }
 
   throwError() {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -1,10 +1,11 @@
 import {
+  HttpStatus,
   InternalServerErrorException,
   Logger,
   RequestMethod,
   StreamableFile,
-  VersioningType,
   VersioningOptions,
+  VersioningType,
   VERSION_NEUTRAL,
 } from '@nestjs/common';
 import { VersionValue } from '@nestjs/common/interfaces';
@@ -91,6 +92,16 @@ export class ExpressAdapter extends AbstractHttpAdapter {
           }
         },
       );
+    }
+    if (
+      response.getHeader('Content-Type') !== undefined &&
+      response.getHeader('Content-Type') !== 'application/json' &&
+      body?.statusCode >= HttpStatus.BAD_REQUEST
+    ) {
+      this.logger.warn(
+        "Content-Type doesn't match Reply body, you might need a custom ExceptionFilter for non-JSON responses",
+      );
+      response.setHeader('Content-Type', 'application/json');
     }
     return isObject(body) ? response.json(body) : response.send(String(body));
   }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -324,6 +324,17 @@ export class FastifyAdapter<
       }
       body = body.getStream();
     }
+    if (
+      fastifyReply.getHeader('Content-Type') !== undefined &&
+      fastifyReply.getHeader('Content-Type') !== 'application/json' &&
+      body?.statusCode >= HttpStatus.BAD_REQUEST
+    ) {
+      Logger.warn(
+        "Content-Type doesn't match Reply body, you might need a custom ExceptionFilter for non-JSON responses",
+        FastifyAdapter.name,
+      );
+      fastifyReply.header('Content-Type', 'application/json');
+    }
     return fastifyReply.send(body);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If the developer overrides the Content-Type header but doesn't add a custom ExceptionFilter to handle unexpected errors, Nest will respond with a JSON error object. This response wouldn't match the content type.

Fastify will throw another error about this mismatch, potentially leaking internal details.

Issue Number: #8469

## What is the new behavior?

The HTTP adapters check if we're trying to send a JSON object despite having a custom Content-Type. If yes, it overrides the Content-Type and adds a warning.

## Doest his PR introduce a breaking change?

- [x] Yes
- [ ] No

If an app uses a more exotic content type, that is none-the-less JSON (like `application/scim+json`) and relies upon the internal server error, the application will override the content type, potentially breaking an endpoint.

## Other information

The above breaking change is unacceptable, but maybe someone has good ideas on how to avoid it, or a desire to fix this issue another way.