### PR TITLE
fix(common): account for when stack is undefined in logger

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -279,6 +279,7 @@ export class ConsoleLogger implements LoggerService {
     }
     const lastElement = messages[messages.length - 1];
     const isStack = isString(lastElement);
+    // https://github.com/nestjs/nest/issues/11074#issuecomment-1421680060
     if (!isStack && !isUndefined(lastElement)) {
       return { messages, context };
     }

--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Optional } from '../decorators/core';
 import { clc, yellow } from '../utils/cli-colors.util';
-import { isPlainObject, isString } from '../utils/shared.utils';
+import { isPlainObject, isString, isUndefined } from '../utils/shared.utils';
 import { LoggerService, LogLevel } from './logger.service';
 import { isLogLevelEnabled } from './utils';
 
@@ -279,7 +279,7 @@ export class ConsoleLogger implements LoggerService {
     }
     const lastElement = messages[messages.length - 1];
     const isStack = isString(lastElement);
-    if (!isStack) {
+    if (!isStack && !isUndefined(lastElement)) {
       return { messages, context };
     }
     return {

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -442,6 +442,17 @@ describe('Logger', () => {
         );
         expect(processStdoutWriteSpy.thirdCall.firstArg).to.include('ms');
       });
+      it('should log out an error to stderr but not include an undefined log', () => {
+        const message = 'message 1';
+
+        logger.error(message);
+
+        expect(processStderrWriteSpy.calledOnce).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
+          `[${globalContext}]`,
+        );
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+      });
     });
 
     describe('when logging is disabled', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Due to a change in #10531 when the `stack` is added as `undefined` a new `undefined` log would be added whenever `this.logger.error()` would be called. 

Issue Number: #11074


## What is the new behavior?

Now, we check that the last element is either a string or undefined, and if so strip the last element. That element should only exist when we artificially add the stack via the changes from #10531.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This at least shouldn't be breaking. Added a new test to ensure it does what I expect it to as well.

## Other information