### PR TITLE
perf: metadata scanner

### DIFF
--- a/packages/core/metadata-scanner.ts
+++ b/packages/core/metadata-scanner.ts
@@ -6,19 +6,28 @@ import {
 } from '@nestjs/common/utils/shared.utils';
 
 export class MetadataScanner {
+  private readonly cachedScannedPrototypes: Map<object, string[]> = new Map();
+
+  /**
+   * @deprecated Use {@link getAllMethodNames} instead.
+   */
   public scanFromPrototype<T extends Injectable, R = any>(
     instance: T,
-    prototype: object | null,
+    prototype: object,
     callback: (name: string) => R,
   ): R[] {
-    if (!prototype) return [];
+    if (!prototype) {
+      return [];
+    }
 
     const visitedNames = new Map<string, boolean>();
     const result: R[] = [];
 
     do {
       for (const property of Object.getOwnPropertyNames(prototype)) {
-        if (visitedNames.has(property)) continue;
+        if (visitedNames.has(property)) {
+          continue;
+        }
 
         visitedNames.set(property, true);
 
@@ -50,15 +59,34 @@ export class MetadataScanner {
     return result;
   }
 
-  getAllFilteredMethodNames(prototype: object | null): string[] {
-    if (!prototype) return [];
+  /**
+   * @deprecated Use {@link getAllMethodNames} instead.
+   */
+  public *getAllFilteredMethodNames(
+    prototype: object,
+  ): IterableIterator<string> {
+    yield* this.getAllMethodNames(prototype);
+  }
+
+  public getAllMethodNames(prototype: object | null): string[] {
+    if (!prototype) {
+      return [];
+    }
+
+    if (this.cachedScannedPrototypes.has(prototype)) {
+      return this.cachedScannedPrototypes.get(prototype);
+    }
 
     const visitedNames = new Map<string, boolean>();
     const result: string[] = [];
 
+    this.cachedScannedPrototypes.set(prototype, result);
+
     do {
       for (const property of Object.getOwnPropertyNames(prototype)) {
-        if (visitedNames.has(property)) continue;
+        if (visitedNames.has(property)) {
+          continue;
+        }
 
         visitedNames.set(property, true);
 

--- a/packages/core/metadata-scanner.ts
+++ b/packages/core/metadata-scanner.ts
@@ -4,36 +4,83 @@ import {
   isFunction,
   isNil,
 } from '@nestjs/common/utils/shared.utils';
-import { iterate } from 'iterare';
 
 export class MetadataScanner {
   public scanFromPrototype<T extends Injectable, R = any>(
     instance: T,
-    prototype: object,
+    prototype: object | null,
     callback: (name: string) => R,
   ): R[] {
-    const methodNames = new Set(this.getAllFilteredMethodNames(prototype));
-    return iterate(methodNames)
-      .map(callback)
-      .filter(metadata => !isNil(metadata))
-      .toArray();
-  }
+    if (!prototype) return [];
 
-  *getAllFilteredMethodNames(prototype: object): IterableIterator<string> {
-    const isMethod = (prop: string) => {
-      const descriptor = Object.getOwnPropertyDescriptor(prototype, prop);
-      if (descriptor.set || descriptor.get) {
-        return false;
-      }
-      return !isConstructor(prop) && isFunction(prototype[prop]);
-    };
+    const visitedNames = new Map<string, boolean>();
+    const result: R[] = [];
+
     do {
-      yield* iterate(Object.getOwnPropertyNames(prototype))
-        .filter(isMethod)
-        .toArray();
+      for (const property of Object.getOwnPropertyNames(prototype)) {
+        if (visitedNames.has(property)) continue;
+
+        visitedNames.set(property, true);
+
+        // reason: https://github.com/nestjs/nest/pull/10821#issuecomment-1411916533
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+
+        if (
+          descriptor.set ||
+          descriptor.get ||
+          isConstructor(property) ||
+          !isFunction(prototype[property])
+        ) {
+          continue;
+        }
+
+        const value = callback(property);
+
+        if (isNil(value)) {
+          continue;
+        }
+
+        result.push(value);
+      }
     } while (
       (prototype = Reflect.getPrototypeOf(prototype)) &&
       prototype !== Object.prototype
     );
+
+    return result;
+  }
+
+  getAllFilteredMethodNames(prototype: object | null): string[] {
+    if (!prototype) return [];
+
+    const visitedNames = new Map<string, boolean>();
+    const result: string[] = [];
+
+    do {
+      for (const property of Object.getOwnPropertyNames(prototype)) {
+        if (visitedNames.has(property)) continue;
+
+        visitedNames.set(property, true);
+
+        // reason: https://github.com/nestjs/nest/pull/10821#issuecomment-1411916533
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, property);
+
+        if (
+          descriptor.set ||
+          descriptor.get ||
+          isConstructor(property) ||
+          !isFunction(prototype[property])
+        ) {
+          continue;
+        }
+
+        result.push(property);
+      }
+    } while (
+      (prototype = Reflect.getPrototypeOf(prototype)) &&
+      prototype !== Object.prototype
+    );
+
+    return result;
   }
 }

--- a/packages/core/repl/native-functions/methods-repl-fn.ts
+++ b/packages/core/repl/native-functions/methods-repl-fn.ts
@@ -20,9 +20,7 @@ export class MethodsReplFn extends ReplFunction {
         ? Object.getPrototypeOf(this.ctx.app.get(token))
         : token?.prototype;
 
-    const methods = new Set(
-      this.metadataScanner.getAllFilteredMethodNames(proto),
-    );
+    const methods = this.metadataScanner.getAllFilteredMethodNames(proto);
 
     this.ctx.writeToStdout('\n');
     this.ctx.writeToStdout(`${clc.green('Methods')}:\n`);

--- a/packages/core/repl/native-functions/methods-repl-fn.ts
+++ b/packages/core/repl/native-functions/methods-repl-fn.ts
@@ -20,7 +20,7 @@ export class MethodsReplFn extends ReplFunction {
         ? Object.getPrototypeOf(this.ctx.app.get(token))
         : token?.prototype;
 
-    const methods = this.metadataScanner.getAllFilteredMethodNames(proto);
+    const methods = this.metadataScanner.getAllMethodNames(proto);
 
     this.ctx.writeToStdout('\n');
     this.ctx.writeToStdout(`${clc.green('Methods')}:\n`);

--- a/packages/core/router/paths-explorer.ts
+++ b/packages/core/router/paths-explorer.ts
@@ -33,18 +33,28 @@ export class PathsExplorer {
       ? Object.getPrototypeOf(instance)
       : prototype;
 
-    return this.metadataScanner.scanFromPrototype<Controller, RouteDefinition>(
-      instance,
-      instancePrototype,
-      method => this.exploreMethodMetadata(instance, instancePrototype, method),
-    );
+    return this.metadataScanner
+      .getAllMethodNames(instancePrototype)
+      .reduce((acc, method) => {
+        const route = this.exploreMethodMetadata(
+          instance,
+          instancePrototype,
+          method,
+        );
+
+        if (route) {
+          acc.push(route);
+        }
+
+        return acc;
+      }, []);
   }
 
   public exploreMethodMetadata(
     instance: Controller,
     prototype: object,
     methodName: string,
-  ): RouteDefinition {
+  ): RouteDefinition | null {
     const instanceCallback = instance[methodName];
     const prototypeCallback = prototype[methodName];
     const routePath = Reflect.getMetadata(PATH_METADATA, prototypeCallback);

--- a/packages/core/test/metadata-scanner.spec.ts
+++ b/packages/core/test/metadata-scanner.spec.ts
@@ -30,12 +30,32 @@ describe('MetadataScanner', () => {
     }
 
     it('should return only methods', () => {
-      const methods = scanner.scanFromPrototype(
+      const methods = scanner.getAllMethodNames(Test.prototype);
+      expect(methods).to.eql(['test', 'test2', 'testParent', 'testParent2']);
+    });
+
+    it('should return the same instance for the same prototype', () => {
+      const methods1 = scanner.getAllMethodNames(Test.prototype);
+      const methods2 = scanner.getAllMethodNames(Test.prototype);
+      expect(methods1 === methods2).to.eql(true);
+    });
+
+    it('should keep compatibility with older methods', () => {
+      const methods1 = scanner.getAllMethodNames(Test.prototype).map(m => m[0]);
+      const methods2 = scanner.scanFromPrototype(
         new Test(),
         Test.prototype,
-        a => a,
+        r => r[0],
       );
-      expect(methods).to.eql(['test', 'test2', 'testParent', 'testParent2']);
+
+      expect(methods1).to.eql(methods2);
+
+      const methods3 = scanner.getAllMethodNames(Test.prototype);
+      const methods4 = [
+        ...new Set(scanner.getAllFilteredMethodNames(Test.prototype)),
+      ];
+
+      expect(methods3).to.eql(methods4);
     });
   });
 });

--- a/packages/microservices/listener-metadata-explorer.ts
+++ b/packages/microservices/listener-metadata-explorer.ts
@@ -37,12 +37,9 @@ export class ListenerMetadataExplorer {
 
   public explore(instance: Controller): EventOrMessageListenerDefinition[] {
     const instancePrototype = Object.getPrototypeOf(instance);
-    return this.metadataScanner.scanFromPrototype<
-      Controller,
-      EventOrMessageListenerDefinition
-    >(instance, instancePrototype, method =>
-      this.exploreMethodMetadata(instancePrototype, method),
-    );
+    return this.metadataScanner
+      .getAllMethodNames(instancePrototype)
+      .map(method => this.exploreMethodMetadata(instancePrototype, method));
   }
 
   public exploreMethodMetadata(

--- a/packages/microservices/test/listeners-metadata-explorer.spec.ts
+++ b/packages/microservices/test/listeners-metadata-explorer.spec.ts
@@ -52,17 +52,16 @@ describe('ListenerMetadataExplorer', () => {
     instance = new ListenerMetadataExplorer(scanner);
   });
   describe('explore', () => {
-    let scanFromPrototype: sinon.SinonSpy;
+    let getAllMethodNames: sinon.SinonSpy;
     beforeEach(() => {
-      scanFromPrototype = sinon.spy(scanner, 'scanFromPrototype');
+      getAllMethodNames = sinon.spy(scanner, 'getAllMethodNames');
     });
     it(`should call "scanFromPrototype" with expected arguments`, () => {
       const obj = new Test();
       instance.explore(obj);
 
-      const { args } = scanFromPrototype.getCall(0);
-      expect(args[0]).to.be.eql(obj);
-      expect(args[1]).to.be.eql(Object.getPrototypeOf(obj));
+      const { args } = getAllMethodNames.getCall(0);
+      expect(args[0]).to.be.eql(Object.getPrototypeOf(obj));
     });
   });
   describe('exploreMethodMetadata', () => {

--- a/packages/websockets/gateway-metadata-explorer.ts
+++ b/packages/websockets/gateway-metadata-explorer.ts
@@ -19,12 +19,9 @@ export class GatewayMetadataExplorer {
 
   public explore(instance: NestGateway): MessageMappingProperties[] {
     const instancePrototype = Object.getPrototypeOf(instance);
-    return this.metadataScanner.scanFromPrototype<
-      NestGateway,
-      MessageMappingProperties
-    >(instance, instancePrototype, method =>
-      this.exploreMethodMetadata(instancePrototype, method),
-    );
+    return this.metadataScanner
+      .getAllMethodNames(instancePrototype)
+      .map(method => this.exploreMethodMetadata(instancePrototype, method));
   }
 
   public exploreMethodMetadata(

--- a/packages/websockets/test/gateway-metadata-explorer.spec.ts
+++ b/packages/websockets/test/gateway-metadata-explorer.spec.ts
@@ -38,16 +38,15 @@ describe('GatewayMetadataExplorer', () => {
     instance = new GatewayMetadataExplorer(scanner);
   });
   describe('explore', () => {
-    let scanFromPrototype: sinon.SinonSpy;
+    let getAllMethodNames: sinon.SinonSpy;
     beforeEach(() => {
-      scanFromPrototype = sinon.spy(scanner, 'scanFromPrototype');
+      getAllMethodNames = sinon.spy(scanner, 'getAllMethodNames');
     });
     it(`should call "scanFromPrototype" with expected arguments`, () => {
       const obj = new Test();
       instance.explore(obj as any);
 
-      const [argObj, argProto] = scanFromPrototype.getCall(0).args;
-      expect(argObj).to.be.eql(obj);
+      const [argProto] = getAllMethodNames.getCall(0).args;
       expect(argProto).to.be.eql(Object.getPrototypeOf(obj));
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This is the current profiler information when we instantiate Nest 10k.

```
 [Shared libraries]:
   ticks  total  nonlib   name
  36987   80.4%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    633    1.4%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      4    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
      3    0.0%          [vdso]

 [JavaScript]:
   ticks  total  nonlib   name
    497    1.1%    5.9%  LazyCompile: *_object /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:192:22
    420    0.9%    5.0%  LazyCompile: *InstanceWrapper /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/instance-wrapper.js:17:16
    336    0.7%    4.0%  LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:15:31
    303    0.7%    3.6%  LazyCompile: *OrdinaryGetMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:600:37
    296    0.6%    3.5%  LazyCompile: *_string /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:304:22
    295    0.6%    3.5%  LazyCompile: *applyDefaults /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:61:23
    273    0.6%    3.3%  LazyCompile: *next /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/iterare/lib/iterate.js:20:9
    264    0.6%    3.2%  LazyCompile: *reflectKeyMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:156:23
```

> [perf-startup-10000_baseline.txt](https://github.com/nestjs/nest/files/10574162/perf-startup-10000_baseline.txt)

The bottleneck is on `getAllFilteredMethodNames`.

Also, I notice this method is called many times during the initialization of the NestJS, see:

```
> test-performance@0.0.1 start:debug
> nest start --debug --watch

c[[90m8:19:04 PM[0m] Starting compilation in watch mode...

[[90m8:19:06 PM[0m] Found 0 errors. Watching for file changes.

[32m[Nest] 59842  - [39m02/01/2023, 8:19:07 PM [32m    LOG[39m [38;5;3m[NestFactory] [39m[32mStarting Nest application...[39m
[36m<ref *1>[39m {
  [constructor]: [class Reflector] {
    [length]: [33m0[39m,
    [name]: [32m'Reflector'[39m,
    [prototype]: [36m[Circular *1][39m
  },
  [get]: [Function: get] { [length]: [33m2[39m, [name]: [32m'get'[39m },
  [getAll]: [Function: getAll] { [length]: [33m2[39m, [name]: [32m'getAll'[39m },
  [getAllAndMerge]: [Function: getAllAndMerge] { [length]: [33m2[39m, [name]: [32m'getAllAndMerge'[39m },
  [getAllAndOverride]: [Function: getAllAndOverride] {
    [length]: [33m2[39m,
    [name]: [32m'getAllAndOverride'[39m
  }
}
[36m<ref *1>[39m {
  [constructor]: [class Reflector] {
    [length]: [33m0[39m,
    [name]: [32m'Reflector'[39m,
    [prototype]: [36m[Circular *1][39m
  },
  [get]: [Function: get] { [length]: [33m2[39m, [name]: [32m'get'[39m },
  [getAll]: [Function: getAll] { [length]: [33m2[39m, [name]: [32m'getAll'[39m },
  [getAllAndMerge]: [Function: getAllAndMerge] { [length]: [33m2[39m, [name]: [32m'getAllAndMerge'[39m },
  [getAllAndOverride]: [Function: getAllAndOverride] {
    [length]: [33m2[39m,
    [name]: [32m'getAllAndOverride'[39m
  }
}
[36m<ref *1>[39m {
  [constructor]: [class Reflector] {
    [length]: [33m0[39m,
    [name]: [32m'Reflector'[39m,
    [prototype]: [36m[Circular *1][39m
  },
  [get]: [Function: get] { [length]: [33m2[39m, [name]: [32m'get'[39m },
  [getAll]: [Function: getAll] { [length]: [33m2[39m, [name]: [32m'getAll'[39m },
  [getAllAndMerge]: [Function: getAllAndMerge] { [length]: [33m2[39m, [name]: [32m'getAllAndMerge'[39m },
  [getAllAndOverride]: [Function: getAllAndOverride] {
    [length]: [33m2[39m,
    [name]: [32m'getAllAndOverride'[39m
  }
}
```

This is the output when we put a `console.log` with `util.inspect` to see the information about the prototype.
So I added a caching mechanism inside the `MetadataScanner` to cache when we see the same prototype, the disadvantage of this approach is we need to remove the `callback` parameter, so I needed to change all the callers of `scanFromPrototype` to map and get the actual values that we are looking for.

> Entire log: [metadata-scanner.log](https://github.com/nestjs/nest/files/10574145/metadata-scanner.log)

Issue Number: Related PR #10821 

## What is the new behavior?

This is the new profiler information:

```
MetadataScanner#scanFromPrototype x 99,767 ops/sec ±2.99% (82 runs sampled)
BetterMetadataScanner#scanFromPrototype x 228,898 ops/sec ±3.84% (79 runs sampled)
BetterMetadataScanner#scanFromPrototype without map x 265,143 ops/sec ±2.36% (84 runs sampled)
Fastest is BetterMetadataScanner#scanFromPrototype without map
```

> [Source](https://gist.github.com/H4ad/c43fd3556ab1e241e4db24443003d395)

The new profiler information don't show anymore the `getAllFilteredMethodsNames`:

```
 [Shared libraries]:
   ticks  total  nonlib   name
  31336   81.2%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    652    1.7%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      4    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
      3    0.0%          [vdso]

 [JavaScript]:
   ticks  total  nonlib   name
    484    1.3%    7.3%  LazyCompile: *_object /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:192:22
    456    1.2%    6.9%  LazyCompile: *InstanceWrapper /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/instance-wrapper.js:17:16
    378    1.0%    5.7%  LazyCompile: *getMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:352:29
    289    0.7%    4.4%  LazyCompile: *_string /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:304:22
    279    0.7%    4.2%  LazyCompile: *applyDefaults /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:61:23
    233    0.6%    3.5%  LazyCompile: *reflectInjectables /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:134:23
    228    0.6%    3.5%  LazyCompile: *OrdinaryGetMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:600:37
```

> [perf-startup-10000_better_metadata_scanner.txt](https://github.com/nestjs/nest/files/10574163/perf-startup-10000_better_metadata_scanner.txt)

And now, the initialization, if we put a `console.log` after the cache, we see:

```

> test-performance@0.0.1 start:debug
> nest start --debug --watch

c[[90m8:11:41 PM[0m] Starting compilation in watch mode...

[[90m8:11:43 PM[0m] Found 0 errors. Watching for file changes.

[32m[Nest] 27816  - [39m02/02/2023, 8:11:43 PM [32m    LOG[39m [38;5;3m[NestFactory] [39m[32mStarting Nest application...[39m
<ref *1> {
  [constructor]: [class Reflector] {
    [length]: 0,
    [name]: 'Reflector',
    [prototype]: [Circular *1]
  },
  [get]: [Function: get] { [length]: 2, [name]: 'get' },
  [getAll]: [Function: getAll] { [length]: 2, [name]: 'getAll' },
  [getAllAndMerge]: [Function: getAllAndMerge] { [length]: 2, [name]: 'getAllAndMerge' },
  [getAllAndOverride]: [Function: getAllAndOverride] {
    [length]: 2,
    [name]: 'getAllAndOverride'
  }
}
<ref *1> {
  [constructor]: [class AppService] {
    [length]: 0,
    [name]: 'AppService',
    [prototype]: [Circular *1]
  },
  [getHello]: [Function: getHello] { [length]: 0, [name]: 'getHello' }
}
<ref *1> {
  [constructor]: [class AppController] {
    [length]: 1,
    [name]: 'AppController',
    [prototype]: [Circular *1],
    [CONTROLLER_ID]: '54c528635d7f4a3af4065'
  },
  [getHello]: [Function: getHello] { [length]: 0, [name]: 'getHello' }
}
<ref *1> {
  [constructor]: [class CatsService] {
    [length]: 0,
    [name]: 'CatsService',
    [prototype]: [Circular *1]
  },
  [create]: [Function: create] { [length]: 1, [name]: 'create' },
  [findAll]: [Function: findAll] { [length]: 0, [name]: 'findAll' },
  [findOne]: [Function: findOne] { [length]: 1, [name]: 'findOne' },
  [update]: [Function: update] { [length]: 2, [name]: 'update' },
  [remove]: [Function: remove] { [length]: 1, [name]: 'remove' }
}
```

> [better-metadata-scanner.log](https://github.com/nestjs/nest/files/10574182/better-metadata-scanner.log)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information