### PR TITLE
fix(core): ModuleRef#get and #resolve opts default values

### DIFF
--- a/packages/core/injector/module-ref.ts
+++ b/packages/core/injector/module-ref.ts
@@ -1,5 +1,4 @@
 import { IntrospectionResult, Scope, Type } from '@nestjs/common';
-import { GetOrResolveOptions } from '@nestjs/common/interfaces';
 import { getClassScope } from '../helpers/get-class-scope';
 import { isDurable } from '../helpers/is-durable';
 import { AbstractInstanceResolver } from './abstract-instance-resolver';
@@ -8,6 +7,20 @@ import { Injector } from './injector';
 import { InstanceLinksHost } from './instance-links-host';
 import { ContextId, InstanceWrapper } from './instance-wrapper';
 import { Module } from './module';
+
+export interface ModuleRefGetOrResolveOpts {
+  /**
+   * If enabled, lookup will only be performed in the host module.
+   * @default true
+   */
+  strict?: boolean;
+  /**
+   * If enabled, instead of returning a first instance registered under a given token,
+   * a list of instances will be returned.
+   * @default false
+   */
+  each?: boolean;
+}
 
 export abstract class ModuleRef extends AbstractInstanceResolver {
   protected readonly injector = new Injector();
@@ -37,7 +50,15 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
    */
   abstract get<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Function | string | symbol,
-    options: { strict?: boolean; each?: undefined | false },
+    options: {
+      /**
+       * If enabled, lookup will only be performed in the host module.
+       * @default true
+       */
+      strict?: boolean;
+      /** This indicates that only the first instance registered will be returned. */
+      each?: undefined | false;
+    },
   ): TResult;
   /**
    * Retrieves a list of instances of either injectables or controllers, otherwise, throws exception.
@@ -45,7 +66,15 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
    */
   abstract get<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Function | string | symbol,
-    options: { strict?: boolean; each: true },
+    options: {
+      /**
+       * If enabled, lookup will only be performed in the host module.
+       * @default true
+       */
+      strict?: boolean;
+      /** This indicates that a list of instances will be returned. */
+      each: true;
+    },
   ): Array<TResult>;
   /**
    * Retrieves an instance (or a list of instances) of either injectable or controller, otherwise, throws exception.
@@ -53,7 +82,7 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
    */
   abstract get<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Function | string | symbol,
-    options?: GetOrResolveOptions,
+    options?: ModuleRefGetOrResolveOpts,
   ): TResult | Array<TResult>;
 
   /**
@@ -96,7 +125,7 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
   abstract resolve<TInput = any, TResult = TInput>(
     typeOrToken: Type<TInput> | Function | string | symbol,
     contextId?: { id: number },
-    options?: GetOrResolveOptions,
+    options?: ModuleRefGetOrResolveOpts,
   ): Promise<TResult | Array<TResult>>;
 
   public abstract create<T = any>(type: Type<T>): Promise<T>;

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -521,8 +521,11 @@ export class Module {
 
       public get<TInput = any, TResult = TInput>(
         typeOrToken: Type<TInput> | string | symbol,
-        options: GetOrResolveOptions = { strict: true },
+        options: GetOrResolveOptions = {},
       ): TResult | Array<TResult> {
+        options.strict ??= true;
+        options.each ??= false;
+
         return !(options && options.strict)
           ? this.find<TInput, TResult>(typeOrToken, options)
           : this.find<TInput, TResult>(typeOrToken, {
@@ -534,8 +537,11 @@ export class Module {
       public resolve<TInput = any, TResult = TInput>(
         typeOrToken: Type<TInput> | string | symbol,
         contextId = createContextId(),
-        options: GetOrResolveOptions = { strict: true },
+        options: GetOrResolveOptions = {},
       ): Promise<TResult | Array<TResult>> {
+        options.strict ??= true;
+        options.each ??= false;
+
         return this.resolvePerContext<TInput, TResult>(
           typeOrToken,
           self,

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -4,7 +4,6 @@ import {
   DynamicModule,
   ExistingProvider,
   FactoryProvider,
-  GetOrResolveOptions,
   Injectable,
   InjectionToken,
   NestModule,
@@ -33,7 +32,7 @@ import { isDurable } from '../helpers/is-durable';
 import { CONTROLLER_ID_KEY } from './constants';
 import { NestContainer } from './container';
 import { InstanceWrapper } from './instance-wrapper';
-import { ModuleRef } from './module-ref';
+import { ModuleRefGetOrResolveOpts, ModuleRef } from './module-ref';
 
 /**
  * @note
@@ -521,7 +520,7 @@ export class Module {
 
       public get<TInput = any, TResult = TInput>(
         typeOrToken: Type<TInput> | string | symbol,
-        options: GetOrResolveOptions = {},
+        options: ModuleRefGetOrResolveOpts = {},
       ): TResult | Array<TResult> {
         options.strict ??= true;
         options.each ??= false;
@@ -540,7 +539,7 @@ export class Module {
       public resolve<TInput = any, TResult = TInput>(
         typeOrToken: Type<TInput> | string | symbol,
         contextId = createContextId(),
-        options: GetOrResolveOptions = {},
+        options: ModuleRefGetOrResolveOpts = {},
       ): Promise<TResult | Array<TResult>> {
         options.strict ??= true;
         options.each ??= false;

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -526,12 +526,15 @@ export class Module {
         options.strict ??= true;
         options.each ??= false;
 
-        return !(options && options.strict)
-          ? this.find<TInput, TResult>(typeOrToken, options)
-          : this.find<TInput, TResult>(typeOrToken, {
-              moduleId: self.id,
-              each: options.each,
-            });
+        return this.find<TInput, TResult>(
+          typeOrToken,
+          options.strict
+            ? {
+                moduleId: self.id,
+                each: options.each,
+              }
+            : options,
+        );
       }
 
       public resolve<TInput = any, TResult = TInput>(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

when suppling an empty object as options to `ModuleRef#get` and `ModuleRef#resolve` methods, defaults options are not taking in count 

```ts
@Module({
  providers: [{ provide: 'foo', useValue: 123 }]
})
class Foo {}

@Module({
  imports: [Foo]
})
export class AppModule {
  constructor(private readonly moduleRef: ModuleRef) {}

  onModuleInit() {
    this.moduleRef.get('foo', {}) // ends up being { strict: undefined, each: undefined }
    // returns [123]
    // which is wrong since "strict" should be enabled by default and the provider is out of this module
  }
}
```

## What is the new behavior?

```ts
this.moduleRef.get('foo', {}) // will raise an 'not found provider' error since "strict" is enabled
```

I also fixed the type def for the second args of `ModuleRef#get`/`ModuleRef#resolve` since it shouldn't be `GetOrResolveOptions` because that interface is saying that the default value of `strict` is `false`, which is wrong for `ModuleRef` while it's correct for `NestApplicationContext`. 

https://github.com/nestjs/nest/blob/95e096fbf6fb8a8b7eb9a74979fd13141f79b0a9/packages/common/interfaces/nest-application-context.interface.ts#L6-L11

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

it's a breaking changes for those there are using `ModuleRef#get`/`ModuleRef#resolve` wrongly.