### PR TITLE
feat: Support async local storage in interceptors

### DIFF
--- a/packages/core/test/interceptors/interceptors-consumer.spec.ts
+++ b/packages/core/test/interceptors/interceptors-consumer.spec.ts
@@ -1,5 +1,7 @@
+import { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
 import { expect } from 'chai';
-import { lastValueFrom, of } from 'rxjs';
+import { lastValueFrom, Observable, of } from 'rxjs';
 import * as sinon from 'sinon';
 import { InterceptorsConsumer } from '../../interceptors/interceptors-consumer';
 
@@ -35,7 +37,7 @@ describe('InterceptorsConsumer', () => {
       beforeEach(() => {
         next = sinon.stub().returns(Promise.resolve(''));
       });
-      it('should call every `intercept` method', async () => {
+      it('does not call `intercept` (lazy evaluation)', async () => {
         await consumer.intercept(
           interceptors,
           null,
@@ -43,6 +45,19 @@ describe('InterceptorsConsumer', () => {
           null,
           next,
         );
+
+        expect(interceptors[0].intercept.called).to.be.false;
+        expect(interceptors[1].intercept.called).to.be.false;
+      });
+      it('should call every `intercept` method when subscribe', async () => {
+        const intercepted = await consumer.intercept(
+          interceptors,
+          null,
+          { constructor: null },
+          null,
+          next,
+        );
+        await transformToResult(intercepted);
 
         expect(interceptors[0].intercept.calledOnce).to.be.true;
         expect(interceptors[1].intercept.calledOnce).to.be.true;
@@ -58,15 +73,6 @@ describe('InterceptorsConsumer', () => {
         expect(next.called).to.be.false;
       });
       it('should call `next` when subscribe', async () => {
-        async function transformToResult(resultOrDeferred: any) {
-          if (
-            resultOrDeferred &&
-            typeof resultOrDeferred.subscribe === 'function'
-          ) {
-            return lastValueFrom(resultOrDeferred);
-          }
-          return resultOrDeferred;
-        }
         const intercepted = await consumer.intercept(
           interceptors,
           null,
@@ -76,6 +82,30 @@ describe('InterceptorsConsumer', () => {
         );
         await transformToResult(intercepted);
         expect(next.called).to.be.true;
+      });
+    });
+
+    describe('AsyncLocalStorage', () => {
+      it('Allows an interceptor to set values in AsyncLocalStorage that are accesible from the controller', async () => {
+        const storage = new AsyncLocalStorage<Record<string, any>>({});
+        class StorageInterceptor implements NestInterceptor {
+          intercept(
+            _context: ExecutionContext,
+            next: CallHandler<any>,
+          ): Observable<any> | Promise<Observable<any>> {
+            return storage.run({ value: 'hello' }, () => next.handle());
+          }
+        }
+        const next = () => Promise.resolve(storage.getStore().value);
+        const intercepted = await consumer.intercept(
+          [new StorageInterceptor()],
+          null,
+          { constructor: null },
+          null,
+          next,
+        );
+        const result = await transformToResult(intercepted);
+        expect(result).to.equal('hello');
       });
     });
   });
@@ -119,3 +149,10 @@ describe('InterceptorsConsumer', () => {
     });
   });
 });
+
+async function transformToResult(resultOrDeferred: any) {
+  if (resultOrDeferred && typeof resultOrDeferred.subscribe === 'function') {
+    return lastValueFrom(resultOrDeferred);
+  }
+  return resultOrDeferred;
+}


### PR DESCRIPTION
This is necessary to allow use cases such as allowing interceptors to
change the context in OpenTelemetry. You might for example want to add
Baggage to the context in an interceptor but because of the way it was
structured before the baggage would not make its way into the controller

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Before this change the context would be lost before the controller was called because of the deferred nature of the next call.

Issue Number: N/A


## What is the new behavior?
This PR makes it possible to use `AsyncLocalStorage` from interceptors in such a way that the controller method will have access to the storage. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Not sure if it's a breaking change. If anyone relies on the interceptor chain running asap, but the controller being deferred this would be a breaking change. I find this a highly unlikely scenario so have put it down as a no. 
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information