### PR TITLE
feat(core): pass signal when manually invoking close

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -227,11 +227,11 @@ export class NestApplicationContext
    * Terminates the application
    * @returns {Promise<void>}
    */
-  public async close(): Promise<void> {
+  public async close(signal?: string): Promise<void> {
     await this.callDestroyHook();
-    await this.callBeforeShutdownHook();
+    await this.callBeforeShutdownHook(signal);
     await this.dispose();
-    await this.callShutdownHook();
+    await this.callShutdownHook(signal);
     this.unsubscribeFromProcessSignals();
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

At the moment, when manually invoking the `app.close()`, no signal can be passed to the shutdown hooks (`beforeApplicationShutdown` & `onApplicationShutdown`). This means creating custom graceful shutdown implementations are limited by the fact that something simple as a signal can't be used for handling shutdown features.

Issue Number: N/A


## What is the new behavior?

By adding the possibility the pass a signal to the `app.close()` function, which is still not required, the signal can be used in shutdown hooks, even when custom graceful shutdown implementations are made. Although it's a small feature, it makes creating graceful shutdowns somewhat easier, even if it's for logging only for example.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information