### PR TITLE
fix(core): process exit before shutdown hook end

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -306,13 +306,20 @@ export class NestApplicationContext
    * @param {string[]} signals The system signals it should listen to
    */
   protected listenToShutdownSignals(signals: string[]) {
+    let receivedSignal = false;
     const cleanup = async (signal: string) => {
       try {
-        signals.forEach(sig => process.removeListener(sig, cleanup));
+        if (receivedSignal) {
+          // If we receive another signal while we're waiting
+          // for the server to stop, just ignore it.
+          return;
+        }
+        receivedSignal = true;
         await this.callDestroyHook();
         await this.callBeforeShutdownHook(signal);
         await this.dispose();
         await this.callShutdownHook(signal);
+        signals.forEach(sig => process.removeListener(sig, cleanup));
         process.kill(process.pid, signal);
       } catch (err) {
         Logger.error(

--- a/packages/core/test/nest-application-context.spec.ts
+++ b/packages/core/test/nest-application-context.spec.ts
@@ -4,6 +4,7 @@ import { ContextIdFactory } from '../helpers/context-id-factory';
 import { InstanceLoader } from '../injector/instance-loader';
 import { NestContainer } from '../injector/container';
 import { NestApplicationContext } from '../nest-application-context';
+import * as sinon from 'sinon';
 
 describe('NestApplicationContext', () => {
   class A {}
@@ -40,6 +41,54 @@ describe('NestApplicationContext', () => {
     const applicationContext = new NestApplicationContext(nestContainer, []);
     return applicationContext;
   }
+
+  describe('listenToShutdownSignals', () => {
+    it('shutdown process should not be interrupted by another handler', async () => {
+      const signal = 'SIGTERM';
+      let processUp = true;
+      let promisesResolved = false;
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+      applicationContext.enableShutdownHooks([signal]);
+
+      const waitProcessDown = new Promise(resolve => {
+        const shutdownCleanupRef = applicationContext['shutdownCleanupRef'];
+        const handler = () => {
+          if (
+            !process
+              .listeners(signal)
+              .find(handler => handler == shutdownCleanupRef)
+          ) {
+            processUp = false;
+            process.removeListener(signal, handler);
+            resolve(undefined);
+          }
+          return undefined;
+        };
+        process.on(signal, handler);
+      });
+
+      // add some third party handler
+      process.on(signal, signal => {
+        // do some work
+        process.kill(process.pid, signal);
+      });
+
+      const hookStub = sinon
+        .stub(applicationContext as any, 'callShutdownHook')
+        .callsFake(async () => {
+          // run some async code
+          await new Promise(resolve => setImmediate(() => resolve(undefined)));
+          if (processUp) {
+            promisesResolved = true;
+          }
+        });
+      process.kill(process.pid, signal);
+      await waitProcessDown;
+      hookStub.restore();
+      expect(processUp).to.be.false;
+      expect(promisesResolved).to.be.true;
+    });
+  });
 
   describe('get', () => {
     describe('when scope = DEFAULT', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Apollo server has own process listener which used in NestJS graphql https://unpkg.com/browse/apollo-server-core@3.0.1/src/ApolloServer.ts
NestJs implementation https://github.com/nestjs/nest/blob/master/packages/core/nest-application-context.ts#L308
so both libs listen SIGINT code and NestJs just after start remove own listeners and then start waiting promise results, in same time event loop go to Apollo handler and just after Apollo server is down it send process.kill event, but NestJs already removed own handler, so app close without wait all promises inited by NestJs

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information