### PR TITLE
test(core): :white_check_mark: added tests for checking durability and staticity calculation when circular dependency

### DIFF
--- a/packages/core/test/injector/instance-wrapper.spec.ts
+++ b/packages/core/test/injector/instance-wrapper.spec.ts
@@ -31,7 +31,7 @@ describe('InstanceWrapper', () => {
   });
 
   describe('isDependencyTreeStatic', () => {
-    describe.only('when circular reference', () => {
+    describe('when circular reference', () => {
       it('should return true', () => {
         const wrapper = new InstanceWrapper();
         const otherWrapper = new InstanceWrapper();
@@ -41,7 +41,30 @@ describe('InstanceWrapper', () => {
         expect(otherWrapper.isDependencyTreeStatic()).to.be.true;
       });
     });
-    describe.only('when request scoped', () => {
+    describe('when circular reference and one non static', () => {
+      it('should return false', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper({ scope: Scope.REQUEST });
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeStatic()).to.be.false;
+        expect(otherWrapper.isDependencyTreeStatic()).to.be.false;
+      });
+    });
+    describe('when circular reference and one durable', () => {
+      it('should return false', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper({
+          scope: Scope.REQUEST,
+          durable: true,
+        });
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeStatic()).to.be.false;
+        expect(otherWrapper.isDependencyTreeStatic()).to.be.false;
+      });
+    });
+    describe('when request scoped', () => {
       it('should return false', () => {
         const wrapper = new InstanceWrapper({
           scope: Scope.REQUEST,
@@ -178,6 +201,39 @@ describe('InstanceWrapper', () => {
   });
 
   describe('isDependencyTreeDurable', () => {
+    describe('when circular reference and default scope', () => {
+      it('should return false', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper();
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeDurable()).to.be.false;
+        expect(otherWrapper.isDependencyTreeDurable()).to.be.false;
+      });
+    });
+    describe('when circular reference and one non durable', () => {
+      it('should return false', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper({ scope: Scope.REQUEST });
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeDurable()).to.be.false;
+        expect(otherWrapper.isDependencyTreeDurable()).to.be.false;
+      });
+    });
+    describe('when circular reference and one durable', () => {
+      it('should return true', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper({
+          scope: Scope.REQUEST,
+          durable: true,
+        });
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeDurable()).to.be.true;
+        expect(otherWrapper.isDependencyTreeDurable()).to.be.true;
+      });
+    });
     describe('when request scoped and durable', () => {
       it('should return true', () => {
         const wrapper = new InstanceWrapper({

--- a/packages/core/test/injector/instance-wrapper.spec.ts
+++ b/packages/core/test/injector/instance-wrapper.spec.ts
@@ -31,7 +31,17 @@ describe('InstanceWrapper', () => {
   });
 
   describe('isDependencyTreeStatic', () => {
-    describe('when request scoped', () => {
+    describe.only('when circular reference', () => {
+      it('should return true', () => {
+        const wrapper = new InstanceWrapper();
+        const otherWrapper = new InstanceWrapper();
+        wrapper.addCtorMetadata(0, otherWrapper);
+        otherWrapper.addCtorMetadata(0, wrapper);
+        expect(wrapper.isDependencyTreeStatic()).to.be.true;
+        expect(otherWrapper.isDependencyTreeStatic()).to.be.true;
+      });
+    });
+    describe.only('when request scoped', () => {
       it('should return false', () => {
         const wrapper = new InstanceWrapper({
           scope: Scope.REQUEST,


### PR DESCRIPTION
Added test for staticity calcuation when circular dependency present

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Added unit tests

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Added a few new unit tests to verify that the calculation of isTreeStatic and isTreeDurable is correct even for circular dependencies.