### PR TITLE
chore(testing, websockets): mark facing apis public

### DIFF
--- a/packages/testing/interfaces/override-by-factory-options.interface.ts
+++ b/packages/testing/interfaces/override-by-factory-options.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface OverrideByFactoryOptions {
   factory: (...args: any[]) => any;
   inject?: any[];

--- a/packages/testing/interfaces/override-by.interface.ts
+++ b/packages/testing/interfaces/override-by.interface.ts
@@ -1,6 +1,9 @@
 import { TestingModuleBuilder } from '../testing-module.builder';
 import { OverrideByFactoryOptions } from './override-by-factory-options.interface';
 
+/**
+ * @publicApi
+ */
 export interface OverrideBy {
   useValue: (value: any) => TestingModuleBuilder;
   useFactory: (options: OverrideByFactoryOptions) => TestingModuleBuilder;

--- a/packages/testing/services/testing-logger.service.ts
+++ b/packages/testing/services/testing-logger.service.ts
@@ -2,6 +2,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { ConsoleLogger } from '@nestjs/common';
 
+/**
+ * @publicApi
+ */
 export class TestingLogger extends ConsoleLogger {
   constructor() {
     super('Testing');

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -8,6 +8,9 @@ import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { MockFactory } from './interfaces';
 
+/**
+ * @publicApi
+ */
 export class TestingInjector extends Injector {
   protected mocker?: MockFactory;
   protected container: NestContainer;

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -3,6 +3,9 @@ import { Module } from '@nestjs/core/injector/module';
 import { MockFactory } from './interfaces';
 import { TestingInjector } from './testing-injector';
 
+/**
+ * @publicApi
+ */
 export class TestingInstanceLoader extends InstanceLoader<TestingInjector> {
   public async createInstancesOfDependencies(
     modules: Map<string, Module> = this.container.getModules(),

--- a/packages/testing/testing-instance-loader.ts
+++ b/packages/testing/testing-instance-loader.ts
@@ -3,9 +3,6 @@ import { Module } from '@nestjs/core/injector/module';
 import { MockFactory } from './interfaces';
 import { TestingInjector } from './testing-injector';
 
-/**
- * @publicApi
- */
 export class TestingInstanceLoader extends InstanceLoader<TestingInjector> {
   public async createInstancesOfDependencies(
     modules: Map<string, Module> = this.container.getModules(),

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -20,6 +20,9 @@ import { TestingInjector } from './testing-injector';
 import { TestingInstanceLoader } from './testing-instance-loader';
 import { TestingModule } from './testing-module';
 
+/**
+ * @publicApi
+ */
 export class TestingModuleBuilder {
   private readonly applicationConfig = new ApplicationConfig();
   private readonly container = new NestContainer(this.applicationConfig);

--- a/packages/testing/testing-module.ts
+++ b/packages/testing/testing-module.ts
@@ -20,6 +20,9 @@ import { NestContainer } from '@nestjs/core/injector/container';
 import { Module } from '@nestjs/core/injector/module';
 import { GraphInspector } from '@nestjs/core/inspector/graph-inspector';
 
+/**
+ * @publicApi
+ */
 export class TestingModule extends NestApplicationContext {
   protected readonly graphInspector: GraphInspector;
 

--- a/packages/websockets/context/exception-filters-context.ts
+++ b/packages/websockets/context/exception-filters-context.ts
@@ -4,6 +4,9 @@ import { BaseExceptionFilterContext } from '@nestjs/core/exceptions/base-excepti
 import { NestContainer } from '@nestjs/core/injector/container';
 import { WsExceptionsHandler } from '../exceptions/ws-exceptions-handler';
 
+/**
+ * @publicApi
+ */
 export class ExceptionFiltersContext extends BaseExceptionFilterContext {
   constructor(container: NestContainer) {
     super(container);

--- a/packages/websockets/decorators/connected-socket.decorator.ts
+++ b/packages/websockets/decorators/connected-socket.decorator.ts
@@ -1,6 +1,9 @@
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 import { createWsParamDecorator } from '../utils/param.utils';
 
+/**
+ * @publicApi
+ */
 export const ConnectedSocket: () => ParameterDecorator = createWsParamDecorator(
   WsParamtype.SOCKET,
 );

--- a/packages/websockets/decorators/gateway-server.decorator.ts
+++ b/packages/websockets/decorators/gateway-server.decorator.ts
@@ -2,6 +2,8 @@ import { GATEWAY_SERVER_METADATA } from '../constants';
 
 /**
  * Attaches native Web Socket Server to a given property.
+ *
+ * @publicApi
  */
 export const WebSocketServer = (): PropertyDecorator => {
   return (target: object, propertyKey: string | symbol) => {

--- a/packages/websockets/decorators/socket-gateway.decorator.ts
+++ b/packages/websockets/decorators/socket-gateway.decorator.ts
@@ -4,6 +4,8 @@ import { GatewayMetadata } from '../interfaces';
 /**
  * Decorator that marks a class as a Nest gateway that enables real-time, bidirectional
  * and event-based communication between the browser and the server.
+ *
+ * @publicApi
  */
 export function WebSocketGateway(port?: number): ClassDecorator;
 export function WebSocketGateway<

--- a/packages/websockets/decorators/subscribe-message.decorator.ts
+++ b/packages/websockets/decorators/subscribe-message.decorator.ts
@@ -2,6 +2,8 @@ import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '../constants';
 
 /**
  * Subscribes to messages that fulfils chosen pattern.
+ *
+ * @publicApi
  */
 export const SubscribeMessage = <T = string>(message: T): MethodDecorator => {
   return (

--- a/packages/websockets/exceptions/base-ws-exception-filter.ts
+++ b/packages/websockets/exceptions/base-ws-exception-filter.ts
@@ -3,6 +3,9 @@ import { isObject } from '@nestjs/common/utils/shared.utils';
 import { MESSAGES } from '@nestjs/core/constants';
 import { WsException } from '../errors/ws-exception';
 
+/**
+ * @publicApi
+ */
 export class BaseWsExceptionFilter<TError = any>
   implements WsExceptionFilter<TError>
 {

--- a/packages/websockets/exceptions/ws-exceptions-handler.ts
+++ b/packages/websockets/exceptions/ws-exceptions-handler.ts
@@ -5,6 +5,9 @@ import { InvalidExceptionFilterException } from '@nestjs/core/errors/exceptions/
 import { WsException } from '../errors/ws-exception';
 import { BaseWsExceptionFilter } from './base-ws-exception-filter';
 
+/**
+ * @publicApi
+ */
 export class WsExceptionsHandler extends BaseWsExceptionFilter {
   private filters: ExceptionFilterMetadata[] = [];
 

--- a/packages/websockets/interfaces/gateway-metadata.interface.ts
+++ b/packages/websockets/interfaces/gateway-metadata.interface.ts
@@ -1,5 +1,7 @@
 /**
  * @external https://github.com/socketio/socket.io/blob/master/lib/index.ts
+ *
+ * @publicApi
  */
 
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';

--- a/packages/websockets/interfaces/hooks/on-gateway-connection.interface.ts
+++ b/packages/websockets/interfaces/hooks/on-gateway-connection.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface OnGatewayConnection<T = any> {
   handleConnection(client: T, ...args: any[]): any;
 }

--- a/packages/websockets/interfaces/hooks/on-gateway-disconnect.interface.ts
+++ b/packages/websockets/interfaces/hooks/on-gateway-disconnect.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface OnGatewayDisconnect<T = any> {
   handleDisconnect(client: T): any;
 }

--- a/packages/websockets/interfaces/hooks/on-gateway-init.interface.ts
+++ b/packages/websockets/interfaces/hooks/on-gateway-init.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface OnGatewayInit<T = any> {
   afterInit(server: T): any;
 }

--- a/packages/websockets/interfaces/nest-gateway.interface.ts
+++ b/packages/websockets/interfaces/nest-gateway.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface NestGateway {
   afterInit?: (server: any) => void;
   handleConnection?: (...args: any[]) => void;

--- a/packages/websockets/interfaces/server-and-event-streams-host.interface.ts
+++ b/packages/websockets/interfaces/server-and-event-streams-host.interface.ts
@@ -1,5 +1,8 @@
 import { ReplaySubject, Subject } from 'rxjs';
 
+/**
+ * @publicApi
+ */
 export interface ServerAndEventStreamsHost<T = any> {
   server: T;
   init: ReplaySubject<T>;

--- a/packages/websockets/interfaces/web-socket-server.interface.ts
+++ b/packages/websockets/interfaces/web-socket-server.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface WebSocketServerOptions {
   port: number;
   namespace: string;

--- a/packages/websockets/interfaces/ws-response.interface.ts
+++ b/packages/websockets/interfaces/ws-response.interface.ts
@@ -1,3 +1,6 @@
+/**
+ * @publicApi
+ */
 export interface WsResponse<T = any> {
   event: string;
   data: T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
In continuation of PR https://github.com/nestjs/nest/pull/10975, https://github.com/nestjs/nest/pull/11032, https://github.com/nestjs/nest/pull/11033

Not all user-facing APIs are annotated with `@publicApi`, which, from contributors like myself who help in NestJS, could lead to some confusion as to which APIs can be changed without breaking any changes.

Add `@publicApi` in:
 - testing
 
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If there are private APIs that are not public, which I forgot, please let me know so I can update the PR.