### PR TITLE
fix(core): Making Request scope non durable win over scope durable

### DIFF
--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -247,7 +247,13 @@ export class InstanceWrapper<T = any> {
     }
     const propertiesHosts = (properties || []).map(item => item.wrapper);
     introspectionResult =
-      introspectionResult && callback(propertiesHosts, lookupRegistry);
+      introspectionResult &&
+      ((properties &&
+        callback(
+          properties.map(item => item.wrapper),
+          lookupRegistry,
+        )) ||
+        !properties);
     if (!introspectionResult || !enhancers) {
       return introspectionResult;
     }

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -210,8 +210,10 @@ export class InstanceWrapper<T = any> {
     }
     const isTreeNonDurable = this.introspectDepsAttribute(
       (collection, registry) =>
-        collection.every(
-          (item: InstanceWrapper) => !item.isDependencyTreeDurable(registry),
+        collection.some(
+          (item: InstanceWrapper) =>
+            !item.isDependencyTreeStatic() &&
+            !item.isDependencyTreeDurable(registry),
         ),
       lookupRegistry,
     );

--- a/packages/core/test/injector/instance-wrapper.spec.ts
+++ b/packages/core/test/injector/instance-wrapper.spec.ts
@@ -152,6 +152,26 @@ describe('InstanceWrapper', () => {
             expect(wrapper.isDependencyTreeDurable()).to.be.true;
           });
         });
+        describe('when one is not static, durable and non durable', () => {
+          it('should return false', () => {
+            const wrapper = new InstanceWrapper();
+            wrapper.addCtorMetadata(0, new InstanceWrapper());
+            wrapper.addCtorMetadata(
+              1,
+              new InstanceWrapper({
+                scope: Scope.REQUEST,
+                durable: true,
+              }),
+            );
+            wrapper.addCtorMetadata(
+              2,
+              new InstanceWrapper({
+                scope: Scope.REQUEST,
+              }),
+            );
+            expect(wrapper.isDependencyTreeDurable()).to.be.false;
+          });
+        });
       });
       describe('properties', () => {
         describe('when each is static', () => {
@@ -184,6 +204,21 @@ describe('InstanceWrapper', () => {
             expect(wrapper.isDependencyTreeDurable()).to.be.true;
           });
         });
+        describe('when one is not static, non durable and durable', () => {
+          it('should return false', () => {
+            const wrapper = new InstanceWrapper();
+            wrapper.addPropertiesMetadata(
+              'key1',
+              new InstanceWrapper({ scope: Scope.REQUEST, durable: true }),
+            );
+            wrapper.addPropertiesMetadata('key2', new InstanceWrapper());
+            wrapper.addPropertiesMetadata(
+              'key3',
+              new InstanceWrapper({ scope: Scope.REQUEST }),
+            );
+            expect(wrapper.isDependencyTreeDurable()).to.be.false;
+          });
+        });
       });
       describe('enhancers', () => {
         describe('when each is static', () => {
@@ -212,6 +247,19 @@ describe('InstanceWrapper', () => {
             );
             wrapper.addEnhancerMetadata(new InstanceWrapper());
             expect(wrapper.isDependencyTreeDurable()).to.be.true;
+          });
+        });
+        describe('when one is not static, non durable and durable', () => {
+          it('should return false', () => {
+            const wrapper = new InstanceWrapper();
+            wrapper.addEnhancerMetadata(
+              new InstanceWrapper({ scope: Scope.REQUEST, durable: true }),
+            );
+            wrapper.addEnhancerMetadata(new InstanceWrapper());
+            wrapper.addEnhancerMetadata(
+              new InstanceWrapper({ scope: Scope.REQUEST }),
+            );
+            expect(wrapper.isDependencyTreeDurable()).to.be.false;
           });
         });
       });


### PR DESCRIPTION
If an instance has at least one dependency that is Request scope non durable, then the instance should be Request scope non durable itself.

Closes #10594

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information