### PR TITLE
feat(common)!: narrow `getInstance` return type for http adapters

### DIFF
--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -18,7 +18,11 @@ export type RequestHandler<TRequest = any, TResponse = any> = (
   next?: Function,
 ) => any;
 
-export interface HttpServer<TRequest = any, TResponse = any> {
+export interface HttpServer<
+  TRequest = any,
+  TResponse = any,
+  ServerInstance = any,
+> {
   use(
     handler:
       | RequestHandler<TRequest, TResponse>
@@ -69,7 +73,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
   getRequestHostname?(request: TRequest): string;
   getRequestMethod?(request: TRequest): string;
   getRequestUrl?(request: TRequest): string;
-  getInstance(): any;
+  getInstance(): ServerInstance;
   registerParserMiddleware(...args: any[]): any;
   enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>): any;
   getHttpServer(): any;

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,7 +1,8 @@
-import { INestApplication } from '@nestjs/common';
-import type { Server as HttpServer } from 'http';
-import type { Server as HttpsServer } from 'https';
+import { INestApplication, HttpServer } from '@nestjs/common';
+import type { Server as CoreHttpServer } from 'http';
+import type { Server as CoreHttpsServer } from 'https';
 import type { Server } from 'net';
+import type { Express } from 'express';
 import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
 import { NestExpressBodyParserType } from './nest-express-body-parser.interface';
 import { ServeStaticOptions } from './serve-static-options.interface';
@@ -14,8 +15,15 @@ import { ServeStaticOptions } from './serve-static-options.interface';
  * @publicApi
  */
 export interface NestExpressApplication<
-  TServer extends HttpServer | HttpsServer = HttpServer,
+  TServer extends CoreHttpServer | CoreHttpsServer = CoreHttpServer,
 > extends INestApplication<TServer> {
+  /**
+   * Returns the underlying HTTP adapter bounded to the Express.js app.
+   *
+   * @returns {HttpServer}
+   */
+  getHttpAdapter(): HttpServer<Express.Request, Express.Response, Express>;
+
   /**
    * Starts the application.
    *

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -1,4 +1,4 @@
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, HttpServer } from '@nestjs/common';
 import {
   FastifyBodyParser,
   FastifyInstance,
@@ -6,6 +6,8 @@ import {
   FastifyPluginCallback,
   FastifyPluginOptions,
   FastifyRegisterOptions,
+  FastifyRequest,
+  FastifyReply,
   RawServerBase,
   RawServerDefault,
 } from 'fastify';
@@ -23,6 +25,13 @@ import { NestFastifyBodyParserOptions } from './nest-fastify-body-parser-options
 export interface NestFastifyApplication<
   TServer extends RawServerBase = RawServerDefault,
 > extends INestApplication<TServer> {
+  /**
+   * Returns the underlying HTTP adapter bounded to a Fastify app.
+   *
+   * @returns {HttpServer}
+   */
+  getHttpAdapter(): HttpServer<FastifyRequest, FastifyReply, FastifyInstance>;
+
   /**
    * A wrapper function around native `fastify.register()` method.
    * Example `app.register(require('@fastify/formbody'))


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The return type of `HttpServer#getInstance` is always `any` even when we explicitly supply the adapter type (`NestExpressApplication`/`NestFastifyApplication`) to `NestFactory.create`

![image](https://user-images.githubusercontent.com/13461315/205470567-0efd9150-d5ea-49f8-a61d-fe5a11752b32.png)


## What is the new behavior?

Depending on which HTTP adapter is being used, we have a type-strong return on `getInstance()`. Now one don't need to find out what's that returned object

![image](https://user-images.githubusercontent.com/13461315/205470579-ed7e0daa-88af-4029-b2b0-d9421eda1756.png)

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No
