### PR TITLE
feat(core): add hint to unknown dependency error msg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: Update NPM version
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install -g npm@^8'
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/integration/injector/e2e/optional-factory-provider-dep.spec.ts
+++ b/integration/injector/e2e/optional-factory-provider-dep.spec.ts
@@ -121,6 +121,7 @@ describe('Optional factory provider deps', () => {
           .equal(`Nest can't resolve dependencies of the POSSIBLY_MISSING_DEP (?). Please make sure that the argument MISSING_DEP at index [0] is available in the RootTestModule context.
 
 Potential solutions:
+- Is RootTestModule a valid NestJS module?
 - If MISSING_DEP is a provider, is it part of the current RootTestModule?
 - If MISSING_DEP is exported from a separate @Module, is that module imported within RootTestModule?
   @Module({

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -60,19 +60,31 @@ export const UNKNOWN_DEPENDENCIES_MESSAGE = (
     dependencies,
     key,
   } = unknownDependencyContext;
-  const moduleName = getModuleName(module) || 'Module';
+  const moduleName = getModuleName(module);
   const dependencyName = getDependencyName(name);
 
-  let message = `Nest can't resolve dependencies of the ${type.toString()}`;
-
-  const potentialSolutions = `\n
+  const potentialSolutions =
+    // If module's name is well defined
+    moduleName !== 'current'
+      ? `\n
 Potential solutions:
+- Is ${moduleName} a valid NestJS module?
 - If ${dependencyName} is a provider, is it part of the current ${moduleName}?
 - If ${dependencyName} is exported from a separate @Module, is that module imported within ${moduleName}?
   @Module({
     imports: [ /* the Module containing ${dependencyName} */ ]
   })
+`
+      : `\n
+Potential solutions:
+- If ${dependencyName} is a provider, is it part of the current Module?
+- If ${dependencyName} is exported from a separate @Module, is that module imported within Module?
+  @Module({
+    imports: [ /* the Module containing ${dependencyName} */ ]
+  })
 `;
+
+  let message = `Nest can't resolve dependencies of the ${type.toString()}`;
 
   if (isNil(index)) {
     message += `. Please make sure that the "${key.toString()}" property is available in the current context.${potentialSolutions}`;
@@ -83,9 +95,7 @@ Potential solutions:
 
   message += ` (`;
   message += dependenciesName.join(', ');
-  message += `). Please make sure that the argument ${dependencyName} at index [${index}] is available in the ${getModuleName(
-    module,
-  )} context.`;
+  message += `). Please make sure that the argument ${dependencyName} at index [${index}] is available in the ${moduleName} context.`;
   message += potentialSolutions;
 
   return message;

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -18,8 +18,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatService). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
       @Module({
         imports: [ /* the Module containing dependency */ ]
       })
@@ -41,8 +41,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
       @Module({
       imports: [ /* the Module containing dependency */ ]
       })
@@ -62,8 +62,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatFunction). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
       @Module({
         imports: [ /* the Module containing dependency */ ]
       })
@@ -83,8 +83,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, +). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
@@ -104,6 +104,7 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument dependency at index [0] is available in the TestModule context.
   
       Potential solutions:
+      - Is TestModule a valid NestJS module?
       - If dependency is a provider, is it part of the current TestModule?
       - If dependency is exported from a separate @Module, is that module imported within TestModule?
         @Module({
@@ -137,8 +138,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the Symbol(CatProvider) (?). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })
@@ -158,8 +159,8 @@ describe('Error Messages', () => {
         stringCleaner(`Nest can't resolve dependencies of the CatProvider (?, Symbol(DogProvider)). Please make sure that the argument dependency at index [0] is available in the current context.
   
       Potential solutions:
-      - If dependency is a provider, is it part of the current current?
-      - If dependency is exported from a separate @Module, is that module imported within current?
+      - If dependency is a provider, is it part of the current Module?
+      - If dependency is exported from a separate @Module, is that module imported within Module?
         @Module({
           imports: [ /* the Module containing dependency */ ]
         })


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Sometimes people wrongly put things that aren't modules inside `imports` array, which leads to errors such as:

![image](https://user-images.githubusercontent.com/13461315/201497999-fd2df7df-98f3-433d-880f-23757d7a4146.png)

in this example we have a class annotated with `@WebSocketGateway()` placed at `imports` array of `EventsModule`

I found that sometimes people didn't understand that the error message tells that `EventsGateway` is being treated as a nestjs module

## What is the new behavior?

In the scenario described above, the error message will be:

![image](https://user-images.githubusercontent.com/13461315/201498100-53b1680c-7c2a-4b17-87b9-181d6f33261d.png)

I hope that with this minor change people we now understand why they got that error faster.

I'm a bit concerd on the proposed message tho. Another suggestion would be:

```
- If ${dependencyName} is a provider, is it part of the current module Module?
- If ${dependencyName} is exported from a separate @Module, is that module imported within the module ${moduleName} 
```

so people won't complain on what it's a 'valid module'

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
