### PR TITLE
feat: add graphql to context type

### DIFF
--- a/packages/common/interfaces/features/arguments-host.interface.ts
+++ b/packages/common/interfaces/features/arguments-host.interface.ts
@@ -1,4 +1,4 @@
-export type ContextType = 'http' | 'ws' | 'rpc';
+export type ContextType = 'http' | 'ws' | 'rpc' | 'graphql';
 
 /**
  * Methods to obtain request and response objects.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

When created a global exception filter I want the same filter to be able to handle both REST requests and also GraphQL requests, in order to do this I would like to use `host.getType()` which _does_ return `http` or `graphql` depending on the type of incoming request, however, the type of `host.getType()` does not include `'graphql'` so it leaves me with a type error.

See example code:

```typescript
import { ExceptionFilter, Catch, ArgumentsHost, HttpException } from '@nestjs/common';
import { GqlExceptionFilter } from '@nestjs/graphql';
import { Request, Response } from 'express';

const REQUEST_TYPE_HTTP = 'http';
const REQUEST_TYPE_GRAPHQL = 'graphql';

@Catch(HttpException)
export class HttpExceptionFilter implements ExceptionFilter, GqlExceptionFilter {
	catch(exception: HttpException, host: ArgumentsHost) {
		switch (host.getType()) {
			case REQUEST_TYPE_HTTP:
				const ctx = host.switchToHttp();
				const response = ctx.getResponse<Response>();
				const status = exception.getStatus();

				response.status(status).json({
					statusCode: status,
				});
				return;
			// @ts-ignore
			case REQUEST_TYPE_GRAPHQL: {
				console.log('>>>>>>>>>>>>>>>>>', host.getType());
			}
		}
	}
}
```

Output after a GraphQL exception:

```
[Nest] 594815  - 15/02/2023, 17:42:45     LOG [GraphQLModule] Mapped {/graphql, POST} route +1077ms
[Nest] 594815  - 15/02/2023, 17:42:45     LOG [NestApplication] Nest application successfully started +32ms
>>>>>>>>>>>>>>>>> graphql
```