### PR TITLE
fix(core,microservices): durable context strategy without payload

### DIFF
--- a/integration/scopes/e2e/durable-providers.spec.ts
+++ b/integration/scopes/e2e/durable-providers.spec.ts
@@ -3,7 +3,10 @@ import { ContextIdFactory } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as request from 'supertest';
-import { DurableContextIdStrategy } from '../src/durable/durable-context-id.strategy';
+import {
+  DurableContextIdStrategy,
+  DurableContextIdWithoutPayloadStrategy,
+} from '../src/durable/durable-context-id.strategy';
 import { DurableModule } from '../src/durable/durable.module';
 
 describe('Durable providers', () => {
@@ -18,8 +21,6 @@ describe('Durable providers', () => {
     app = moduleRef.createNestApplication();
     server = app.getHttpServer();
     await app.init();
-
-    ContextIdFactory.apply(new DurableContextIdStrategy());
   });
 
   describe('when service is durable', () => {
@@ -36,53 +37,72 @@ describe('Durable providers', () => {
           end(res);
         });
 
-    it(`should share durable providers per tenant`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
+    describe('when the strategy returns ContextIdResolver', () => {
+      before(() => {
+        ContextIdFactory.apply(new DurableContextIdStrategy());
+      });
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 2');
+      it('should share durable providers per tenant', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 3');
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 2');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 3');
+      });
+
+      it('should create per-tenant DI sub-tree', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(4, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(5, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(6, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+      });
+
+      it('should register a custom per-tenant request payload', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve, '/durable/echo'),
+        );
+        expect(result.body).deep.equal({ tenantId: '1' });
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(3, resolve, '/durable/echo'),
+        );
+        expect(result.body).deep.equal({ tenantId: '3' });
+      });
     });
 
-    it(`should create per-tenant DI sub-tree`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(4, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
+    describe('when the strategy returns ContextIdResolverFn', () => {
+      before(() => {
+        ContextIdFactory.apply(new DurableContextIdWithoutPayloadStrategy());
+      });
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(5, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
-
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(6, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
-    });
-
-    it(`should register a custom per-tenant request payload`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve, '/durable/echo'),
-      );
-      expect(result.body).deep.equal({ tenantId: '1' });
-
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(3, resolve, '/durable/echo'),
-      );
-      expect(result.body).deep.equal({ tenantId: '3' });
+      it('should have the REQUEST provider sdefined', () => {
+        return request(server)
+          .get('/durable/is-req-defined')
+          .expect(200)
+          .expect('yes');
+      });
     });
   });
 

--- a/integration/scopes/src/durable/durable.controller.ts
+++ b/integration/scopes/src/durable/durable.controller.ts
@@ -14,4 +14,9 @@ export class DurableController {
   echo() {
     return this.durableService.requestPayload;
   }
+
+  @Get('is-req-defined')
+  getIfReqObjectIsDefined(): string {
+    return this.durableService.requestPayload ? 'yes' : 'no';
+  }
 }

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -218,7 +218,7 @@ export class MiddlewareModule {
               configurable: false,
             });
             this.container.registerRequestProvider(
-              contextId.getParent ? contextId.payload : req,
+              isUndefined(contextId.payload) ? req : contextId.payload,
               contextId,
             );
           }

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -425,7 +425,7 @@ export class RouterExplorer {
         configurable: false,
       });
       this.container.registerRequestProvider(
-        contextId.getParent ? contextId.payload : request,
+        isUndefined(contextId.payload) ? request : contextId.payload,
         contextId,
       );
     }

--- a/packages/microservices/listeners-controller.ts
+++ b/packages/microservices/listeners-controller.ts
@@ -183,7 +183,7 @@ export class ListenersController {
           );
           contextId = this.getContextId(request);
           this.container.registerRequestProvider(
-            contextId.getParent ? contextId.payload : request,
+            isUndefined(contextId.payload) ? request : contextId.payload,
             contextId,
           );
           dataOrContextHost = request;
@@ -241,7 +241,7 @@ export class ListenersController {
         configurable: false,
       });
       this.container.registerRequestProvider(
-        contextId.getParent ? contextId.payload : request,
+        isUndefined(contextId.payload) ? request : contextId.payload,
         contextId,
       );
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

A regression since v9.1.1 

## What is the current behavior?

> Reproduction: https://gitlab.com/micalevisk/nestjs-bug-pr-10793/-/blob/main/src/app.module.ts

Adding `ContextIdFactory.apply(new AggregateByTenantContextIdStrategy())` (taking the first snippet from the docs), request-scoped providers will have the `REQUEST` provider being `undefined` because of the following:

https://github.com/nestjs/nest/blob/1ebe10868c62c2d33abbcf319f3be8af731f5f47/packages/core/helpers/context-id-factory.ts#L77-L82

you can see that the `getParent` field is always defined.

In several places, we're checking if it's being present:

https://github.com/nestjs/nest/blob/1ebe10868c62c2d33abbcf319f3be8af731f5f47/packages/core/router/router-explorer.ts#L427-L430

so we end up passing `contextId.payload` as the context value instead of `request`, even tho there's no 'payload' defined.

## What is the new behavior?

the value of the `REQUEST` provider is the request when the context id strategy doesn't return the `{ resolve, payload }` object, or if `payload` is `undefined` (since I didn't find any way to cover this case)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
