### PR TITLE
fix(express-adapter): streaming file header error

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -63,7 +63,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       return response.send();
     }
     if (body instanceof StreamableFile) {
-      const streamHeaders = body.getHeaders();
+      const streamHeaders = !!body.getHeaders ? body.getHeaders() : response.getHeader();
       if (
         response.getHeader('Content-Type') === undefined &&
         streamHeaders.type !== undefined


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When `return new StreamableFile(stream)`, body does not have fundtion `getHeaders()` while response has. 

So, It should check body has `getHeaders()`.

When it does not have `getHeaders()`, I use response object to get headers.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information