### PR TITLE
chore(fastify): mark facing apis public fastify

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -93,6 +93,9 @@ type VersionedRoute<TRequest, TResponse> = ((
 type FastifyRawRequest<TServer extends RawServerBase> =
   RawRequestDefaultExpression<TServer> & { originalUrl?: string };
 
+/**
+ * @publicApi
+ */
 export class FastifyAdapter<
   TServer extends RawServerBase = RawServerDefault,
   TRawRequest extends FastifyRawRequest<TServer> = FastifyRawRequest<TServer>,

--- a/packages/platform-fastify/interfaces/external/fastify-static-options.interface.ts
+++ b/packages/platform-fastify/interfaces/external/fastify-static-options.interface.ts
@@ -1,6 +1,7 @@
 /**
  * "fastify-static" interfaces
  * @see https://github.com/fastify/fastify-static/blob/master/types/index.d.ts
+ * @publicApi
  */
 import { Stats } from 'fs';
 

--- a/packages/platform-fastify/interfaces/external/fastify-view-options.interface.ts
+++ b/packages/platform-fastify/interfaces/external/fastify-view-options.interface.ts
@@ -1,6 +1,7 @@
 /**
  * "fastify/view" interfaces
  * @see https://github.com/fastify/point-of-view/blob/master/types/index.d.ts
+ * @publicApi
  */
 export interface FastifyViewOptions {
   engine: {

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -16,6 +16,9 @@ import {
 import { FastifyStaticOptions, FastifyViewOptions } from './external';
 import { NestFastifyBodyParserOptions } from './nest-fastify-body-parser-options.interface';
 
+/**
+ * @publicApi
+ */
 export interface NestFastifyApplication extends INestApplication {
   /**
    * A wrapper function around native `fastify.register()` method.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
In continuation of PR https://github.com/nestjs/nest/pull/10975

Not all user-facing APIs are annotated with `@publicApi`, which, from contributors like myself who help in NestJS, could lead to some confusion as to which APIs can be changed without breaking any changes.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If there are private APIs that are not public, which I forgot, please let me know so I can update the PR.