### PR TITLE
Parse file pipe fix (multiple files validation)

### DIFF
--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -49,9 +49,6 @@ export class ParseFilePipe implements PipeTransform<any> {
     if (this.validators.length) {
       if (Array.isArray(value)) {
         await this.validateFiles(value);
-      } else if (isObject(value)) {
-        const files = [].concat(...Object.values(value));
-        await this.validateFiles(files);
       } else {
         await this.validate(value);
       }
@@ -67,8 +64,6 @@ export class ParseFilePipe implements PipeTransform<any> {
   private thereAreNoFilesIn(value: any): boolean {
     if (Array.isArray(value)) {
       return value.length === 0;
-    } else if (isObject(value)) {
-      return Object.keys(value).length === 0;
     } else {
       return isEmpty(value);
     }

--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -1,10 +1,10 @@
-import { isUndefined } from '../../utils/shared.utils';
 import { Injectable, Optional } from '../../decorators/core';
 import { HttpStatus } from '../../enums';
 import { PipeTransform } from '../../interfaces/features/pipe-transform.interface';
 import { HttpErrorByCode } from '../../utils/http-error-by-code.util';
 import { FileValidator } from './file-validator.interface';
 import { ParseFileOptions } from './parse-file-options.interface';
+import { isEmpty, isObject } from 'class-validator';
 
 /**
  * Defines the built-in ParseFile Pipe. This pipe can be used to validate incoming files
@@ -39,18 +39,39 @@ export class ParseFilePipe implements PipeTransform<any> {
   }
 
   async transform(value: any): Promise<any> {
-    if (isUndefined(value)) {
+    if (this.thereAreNoFilesIn(value)) {
       if (this.fileIsRequired) {
         throw this.exceptionFactory('File is required');
       }
-
       return value;
     }
 
     if (this.validators.length) {
-      await this.validate(value);
+      if (Array.isArray(value)) {
+        await this.validateFiles(value);
+      } else if (isObject(value)) {
+        const files = [].concat(...Object.values(value));
+        await this.validateFiles(files);
+      } else {
+        await this.validate(value);
+      }
     }
+
     return value;
+  }
+
+  private validateFiles(files: any[]): Promise<any[]> {
+    return Promise.all(files.map(f => this.validate(f)));
+  }
+
+  private thereAreNoFilesIn(value: any): boolean {
+    if (Array.isArray(value)) {
+      return value.length === 0;
+    } else if (isObject(value)) {
+      return Object.keys(value).length === 0;
+    } else {
+      return isEmpty(value);
+    }
   }
 
   protected async validate(file: any): Promise<any> {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
The parse file validation pipe doesn't work if multiple files were passed.

Issue Number: N/A


## What is the new behavior?
- ParseFilePipe will now handle multiple files validations where the `IUploadValidatorOptions` will be applied to each file.
- It still works with single file as it already was.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm aware of the existing pull-request that introduces a similar solution, I tried to help with it but it seems to be abandoned, so I create this one to help ship this improvement quicker.