### PR TITLE
fix(core): middleware does not apply to a controller that has versioning

### DIFF
--- a/integration/versioning/e2e/middleware-versioning.spec.ts
+++ b/integration/versioning/e2e/middleware-versioning.spec.ts
@@ -1,0 +1,47 @@
+import { INestApplication, VersioningType } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { expect } from 'chai';
+import { AppWithMiddlewareModule } from '../src/app-with-middleware.module';
+import * as sinon from 'sinon';
+import { SpyInjectToken } from '../src/versioning-middleware';
+
+describe('MiddlewareVersioning', () => {
+  let app: INestApplication;
+  let spy = sinon.spy();
+
+  before(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppWithMiddlewareModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.enableVersioning({
+      type: VersioningType.URI,
+      defaultVersion: '-default-version',
+    });
+    await app.init();
+
+    spy = app.get<sinon.SinonSpy>(SpyInjectToken);
+  });
+
+  beforeEach(() => spy.resetHistory());
+
+  ['/v-default-version/foo/bar', '/v1/', '/v3', '/v4'].forEach(path => {
+    it('should call middleware for route with version', async () => {
+      const response = await request(app.getHttpServer()).get(path);
+
+      expect(response.status).to.eq(200);
+      expect(spy.called).to.be.true;
+    });
+  });
+
+  it('should not call middleware if the controller route is not defined', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/');
+
+    expect(response.status).to.eq(200);
+    expect(spy.called).to.be.false;
+  });
+
+  after(() => app.close());
+});

--- a/integration/versioning/src/app-v3.controller.ts
+++ b/integration/versioning/src/app-v3.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Version } from '@nestjs/common';
+
+@Controller({
+  version: '3',
+})
+export class AppV3Controller {
+  @Get()
+  paramV3() {
+    return 'V3';
+  }
+
+  @Version('4')
+  @Get()
+  paramV4() {
+    return 'V4';
+  }
+}

--- a/integration/versioning/src/app-with-middleware.module.ts
+++ b/integration/versioning/src/app-with-middleware.module.ts
@@ -1,0 +1,29 @@
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { SpyInjectToken, VersioningMiddleware } from './versioning-middleware';
+import { AppV1Controller } from './app-v1.controller';
+import * as sinon from 'sinon';
+import { AppV3Controller } from './app-v3.controller';
+import { NoVersioningController } from './no-versioning.controller';
+import { AppV2Controller } from './app-v2.controller';
+
+@Module({
+  providers: [
+    {
+      provide: SpyInjectToken,
+      useValue: sinon.spy(),
+    },
+  ],
+  controllers: [
+    NoVersioningController,
+    AppV1Controller,
+    AppV2Controller,
+    AppV3Controller,
+  ],
+})
+export class AppWithMiddlewareModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(VersioningMiddleware)
+      .forRoutes(NoVersioningController, AppV1Controller, AppV3Controller);
+  }
+}

--- a/integration/versioning/src/versioning-middleware.ts
+++ b/integration/versioning/src/versioning-middleware.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable, NestMiddleware } from '@nestjs/common';
+import * as sinon from 'sinon';
+import { NextFunction } from 'express';
+
+export const SpyInjectToken = 'SpyInjectToken';
+
+@Injectable()
+export class VersioningMiddleware implements NestMiddleware {
+  constructor(@Inject(SpyInjectToken) private readonly spy: sinon.SinonSpy) {}
+
+  use(req: any, res: any, next: NextFunction): any {
+    this.spy(req, res);
+    next();
+  }
+}

--- a/packages/core/middleware/routes-mapper.ts
+++ b/packages/core/middleware/routes-mapper.ts
@@ -15,7 +15,10 @@ export class RoutesMapper {
   private readonly pathsExplorer: PathsExplorer;
 
   constructor(private readonly container: NestContainer) {
-    this.pathsExplorer = new PathsExplorer(new MetadataScanner());
+    this.pathsExplorer = new PathsExplorer(
+      new MetadataScanner(),
+      container.applicationConfig?.getVersioning(),
+    );
   }
 
   public mapRouteToRouteInfo(

--- a/packages/core/router/paths-explorer.ts
+++ b/packages/core/router/paths-explorer.ts
@@ -5,7 +5,10 @@ import {
 } from '@nestjs/common/constants';
 import { RequestMethod } from '@nestjs/common/enums';
 import { Controller } from '@nestjs/common/interfaces/controllers/controller.interface';
-import { VersionValue } from '@nestjs/common/interfaces/version-options.interface';
+import {
+  VersioningOptions,
+  VersionValue,
+} from '@nestjs/common/interfaces/version-options.interface';
 import {
   addLeadingSlash,
   isString,
@@ -23,7 +26,10 @@ export interface RouteDefinition {
 }
 
 export class PathsExplorer {
-  constructor(private readonly metadataScanner: MetadataScanner) {}
+  constructor(
+    private readonly metadataScanner: MetadataScanner,
+    private readonly versioningOptions?: VersioningOptions,
+  ) {}
 
   public scanForPaths(
     instance: Controller,
@@ -55,20 +61,26 @@ export class PathsExplorer {
       METHOD_METADATA,
       prototypeCallback,
     );
-    const version: VersionValue | undefined = Reflect.getMetadata(
+    const methodVersion: VersionValue | undefined = Reflect.getMetadata(
       VERSION_METADATA,
       prototypeCallback,
+    );
+    const controllerVersion: VersionValue | undefined = Reflect.getMetadata(
+      VERSION_METADATA,
+      prototype.constructor,
     );
     const path = isString(routePath)
       ? [addLeadingSlash(routePath)]
       : routePath.map((p: string) => addLeadingSlash(p));
+
+    const globalVersion = this.versioningOptions?.defaultVersion;
 
     return {
       path,
       requestMethod,
       targetCallback: instanceCallback,
       methodName,
-      version,
+      version: methodVersion || controllerVersion || globalVersion,
     };
   }
 }

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -73,7 +73,10 @@ export class RouterExplorer {
     private readonly routePathFactory: RoutePathFactory,
     private readonly graphInspector: GraphInspector,
   ) {
-    this.pathsExplorer = new PathsExplorer(metadataScanner);
+    this.pathsExplorer = new PathsExplorer(
+      metadataScanner,
+      config.getVersioning(),
+    );
 
     const routeParamsFactory = new RouteParamsFactory();
     const pipesContextCreator = new PipesContextCreator(container, config);

--- a/packages/core/test/middleware/routes-mapper.spec.ts
+++ b/packages/core/test/middleware/routes-mapper.spec.ts
@@ -27,6 +27,7 @@ describe('RoutesMapper', () => {
 
   let mapper: RoutesMapper;
   let mapperWithGlobalVersioning: RoutesMapper;
+  
   beforeEach(() => {
     mapper = new RoutesMapper(new NestContainer());
 

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -210,7 +210,7 @@ describe('RoutesResolver', () => {
         versioningOptions: {
           type: VersioningType.URI,
         },
-        methodVersion: undefined,
+        methodVersion: '1',
         methodPath: '/',
       };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [10847](https://github.com/nestjs/nest/issues/10847)
However, the middleware didn't apply to controllers which contain versioning at the class level (`version` property inside `@Controller` decorator)


## What is the new behavior?
Passing a controller that has class-level versioning or global versioning is enough to apply middleware on it.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information