### PR TITLE
feat(microservices): add package definition option to server-grpc

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -10,6 +10,7 @@ import { ClientGrpc, GrpcOptions } from '../interfaces';
 import { ClientProxy } from './client-proxy';
 import { GRPC_CANCELLED } from './constants';
 import { ChannelOptions } from '../external/grpc-options.interface';
+import { getGrpcPackageDefinition } from '../helpers';
 
 let grpcPackage: any = {};
 let grpcProtoLoaderPackage: any = {};
@@ -286,16 +287,11 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
 
   public loadProto(): any {
     try {
-      const file = this.getOptionsProp(this.options, 'protoPath');
-      const loader = this.getOptionsProp(this.options, 'loader');
-
-      const packageDefinition =
-        this.getOptionsProp(this.options, 'packageDefinition') ||
-        grpcProtoLoaderPackage.loadSync(file, loader);
-
-      const packageObject =
-        grpcPackage.loadPackageDefinition(packageDefinition);
-      return packageObject;
+      const packageDefinition = getGrpcPackageDefinition(
+        this.options,
+        grpcProtoLoaderPackage,
+      );
+      return grpcPackage.loadPackageDefinition(packageDefinition);
     } catch (err) {
       const invalidProtoError = new InvalidProtoDefinitionException(err.path);
       const message =

--- a/packages/microservices/errors/invalid-grpc-package-definition-missing-package-definition.exception.ts
+++ b/packages/microservices/errors/invalid-grpc-package-definition-missing-package-definition.exception.ts
@@ -1,0 +1,7 @@
+import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
+
+export class InvalidGrpcPackageDefinitionMissingPacakgeDefinitionException extends RuntimeException {
+  constructor() {
+    super('protoPath or packageDefinition must be defined');
+  }
+}

--- a/packages/microservices/errors/invalid-grpc-package-definition-mutex.exception.ts
+++ b/packages/microservices/errors/invalid-grpc-package-definition-mutex.exception.ts
@@ -1,0 +1,9 @@
+import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
+
+export class InvalidGrpcPackageDefinitionMutexException extends RuntimeException {
+  constructor() {
+    super(
+      'Both protoPath and packageDefinition were provided, but only one can be defined',
+    );
+  }
+}

--- a/packages/microservices/helpers/grpc-helpers.ts
+++ b/packages/microservices/helpers/grpc-helpers.ts
@@ -1,0 +1,24 @@
+import { GrpcOptions } from '../interfaces';
+import { InvalidGrpcPackageDefinitionMutexException } from '../errors/invalid-grpc-package-definition-mutex.exception';
+import { InvalidGrpcPackageDefinitionMissingPacakgeDefinitionException } from '../errors/invalid-grpc-package-definition-missing-package-definition.exception';
+
+export function getGrpcPackageDefinition(
+  options: GrpcOptions['options'],
+  grpcProtoLoaderPackage: any,
+) {
+  const file = options['protoPath'];
+  const packageDefinition = options['packageDefinition'];
+
+  if ([file, packageDefinition].every(x => x != undefined)) {
+    throw new InvalidGrpcPackageDefinitionMutexException();
+  }
+
+  if ([file, packageDefinition].every(x => x == undefined)) {
+    throw new InvalidGrpcPackageDefinitionMissingPacakgeDefinitionException();
+  }
+
+  return (
+    packageDefinition ||
+    grpcProtoLoaderPackage.loadSync(file, options['loader'])
+  );
+}

--- a/packages/microservices/helpers/index.ts
+++ b/packages/microservices/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './kafka-logger';
 export * from './kafka-parser';
 export * from './kafka-reply-partition-assigner';
 export * from './tcp-socket';
+export * from './grpc-helpers';

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -50,7 +50,7 @@ export interface GrpcOptions {
     };
     channelOptions?: ChannelOptions;
     credentials?: any;
-    protoPath: string | string[];
+    protoPath?: string | string[];
     package: string | string[];
     protoLoader?: string;
     packageDefinition?: any;

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -18,6 +18,7 @@ import { ChannelOptions } from '../external/grpc-options.interface';
 import { CustomTransportStrategy, MessageHandler } from '../interfaces';
 import { GrpcOptions } from '../interfaces/microservice-configuration.interface';
 import { Server } from './server';
+import { getGrpcPackageDefinition } from '../helpers';
 
 let grpcPackage: any = {};
 let grpcProtoLoaderPackage: any = {};
@@ -380,20 +381,18 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
 
   public loadProto(): any {
     try {
-      const file = this.getOptionsProp(this.options, 'protoPath');
-      const loader = this.getOptionsProp(this.options, 'loader');
-
-      const packageDefinition = grpcProtoLoaderPackage.loadSync(file, loader);
-      const packageObject =
-        grpcPackage.loadPackageDefinition(packageDefinition);
-      return packageObject;
+      const packageDefinition = getGrpcPackageDefinition(
+        this.options,
+        grpcProtoLoaderPackage,
+      );
+      return grpcPackage.loadPackageDefinition(packageDefinition);
     } catch (err) {
       const invalidProtoError = new InvalidProtoDefinitionException(err.path);
       const message =
         err && err.message ? err.message : invalidProtoError.message;
 
       this.logger.error(message, invalidProtoError.stack);
-      throw err;
+      throw invalidProtoError;
     }
   }
 

--- a/packages/microservices/test/client/client-grpc.spec.ts
+++ b/packages/microservices/test/client/client-grpc.spec.ts
@@ -3,10 +3,11 @@ import { expect } from 'chai';
 import { join } from 'path';
 import { Observable, Subject } from 'rxjs';
 import * as sinon from 'sinon';
-import { ClientGrpcProxy } from '../../client/client-grpc';
+import { ClientGrpcProxy } from '../../client';
 import { InvalidGrpcPackageException } from '../../errors/invalid-grpc-package.exception';
 import { InvalidGrpcServiceException } from '../../errors/invalid-grpc-service.exception';
 import { InvalidProtoDefinitionException } from '../../errors/invalid-proto-definition.exception';
+import * as grpcHelpers from '../../helpers/grpc-helpers';
 
 class NoopLogger extends Logger {
   log(message: any, context?: string): void {}
@@ -386,13 +387,18 @@ describe('ClientGrpcProxy', () => {
   describe('loadProto', () => {
     describe('when proto is invalid', () => {
       it('should throw InvalidProtoDefinitionException', () => {
-        sinon.stub(client, 'getOptionsProp' as any).callsFake(() => {
+        const getPackageDefinitionStub = sinon.stub(
+          grpcHelpers,
+          'getGrpcPackageDefinition' as any,
+        );
+        getPackageDefinitionStub.callsFake(() => {
           throw new Error();
         });
         (client as any).logger = new NoopLogger();
         expect(() => client.loadProto()).to.throws(
           InvalidProtoDefinitionException,
         );
+        getPackageDefinitionStub.restore();
       });
     });
   });

--- a/packages/microservices/test/helpers/grpc-helpers.spec.ts
+++ b/packages/microservices/test/helpers/grpc-helpers.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import { getGrpcPackageDefinition } from '../../helpers/grpc-helpers';
+import { InvalidGrpcPackageDefinitionMutexException } from '../../errors/invalid-grpc-package-definition-mutex.exception';
+import { InvalidGrpcPackageDefinitionMissingPacakgeDefinitionException } from '../../errors/invalid-grpc-package-definition-missing-package-definition.exception';
+
+const grpcProtoLoaderPackage = { loadSync: (a, b) => 'withLoader' };
+
+describe('getGrpcPackageDefinition', () => {
+  it('missing both protoPath and packageDefinition', () => {
+    expect(() =>
+      getGrpcPackageDefinition(
+        {
+          package: 'somePackage',
+        },
+        grpcProtoLoaderPackage,
+      ),
+    ).to.throw(InvalidGrpcPackageDefinitionMissingPacakgeDefinitionException);
+  });
+
+  it('got both protoPath and packageDefinition', () => {
+    expect(() =>
+      getGrpcPackageDefinition(
+        {
+          package: 'somePackage',
+          protoPath: 'some/path',
+          packageDefinition: {},
+        },
+        grpcProtoLoaderPackage,
+      ),
+    ).to.throw(InvalidGrpcPackageDefinitionMutexException);
+  });
+
+  it('success with protoPath', () => {
+    expect(() =>
+      getGrpcPackageDefinition(
+        {
+          package: 'somePackage',
+          protoPath: 'some/path',
+        },
+        grpcProtoLoaderPackage,
+      ),
+    ).to.not.throw(Error);
+  });
+
+  it('success with packageDef', () => {
+    expect(() =>
+      getGrpcPackageDefinition(
+        {
+          package: 'somePackage',
+          packageDefinition: {},
+        },
+        grpcProtoLoaderPackage,
+      ),
+    ).to.not.throw(Error);
+  });
+});

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -6,7 +6,9 @@ import * as sinon from 'sinon';
 import { CANCEL_EVENT } from '../../constants';
 import { InvalidGrpcPackageException } from '../../errors/invalid-grpc-package.exception';
 import { GrpcMethodStreamingType } from '../../index';
-import { ServerGrpc } from '../../server/server-grpc';
+import { ServerGrpc } from '../../server';
+import { InvalidProtoDefinitionException } from '../../errors/invalid-proto-definition.exception';
+import * as grpcHelpers from '../../helpers/grpc-helpers';
 
 class NoopLogger extends Logger {
   log(message: any, context?: string): void {}
@@ -529,6 +531,25 @@ describe('ServerGrpc', () => {
       fn(args as any, sinon.spy());
 
       expect(handler.calledWith(args)).to.be.true;
+    });
+  });
+
+  describe('loadProto', () => {
+    describe('when proto is invalid', () => {
+      it('should throw InvalidProtoDefinitionException', () => {
+        const getPackageDefinitionStub = sinon.stub(
+          grpcHelpers,
+          'getGrpcPackageDefinition' as any,
+        );
+        getPackageDefinitionStub.callsFake(() => {
+          throw new Error();
+        });
+        (server as any).logger = new NoopLogger();
+        expect(() => server.loadProto()).to.throws(
+          InvalidProtoDefinitionException,
+        );
+        getPackageDefinitionStub.restore();
+      });
     });
   });
 


### PR DESCRIPTION
PR #8465 added support for packageDefinition for `ClientGrpc`, this PR adds it to `ServerGrpc`.

- Export common `packageDefinition` logic to `getGrpcPackageDefinition` and used it in both gRPC Server & Client, for consistency
- This change means that `GrpcOptions['options']['protoPath']` is now optional - `getGrpcPackageDefinition` verifies that either `protoPath` or `PackageDefinition` exist
- Also, changed the error thrown from `ServerGrpc.loadProto`: it was Error, now `InvalidProtoDefinitionException`, as it is in `ClientGrpc`
- Add a `loadProto` test for `ServerGrpc`, similar to the one that exists for `ClientGrpc`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, it's impossible to create a gRPC microservice by providing a `packageDefinition`, which means statically generated code can't be used — users must provide `*.proto` files. This situation isn't suitable for all (e.g. if your organization holds a dedicated repo for Protobufs, rather than storing them in the nestjs-based API repo they're developing, which is quite common).

Issue Number: N/A


## What is the new behavior?
It's possible to create a gRPC microservice by providing `packageDefinition`.

This change is inspired by https://github.com/nestjs/nest/pull/8465, which allowed `packageDefinition` to be provided when creating a gRPC **client**. I think that the fact that the author kept `GrpcOptions['options']['protoPath']` as a required field is confusing and inconsistent - even when providing `packageDefinition`, one still needs to provide `protoPath` which will simply be ignored. In this PR I suggest that `protoPath` will be optional, and when initiating the gRPC server we'll make sure that either `protoPath` or `packageDefinition` are supplied. I'd like to hear your thoughts on that.


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No
- [x] Kinda :)

I'm not sure if changing `protoPath` to optional is considered a breaking change... either way, the documentation should be updated as well, so users will know it's not `protoPath` that's required, but either `protoPath` or `packageDefinition`. The docs are in a separate repo, right? 


## Other information

I'm open for discussion and willing to move around code (for example, I'm not sure that the `getGrpcPackageDefinition` validation should happen in `loadProto`, maybe in the constructor?). 

Thanks! 