### PR TITLE
fix(common): fix cache ttl not beeing respected

### DIFF
--- a/integration/cache/e2e/custom-ttl.spec.ts
+++ b/integration/cache/e2e/custom-ttl.spec.ts
@@ -1,0 +1,35 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { CustomTtlModule } from '../src/custom-ttl/custom-ttl.module';
+
+describe('Caching Custom TTL', () => {
+  let server;
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      imports: [CustomTtlModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+  });
+
+  it('should return a differnt value after the TTL is elapsed', async () => {
+    await request(server).get('/').expect(200, '0');
+    await new Promise(resolve => setTimeout(resolve, 500));
+    await request(server).get('/').expect(200, '1');
+  });
+
+  it('should return the cached value within the TTL', async () => {
+    await request(server).get('/').expect(200, '0');
+    await new Promise(resolve => setTimeout(resolve, 200));
+    await request(server).get('/').expect(200, '0');
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/integration/cache/src/custom-ttl/custom-ttl.controller.ts
+++ b/integration/cache/src/custom-ttl/custom-ttl.controller.ts
@@ -1,0 +1,20 @@
+import {
+  CacheInterceptor,
+  CacheTTL,
+  Controller,
+  Get,
+  UseInterceptors,
+} from '@nestjs/common';
+
+@Controller()
+export class CustomTtlController {
+  counter = 0;
+  constructor() {}
+
+  @Get()
+  @CacheTTL(500)
+  @UseInterceptors(CacheInterceptor)
+  getNumber() {
+    return this.counter++;
+  }
+}

--- a/integration/cache/src/custom-ttl/custom-ttl.module.ts
+++ b/integration/cache/src/custom-ttl/custom-ttl.module.ts
@@ -1,0 +1,8 @@
+import { CacheModule, Module } from '@nestjs/common';
+import { CustomTtlController } from './custom-ttl.controller';
+
+@Module({
+  imports: [CacheModule.register()],
+  controllers: [CustomTtlController],
+})
+export class CustomTtlModule {}

--- a/integration/cache/src/custom-ttl/tsconfig.json
+++ b/integration/cache/src/custom-ttl/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": false,
+    "noImplicitAny": false,
+    "removeComments": true,
+    "noLib": false,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "es6",
+    "sourceMap": true,
+    "allowJs": true,
+    "outDir": "./dist",
+    "paths": {
+      "@nestjs/common": ["../../packages/common"],
+      "@nestjs/common/*": ["../../packages/common/*"],
+      "@nestjs/core": ["../../packages/core"],
+      "@nestjs/core/*": ["../../packages/core/*"],
+      "@nestjs/microservices": ["../../packages/microservices"],
+      "@nestjs/microservices/*": ["../../packages/microservices/*"],
+      "@nestjs/websockets": ["../../packages/websockets"],
+      "@nestjs/websockets/*": ["../../packages/websockets/*"],
+      "@nestjs/testing": ["../../packages/testing"],
+      "@nestjs/testing/*": ["../../packages/testing/*"],
+      "@nestjs/platform-express": ["../../packages/platform-express"],
+      "@nestjs/platform-express/*": ["../../packages/platform-express/*"],
+      "@nestjs/platform-socket.io": ["../../packages/platform-socket.io"],
+      "@nestjs/platform-socket.io/*": ["../../packages/platform-socket.io/*"],
+      "@nestjs/platform-ws": ["../../packages/platform-ws"],
+      "@nestjs/platform-ws/*": ["../../packages/platform-ws/*"]
+    }
+  },
+  "include": [
+    "src/**/*",
+    "e2e/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+  ]
+}

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -1,4 +1,3 @@
-import { Store } from 'cache-manager';
 import { Observable, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Inject, Injectable, Optional } from '../../decorators';

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -38,6 +38,7 @@ export class CacheInterceptor implements NestInterceptor {
   protected allowedMethods = ['GET'];
 
   private cacheManagerIsv5OrGreater: boolean;
+  
   constructor(
     @Inject(CACHE_MANAGER) protected readonly cacheManager: any,
     @Inject(REFLECTOR) protected readonly reflector: any,

--- a/packages/common/cache/interceptors/cache.interceptor.ts
+++ b/packages/common/cache/interceptors/cache.interceptor.ts
@@ -20,13 +20,6 @@ import {
 const HTTP_ADAPTER_HOST = 'HttpAdapterHost';
 const REFLECTOR = 'Reflector';
 
-// We need to check if the cache-manager package is v5 or greater
-// because the set method signature changed in v5
-const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
-  require('cache-manager'),
-);
-const cacheManagerIsv5OrGreater = 'memoryStore' in cacheManager;
-
 export interface HttpAdapterHost<T extends HttpServer = any> {
   httpAdapter: T;
 }
@@ -67,6 +60,14 @@ export class CacheInterceptor implements NestInterceptor {
       const ttl = isFunction(ttlValueOrFactory)
         ? await ttlValueOrFactory(context)
         : ttlValueOrFactory;
+
+      // We need to check if the cache-manager package is v5 or greater
+      // because the set method signature changed in v5
+      const cacheManager = loadPackage('cache-manager', 'CacheModule', () =>
+        require('cache-manager'),
+      );
+      const cacheManagerIsv5OrGreater = 'memoryStore' in cacheManager;
+
       return next.handle().pipe(
         tap(async response => {
           if (response instanceof StreamableFile) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the ``@CacheTTL`` decorator does not work. With cachemanager v5

Issue Number: #11119 


## What is the new behavior?
``@CacheTTL`` Works again and the behavior is inline with the docs (expects milliseconds)

The interceptor has been updated to also check, like the provider does, if version 5 or later is beeing used.
If so the inteceptor uses the new signature for the ``set(key, value, ttl)`` method. Version 4 used an options object as third paremeter. V5 uses a number directly.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Because it checks which version of cache manager is beeing used.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information