### PR TITLE
perf(common): faster random string generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2977,6 +2977,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@lukeed/csprng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.0.1.tgz",
+      "integrity": "sha512-uSvJdwQU5nK+Vdf6zxcWAY2A8r7uqe+gePwLWzJ+fsQehq18pc0I2hJKwypZ2aLM90+Er9u1xn4iLJPZ+xlL4g=="
+    },
     "@nestjs/apollo": {
       "version": "10.1.7",
       "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-10.1.7.tgz",
@@ -12496,8 +12501,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -12515,8 +12519,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -23929,6 +23932,14 @@
           "dev": true,
           "optional": true
         }
+      }
+    },
+    "uid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.1.tgz",
+      "integrity": "sha512-PF+1AnZgycpAIEmNtjxGBVmKbZAQguaa4pBUq6KNaGEcpzZ2klCNZLM34tsjp76maN00TttiiUf6zkIBpJQm2A==",
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
       }
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "rxjs": "7.8.0",
     "socket.io": "4.5.4",
     "tslib": "2.4.1",
+    "uid": "2.0.1",
     "uuid": "9.0.0"
   },
   "devDependencies": {

--- a/packages/common/utils/random-string-generator.util.ts
+++ b/packages/common/utils/random-string-generator.util.ts
@@ -1,3 +1,3 @@
-import { v4 as uuid } from 'uuid';
+import { uid } from 'uid';
 
-export const randomStringGenerator = () => uuid();
+export const randomStringGenerator = () => uid(21);

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -362,9 +362,7 @@ export class DependenciesScanner {
     if (!providersKeys.includes(type as string)) {
       return this.container.addProvider(provider as any, token);
     }
-    const providerToken = `${
-      type as string
-    } (UUID: ${randomStringGenerator()})`;
+    const providerToken = `${type as string} (UID: ${randomStringGenerator()})`;
 
     let scope = (provider as ClassProvider | FactoryProvider).scope;
     if (isNil(scope) && (provider as ClassProvider).useClass) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The method `randomStringGenerator` is implemented with `uuid` package, which is slow when we compare with other package like `uid`:

```
uuid x 4,724,786 ops/sec ±2.35% (81 runs sampled)
nanoid x 2,880,683 ops/sec ±2.16% (79 runs sampled)
uid x 37,413,066 ops/sec ±1.91% (85 runs sampled)
Fastest is uid
```

> [Benchmark](https://gist.github.com/H4ad/0d4efdf2b1ccd2f944419671aabb9db2)

This method is also used inside `instance-wrapper.ts`, which is instantiated a lot during the initialization of NestJS, above the profiling information:

```
 [Shared libraries]:
   ticks  total  nonlib   name
  35505   66.5%          /home/h4ad/.asdf/installs/nodejs/12.22.12/bin/node
    725    1.4%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
     18    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
      3    0.0%          [vdso]

[JavaScript]:
   ticks  total  nonlib   name
    435    0.8%    2.5%  LazyCompile: *OrdinaryGetMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:600:37
    316    0.6%    1.8%  LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:14:31
    307    0.6%    1.8%  LazyCompile: *reflectKeyMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:150:23
    264    0.5%    1.5%  LazyCompile: *reflectDynamicMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:117:27
    251    0.5%    1.5%  LazyCompile: *next /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/iterare/lib/iterate.js:20:9
    217    0.4%    1.3%  LazyCompile: *_object /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:192:22
    213    0.4%    1.2%  LazyCompile: *loadInstance /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/injector.js:30:23
    177    0.3%    1.0%  LazyCompile: *_string /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:304:22
    175    0.3%    1.0%  LazyCompile: *__rest /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/tslib/tslib.js:85:23
    174    0.3%    1.0%  LazyCompile: *unsafeStringify /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/uuid/dist/stringify.js:23:25
```

> [Source](https://github.com/nestjs/nest/files/10367472/perf-startup-10000-clean.txt)

The last call `unsafeStringify` is the problem.

Issue Number: N/A

## What is the new behavior?

I added a new package called `uid` based on the previous benchmark to generate faster random strings.

Now, when we see the profiling information:

```
[Shared libraries]:
   ticks  total  nonlib   name
  32573   66.1%          /home/h4ad/.asdf/installs/nodejs/12.22.12/bin/node
    696    1.4%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      6    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
      2    0.0%          [vdso]

 [JavaScript]:
   ticks  total  nonlib   name
    468    1.0%    2.9%  LazyCompile: *OrdinaryGetMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:600:37
    320    0.6%    2.0%  LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:14:31
    274    0.6%    1.7%  LazyCompile: *reflectKeyMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:150:23
    249    0.5%    1.6%  LazyCompile: *next /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/iterare/lib/iterate.js:20:9
    237    0.5%    1.5%  LazyCompile: *applyDefaults /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:61:23
    205    0.4%    1.3%  LazyCompile: *write /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:169:23
    192    0.4%    1.2%  LazyCompile: *loadInstance /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/injector.js:30:23
    186    0.4%    1.2%  LazyCompile: *reflectDynamicMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:117:27
    176    0.4%    1.1%  LazyCompile: *_string /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:304:22
    165    0.3%    1.0%  LazyCompile: *__rest /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/tslib/tslib.js:85:23
 ```

> [Source](https://github.com/nestjs/nest/files/10367473/perf-startup-10000-clean_uid.txt)

We have almost 3k ticks less than the previous version using `uuid`, when we search for `uid`, we found this line:

```
23    0.0%    0.1%  LazyCompile: *uid /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/uid/dist/index.js:4:13  
```

Much faster compared to 174 ticks from the previous package.

From my tests, creating 10,000 times an API with 20 modules, I went from 7.1213ms to 6.451ms to initialize NestJS.
This value can fluctuate depending on the machine and how many times you run but my baseline of improvement was the profiler information.

> [Benchmark](https://gist.github.com/H4ad/da838dfc33b2060504ca980644d804b5).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information