### PR TITLE
feat(websockets): add prefix option for api versioning

### DIFF
--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -15,6 +15,11 @@ export interface GatewayMetadata {
    */
   path?: string;
   /**
+   * Api version acts as prefix to path
+   * @default undefined
+   */
+  prefix?: string;
+  /**
    * Whether to serve the client files
    * @default true
    */

--- a/packages/websockets/socket-server-provider.ts
+++ b/packages/websockets/socket-server-provider.ts
@@ -15,6 +15,7 @@ export class SocketServerProvider {
     options: T,
     port: number,
   ): ServerAndEventStreamsHost {
+    options = this.mergePathOptions(options) as T;
     const serverAndStreamsHost = this.socketsContainer.getOneByConfig({
       port,
       path: options.path,
@@ -35,6 +36,7 @@ export class SocketServerProvider {
     options: T,
     port: number,
   ): ServerAndEventStreamsHost {
+    options = this.mergePathOptions(options) as T;
     const adapter = this.applicationConfig.getIoAdapter();
     const { namespace, server, ...partialOptions } = options as Record<
       string,
@@ -64,10 +66,15 @@ export class SocketServerProvider {
       port,
       targetServer,
     );
+    options = this.mergePathOptions(options) as T;
     const serverAndEventStreamsHost =
       ServerAndEventStreamsFactory.create(namespaceServer);
     this.socketsContainer.addOne(
-      { port, path: options.path, namespace: options.namespace },
+      {
+        port,
+        path: options.path,
+        namespace: options.namespace,
+      },
       serverAndEventStreamsHost,
     );
     return serverAndEventStreamsHost;
@@ -83,6 +90,12 @@ export class SocketServerProvider {
       namespace: this.validateNamespace(options.namespace || ''),
       server,
     });
+  }
+  private mergePathOptions<TOptions extends GatewayMetadata = any>(
+    options: TOptions,
+  ) {
+    const { path = '', prefix = '', ...passthrough } = options;
+    return { path: prefix + path, ...passthrough };
   }
 
   private validateNamespace(namespace: string | RegExp): string | RegExp {

--- a/packages/websockets/test/utils/socket-gateway.decorator.spec.ts
+++ b/packages/websockets/test/utils/socket-gateway.decorator.spec.ts
@@ -27,16 +27,21 @@ describe('@WebSocketGateway', () => {
     expect(port).to.be.eql(0);
   });
 
-  @WebSocketGateway({ namespace: '/' })
+  @WebSocketGateway({ namespace: '/', path: '/path', prefix: '/prefix' })
   class TestGateway3 {}
 
   it('should decorate transport with expected options', () => {
     const isGateway = Reflect.getMetadata(GATEWAY_METADATA, TestGateway3);
     const port = Reflect.getMetadata('port', TestGateway3);
-    const { namespace } = Reflect.getMetadata(GATEWAY_OPTIONS, TestGateway3);
+    const { namespace, path, prefix } = Reflect.getMetadata(
+      GATEWAY_OPTIONS,
+      TestGateway3,
+    );
 
     expect(isGateway).to.be.eql(true);
     expect(port).to.be.eql(0);
     expect(namespace).to.be.eql('/');
+    expect(path).to.be.eql('/path');
+    expect(prefix).to.be.eql('/prefix');
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Websocket gateway options has only `path` and no 'prefix'

Issue Number: (https://github.com/nestjs/nest/issues/9376)


## What is the new behavior?
websocket gateway options now has `path` and `prefix` which get joined for the full path. this can be used for api versioning

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information