### PR TITLE
fix(core): false-positive value provider not registered error when the value is `undefined`

### DIFF
--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -22,6 +22,7 @@ import {
   isString,
   isSymbol,
   isUndefined,
+  isObject,
 } from '@nestjs/common/utils/shared.utils';
 import { iterate } from 'iterare';
 import { ApplicationConfig } from '../application-config';
@@ -344,7 +345,10 @@ export class Module {
   }
 
   public isCustomValue(provider: any): provider is ValueProvider {
-    return !isUndefined((provider as ValueProvider).useValue);
+    return (
+      isObject(provider) &&
+      Object.prototype.hasOwnProperty.call(provider, 'useValue')
+    );
   }
 
   public isCustomFactory(provider: any): provider is FactoryProvider {

--- a/packages/core/test/injector/module.spec.ts
+++ b/packages/core/test/injector/module.spec.ts
@@ -137,6 +137,16 @@ describe('Module', () => {
     expect((addCustomValue as sinon.SinonSpy).called).to.be.true;
   });
 
+  it('should call "addCustomValue" when "useValue" property exists but its value is `undefined`', () => {
+    const addCustomValue = sinon.spy();
+    module.addCustomValue = addCustomValue;
+
+    const provider = { provide: 'test', useValue: undefined };
+
+    module.addCustomProvider(provider as any, new Map());
+    expect((addCustomValue as sinon.SinonSpy).called).to.be.true;
+  });
+
   it('should call "addCustomFactory" when "useFactory" property exists', () => {
     const addCustomFactory = sinon.spy();
     module.addCustomFactory = addCustomFactory;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

```ts
import { Module } from '@nestjs/common';

@Module({
  providers: [
    { provide: 'foo', useValue: undefined  },
    { provide: 'bar', useFactory: () => undefined  },
  ],
  exports: [
    // This triggers the 'cannot export a provider ...' error
    'foo',
    // This won't
    'bar',
  ]
})
export class AppModule {}
```

when exporting some custom value provider that was registered with the value `undefined` we got the following error

![image](https://user-images.githubusercontent.com/13461315/219535960-d64dc230-dd1f-49f2-a4d6-07165c5e3142.png)

## What is the new behavior?

We could now have mandatory custom provider values with the value `undefined`. Although this unlikely make sense, it's aligned with the present behavior of factory providers that could return `undefined`

I find this bug when trying to help one dev on our Discord. He was importing some value from a 3rd-party package and that value was used at the `useValue`. Later he find out that the import clause was wrong (named import vs namespace import), so that has nothing to do with the error raised by nestjs internals. Thus, that error was a false-positive signal on provider not registered within the module.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This has implications on circular file imports because in the current version they are caught at bootstrapping time, while after this PR they won't lead to any injection error (given that case). So you should consider this trade-off.

Another solution would be improving that error message to give a hint that the value of the provider might be `undefined` and suggesting the use of `optional: true` flag.