### PR TITLE
chore(deps): remove old cache-manager typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3697,12 +3697,6 @@
       "integrity": "sha512-lOGyCnw+2JVPKU3wIV0srU0NyALwTBJlVSx5DfMQOFuuohA8y9S8orImpuIQikZ0uIQ8gehrRjxgQC1rLRi11w==",
       "dev": true
     },
-    "@types/cache-manager": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cache-manager/-/cache-manager-4.0.2.tgz",
-      "integrity": "sha512-fT5FMdzsiSX0AbgnS5gDvHl2Nco0h5zYyjwDQy4yPC7Ww6DeGMVKPRqIZtg9HOXDV2kkc18SL1B0N8f0BecrCA==",
-      "dev": true
-    },
     "@types/cacheable-request": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@nestjs/typeorm": "9.0.1",
     "@types/amqplib": "0.8.2",
     "@types/bytes": "3.1.1",
-    "@types/cache-manager": "4.0.2",
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",
     "@types/cors": "2.8.12",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

currently, typings for cache-manager are in devDependencies. These are for [version 4](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/cache-manager/index.d.ts) but the `cache-manager` version installed is `5.1.3` and it already comes with built-in types, so this dependency is unnecessary

## What is the new behavior?

This removes an unneeded development dependency. The behavior is the same.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information