### PR TITLE
fix: check if methods isHeaderSent and end exists

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -61,6 +61,15 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
           message: MESSAGES.UNKNOWN_EXCEPTION_MESSAGE,
         };
 
+    if (!applicationRef.isHeadersSent || !applicationRef.end) {
+      // In the case of the uncaughtException error
+      // isHeadersSent and end are not available
+      return BaseExceptionFilter.logger.error(
+          exception.message,
+          exception.stack,
+      );
+    }
+
     const response = host.getArgByIndex(1);
     if (!applicationRef.isHeadersSent(response)) {
       applicationRef.reply(response, body, body.statusCode);

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -63,7 +63,7 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
 
     if (!applicationRef.isHeadersSent || !applicationRef.end) {
       // In the case of the uncaughtException error
-      // isHeadersSent and end are not available
+      // isHeadersSent or end are not available
       return BaseExceptionFilter.logger.error(
           exception.message,
           exception.stack,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The current issue is related with new version of the TypeOrm when will be issue with insert/update data application exit.

```
/Users/mkubaszek/Projects/laminar/admin/node_modules/@nestjs/core/exceptions/base-exception-filter.js:45
        if (!applicationRef.isHeadersSent(response)) {
                            ^
TypeError: applicationRef.isHeadersSent is not a function
    at ExceptionsHandler.handleUnknownError (/Users/mkubaszek/Projects/laminar/admin/node_modules/@nestjs/core/exceptions/base-exception-filter.js:45:29)
    at ExceptionsHandler.catch (/Users/mkubaszek/Projects/laminar/admin/node_modules/@nestjs/core/exceptions/base-exception-filter.js:17:25)
    at ExceptionsHandler.next (/Users/mkubaszek/Projects/laminar/admin/node_modules/@nestjs/core/exceptions/exceptions-handler.js:16:20)
 ```

Issue Number: N/A


## What is the new behavior?
In the case of the appearing 'uncaughtException' while issue in TypeOrm application will be working still.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No


## Other information