### PR TITLE
feat: create method on client to get websocket pattern

### DIFF
--- a/integration/websockets/e2e/gateway.spec.ts
+++ b/integration/websockets/e2e/gateway.spec.ts
@@ -66,5 +66,21 @@ describe('WebSocketGateway', () => {
     );
   });
 
+  it(`should be ableto get the pattern in an interceptor`, async () => {
+    app = await createNestApp(ApplicationGateway);
+    await app.listen(3000);
+
+    ws = io('http://localhost:8080');
+    ws.emit('getClient', {
+      test: 'test',
+    });
+    await new Promise<void>(resolve =>
+      ws.on('popClient', data => {
+        expect(data.path).to.be.eql('getClient');
+        resolve();
+      }),
+    );
+  });
+
   afterEach(() => app.close());
 });

--- a/integration/websockets/e2e/gateway.spec.ts
+++ b/integration/websockets/e2e/gateway.spec.ts
@@ -66,7 +66,7 @@ describe('WebSocketGateway', () => {
     );
   });
 
-  it(`should be ableto get the pattern in an interceptor`, async () => {
+  it(`should be able to get the pattern in an interceptor`, async () => {
     app = await createNestApp(ApplicationGateway);
     await app.listen(3000);
 

--- a/integration/websockets/e2e/ws-gateway.spec.ts
+++ b/integration/websockets/e2e/ws-gateway.spec.ts
@@ -194,6 +194,30 @@ describe('WebSocketGateway (WsAdapter)', () => {
     });
   });
 
+  it('should let the execution context have a getPattern() method on getClient()', async () => {
+    app = await createNestApp(ApplicationGateway);
+    await app.listen(3000);
+
+    ws = new WebSocket('ws://localhost:8080');
+    await new Promise(resolve => ws.on('open', resolve));
+
+    ws.send(
+      JSON.stringify({
+        event: 'getClient',
+        data: {
+          test: 'test',
+        },
+      }),
+    );
+    await new Promise<void>(resolve =>
+      ws.on('message', data => {
+        expect(JSON.parse(data).data.path).to.be.eql('getClient');
+        ws.close();
+        resolve();
+      }),
+    );
+  });
+
   afterEach(async function () {
     await app.close();
   });

--- a/integration/websockets/src/app.gateway.ts
+++ b/integration/websockets/src/app.gateway.ts
@@ -1,8 +1,10 @@
+import { UseInterceptors } from '@nestjs/common';
 import {
   MessageBody,
   SubscribeMessage,
   WebSocketGateway,
 } from '@nestjs/websockets';
+import { RequestInterceptor } from './request.interceptor';
 
 @WebSocketGateway(8080)
 export class ApplicationGateway {
@@ -11,6 +13,15 @@ export class ApplicationGateway {
     return {
       event: 'pop',
       data,
+    };
+  }
+
+  @UseInterceptors(RequestInterceptor)
+  @SubscribeMessage('getClient')
+  getPathCalled(client, data) {
+    return {
+      event: 'popClient',
+      data: { ...data, path: client.pattern },
     };
   }
 }

--- a/integration/websockets/src/request.interceptor.ts
+++ b/integration/websockets/src/request.interceptor.ts
@@ -4,7 +4,7 @@ import { CallHandler, ExecutionContext, Injectable } from '@nestjs/common';
 export class RequestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler) {
     const client = context.switchToWs().getClient();
-    const pattern = client.getPattern();
+    const pattern = context.switchToWs().getPattern();
     client.pattern = pattern;
     return next.handle();
   }

--- a/integration/websockets/src/request.interceptor.ts
+++ b/integration/websockets/src/request.interceptor.ts
@@ -1,0 +1,11 @@
+import { CallHandler, ExecutionContext, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class RequestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler) {
+    const client = context.switchToWs().getClient();
+    const pattern = client.getPattern();
+    client.pattern = pattern;
+    return next.handle();
+  }
+}

--- a/integration/websockets/src/server.gateway.ts
+++ b/integration/websockets/src/server.gateway.ts
@@ -1,4 +1,6 @@
+import { UseInterceptors } from '@nestjs/common';
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
+import { RequestInterceptor } from './request.interceptor';
 
 @WebSocketGateway()
 export class ServerGateway {
@@ -7,6 +9,15 @@ export class ServerGateway {
     return {
       event: 'pop',
       data,
+    };
+  }
+
+  @UseInterceptors(RequestInterceptor)
+  @SubscribeMessage('getClient')
+  getPathCalled(client, data) {
+    return {
+      event: 'popClient',
+      data: { ...data, path: client.pattern },
     };
   }
 }

--- a/packages/common/interfaces/features/arguments-host.interface.ts
+++ b/packages/common/interfaces/features/arguments-host.interface.ts
@@ -31,6 +31,10 @@ export interface WsArgumentsHost {
    * Returns the client object.
    */
   getClient<T = any>(): T;
+  /**
+   * Returns the pattern for the event
+   */
+  getPattern(): string;
 }
 
 /**

--- a/packages/core/helpers/execution-context-host.ts
+++ b/packages/core/helpers/execution-context-host.ts
@@ -59,6 +59,7 @@ export class ExecutionContextHost implements ExecutionContext {
     return Object.assign(this, {
       getClient: () => this.getArgByIndex(0),
       getData: () => this.getArgByIndex(1),
+      getPattern: () => this.getArgByIndex(this.getArgs().length - 1),
     });
   }
 }

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -109,6 +109,7 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
+      console.log(args);
       args.push(this.reflectCallbackPattern(callback));
       const initialArgs = this.contextUtils.createNullArray(argsLength);
       fnCanActivate && (await fnCanActivate(args));

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -109,9 +109,7 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
-      Object.assign(args[0] ?? {}, {
-        getPattern: () => this.reflectCallbackPattern(callback),
-      });
+      args.push(this.reflectCallbackPattern(callback));
       const initialArgs = this.contextUtils.createNullArray(argsLength);
       fnCanActivate && (await fnCanActivate(args));
 

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -109,7 +109,7 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
-      Object.assign(args[0], {
+      Object.assign(args[0] ?? {}, {
         getPattern: () => this.reflectCallbackPattern(callback),
       });
       const initialArgs = this.contextUtils.createNullArray(argsLength);

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -23,7 +23,7 @@ import {
   InterceptorsContextCreator,
 } from '@nestjs/core/interceptors';
 import { PipesConsumer, PipesContextCreator } from '@nestjs/core/pipes';
-import { PARAM_ARGS_METADATA } from '../constants';
+import { MESSAGE_METADATA, PARAM_ARGS_METADATA } from '../constants';
 import { WsException } from '../errors/ws-exception';
 import { WsParamsFactory } from '../factories/ws-params-factory';
 import { ExceptionFiltersContext } from './exception-filters-context';
@@ -66,7 +66,6 @@ export class WsContextCreator {
       methodName,
       contextType,
     );
-
     const exceptionHandler = this.exceptionFiltersContext.create(
       instance,
       callback,
@@ -110,6 +109,9 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
+      Object.assign(args[0], {
+        getPattern: () => this.reflectCallbackPattern(callback),
+      });
       const initialArgs = this.contextUtils.createNullArray(argsLength);
       fnCanActivate && (await fnCanActivate(args));
 
@@ -129,6 +131,10 @@ export class WsContextCreator {
     callback: (...args: any[]) => any,
   ): any[] {
     return Reflect.getMetadata(PARAMTYPES_METADATA, instance, callback.name);
+  }
+
+  public reflectCallbackPattern(callback: (...args: any[]) => any): string {
+    return Reflect.getMetadata(MESSAGE_METADATA, callback);
   }
 
   public createGuardsFn<TContext extends string = ContextType>(

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -109,8 +109,8 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
-      console.log(args);
       args.push(this.reflectCallbackPattern(callback));
+
       const initialArgs = this.contextUtils.createNullArray(argsLength);
       fnCanActivate && (await fnCanActivate(args));
 


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The only way to get the websocket pattern is through reflection, which is unavailable inside of filters as the `ArgumentsHost` doesn't have a `getClass` or `getHandler` method. 

Issue Number: #10520


## What is the new behavior?

`ExecutionContext#switchToWs().getClient()` now has a `getPattern()` method attached to it so that the pattern can be retrieved in filters.

This pattern **is still a reflected pattern**, and not retrieved from the direct request, as we don't, to my knowledge, bind the exception filter for when invalid patterns are called (if I'm wrong about that please point to where it is)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information