### PR TITLE
fix(core): fix reflectConstructorParams mutating constructor metadata

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -351,7 +351,7 @@ export class Injector {
   }
 
   public reflectConstructorParams<T>(type: Type<T>): any[] {
-    const paramtypes = Reflect.getMetadata(PARAMTYPES_METADATA, type) || [];
+    const paramtypes = [...(Reflect.getMetadata(PARAMTYPES_METADATA, type) || [])];
     const selfParams = this.reflectSelfParams<T>(type);
 
     selfParams.forEach(({ index, param }) => (paramtypes[index] = param));

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -842,14 +842,18 @@ describe('Injector', () => {
 
     it('should not mutate the constructor metadata', async () => {
       class FixtureDep1 {}
+      /** This needs to be something other than FixtureDep1 so the test can ensure that the metadata was not mutated */
       const injectionToken = 'test_token';
+
       @Injectable()
       class FixtureClass {
         constructor(@Inject(injectionToken) private dep1: FixtureDep1) {}
       }
+
       const wrapper = new InstanceWrapper({ metatype: FixtureClass });
       const [dependencies] = injector.getClassDependencies(wrapper);
       expect(dependencies).to.deep.eq([injectionToken]);
+
       const paramtypes = Reflect.getMetadata(PARAMTYPES_METADATA, FixtureClass);
       expect(paramtypes).to.deep.eq([FixtureDep1]);
     });

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -11,6 +11,7 @@ import { Injector, PropertyDependency } from '../../injector/injector';
 import { InstanceWrapper } from '../../injector/instance-wrapper';
 import { Module } from '../../injector/module';
 import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
+
 chai.use(chaiAsPromised);
 
 describe('Injector', () => {

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -10,6 +10,7 @@ import { NestContainer } from '../../injector/container';
 import { Injector, PropertyDependency } from '../../injector/injector';
 import { InstanceWrapper } from '../../injector/instance-wrapper';
 import { Module } from '../../injector/module';
+import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
 chai.use(chaiAsPromised);
 
 describe('Injector', () => {
@@ -837,6 +838,20 @@ describe('Injector', () => {
 
       expect(dependencies).to.deep.eq([FixtureDep1, FixtureDep2]);
       expect(optionalDependenciesIds).to.deep.eq([1]);
+    });
+
+    it('should not mutate the constructor metadata', async () => {
+      class FixtureDep1 {}
+      const injectionToken = 'test_token';
+      @Injectable()
+      class FixtureClass {
+        constructor(@Inject(injectionToken) private dep1: FixtureDep1) {}
+      }
+      const wrapper = new InstanceWrapper({ metatype: FixtureClass });
+      const [dependencies] = injector.getClassDependencies(wrapper);
+      expect(dependencies).to.deep.eq([injectionToken]);
+      const paramtypes = Reflect.getMetadata(PARAMTYPES_METADATA, FixtureClass);
+      expect(paramtypes).to.deep.eq([FixtureDep1]);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently `reflectConstructorParams` mutates the original constructor parameter type metadata when applying the parameter decorator information.


## What is the new behavior?
It uses a shallow copy of the metadata so it doesn't mutate the original.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information