### PR TITLE
fix(common)!: when transforming optional boolean parameters on `ValidationPipe`

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -18,7 +18,7 @@ import {
   HttpErrorByCode,
 } from '../utils/http-error-by-code.util';
 import { loadPackage } from '../utils/load-package.util';
-import { isNil } from '../utils/shared.utils';
+import { isNil, isUndefined } from '../utils/shared.utils';
 
 export interface ValidationPipeOptions extends ValidatorOptions {
   transform?: boolean;
@@ -179,6 +179,13 @@ export class ValidationPipe implements PipeTransform<any> {
       return value;
     }
     if (metatype === Boolean) {
+      if (isUndefined(value)) {
+        // This is an workaround to deal with optional boolean values since
+        // optional booleans shouldn't be parsed to a valid boolean when
+        // they were not defined
+        return undefined;
+      }
+      // Any fasly value but `undefined` will be parsed to `false`
       return value === true || value === 'true';
     }
     if (metatype === Number) {

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -221,7 +221,7 @@ describe('ValidationPipe', () => {
         });
       });
       describe('when input is a query parameter (boolean)', () => {
-        it('should parse to boolean', async () => {
+        it('should parse the string "true" to the boolean true', async () => {
           target = new ValidationPipe({ transform: true });
           const value = 'true';
 
@@ -233,9 +233,45 @@ describe('ValidationPipe', () => {
             }),
           ).to.be.true;
         });
+        it('should parse the string "false" to the boolean false', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = 'false';
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'query',
+            }),
+          ).to.be.false;
+        });
+        it('should parse an empty string to false', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = '';
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'query',
+            }),
+          ).to.be.false;
+        });
+        it('should parse undefined to undefined', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = undefined;
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'query',
+            }),
+          ).to.be.undefined;
+        });
       });
       describe('when input is a path parameter (boolean)', () => {
-        it('should parse to boolean', async () => {
+        it('should parse the string "true" to boolean true', async () => {
           target = new ValidationPipe({ transform: true });
           const value = 'true';
 
@@ -246,6 +282,42 @@ describe('ValidationPipe', () => {
               type: 'param',
             }),
           ).to.be.true;
+        });
+        it('should parse the string "false" to boolean false', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = 'false';
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'param',
+            }),
+          ).to.be.false;
+        });
+        it('should parse an empty string to false', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = '';
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'param',
+            }),
+          ).to.be.false;
+        });
+        it('should parse undefined to undefined', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = undefined;
+
+          expect(
+            await target.transform(value, {
+              metatype: Boolean,
+              data: 'test',
+              type: 'param',
+            }),
+          ).to.be.undefined;
         });
       });
       describe('when validation strips', () => {


### PR DESCRIPTION
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: the issue #10246 is broader than what this PR address. For optional boolean values, when they are not supplied, the value is parsed to `false`

## What is the new behavior?

(using `ValidationPipe({ transform: true })`)

This only fixes(?) the following use case:

```
@Query('foo') foo?: boolean
```
```
@Param('foo') foo?: boolean
```

now leads to `foo === undefined` if no query/path parameter for `foo` key was supplied instead of always failing back to `false`. Note that marking them as optional doesn't matter

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No
- [x] Maybe - if people are not treating optional values properly, since, strictly speaking, if the request doesn't have some field (a expected boolean one), the value of that field should be `undefined` instead of `false` (unless this was a design decision for `ValidationPipe` when dealing with primitive values). If this introduces a breaking change, you can close it. If they want to model false as the default value, they should use this:

```
@Query('foo', new DefaultValue(false)): foo = false
```