### PR TITLE
test(integration): cover the case of returning a `ContextIdResolverFn`

### DIFF
--- a/integration/scopes/e2e/durable-providers.spec.ts
+++ b/integration/scopes/e2e/durable-providers.spec.ts
@@ -3,7 +3,10 @@ import { ContextIdFactory } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as request from 'supertest';
-import { DurableContextIdStrategy } from '../src/durable/durable-context-id.strategy';
+import {
+  DurableContextIdStrategy,
+  DurableContextIdWithoutPayloadStrategy,
+} from '../src/durable/durable-context-id.strategy';
 import { DurableModule } from '../src/durable/durable.module';
 
 describe('Durable providers', () => {
@@ -18,8 +21,6 @@ describe('Durable providers', () => {
     app = moduleRef.createNestApplication();
     server = app.getHttpServer();
     await app.init();
-
-    ContextIdFactory.apply(new DurableContextIdStrategy());
   });
 
   describe('when service is durable', () => {
@@ -36,53 +37,72 @@ describe('Durable providers', () => {
           end(res);
         });
 
-    it(`should share durable providers per tenant`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
+    describe('when the strategy returns ContextIdResolver', () => {
+      before(() => {
+        ContextIdFactory.apply(new DurableContextIdStrategy());
+      });
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 2');
+      it('should share durable providers per tenant', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 3');
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 2');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 3');
+      });
+
+      it('should create per-tenant DI sub-tree', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(4, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(5, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(6, resolve),
+        );
+        expect(result.text).equal('Hello world! Counter: 1');
+      });
+
+      it('should register a custom per-tenant request payload', async () => {
+        let result: request.Response;
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(1, resolve, '/durable/echo'),
+        );
+        expect(result.body).deep.equal({ tenantId: '1' });
+
+        result = await new Promise<request.Response>(resolve =>
+          performHttpCall(3, resolve, '/durable/echo'),
+        );
+        expect(result.body).deep.equal({ tenantId: '3' });
+      });
     });
 
-    it(`should create per-tenant DI sub-tree`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(4, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
+    describe('when the strategy returns ContextIdResolverFn', () => {
+      before(() => {
+        ContextIdFactory.apply(new DurableContextIdWithoutPayloadStrategy());
+      });
 
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(5, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
-
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(6, resolve),
-      );
-      expect(result.text).equal('Hello world! Counter: 1');
-    });
-
-    it(`should register a custom per-tenant request payload`, async () => {
-      let result: request.Response;
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(1, resolve, '/durable/echo'),
-      );
-      expect(result.body).deep.equal({ tenantId: '1' });
-
-      result = await new Promise<request.Response>(resolve =>
-        performHttpCall(3, resolve, '/durable/echo'),
-      );
-      expect(result.body).deep.equal({ tenantId: '3' });
+      it('should have the REQUEST provider defined', () => {
+        return request(server)
+          .get('/durable/is-req-defined')
+          .expect(200)
+          .expect('yes');
+      });
     });
   });
 

--- a/integration/scopes/src/durable/durable.controller.ts
+++ b/integration/scopes/src/durable/durable.controller.ts
@@ -14,4 +14,9 @@ export class DurableController {
   echo() {
     return this.durableService.requestPayload;
   }
+
+  @Get('is-req-defined')
+  getIfReqObjectIsDefined(): string {
+    return this.durableService.requestPayload ? 'yes' : 'no';
+  }
 }


### PR DESCRIPTION
As of now, we only have an integration test for the `ContextIdResolver` interface (ie., `ContextIdStrategy#attach` returns `resolve`+`payload`).

After this PR we will have a test suite for a request-scoped durable provider for a app that is using the `ContextIdResolverFn` interface (ie., `ContextIdStrategy#attach` returns the `resolve` function), which should still inject the `REQUEST` provider properly (being the `request` object)

---

This PR is just a demo to illustrate what I think it was a regression introduced at v9.1.1

See:

![image](https://user-images.githubusercontent.com/13461315/210392677-153c8eea-b3fd-4813-a8ac-22cb3afb1225.png)

https://app.circleci.com/pipelines/github/nestjs/nest/19897/workflows/e4fa8f61-2cbf-4188-8275-5f62b0f1d13a/jobs/131742/parallel-runs/0/steps/0-108
