### PR TITLE
feat(core): display class's name on request mapping exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,13 @@ node_modules/
 /.devcontainer
 *.code-workspace
 
+# Vim
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
 # bundle
 packages/**/*.d.ts
 packages/**/*.js

--- a/packages/core/errors/exceptions/unknown-request-mapping.exception.ts
+++ b/packages/core/errors/exceptions/unknown-request-mapping.exception.ts
@@ -1,8 +1,9 @@
+import type { Type } from '@nestjs/common';
 import { RuntimeException } from './runtime.exception';
 import { UNKNOWN_REQUEST_MAPPING } from '../messages';
 
 export class UnknownRequestMappingException extends RuntimeException {
-  constructor() {
-    super(UNKNOWN_REQUEST_MAPPING);
+  constructor(metatypeWrongPlaced: Type) {
+    super(UNKNOWN_REQUEST_MAPPING(metatypeWrongPlaced));
   }
 }

--- a/packages/core/errors/exceptions/unknown-request-mapping.exception.ts
+++ b/packages/core/errors/exceptions/unknown-request-mapping.exception.ts
@@ -3,7 +3,7 @@ import { RuntimeException } from './runtime.exception';
 import { UNKNOWN_REQUEST_MAPPING } from '../messages';
 
 export class UnknownRequestMappingException extends RuntimeException {
-  constructor(metatypeWrongPlaced: Type) {
-    super(UNKNOWN_REQUEST_MAPPING(metatypeWrongPlaced));
+  constructor(metatype: Type) {
+    super(UNKNOWN_REQUEST_MAPPING(metatype));
   }
 }

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -172,8 +172,14 @@ export const INVALID_CLASS_SCOPE_MESSAGE = (
     name || 'This class'
   } is marked as a scoped provider. Request and transient-scoped providers can't be used in combination with "get()" method. Please, use "resolve()" instead.`;
 
+export const UNKNOWN_REQUEST_MAPPING = (metatypeWrongPlaced: Type) => {
+  const className = metatypeWrongPlaced.name;
+  return className
+    ? `An invalid controller has been detected. "${className}" do not have the @Controller() decorator but it is being listed in the controllers array of some module.`
+    : `An invalid controller has been detected. Perhaps, one of your controllers is missing @Controller() decorator.`;
+};
+
 export const INVALID_MIDDLEWARE_CONFIGURATION = `An invalid middleware configuration has been passed inside the module 'configure()' method.`;
-export const UNKNOWN_REQUEST_MAPPING = `An invalid controller has been detected. Perhaps, one of your controllers is missing @Controller() decorator.`;
 export const UNHANDLED_RUNTIME_EXCEPTION = `Unhandled Runtime Exception.`;
 export const INVALID_EXCEPTION_FILTER = `Invalid exception filters (@UseFilters()).`;
 export const MICROSERVICES_PACKAGE_NOT_FOUND_EXCEPTION = `Unable to load @nestjs/microservices package. (Please make sure that it's already installed.)`;

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -172,11 +172,11 @@ export const INVALID_CLASS_SCOPE_MESSAGE = (
     name || 'This class'
   } is marked as a scoped provider. Request and transient-scoped providers can't be used in combination with "get()" method. Please, use "resolve()" instead.`;
 
-export const UNKNOWN_REQUEST_MAPPING = (metatypeWrongPlaced: Type) => {
-  const className = metatypeWrongPlaced.name;
+export const UNKNOWN_REQUEST_MAPPING = (metatype: Type) => {
+  const className = metatype.name;
   return className
-    ? `An invalid controller has been detected. "${className}" do not have the @Controller() decorator but it is being listed in the controllers array of some module.`
-    : `An invalid controller has been detected. Perhaps, one of your controllers is missing @Controller() decorator.`;
+    ? `An invalid controller has been detected. "${className}" does not have the @Controller() decorator but it is being listed in the "controllers" array of some module.`
+    : `An invalid controller has been detected. Perhaps, one of your controllers is missing the @Controller() decorator.`;
 };
 
 export const INVALID_MIDDLEWARE_CONFIGURATION = `An invalid middleware configuration has been passed inside the module 'configure()' method.`;

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -116,7 +116,7 @@ export class RouterExplorer {
     const path = Reflect.getMetadata(PATH_METADATA, metatype);
 
     if (isUndefined(path)) {
-      throw new UnknownRequestMappingException();
+      throw new UnknownRequestMappingException(metatype);
     }
     if (Array.isArray(path)) {
       return path.map(p => addLeadingSlash(p));

--- a/packages/core/test/exceptions/external-exception-filter-context.spec.ts
+++ b/packages/core/test/exceptions/external-exception-filter-context.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import { ExceptionFilter } from '../../../common';
 import { Catch } from '../../../common/decorators/core/catch.decorator';
 import { UseFilters } from '../../../common/decorators/core/exception-filters.decorator';
 import { ApplicationConfig } from '../../application-config';
@@ -13,7 +14,10 @@ describe('ExternalExceptionFilterContext', () => {
 
   class CustomException {}
   @Catch(CustomException)
-  class ExceptionFilter {
+  class ExceptionFilter implements ExceptionFilter {
+    public catch(exc, res) {}
+  }
+  class ClassWithNoMetadata implements ExceptionFilter {
     public catch(exc, res) {}
   }
 
@@ -58,6 +62,11 @@ describe('ExternalExceptionFilterContext', () => {
       expect(
         exceptionFilter.reflectCatchExceptions(new ExceptionFilter()),
       ).to.be.eql([CustomException]);
+    });
+    it('should return an empty array when metadata was found', () => {
+      expect(
+        exceptionFilter.reflectCatchExceptions(new ClassWithNoMetadata()),
+      ).to.be.eql([]);
     });
   });
   describe('createConcreteContext', () => {

--- a/packages/core/test/router/router-explorer.spec.ts
+++ b/packages/core/test/router/router-explorer.spec.ts
@@ -19,6 +19,7 @@ import { RoutePathFactory } from '../../router/route-path-factory';
 import { RouterExceptionFilters } from '../../router/router-exception-filters';
 import { RouterExplorer } from '../../router/router-explorer';
 import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
+import { UnknownRequestMappingException } from '../../errors/exceptions/unknown-request-mapping.exception';
 
 describe('RouterExplorer', () => {
   @Controller('global')
@@ -50,6 +51,8 @@ describe('RouterExplorer', () => {
     @Get(['foo', 'bar'])
     public getTestUsingArray() {}
   }
+
+  class ClassWithMissingControllerDecorator {}
 
   let routerBuilder: RouterExplorer;
   let injector: Injector;
@@ -314,6 +317,15 @@ describe('RouterExplorer', () => {
         '/global',
         '/global-alias',
       ]);
+    });
+
+    it("should throw UnknownRequestMappingException when missing the `@Controller()` decorator in the class, displaying class's name", () => {
+      expect(() =>
+        routerBuilder.extractRouterPath(ClassWithMissingControllerDecorator),
+      ).to.throw(
+        UnknownRequestMappingException,
+        /ClassWithMissingControllerDecorator/,
+      );
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If we have an invalid controller class listed in some `controllers` array, we'll got this error:

![image](https://user-images.githubusercontent.com/13461315/198848442-2db64120-00d8-445d-9086-6430de443eac.png)

![image](https://user-images.githubusercontent.com/13461315/198848420-7056ee2f-0495-4037-b17b-b1a62c84884f.png)

## What is the new behavior?

Now the error will looks like this:

![image](https://user-images.githubusercontent.com/13461315/198848532-2fbe3ee1-d5ad-4d97-b187-5045ee955519.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Also, I've leverage on this PR to increase the code coverage on `/core/exceptions` a bit as well because why not :cat: 

<details>
<summary>before</summary>

![image](https://user-images.githubusercontent.com/13461315/198898148-16e8351e-936a-4c53-98b2-743be47e94a8.png)

</details>

<details>
<summary>now</summary>

![image](https://user-images.githubusercontent.com/13461315/198898174-beccbe6d-58eb-442e-b949-e32f0d2c9495.png)

</details>