### PR TITLE
perf: module token factory fast path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3236,6 +3236,104 @@
         }
       }
     },
+    "@node-rs/xxhash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash/-/xxhash-1.3.0.tgz",
+      "integrity": "sha512-uy+/zGE0p17e9qbeo6aul/TaRBpRr9p7oDgSgkqduCWDr2vFGqdJuKM8ENmG3uuE9B6CNXhwf4Mho5xZ2kmWFQ==",
+      "requires": {
+        "@node-rs/xxhash-android-arm-eabi": "1.3.0",
+        "@node-rs/xxhash-android-arm64": "1.3.0",
+        "@node-rs/xxhash-darwin-arm64": "1.3.0",
+        "@node-rs/xxhash-darwin-x64": "1.3.0",
+        "@node-rs/xxhash-freebsd-x64": "1.3.0",
+        "@node-rs/xxhash-linux-arm-gnueabihf": "1.3.0",
+        "@node-rs/xxhash-linux-arm64-gnu": "1.3.0",
+        "@node-rs/xxhash-linux-arm64-musl": "1.3.0",
+        "@node-rs/xxhash-linux-x64-gnu": "1.3.0",
+        "@node-rs/xxhash-linux-x64-musl": "1.3.0",
+        "@node-rs/xxhash-win32-arm64-msvc": "1.3.0",
+        "@node-rs/xxhash-win32-ia32-msvc": "1.3.0",
+        "@node-rs/xxhash-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "@node-rs/xxhash-android-arm-eabi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-android-arm-eabi/-/xxhash-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-Wq2pFlOYs6JpPn23lcRyxjSUmVuv92w+vywuhba4Bj556r3RPYbZH49LGfu90AdcUlEYI/+RwVKjSFusz5zTPA==",
+      "optional": true
+    },
+    "@node-rs/xxhash-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-android-arm64/-/xxhash-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-dw77/P7jHgtZzReGRgqc2PS6wmfCn/1PVKVQZW/b/6/10E4EiDWgiD4U6BxSN+2InePnsfb/IRjJ9dvkmiNHVg==",
+      "optional": true
+    },
+    "@node-rs/xxhash-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-darwin-arm64/-/xxhash-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-2SKiITOr5Lt35vv2PpdcKV7mhdfudR0Cheuk9dj1fBx6hXrl9lDf5Yu+RWPC1j8CskSYbxFqWQC1iSZJD1MFcw==",
+      "optional": true
+    },
+    "@node-rs/xxhash-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-darwin-x64/-/xxhash-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-V4D05YuiI7Hwn1L8IKr3cEhERBEd+mFte0aKM1rnlMxFV4IBtdevM8asXv4hKcJTtV+4h0QAVpTydb4+MW21KQ==",
+      "optional": true
+    },
+    "@node-rs/xxhash-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-freebsd-x64/-/xxhash-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-/tffg1aJ/M2XDwCKVOkUs/J3aCarZzTJbTg26mi4T6E9YqSjpCNIkQidJPZT2VEIw2xqU/Rlj+ccar39vVk2ww==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm-gnueabihf/-/xxhash-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-zjpHjOonCdBb+ccAtHO3HShc7sXKe1PsMWY9kklAX1Gxv+MRok0+ZzmLvO878IRExgKgMQESG27y+gey15yu8Q==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm64-gnu/-/xxhash-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-Ayr72tbWAsroADMBNnV/cuDFgwKDKXxFoDGdGrtL11A4Fyn39dQwsh3hgL2iO+JeLHIqsfSej+djBE5XaLQGjQ==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-arm64-musl/-/xxhash-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-CkvDh0+gAyTuy3J3jZa5mUO64GV9701VC5iOsd5IN4iJz9DYiv/C+7ci9d0CwcjsWm3/oNM35K1IlX52xPfQdw==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-x64-gnu/-/xxhash-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-F6wqncSd+Cp+Hfaumo0hrb5TIKdJtNCOGRCmeKH7XmJu5iDzinIPYb0TLKNlpfIKVlMT2xE+PWq3YF4K1+zgyw==",
+      "optional": true
+    },
+    "@node-rs/xxhash-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-linux-x64-musl/-/xxhash-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-YdUrXxSMk20Hn/16DClyerpk4vWuHrEUOMK6Vuov+xYHehkd33MFDUyTg0O5//VPUWP49FS/wzDNtSHQVEJNcg==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-arm64-msvc/-/xxhash-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-qwf12QVJNkaLvgCza05bJM1DC2xHRh/UUG6kE6tE+x+a3rP4008V0i5ns6fl0UMM+gts1uHUpW6dPIWkVqq86Q==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-ia32-msvc/-/xxhash-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-bFVThe4OH1gbT0MXD+F3cDwEeVVjnnb3BazkkB8lH0zOwSQANc1qunftivSeYTiGupLvw/xIE0eelXjDv6w1hQ==",
+      "optional": true
+    },
+    "@node-rs/xxhash-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/xxhash-win32-x64-msvc/-/xxhash-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-hIyWzIAGGRF/WFdJd56+VgnZ37V/PzGv1GIkLEv/iDbjpap0FJpY6MBXB/WERwrBgy9QGoE3DXfT00uKCxN25A==",
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.2.tgz",
@@ -12733,8 +12831,7 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
@@ -12752,8 +12849,7 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     ]
   },
   "dependencies": {
+    "@node-rs/xxhash": "^1.3.0",
     "@nuxtjs/opencollective": "0.3.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.0",

--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -2,8 +2,8 @@ import { DynamicModule } from '@nestjs/common';
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
+import { xxh32 } from '@node-rs/xxhash';
 import stringify from 'fast-safe-stringify';
-import { createHash } from 'crypto';
 
 const checkClass = 'class ';
 const checkClassLength = checkClass.length;
@@ -68,7 +68,7 @@ export class ModuleTokenFactory {
   }
 
   private hashString(value: string): string {
-    return createHash('sha1').update(value).digest('hex');
+    return xxh32(value).toString();
   }
 
   private replacer(key: string, value: any) {

--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -3,9 +3,13 @@ import { Type } from '@nestjs/common/interfaces/type.interface';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
 import stringify from 'fast-safe-stringify';
-import * as hash from 'object-hash';
+import { createHash } from 'crypto';
+
+const checkClass = 'class ';
+const checkClassLength = checkClass.length;
 
 export class ModuleTokenFactory {
+  private readonly moduleTokenCache = new Map<string, string>();
   private readonly moduleIdsCache = new WeakMap<Type<unknown>, string>();
 
   public create(
@@ -13,23 +17,40 @@ export class ModuleTokenFactory {
     dynamicModuleMetadata?: Partial<DynamicModule> | undefined,
   ): string {
     const moduleId = this.getModuleId(metatype);
+
+    if (!dynamicModuleMetadata) {
+      return this.getFastModuleToken(moduleId, this.getModuleName(metatype));
+    }
+
     const opaqueToken = {
       id: moduleId,
       module: this.getModuleName(metatype),
-      dynamic: this.getDynamicMetadataToken(dynamicModuleMetadata),
+      dynamic: dynamicModuleMetadata || '',
     };
-    return hash(opaqueToken, { ignoreUnknown: true });
+    const opaqueTokenString = this.getStringifiedOpaqueToken(opaqueToken);
+
+    return this.hashString(opaqueTokenString);
   }
 
-  public getDynamicMetadataToken(
-    dynamicModuleMetadata: Partial<DynamicModule> | undefined,
-  ): string {
+  public getFastModuleToken(moduleId: string, moduleName: string): string {
+    const key = `${moduleId}_${moduleName}`;
+
+    if (this.moduleTokenCache.has(key)) {
+      return this.moduleTokenCache.get(key);
+    }
+
+    const hash = this.hashString(key);
+
+    this.moduleTokenCache.set(key, hash);
+
+    return hash;
+  }
+
+  public getStringifiedOpaqueToken(opaqueToken: object | undefined): string {
     // Uses safeStringify instead of JSON.stringify to support circular dynamic modules
     // The replacer function is also required in order to obtain real class names
     // instead of the unified "Function" key
-    return dynamicModuleMetadata
-      ? stringify(dynamicModuleMetadata, this.replacer)
-      : '';
+    return opaqueToken ? stringify(opaqueToken, this.replacer) : '';
   }
 
   public getModuleId(metatype: Type<unknown>): string {
@@ -46,14 +67,18 @@ export class ModuleTokenFactory {
     return metatype.name;
   }
 
+  private hashString(value: string): string {
+    return createHash('sha1').update(value).digest('hex');
+  }
+
   private replacer(key: string, value: any) {
     if (isFunction(value)) {
       const funcAsString = value.toString();
-      const isClass = /^class\s/.test(funcAsString);
+      const isClass = funcAsString.slice(0, checkClassLength) === checkClass;
       if (isClass) {
         return value.name;
       }
-      return hash(funcAsString, { ignoreUnknown: true });
+      return funcAsString;
     }
     if (isSymbol(value)) {
       return value.toString();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@nuxtjs/opencollective": "0.3.2",
+    "@node-rs/xxhash": "^1.3.0",
     "fast-safe-stringify": "2.1.1",
     "iterare": "1.2.1",
     "path-to-regexp": "3.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,6 @@
     "@nuxtjs/opencollective": "0.3.2",
     "fast-safe-stringify": "2.1.1",
     "iterare": "1.2.1",
-    "object-hash": "3.0.0",
     "path-to-regexp": "3.2.0",
     "tslib": "2.4.1",
     "uuid": "9.0.0"


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

This PR aims to improve the speed of `ModuleTokenFactory#create`, today, here's the profiler information of the initialization (when we initialize 10k times):

```
 [Shared libraries]:
   ticks  total  nonlib   name
  36828   80.3%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    614    1.3%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      7    0.0%          [vdso]
      1    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28

 [JavaScript]:
   ticks  total  nonlib   name
    562    1.2%    6.7%  LazyCompile: *_object /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:192:22
    475    1.0%    5.6%  LazyCompile: *InstanceWrapper /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/instance-wrapper.js:17:16
    343    0.7%    4.1%  LazyCompile: *applyDefaults /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:61:23
    330    0.7%    3.9%  LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:14:31
    314    0.7%    3.7%  LazyCompile: *reflectKeyMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:156:23
    304    0.7%    3.6%  LazyCompile: *_string /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/object-hash/index.js:304:22
```

> [perf-startup-10000_old_module_token_factory.js.txt](https://github.com/nestjs/nest/files/10574398/perf-startup-10000_old_module_token_factory.js.txt)

The main issues are with methods that belong to `object-hash`.

Issue Number: #10844

## What is the new behavior?

Now, I made two optimizations:

- Add a fast path when don't have metadata.
- Remove `object-hash` and perform what they will do manually.

The first optimization is the simpler one, we don't need to create an object and pass it to the `object-hash`, is way simpler to just get the main information and then generate a hash from it.

The second optimization was based on: the usage of `object-hash` is redundant, we don't need a library to traverse all the properties of the object and then generate a hash, we just need a hash, so I just serialize the entire token and then create a hash from it.

The results are these:

```
ModuleTokenFactory#create x 31,722 ops/sec ±2.45% (84 runs sampled)
BetterModuleTokenFactory#create x 356,129 ops/sec ±1.94% (84 runs sampled)

ModuleTokenFactory#create with metadata x 26,051 ops/sec ±2.36% (85 runs sampled)
BetterModuleTokenFactory#create with metadata x 126,754 ops/sec ±1.82% (89 runs sampled)

Fastest is BetterModuleTokenFactory#create
```

> [Benchmark](https://gist.github.com/H4ad/2c07b7e88f4126d49a3b6e43fa44d233)

When we don't have metadata, the improvement is 11x, with metadata the improvement is almost 5x.

Now, the profiler information looks like:

```
 [Shared libraries]:
   ticks  total  nonlib   name
  25708   80.0%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    308    1.0%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
      4    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28
      1    0.0%          [vdso]

 [JavaScript]:
   ticks  total  nonlib   name
    384    1.2%    6.3%  LazyCompile: *InstanceWrapper /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/injector/instance-wrapper.js:17:16
    328    1.0%    5.3%  LazyCompile: *getAllFilteredMethodNames /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:14:31
    322    1.0%    5.3%  LazyCompile: *reflectKeyMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/scanner.js:156:23
    312    1.0%    5.1%  LazyCompile: *OrdinaryGetMetadata /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/reflect-metadata/Reflect.js:600:37
    239    0.7%    3.9%  LazyCompile: *next /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/iterare/lib/iterate.js:20:9
    197    0.6%    3.2%  LazyCompile: *isMethod /home/h4ad/Projects/opensource/performance-analysis/test-performance-nestjs/node_modules/@nestjs/core/metadata-scanner.js:15:26
```

> [perf-startup-10000_better_module_token_factory.js.txt](https://github.com/nestjs/nest/files/10574397/perf-startup-10000_better_module_token_factory.js.txt)


We have more space to optimize it, like changing how the hash is generated but for now I keep it simple. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information