### PR TITLE
fix(platform-express) Add support to BigInt.toJSON() for response JSON parser

### DIFF
--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -20,6 +20,7 @@ export abstract class AbstractHttpAdapter<
   constructor(protected instance?: any) {}
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public init(): any;
   public async init() {}
 
   public use(...args: any[]) {

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -19,8 +19,8 @@ export abstract class AbstractHttpAdapter<
 
   constructor(protected instance?: any) {}
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public init(): any;
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   public async init() {}
 
   public use(...args: any[]) {

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -55,6 +55,13 @@ export class ExpressAdapter extends AbstractHttpAdapter {
     super(instance || express());
   }
 
+  public init() {
+    BigInt.prototype['toJSON'] = function () {
+      return this.toString();
+    };
+    return this;
+  }
+
   public reply(response: any, body: any, statusCode?: number) {
     if (statusCode) {
       response.status(statusCode);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
- Using a BigInt type on MySQL Server + Prisma
- Express is not able to serialize a BigInt
- Express throws error on /platform-express/adapters/express-adapter.ts (reply() method)

Error example:
```terminal
ERROR [ExceptionsHandler] Do not know how to serialize a BigInt
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at stringify (/Users/user/nest-project/node_modules/express/lib/response.js:1150:12)
    at ServerResponse.json (/Users/user/nest-project/node_modules/express/lib/response.js:271:14)
    at ExpressAdapter.reply (/Users/user/nest-project/node_modules/@nestjs/platform-express/adapters/express-adapter.js:51:62)
    at RouterResponseController.apply (/Users/user/nest-project/node_modules/@nestjs/core/router/router-response-controller.js:15:36)
    at /Users/user/nest-project/node_modules/@nestjs/core/router/router-execution-context.js:176:48
    at /Users/user/nest-project/node_modules/@nestjs/core/router/router-execution-context.js:47:13
    at /Users/user/nest-project/node_modules/@nestjs/core/router/router-proxy.js:9:17
```

Issue Number: #6919


## What is the new behavior?
- BigInt was prototyped to have toJSON() method
- Express will be able to serialize BigInt type to String
- No more TypeError related to BigInt serialization


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No