### PR TITLE
fix(common): streamable file for headers already sent case

### DIFF
--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -4,9 +4,16 @@ import { isFunction } from '../utils/shared.utils';
 import { StreamableFileOptions } from './streamable-options.interface';
 
 export interface StreamableHandlerResponse {
+  /** `true` if the connection is destroyed, `false` otherwise. */
   destroyed: boolean;
+  /** `true` if headers were sent, `false` otherwise. */
+  headersSent: boolean;
+  /** The status code that will be sent to the client when the headers get flushed. */
   statusCode: number;
-  send: (msg: string) => void;
+  /** Sends the HTTP response. */
+  send: (body: string) => void;
+  /** Signals to the server that all of the response headers and body have been sent. */
+  end: () => void;
 }
 
 export class StreamableFile {
@@ -16,10 +23,16 @@ export class StreamableFile {
     err: Error,
     response: StreamableHandlerResponse,
   ) => void = (err: Error, res) => {
-    if (!res.destroyed) {
-      res.statusCode = 400;
-      res.send(err.message);
+    if (res.destroyed) {
+      return;
     }
+    if (res.headersSent) {
+      res.end();
+      return;
+    }
+
+    res.statusCode = 400;
+    res.send(err.message);
   };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #10681

## What is the new behavior?

the app won't crash anymore on _headers already sent_ errors

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No