### PR TITLE
fix(core): execute middleware in topological order of module imports

### DIFF
--- a/integration/hello-world/e2e/middleware-execute-order.spec.ts
+++ b/integration/hello-world/e2e/middleware-execute-order.spec.ts
@@ -56,13 +56,18 @@ describe('Middleware (execution order)', () => {
       }).compile()
     ).createNestApplication();
 
+    app.use((req, res, next) => {
+      res.append('x-trace', 'global');
+      next();
+    });
+
     await app.init();
   });
 
   it(`should execute middleware in topological order`, () => {
     return request(app.getHttpServer())
       .get('/')
-      .expect('x-trace', 'module-a, module-b, module-c');
+      .expect('x-trace', 'global, module-a, module-b, module-c');
   });
 
   afterEach(async () => {

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -145,15 +145,7 @@ export class MiddlewareModule<
       }
     };
 
-    const entriesSortedByDistance = [...configs.entries()].sort(
-      ([moduleA], [moduleB]) => {
-        return (
-          this.container.getModuleByKey(moduleA).distance -
-          this.container.getModuleByKey(moduleB).distance
-        );
-      },
-    );
-    for (const [moduleRef, moduleConfigurations] of entriesSortedByDistance) {
+    for (const [moduleRef, moduleConfigurations] of configs.entries()) {
       await registerAllConfigs(moduleRef, [...moduleConfigurations]);
     }
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Middleware registration does not respect DI module imports.

Given:

- Module A
  - Middleware A
  - Module B
    - Middleware B
- Module C
  - Middleware C

Resolution:

1. Middleware A
2. Middleware C
3. Middleware B 

## What is the new behavior?

Order of middleware registration is resolved by DI module imports as described by the community. 

Resolution:

1. Middleware A
2. Middleware B
3. Middleware C 

> Middleware will run in the order that the modules are added to the imports array.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information