### PR TITLE
fix(fastify): return the response on exception

### DIFF
--- a/packages/core/router/router-proxy.ts
+++ b/packages/core/router/router-proxy.ts
@@ -22,6 +22,7 @@ export class RouterProxy {
       } catch (e) {
         const host = new ExecutionContextHost([req, res, next]);
         exceptionsHandler.next(e, host);
+        return res;
       }
     };
   }
@@ -46,6 +47,7 @@ export class RouterProxy {
       } catch (e) {
         const host = new ExecutionContextHost([req, res, next]);
         exceptionsHandler.next(e, host);
+        return res;
       }
     };
   }


### PR DESCRIPTION
Fastify requires us to return the response object when handling async methods and dealing with exceptions, otherwise a thenable gets wrapped and improperly handled later causing an exception. This is shown by [this repo][1] and discuessed in [this issue][2].

[1]: https://github.com/sgrigorev/nestjs-compress-issue
[2]: https://github.com/fastify/fastify-compress/issues/215#issuecomment-1210598312

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If we use a fastify plugin, like `@fastify/compress` and there is an error handled by the exception filter, we end up getting a response without any body, and if the `onSend` hook is debugged we will see that it gets called twice, once with the proper response and once with an `undefined` payload. Further debugging shows the message

```
{"level":30,"time":1673900898912,"pid":65238,"hostname":"nixos","reqId":"req-1","msg":"Response payload: undefined"}
{"level":50,"time":1673900898916,"pid":65238,"hostname":"nixos","reqId":"req-1","err":{"type":"Error","message":"premature close","stack":"Error: premature close\n    at onclosenexttick (~/node_modules/.pnpm/end-of-stream@1.4.4/node_modules/end-of-stream/index.js:54:86)\n    at processTicksAndRejections (node:internal/process/task_queues:77:11)"},"msg":"premature close"}
```

Issue Number: #10736


## What is the new behavior?

Because we return the `res` object from the `router-proxy` now, we no longer get this issue with fastify trying to watch for the `thenable` and handling it internally. 


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I have verified that this does not affect express in any way.