### PR TITLE
fix: skip caching the response if it is a streamable file instance

### DIFF
--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -1,6 +1,7 @@
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Inject, Injectable, Optional } from '../../decorators';
+import { StreamableFile } from '../../file-stream';
 import {
   CallHandler,
   ExecutionContext,
@@ -60,6 +61,10 @@ export class CacheInterceptor implements NestInterceptor {
         : ttlValueOrFactory;
       return next.handle().pipe(
         tap(async response => {
+          if (response instanceof StreamableFile) {
+            return;
+          }
+
           const args = isNil(ttl) ? [key, response] : [key, response, { ttl }];
 
           try {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If the `CacheIntereceptor` is used and a `StreamableFile` is returned, the class instance won't be properly cached due to serialization of the stream. 

Issue Number: #10575 


## What is the new behavior?

This is the easier fix to do rather than taking the stream and serializing it to something that can be cached in. If we'd rather actually serialize the stream I can work on that functionality instead


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information