### PR TITLE
perf(core): better performance to get method names

### DIFF
--- a/packages/core/metadata-scanner.ts
+++ b/packages/core/metadata-scanner.ts
@@ -4,36 +4,83 @@ import {
   isFunction,
   isNil,
 } from '@nestjs/common/utils/shared.utils';
-import { iterate } from 'iterare';
 
 export class MetadataScanner {
   public scanFromPrototype<T extends Injectable, R = any>(
     instance: T,
-    prototype: object,
+    prototype: object | null,
     callback: (name: string) => R,
   ): R[] {
-    const methodNames = new Set(this.getAllFilteredMethodNames(prototype));
-    return iterate(methodNames)
-      .map(callback)
-      .filter(metadata => !isNil(metadata))
-      .toArray();
-  }
+    if (!prototype) return [];
 
-  *getAllFilteredMethodNames(prototype: object): IterableIterator<string> {
-    const isMethod = (prop: string) => {
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, prop);
-      if (descriptor.set || descriptor.get) {
-        return false;
-      }
-      return !isConstructor(prop) && isFunction(prototype[prop]);
-    };
+    const visitedNames = new Map<string, boolean>();
+    const result: R[] = [];
+
     do {
-      yield* iterate(Object.getOwnPropertyNames(prototype))
-        .filter(isMethod)
-        .toArray();
+      for (const property of Object.getOwnPropertyNames(prototype)) {
+        if (visitedNames.has(property)) continue;
+
+        visitedNames.set(property, true);
+
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+
+        if (
+          descriptor.set ||
+          descriptor.get ||
+          isConstructor(property) ||
+          !isFunction(prototype[property])
+        ) {
+          continue;
+        }
+
+        const value = callback(property);
+
+        if (isNil(value)) {
+          continue;
+        }
+
+        result.push(value);
+      }
     } while (
       (prototype = Reflect.getPrototypeOf(prototype)) &&
       prototype !== Object.prototype
     );
+
+    return result;
+  }
+
+  *getAllFilteredMethodNames(
+    prototype: object | null,
+  ): IterableIterator<string> {
+    if (!prototype) return [];
+
+    const visitedNames = new Map<string, boolean>();
+    const result: string[] = [];
+
+    do {
+      for (const property of Object.getOwnPropertyNames(prototype)) {
+        if (visitedNames.has(property)) continue;
+
+        visitedNames.set(property, true);
+
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+
+        if (
+          descriptor.set ||
+          descriptor.get ||
+          isConstructor(property) ||
+          !isFunction(prototype[property])
+        ) {
+          continue;
+        }
+
+        result.push(property);
+      }
+    } while (
+      (prototype = Reflect.getPrototypeOf(prototype)) &&
+      prototype !== Object.prototype
+    );
+
+    return result.values();
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

I run some performance tests on `NestFactory.create(AppModule, { logger: false })` and I found that the function `getAllFilteredMethodNames` was heavily called on NodeJS profiler.

```
[Bottom up (heavy) profile]:
  Note: percentage shows a share of a particular caller in the total
  amount of its parent calls.
  Callers occupying less than 1.0% are not shown.

   ticks parent  name
   6488   80.6%  /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
   2883   44.4%    /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    407   14.1%      /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    133   32.7%        LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/metadata-scanner.js:35:31
    133  100.0%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    133  100.0%            /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
```

> [Source](https://github.com/nestjs/nest/files/10365235/isolate-0x4c657a0-134276-v8_original_diff.log)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

This method was called inside `MetadataScanner`, so I refactored the method to don't use any library, the profiler after this modification became:

```
 [Bottom up (heavy) profile]:
  Note: percentage shows a share of a particular caller in the total
  amount of its parent calls.
  Callers occupying less than 1.0% are not shown.

   ticks parent  name
   6068   81.5%  /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
   2646   43.6%    /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    330   12.5%      /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
     74   22.4%        LazyCompile: *reflectInjectables /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:134:23
     58   78.4%          LazyCompile: *reflectDynamicMetadata /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:117:27
     58  100.0%            LazyCompile: *scanModulesForDependencies /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:80:37
      8   10.8%          LazyCompile: *scanModulesForDependencies /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:80:37
      8  100.0%            /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
      5    6.8%          Function: ^reflectDynamicMetadata /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:117:27
      4   80.0%            Function: ^<anonymous> /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:112:29
      1   20.0%            Function: ^<anonymous> /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:102:27
      3    4.1%          LazyCompile: *<anonymous> /home/h4ad/Projects/opensource/performance-test-nestjs/test-performance/node_modules/@nestjs/core/scanner.js:102:27
      3  100.0%            /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
```

> [Source](https://github.com/nestjs/nest/files/10365240/perf-startup-10000_faster_scanFromPrototype_v2.txt)

The benchmark shows an almost 3x improvement in performance:

```
MetadataScanner#scanFromPrototype x 105,154 ops/sec ±2.32% (88 runs sampled)
BetterMetadataScanner#scanFromPrototype x 269,063 ops/sec ±1.72% (86 runs sampled)
Fastest is BetterMetadataScanner#scanFromPrototype
```

You can find the source code of the benchmark and how to generate the profiler information here: https://gist.github.com/H4ad/c43fd3556ab1e241e4db24443003d395

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information