### PR TITLE
fix(common): CacheStoreFactory type

### DIFF
--- a/packages/common/cache/interfaces/cache-manager.interface.ts
+++ b/packages/common/cache/interfaces/cache-manager.interface.ts
@@ -47,15 +47,17 @@ export interface CacheStoreSetOptions<T> {
  *
  * @publicApi
  */
-export interface CacheStoreFactory {
-  /**
-   * Return a configured cache store.
-   *
-   * @param args Cache manager options received from `CacheModule.register()`
-   * or `CacheModule.registerAsync()`
-   */
-  create(args: LiteralObject): CacheStore;
-}
+export type CacheStoreFactory =
+  | {
+      /**
+       * Return a configured cache store.
+       *
+       * @param args Cache manager options received from `CacheModule.register()`
+       * or `CacheModule.registerAsync()`
+       */
+      create(args: LiteralObject): CacheStore;
+    }
+  | ((args: LiteralObject) => CacheStore | Promise<CacheStore>);
 
 /**
  * Interface defining Cache Manager configuration options.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
After cache-manager v5, `cacheManager.caching` method has been allowed to receive synchronous or asynchronous store factory function, but current nest's interface is still accepting v4 styled factory type only.

## What is the new behavior?
update `CacheStoreFactory` as union type to match pure factory function.

Issue Number: N/A

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
packages:
- NestJS: 9.2.0
- cache-manager-ioredis-yet: 1.0.1
