### PR TITLE
Adapt fastify adapter to comply with fastify.listen(FastifyListenOptions) - and make it compatible with Microsoft IIS

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -32,6 +32,7 @@ import {
   RawServerBase,
   RawServerDefault,
   RequestGenericInterface,
+  FastifyListenOptions,
 } from 'fastify';
 import * as Reply from 'fastify/lib/reply';
 import { RouteShorthandMethod } from 'fastify/types/route';
@@ -226,12 +227,19 @@ export class FastifyAdapter<
     hostname: string,
     callback?: () => void,
   ): void;
-  public listen(port: string | number, ...args: any[]): void {
+  public listen(listenOptions: string | number | FastifyListenOptions, ...args: any[]): void {
     const isFirstArgTypeofFunction = typeof args[0] === 'function';
     const callback = isFirstArgTypeofFunction ? args[0] : args[1];
-    const options: Record<string, any> = {
-      port: +port,
-    };
+    let options: Record<string, any> = {}
+    if (typeof(listenOptions) == 'object' && (listenOptions.host || listenOptions.port || listenOptions.path)) {
+        // Handle new function signature : first parameter is an object with path, port and/or host attributes
+        options = listenOptions;
+    } else {
+        // Old signature - first parameter MUST be an integer (port number)
+        options = {
+            port: +listenOptions
+        };
+    }
     if (!isFirstArgTypeofFunction) {
       options.host = args[0];
     }

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -231,7 +231,7 @@ export class FastifyAdapter<
     const isFirstArgTypeofFunction = typeof args[0] === 'function';
     const callback = isFirstArgTypeofFunction ? args[0] : args[1];
     let options: Record<string, any> = {}
-    if (typeof(listenOptions) == 'object' && (listenOptions.host || listenOptions.port || listenOptions.path)) {
+    if (typeof(listenOptions) == 'object' && (listenOptions.host !== undefined || listenOptions.port !== undefined || listenOptions.path !== undefined)) {
         // Handle new function signature : first parameter is an object with path, port and/or host attributes
         options = listenOptions;
     } else {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: complies with latest Fastify

## What is the current behavior?

When using NestJS behind Microsoft IIS, the following error occurs : **options.port should be >= 0 and < 65536. Received NaN.**

Issue Number: #10602


## What is the new behavior?

No error message - calling listen() with a full FastifyListenOptions object is supported:
```javascript
async function bootstrap() {
  const app = await NestFactory.create<NestFastifyApplication>(
    AppModule,
    new FastifyAdapter({ logger: true, ignoreTrailingSlash: true })
  );
  await app.listen({ port: '3000', host: 'localhost', path:'pipe' }, '0.0.0.0');
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Microsoft IIS (and IISNode) uses a named pipe to communicate with Node - thus the "port" is not a number (it's a string). Supporting Fastify's latest syntax for listen() is mandatory to be compatible with Microsoft IIS.
