### PR TITLE
build(core): need to depend on the uid

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,8 @@
     "fast-safe-stringify": "2.1.1",
     "iterare": "1.2.1",
     "path-to-regexp": "3.2.0",
-    "tslib": "2.5.0"
+    "tslib": "2.5.0",
+    "uid": "2.0.1"
   },
   "devDependencies": {
     "@nestjs/common": "9.3.3"


### PR DESCRIPTION
Closes #11068

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently Yarn 3.x PnP support is broken.

Issue Number: 11068


## What is the new behavior?
Works with Yarn 3.x PnP now.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information