### PR TITLE
chore(platform): mark facing apis public adapter express, socket.io, ws

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -49,6 +49,9 @@ type VersionedRoute = <
   next: () => void,
 ) => any;
 
+/**
+ * @publicApi
+ */
 export class ExpressAdapter extends AbstractHttpAdapter {
   private readonly routerMethodFactory = new RouterMethodFactory();
   private readonly logger = new Logger(ExpressAdapter.name);

--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -8,6 +8,9 @@ import { fromEvent, Observable } from 'rxjs';
 import { filter, first, map, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { Server, ServerOptions, Socket } from 'socket.io';
 
+/**
+ * @publicApi
+ */
 export class IoAdapter extends AbstractWsAdapter {
   public create(
     port: number,

--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -27,6 +27,9 @@ type WsServerRegistryEntry = any[];
 
 const UNDERLYING_HTTP_SERVER_PORT = 0;
 
+/**
+ * @publicApi
+ */
 export class WsAdapter extends AbstractWsAdapter {
   protected readonly logger = new Logger(WsAdapter.name);
   protected readonly httpServersRegistry = new Map<


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
In continuation of PR https://github.com/nestjs/nest/pull/10975, https://github.com/nestjs/nest/pull/11032

Not all user-facing APIs are annotated with `@publicApi`, which, from contributors like myself who help in NestJS, could lead to some confusion as to which APIs can be changed without breaking any changes.

Add `@publicApi` in:
 - adapter `express`
 - adapter `socket.io`
 - adapter `ws`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If there are private APIs that are not public, which I forgot, please let me know so I can update the PR.