### PR TITLE
fix(microservices): allow falsy values in options

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -57,14 +57,22 @@ export class ClientKafka extends ClientProxy {
   constructor(protected readonly options: KafkaOptions['options']) {
     super();
 
-    const clientOptions =
-      this.getOptionsProp(this.options, 'client') || ({} as KafkaConfig);
-    const consumerOptions =
-      this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
-    const postfixId =
-      this.getOptionsProp(this.options, 'postfixId') ?? '-client';
-    this.producerOnlyMode =
-      this.getOptionsProp(this.options, 'producerOnlyMode') || false;
+    const clientOptions = this.getOptionsProp(
+      this.options,
+      'client',
+      {} as KafkaConfig,
+    );
+    const consumerOptions = this.getOptionsProp(
+      this.options,
+      'consumer',
+      {} as ConsumerConfig,
+    );
+    const postfixId = this.getOptionsProp(this.options, 'postfixId', '-client');
+    this.producerOnlyMode = this.getOptionsProp(
+      this.options,
+      'producerOnlyMode',
+      false,
+    );
 
     this.brokers = clientOptions.brokers || [KAFKA_DEFAULT_BROKER];
 

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -130,7 +130,7 @@ export abstract class ClientProxy {
     T extends ClientOptions['options'],
     K extends keyof T,
   >(obj: T, prop: K, defaultValue: T[K] = undefined) {
-    return (obj && obj[prop]) || defaultValue;
+    return obj && prop in obj ? obj[prop] : defaultValue;
   }
 
   protected normalizePattern(pattern: MsPattern): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Falsy values passed to `ClientsModule` options would be overwritten by defaults.
Noticeably, the `postfixId` passesd to `ClientKafka`.

This happens because of faulty logic in the `getOptionsProp` method on `ClientProxy`. I have changed it to align with the behavior of the corresponding method in `Server`.

## What is the new behavior?
When passing empty string to `postfixId` to options of `ClientKafka`, the `-client` postfix no longer gets appended. This probably fixes a bunch of other defaults as well.

## Does this PR introduce a breaking change?
- [x] Yes
- [x] No, unless someone relied on the wrong behavior.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have also uncommented the skipped Kafka integration tests, but they got stuck on the error below (after the annoying rebalancing errors) and I had to cancel them.
![image](https://user-images.githubusercontent.com/46406259/200867955-0cac2665-eef5-433d-a979-cc167f2d40df.png)
I did not investigate further, because I think this is for another issue, but it doesn't feel right skipping all Kafka integration tests.
