### PR TITLE
feat(core): expose external-context-creator

### DIFF
--- a/packages/core/helpers/index.ts
+++ b/packages/core/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './context-id-factory';
+export * from './external-context-creator';
 export * from './http-adapter-host';


### PR DESCRIPTION
Allow third party packages to register handlers (like controller methods) that pass through the whole pipeline of interceptors, pipes, guards, filters and param decorators while still being compliant with node16 moduleResolution, where imports like

```typescript
import {
  ExternalContextCreator,
  ParamsFactory,
} from "@nestjs/core/helpers/external-context-creator";
```

are not allowed.

No tests are added here because functionality is not changed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`ExternalContextCreator` and `ParamsFactory` are not exposed for third party packages to use.

Issue Number: N/A


## What is the new behavior?
`ExternalContextCreator` and `ParamsFactory` are exposed for third party packages to use.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information
No tests are added because no functionality has changed. Only existing functionality has been exposed to the API.