### PR TITLE
fix(core,microservices): inject the context when the tree is not durable

### DIFF
--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -17,7 +17,7 @@ import { ExecutionContextHost } from '../helpers/execution-context-host';
 import { STATIC_CONTEXT } from '../injector/constants';
 import { NestContainer } from '../injector/container';
 import { Injector } from '../injector/injector';
-import { InstanceWrapper } from '../injector/instance-wrapper';
+import { ContextId, InstanceWrapper } from '../injector/instance-wrapper';
 import { InstanceToken, Module } from '../injector/module';
 import { REQUEST_CONTEXT_ID } from '../router/request/request-constants';
 import { RoutePathFactory } from '../router/route-path-factory';
@@ -200,6 +200,9 @@ export class MiddlewareModule {
       const proxy = await this.createProxy(instance);
       return this.registerHandler(applicationRef, routeInfo, proxy);
     }
+
+    const isTreeDurable = wrapper.isDependencyTreeDurable();
+
     await this.registerHandler(
       applicationRef,
       routeInfo,
@@ -217,8 +220,12 @@ export class MiddlewareModule {
               writable: false,
               configurable: false,
             });
+
+            const requestProviderValue = isTreeDurable
+              ? contextId.payload
+              : req;
             this.container.registerRequestProvider(
-              contextId.getParent ? contextId.payload : req,
+              requestProviderValue,
               contextId,
             );
           }

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -212,23 +212,7 @@ export class MiddlewareModule {
         next: () => void,
       ) => {
         try {
-          const contextId = ContextIdFactory.getByRequest(req);
-          if (!req[REQUEST_CONTEXT_ID]) {
-            Object.defineProperty(req, REQUEST_CONTEXT_ID, {
-              value: contextId,
-              enumerable: false,
-              writable: false,
-              configurable: false,
-            });
-
-            const requestProviderValue = isTreeDurable
-              ? contextId.payload
-              : req;
-            this.container.registerRequestProvider(
-              requestProviderValue,
-              contextId,
-            );
-          }
+          const contextId = this.getContextId(req, isTreeDurable);
           const contextInstance = await this.injector.loadPerContext(
             instance,
             moduleRef,
@@ -324,5 +308,21 @@ export class MiddlewareModule {
             return next();
           },
     );
+  }
+
+  private getContextId(request: unknown, isTreeDurable: boolean): ContextId {
+    const contextId = ContextIdFactory.getByRequest(request);
+    if (!request[REQUEST_CONTEXT_ID]) {
+      Object.defineProperty(request, REQUEST_CONTEXT_ID, {
+        value: contextId,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+
+      const requestProviderValue = isTreeDurable ? contextId.payload : request;
+      this.container.registerRequestProvider(requestProviderValue, contextId);
+    }
+    return contextId;
   }
 }

--- a/packages/microservices/listeners-controller.ts
+++ b/packages/microservices/listeners-controller.ts
@@ -166,13 +166,15 @@ export class ListenersController {
     const collection = moduleRef.controllers;
     const { instance } = wrapper;
 
+    const isTreeDurable = wrapper.isDependencyTreeDurable();
+
     const requestScopedHandler: MessageHandler = async (...args: unknown[]) => {
       try {
         let contextId: ContextId;
 
         let [dataOrContextHost] = args;
         if (dataOrContextHost instanceof RequestContextHost) {
-          contextId = this.getContextId(dataOrContextHost);
+          contextId = this.getContextId(dataOrContextHost, isTreeDurable);
           args.shift();
         } else {
           const [data, reqCtx] = args;
@@ -181,11 +183,7 @@ export class ListenersController {
             data,
             reqCtx as BaseRpcContext,
           );
-          contextId = this.getContextId(request);
-          this.container.registerRequestProvider(
-            contextId.getParent ? contextId.payload : request,
-            contextId,
-          );
+          contextId = this.getContextId(request, isTreeDurable);
           dataOrContextHost = request;
         }
         const contextInstance = await this.injector.loadPerContext(
@@ -231,7 +229,10 @@ export class ListenersController {
     return requestScopedHandler;
   }
 
-  private getContextId<T extends RequestContext = any>(request: T): ContextId {
+  private getContextId<T extends RequestContext = any>(
+    request: T,
+    isTreeDurable: boolean,
+  ): ContextId {
     const contextId = ContextIdFactory.getByRequest(request);
     if (!request[REQUEST_CONTEXT_ID as any]) {
       Object.defineProperty(request, REQUEST_CONTEXT_ID, {
@@ -240,10 +241,9 @@ export class ListenersController {
         writable: false,
         configurable: false,
       });
-      this.container.registerRequestProvider(
-        contextId.getParent ? contextId.payload : request,
-        contextId,
-      );
+
+      const requestProviderValue = isTreeDurable ? contextId.payload : request;
+      this.container.registerRequestProvider(requestProviderValue, contextId);
     }
     return contextId;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

regression introduce at v9.1.1

## What is the current behavior?

When injecting `REQUEST` for non-durable providers, its value is always being context payload even when the injectable chain is not durable, like this:

```ts
@Injectable({ scope: Scope.REQUEST, durable: false })
class AppService {
  constructor(@Inject(REQUEST) private readonly req: any) {
    console.log('Is req fasly?', !!req === false) // true but should be false
  }

  isReqDefined() {
    return typeof this.req !== 'undefined' // false but should be true
  }
}

@Controller() // request-scoped but not durable, due to its dependency
class AppController {
  constructor(private readonly appService: AppService) {}

  @Get()
  getHello() {
    return {
      is_req_defined: this.appService.isReqDefined(),
    }
  }
}
```

## What is the new behavior?

non-durable providers can inject the `REQUEST` (or `CONTEXT`. I didn't tested this patch with `CONTEXT` tho) regardless of the `ContextIdStrategy#attach`. I'm under the assumption that the context id being resolved doesn't affect the `REQUEST` provider for a non-durable provider.

You can try this patch:

```bash
git clone -b with-10809 https://gitlab.com/micalevisk/nestjs-bug-pr-10793
npm ci
npm start

./request.sh
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

After digging a bit into the source, I didn't find any other way to fix that bug other than checking if the tree is durable in order to define what would be the value for `REQUEST`/`CONTEXT` provider.
