### PR TITLE
ttl should not be an object at set cache in CacheInterceptor

### DIFF
--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -55,7 +55,7 @@ export class CacheInterceptor implements NestInterceptor {
         : ttlValueOrFactory;
       return next.handle().pipe(
         tap(async response => {
-          const args = isNil(ttl) ? [key, response] : [key, response, { ttl }];
+          const args = isNil(ttl) ? [key, response] : [key, response, ttl];
 
           try {
             await this.cacheManager.set(...args);


### PR DESCRIPTION
I have an following error when I use CacheInterceptor(with redis or ioredis configuration) and CacheTTL at a controller method
```
[Nest] 37602  - 12/31/2022, 10:06:57 PM   ERROR [CacheInterceptor] An error has occured when inserting "key: /rest-without-auth/17", "value: [object Object]"
```

My Controller method
```typescript
  @Get(':id')
  @UseInterceptors(CacheInterceptor)
  @CacheTTL(88888)
  getById(@Param('id', ParseIntPipe) id: number): SampleRestResponseDto {
    const ttl = this.reflector.get('cache_module:cache_ttl', this.getById);
    console.log(ttl);

    this.logger.log(`send comment id: ${id} WITHOUT auth`);
    return this.sampleRestService.getCommentById(id);
  }
```


Redis MONITOR log (ioredis store "node-cache-manager-ioredis-yet")

```
1672513617.562010 [0 172.17.0.1:59148] "get" "/rest-without-auth/17"
1672513617.567794 [0 172.17.0.1:59148] "setex" "/rest-without-auth/17" "NaN" "{\"postId\":4,\"id\":17,\"name\":\"eos est animi quis\",\"email\":\"Preston_Hudson@blaise.tv\",\"body\":\"consequatur necessitatibus totam sed sit dolorum\\nrecusandae quae odio excepturi voluptatum harum voluptas\\nquisquam sit ad eveniet delectus\\ndoloribus odio qui non labore\"}"
```

ttl is NaN
 
Redis MONITOR log (redis store "node-cache-manager-redis-yet")
```
1672506411.988059 [0 172.17.0.1:60392] "GET" "/rest-without-auth/17"
1672506411.990346 [0 172.17.0.1:60392] "SET" "/rest-without-auth/17" "{\"postId\":4,\"id\":17,\"name\":\"eos est animi quis\",\"email\":\"Preston_Hudson@blaise.tv\",\"body\":\"consequatur necessitatibus totam sed sit dolorum\\nrecusandae quae odio excepturi voluptatum harum voluptas\\nquisquam sit ad eveniet delectus\\ndoloribus odio qui non labore\"}" "PX" "[object Object]"
```

ttl is [object Object]

Redis MONITOR log (ioredis store "@tirke/node-cache-manager-ioredis")

```
1672515106.891908 [0 172.17.0.1:59670] "get" "/rest-without-auth/17"
1672515106.909389 [0 172.17.0.1:59670] "setex" "/rest-without-auth/17" "[object Object]" "{\"postId\":4,\"id\":17,\"name\":\"eos est animi quis\",\"email\":\"Preston_Hudson@blaise.tv\",\"body\":\"consequatur necessitatibus totam sed sit dolorum\\nrecusandae quae odio excepturi voluptatum harum voluptas\\nquisquam sit ad eveniet delectus\\ndoloribus odio qui non labore\"}"
```

ttl is [object Object]


[in the documantation, ](https://docs.nestjs.com/techniques/caching#interacting-with-the-cache-store)
```typescript
await this.cacheManager.set('key', 'value', 1000);
```
because of above logs I fixed passing ttl at set cache in  CacheInterceptor and it's work
