### PR TITLE
refactor(microservices): disable ping timer message in nats by flag

### DIFF
--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -52,15 +52,28 @@ export class ClientNats extends ClientProxy {
         status.data && isObject(status.data)
           ? JSON.stringify(status.data)
           : status.data;
-      if (status.type === 'disconnect' || status.type === 'error') {
-        this.logger.error(
-          `NatsError: type: "${status.type}", data: "${data}".`,
-        );
-      }
-      if (status.type === 'pingTimer' && this.options.debug) {
-        this.logger.debug(
-          `NatsStatus: type: "${status.type}", data: "${data}".`,
-        );
+
+      switch (status.type) {
+        case 'error':
+        case 'disconnect':
+          this.logger.error(
+            `NatsError: type: "${status.type}", data: "${data}".`,
+          );
+          break;
+
+        case 'pingTimer':
+          if (this.options.debug) {
+            this.logger.debug(
+              `NatsStatus: type: "${status.type}", data: "${data}".`,
+            );
+          }
+          break;
+
+        default:
+          this.logger.log(
+            `NatsStatus: type: "${status.type}", data: "${data}".`,
+          );
+          break;
       }
     }
   }

--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -56,13 +56,11 @@ export class ClientNats extends ClientProxy {
         this.logger.error(
           `NatsError: type: "${status.type}", data: "${data}".`,
         );
-      } else {
-        const message = `NatsStatus: type: "${status.type}", data: "${data}".`;
-        if (status.type === 'pingTimer') {
-          this.logger.debug(message);
-        } else {
-          this.logger.log(message);
-        }
+      }
+      if (status.type === 'pingTimer' && this.options.debug) {
+        this.logger.debug(
+          `NatsStatus: type: "${status.type}", data: "${data}".`,
+        );
       }
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The debug message of nats server is annoying and its cant be disabled.
`DEBUG [Server] NatsStatus: type: "pingTimer", data: "1".`

Issue Number: 10783


## What is the new behavior?
My propose it is extends the implementation existed flag **debug** of **MicroserviceOptions** for disable **pingTimer** message.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information