### PR TITLE
feat(core/common): Add @Search decorator to the available HTTP route handlers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: Update NPM version
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install -g npm@^8'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -109,3 +109,12 @@ export const Head = createMappingDecorator(RequestMethod.HEAD);
  * @publicApi
  */
 export const All = createMappingDecorator(RequestMethod.ALL);
+
+/**
+ * Route handler (method) Decorator. Routes all HTTP requests to the specified path.
+ *
+ * @see [Routing](https://docs.nestjs.com/controllers#routing)
+ *
+ * @publicApi
+ */
+export const Search = createMappingDecorator(RequestMethod.SEARCH);

--- a/packages/common/enums/request-method.enum.ts
+++ b/packages/common/enums/request-method.enum.ts
@@ -7,4 +7,5 @@ export enum RequestMethod {
   ALL,
   OPTIONS,
   HEAD,
+  SEARCH,
 }

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -363,7 +363,6 @@ describe('@Search', () => {
 
     const path = Reflect.getMetadata('path', Test.test);
     const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
-
     expect(path).to.be.eql('/');
     expect(pathUsingArray).to.be.eql('/');
   });

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Body, HostParam, Param, Query } from '../../decorators';
+import { Body, HostParam, Param, Query, Search } from '../../decorators';
 import { RequestMethod } from '../../enums/request-method.enum';
 import { All, Delete, Get, Patch, Post, Put } from '../../index';
 
@@ -301,6 +301,64 @@ describe('@Patch', () => {
 
       @Patch([])
       public static testUsingArray() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+
+    expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
+  });
+});
+
+describe('@Search', () => {
+  const requestPath = 'test';
+  const requestProps = {
+    path: requestPath,
+    method: RequestMethod.SEARCH,
+  };
+
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.SEARCH,
+  };
+
+  it('should enhance class with expected request metadata', () => {
+    class Test {
+      @Search(requestPath)
+      public static test() {}
+
+      @Search(requestPathUsingArray)
+      public static testUsingArray() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
+
+    expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
+  });
+
+  it('should set path on "/" by default', () => {
+    class Test {
+      @Search()
+      public static test(
+        @Query() query,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
+
+      @Search([])
+      public static testUsingArray(
+        @Query() query,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
     }
 
     const path = Reflect.getMetadata('path', Test.test);

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -68,6 +68,12 @@ export abstract class AbstractHttpAdapter<
     return this.instance.all(...args);
   }
 
+  public search(port: string | number, callback?: () => void);
+  public search(port: string | number, hostname: string, callback?: () => void);
+  public search(port: any, hostname?: any, callback?: any) {
+    return this.instance.search(port, hostname, callback);
+  }
+
   public options(handler: RequestHandler);
   public options(path: any, handler: RequestHandler);
   public options(...args: any[]) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #10420


## What is the new behavior?
This PR adds the new Search method decorator to be a valid handler to routes. 
This change was rather simple, since both express and fastify already support this little akward and rather new http method

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information