### PR TITLE
[Feature] Allow registering body parsers, while respecting application's `rawBody` option

### DIFF
--- a/integration/nest-application/use-body-parser/e2e/express.spec.ts
+++ b/integration/nest-application/use-body-parser/e2e/express.spec.ts
@@ -1,0 +1,95 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { OptionsUrlencoded } from 'body-parser';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Body Parser (Express Application)', () => {
+  const moduleFixture = Test.createTestingModule({
+    imports: [AppModule],
+  });
+  let app: NestExpressApplication;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('application/json', () => {
+    const stringLimit = '{ "msg": "Hello, World" }';
+    const stringOverLimit = '{ "msg": "Hello, World!" }';
+
+    beforeEach(async () => {
+      const testFixture = await moduleFixture.compile();
+
+      app = testFixture
+        .createNestApplication<NestExpressApplication>({
+          rawBody: true,
+          logger: false,
+        })
+        .useBodyParser('json', { limit: Buffer.from(stringLimit).byteLength });
+
+      await app.init();
+    });
+
+    it('should allow request with matching body limit', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send(stringLimit)
+        .expect(201);
+
+      expect(response.body).to.eql({
+        raw: stringLimit,
+      });
+    });
+
+    it('should fail if post body is larger than limit', async () => {
+      await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send(stringOverLimit)
+        .expect(413);
+    });
+  });
+
+  describe('application/x-www-form-urlencoded', () => {
+    const stringLimit = 'msg=Hello, World';
+    const stringOverLimit = 'msg=Hello, World!';
+
+    beforeEach(async () => {
+      const testFixture = await moduleFixture.compile();
+
+      app = testFixture
+        .createNestApplication<NestExpressApplication>({
+          rawBody: true,
+          logger: false,
+        })
+        .useBodyParser<OptionsUrlencoded>('urlencoded', {
+          limit: Buffer.from(stringLimit).byteLength,
+          extended: true,
+        });
+
+      await app.init();
+    });
+    it('should allow request with matching body limit', async () => {
+      const response = await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(stringLimit)
+        .expect(201);
+
+      expect(response.body).to.eql({
+        raw: stringLimit,
+      });
+    });
+
+    it('should fail if post body is larger than limit', async () => {
+      await request(app.getHttpServer())
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(stringOverLimit)
+        .expect(413);
+    });
+  });
+});

--- a/integration/nest-application/use-body-parser/e2e/fastify.spec.ts
+++ b/integration/nest-application/use-body-parser/e2e/fastify.spec.ts
@@ -1,0 +1,106 @@
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { AppModule } from '../src/app.module';
+
+describe('Body Parser (Fastify Application)', () => {
+  const moduleFixture = Test.createTestingModule({
+    imports: [AppModule],
+  });
+  let app: NestFastifyApplication;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('application/json', () => {
+    const stringLimit = '{ "msg": "Hello, World" }';
+    const stringOverLimit = '{ "msg": "Hello, World!" }';
+
+    beforeEach(async () => {
+      const testFixture = await moduleFixture.compile();
+
+      app = testFixture
+        .createNestApplication<NestFastifyApplication>(new FastifyAdapter(), {
+          rawBody: true,
+          logger: false,
+        })
+        .useBodyParser('application/json', {
+          bodyLimit: Buffer.from(stringLimit).byteLength,
+        });
+
+      await app.init();
+    });
+
+    it('should allow request with matching body limit', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        headers: { 'content-type': 'application/json' },
+        payload: stringLimit,
+      });
+
+      expect(JSON.parse(response.body)).to.eql({
+        raw: stringLimit,
+      });
+    });
+
+    it('should fail if post body is larger than limit', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        headers: { 'content-type': 'application/json' },
+        payload: stringOverLimit,
+      });
+
+      expect(response.statusCode).to.equal(413);
+    });
+  });
+
+  describe('application/x-www-form-urlencoded', () => {
+    const stringLimit = 'msg=Hello, World';
+    const stringOverLimit = 'msg=Hello, World!';
+
+    beforeEach(async () => {
+      const testFixture = await moduleFixture.compile();
+
+      app = testFixture
+        .createNestApplication<NestFastifyApplication>(new FastifyAdapter(), {
+          rawBody: true,
+          logger: false,
+        })
+        .useBodyParser('application/x-www-form-urlencoded', {
+          bodyLimit: Buffer.from(stringLimit).byteLength,
+        });
+
+      await app.init();
+    });
+
+    it('should allow request with matching body limit', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: stringLimit,
+      });
+
+      expect(JSON.parse(response.body)).to.eql({
+        raw: stringLimit,
+      });
+    });
+
+    it('should fail if post body is larger than limit', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: stringOverLimit,
+      });
+
+      expect(response.statusCode).to.equal(413);
+    });
+  });
+});

--- a/integration/nest-application/use-body-parser/src/app.controller.ts
+++ b/integration/nest-application/use-body-parser/src/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post, Req, RawBodyRequest } from '@nestjs/common';
+import { IncomingMessage } from 'http';
+
+@Controller()
+export class AppController {
+  @Post()
+  index(@Req() req: RawBodyRequest<IncomingMessage>) {
+    return {
+      raw: req.rawBody?.toString(),
+    };
+  }
+}

--- a/integration/nest-application/use-body-parser/src/app.module.ts
+++ b/integration/nest-application/use-body-parser/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { AppController } from './app.controller';
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/integration/nest-application/use-body-parser/tsconfig.json
+++ b/integration/nest-application/use-body-parser/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "lib": ["dom"],
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist"
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -30,6 +30,7 @@ export interface HttpServer<TRequest = any, TResponse = any> {
       | RequestHandler<TRequest, TResponse>
       | ErrorHandler<TRequest, TResponse>,
   ): any;
+  useBodyParser?(...args: any[]): any;
   get(handler: RequestHandler<TRequest, TResponse>): any;
   get(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   post(handler: RequestHandler<TRequest, TResponse>): any;

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -96,9 +96,6 @@ export abstract class AbstractHttpAdapter<
     return this.instance as T;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public useBodyParser(..._args: any[]) {}
-
   abstract close();
   abstract initHttpServer(options: NestApplicationOptions);
   abstract useStaticAssets(...args: any[]);

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -96,6 +96,9 @@ export abstract class AbstractHttpAdapter<
     return this.instance as T;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public useBodyParser(..._args: any[]) {}
+
   abstract close();
   abstract initHttpServer(options: NestApplicationOptions);
   abstract useStaticAssets(...args: any[]);

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -245,6 +245,20 @@ export class NestApplication
     return this;
   }
 
+  public useBodyParser(...args: [any, any?]): this {
+    if (!('useBodyParser' in this.httpAdapter)) {
+      this.logger.warn('Your HTTP Adapter does not support `.useBodyParser`.');
+      return this;
+    }
+
+    const [parserType, ...otherArgs] = args;
+    const rawBody = !!this.appOptions.rawBody;
+
+    this.httpAdapter.useBodyParser(...[parserType, rawBody, ...otherArgs]);
+
+    return this;
+  }
+
   public enableCors(options?: CorsOptions | CorsOptionsDelegate<any>): void {
     this.httpAdapter.enableCors(options);
   }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -29,6 +29,7 @@ import {
   OptionsUrlencoded,
   urlencoded as bodyParserUrlencoded,
 } from 'body-parser';
+import * as bodyparser from 'body-parser';
 import * as cors from 'cors';
 import * as express from 'express';
 import * as http from 'http';
@@ -233,6 +234,19 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     Object.keys(parserMiddleware)
       .filter(parser => !this.isMiddlewareApplied(parser))
       .forEach(parserKey => this.use(parserMiddleware[parserKey]));
+  }
+
+  public useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
+    type: keyof bodyparser.BodyParser,
+    rawBody: boolean,
+    options?: Omit<Options, 'verify'>,
+  ): this {
+    const parserOptions = getBodyParserOptions(rawBody, options || {});
+    const parser = bodyparser[type](parserOptions);
+
+    this.use(parser);
+
+    return this;
   }
 
   public setLocal(key: string, value: any) {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -35,6 +35,7 @@ import * as express from 'express';
 import * as http from 'http';
 import * as https from 'https';
 import { Duplex, pipeline } from 'stream';
+import { NestExpressBodyParserOptions } from '../interfaces/nest-express-body-parser-options.interface';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
 import { getBodyParserOptions } from './utils/get-body-parser-options.util';
 
@@ -239,7 +240,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   public useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
     type: keyof bodyparser.BodyParser,
     rawBody: boolean,
-    options?: Omit<Options, 'verify'>,
+    options?: NestExpressBodyParserOptions<Options>,
   ): this {
     const parserOptions = getBodyParserOptions(rawBody, options || {});
     const parser = bodyparser[type](parserOptions);

--- a/packages/platform-express/interfaces/index.ts
+++ b/packages/platform-express/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './nest-express-application.interface';
+export * from './nest-express-body-parser-options.interface';

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,5 +1,6 @@
 import { Server } from 'net';
 import { INestApplication } from '@nestjs/common';
+import * as bodyparser from 'body-parser';
 import { ServeStaticOptions } from './serve-static-options.interface';
 
 /**
@@ -72,6 +73,17 @@ export interface NestExpressApplication extends INestApplication {
    * @returns {this}
    */
   useStaticAssets(path: string, options?: ServeStaticOptions): this;
+
+  /**
+   * Register Express body parsers on the fly. Will respect
+   * the `rawBody` option.
+   * @returns {this}
+   */
+  useBodyParser(parser: keyof bodyparser.BodyParser): this;
+  useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
+    parser: keyof bodyparser.BodyParser,
+    options: Omit<Options, 'verify'>,
+  ): this;
 
   /**
    * Sets one or multiple base directories for templates (views).

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,6 +1,7 @@
 import { Server } from 'net';
 import { INestApplication } from '@nestjs/common';
 import * as bodyparser from 'body-parser';
+import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
 import { ServeStaticOptions } from './serve-static-options.interface';
 
 /**
@@ -82,7 +83,7 @@ export interface NestExpressApplication extends INestApplication {
   useBodyParser(parser: keyof bodyparser.BodyParser): this;
   useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
     parser: keyof bodyparser.BodyParser,
-    options: Omit<Options, 'verify'>,
+    options?: NestExpressBodyParserOptions<Options>,
   ): this;
 
   /**

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -77,10 +77,17 @@ export interface NestExpressApplication extends INestApplication {
 
   /**
    * Register Express body parsers on the fly. Will respect
-   * the `rawBody` option.
+   * the application's `rawBody` option.
+   *
+   * @example
+   * const app = await NestFactory.create<NestExpressApplication>(
+   *   AppModule,
+   *   { rawBody: true }
+   * );
+   * app.useBodyParser('json', { limit: '50mb' });
+   *
    * @returns {this}
    */
-  useBodyParser(parser: keyof bodyparser.BodyParser): this;
   useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
     parser: keyof bodyparser.BodyParser,
     options?: NestExpressBodyParserOptions<Options>,

--- a/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
@@ -1,4 +1,4 @@
-import { Options } from 'body-parser';
+import type { Options } from 'body-parser';
 
 export type NestExpressBodyParserOptions<T extends Options = Options> = Omit<
   T,

--- a/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
@@ -1,0 +1,6 @@
+import { Options } from 'body-parser';
+
+export type NestExpressBodyParserOptions<T extends Options = Options> = Omit<
+  T,
+  'verify'
+>;

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -17,7 +17,6 @@ import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { isString, isUndefined } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
 import {
-  AddContentTypeParser,
   fastify,
   FastifyBodyParser,
   FastifyInstance,
@@ -45,6 +44,7 @@ import {
 } from 'light-my-request';
 // `querystring` is used internally in fastify for registering urlencoded body parser.
 import { parse as querystringParse } from 'querystring';
+import { NestFastifyBodyParserOptions } from '../interfaces';
 import {
   FastifyStaticOptions,
   PointOfViewOptions,
@@ -468,7 +468,7 @@ export class FastifyAdapter<
   public useBodyParser(
     type: string | string[] | RegExp,
     rawBody: boolean,
-    options?: Omit<Parameters<AddContentTypeParser>[1], 'parseAs'>,
+    options?: NestFastifyBodyParserOptions,
     parser?: FastifyBodyParser<Buffer, TServer>,
   ) {
     const parserOptions = {

--- a/packages/platform-fastify/interfaces/index.ts
+++ b/packages/platform-fastify/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './nest-fastify-application.interface';
+export * from './nest-fastify-body-parser-options.interface';

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -33,14 +33,19 @@ export interface NestFastifyApplication extends INestApplication {
 
   /**
    * Register Fastify body parsers on the fly. Will respect
-   * the `rawBody` option.
+   * the application's `rawBody` option.
+   *
+   * @example
+   * const app = await NestFactory.create<NestFastifyApplication>(
+   *   AppModule,
+   *   new FastifyAdapter(),
+   *   { rawBody: true }
+   * );
+   * // enable the json parser with a parser limit of 50mb
+   * app.useBodyParser('application/json', { bodyLimit: 50 * 1000 * 1024 });
+   *
    * @returns {this}
    */
-  useBodyParser(type: string | string[] | RegExp): this;
-  useBodyParser(
-    type: string | string[] | RegExp,
-    options: NestFastifyBodyParserOptions,
-  ): this;
   useBodyParser<TServer extends RawServerBase = RawServerBase>(
     type: string | string[] | RegExp,
     options?: NestFastifyBodyParserOptions,

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -1,10 +1,13 @@
 import { INestApplication } from '@nestjs/common';
 import {
+  AddContentTypeParser,
+  FastifyBodyParser,
   FastifyInstance,
   FastifyPluginAsync,
   FastifyPluginCallback,
   FastifyPluginOptions,
   FastifyRegisterOptions,
+  RawServerBase,
 } from 'fastify';
 import {
   Chain as LightMyRequestChain,
@@ -27,6 +30,22 @@ export interface NestFastifyApplication extends INestApplication {
       | Promise<{ default: FastifyPluginAsync<Options> }>,
     opts?: FastifyRegisterOptions<Options>,
   ): Promise<FastifyInstance>;
+
+  /**
+   * Register Fastify body parsers on the fly. Will respect
+   * the `rawBody` option.
+   * @returns {this}
+   */
+  useBodyParser(type: string | string[] | RegExp): this;
+  useBodyParser(
+    type: string | string[] | RegExp,
+    options: Omit<Parameters<AddContentTypeParser>[1], 'parseAs'>,
+  ): this;
+  useBodyParser<TServer extends RawServerBase = RawServerBase>(
+    type: string | string[] | RegExp,
+    options?: Omit<Parameters<AddContentTypeParser>[1], 'parseAs'>,
+    parser?: FastifyBodyParser<Buffer, TServer>,
+  ): this;
 
   /**
    * Sets a base directory for public assets.

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -1,6 +1,5 @@
 import { INestApplication } from '@nestjs/common';
 import {
-  AddContentTypeParser,
   FastifyBodyParser,
   FastifyInstance,
   FastifyPluginAsync,
@@ -15,6 +14,7 @@ import {
   Response as LightMyRequestResponse,
 } from 'light-my-request';
 import { FastifyStaticOptions, PointOfViewOptions } from './external';
+import { NestFastifyBodyParserOptions } from './nest-fastify-body-parser-options.interface';
 
 export interface NestFastifyApplication extends INestApplication {
   /**
@@ -39,11 +39,11 @@ export interface NestFastifyApplication extends INestApplication {
   useBodyParser(type: string | string[] | RegExp): this;
   useBodyParser(
     type: string | string[] | RegExp,
-    options: Omit<Parameters<AddContentTypeParser>[1], 'parseAs'>,
+    options: NestFastifyBodyParserOptions,
   ): this;
   useBodyParser<TServer extends RawServerBase = RawServerBase>(
     type: string | string[] | RegExp,
-    options?: Omit<Parameters<AddContentTypeParser>[1], 'parseAs'>,
+    options?: NestFastifyBodyParserOptions,
     parser?: FastifyBodyParser<Buffer, TServer>,
   ): this;
 

--- a/packages/platform-fastify/interfaces/nest-fastify-body-parser-options.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-body-parser-options.interface.ts
@@ -1,0 +1,6 @@
+import { AddContentTypeParser } from 'fastify';
+
+export type NestFastifyBodyParserOptions = Omit<
+  Parameters<AddContentTypeParser>[1],
+  'parseAs'
+>;

--- a/packages/platform-fastify/interfaces/nest-fastify-body-parser-options.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-body-parser-options.interface.ts
@@ -1,4 +1,4 @@
-import { AddContentTypeParser } from 'fastify';
+import type { AddContentTypeParser } from 'fastify';
 
 export type NestFastifyBodyParserOptions = Omit<
   Parameters<AddContentTypeParser>[1],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #10471 

It wasn't possible to set a body parser limit, and have the `rawBody` functionality work together.


## What is the new behavior?

We expose a new `app.useBodyParser()`. This allows configuring the application with specific body parser settings, and it respects the application's `rawBody` option. The implementation is Express and Fastify specific.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

I kept the `useBodyParser` function on `HttpAdapter` as an optional method.

## Other information

Reviewing this commit by commit is the best way to go about it.