### PR TITLE
feat: include support for logging maps and sets

### DIFF
--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -394,6 +394,102 @@ describe('Logger', () => {
         );
         expect(processStderrWriteSpy.thirdCall.firstArg).to.equal(stack + '\n');
       });
+
+      it('should print one message with Set to the console', () => {
+        const setElements = ['foo', 'bar', 123];
+        const set = new Set(setElements);
+        const context = 'RandomContext';
+        logger.log(set, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include('Set:');
+        const expectedSerializedSetItems = `[\n  "foo",\n  "bar",\n  123\n]`;
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          expectedSerializedSetItems,
+        );
+      });
+
+      it('should print one message with Map to the console', () => {
+        const map = new Map();
+        map.set('foo', 'bar');
+        map.set('rab', 123);
+        const context = 'RandomContext';
+        logger.log(map, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include('Map:');
+        const expectedSerializedMapItems = `{\n  "foo": "bar",\n  "rab": 123\n}`;
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          expectedSerializedMapItems,
+        );
+      });
+
+      it('should print one message with nested Map to the console', () => {
+        const map = new Map();
+        map.set('foo', 'bar');
+        map.set('rab', 123);
+
+        const plainObject = {
+          blah: 'blah',
+          map,
+        };
+
+        const plainObjectWithRepeatedMap = {
+          ...plainObject,
+          map: {
+            foo: 'bar',
+            rab: 123,
+          },
+        };
+        const stringifiedPlainObjectWithRepeatedMap = JSON.stringify(
+          plainObjectWithRepeatedMap,
+          null,
+          2,
+        );
+
+        const context = 'RandomContext';
+        logger.log(plainObject, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include('Object:');
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          stringifiedPlainObjectWithRepeatedMap,
+        );
+      });
+
+      it('should print one message with nested Set to the console', () => {
+        const setItems = ['foo', 'bar', 123];
+        const set = new Set(setItems);
+
+        const plainObject = {
+          blah: 'blah',
+          set,
+        };
+
+        const plainObjectWithRepeatedSet = {
+          ...plainObject,
+          set: ['foo', 'bar', 123],
+        };
+
+        const stringifiedPlainObjectWithRepeatedSet = JSON.stringify(
+          plainObjectWithRepeatedSet,
+          null,
+          2,
+        );
+
+        const context = 'RandomContext';
+        logger.log(plainObject, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include('Object:');
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+          stringifiedPlainObjectWithRepeatedSet,
+        );
+      });
     });
 
     describe('when the default logger is used and global context is set and timestamp enabled', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

```
[Nest] 76153  - 03/10/2023, 10:59:02 AM     LOG [RandomContext] [object Map]
```

```
[Nest] 76153  - 03/10/2023, 10:59:02 AM     LOG [RandomContext] [object Set]
```

```
[Nest] 74793  - 03/10/2023, 10:56:39 AM     LOG [RandomContext] Object:
{
         "blah": "blah",
         "map": {}
}
```

```
[Nest] 74793  - 03/10/2023, 10:56:39 AM     LOG [RandomContext] Object:
{
         "blah": "blah",
        "set": {}
}
```

Issue Number: #11189 


## What is the new behavior?

```
[Nest] 73354  - 03/10/2023, 10:54:11 AM     LOG [RandomContext] Map:
       {
         "foo": "bar",
         "rab": 123
      }
```

```
[Nest] 73354  - 03/10/2023, 10:54:11 AM     LOG [RandomContext] Set:
       [
         "foo",
         "bar",
         123
      ]
```

```
[Nest] 73354  - 03/10/2023, 10:54:11 AM     LOG [RandomContext] Object:
       {
         "blah": "blah",
         "set": [
           "foo",
           "bar",
           123
         ]
      }
```

```
[Nest] 73354  - 03/10/2023, 10:54:11 AM     LOG [RandomContext] Object:
       {
         "blah": "blah",
         "map": {
           "foo": "bar",
           "rab": 123
         }
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Unfortunately because the way of how JSON.stringify works making it:
```
"map": Map {
  "foo": "bar"
}
```
is pretty complex (same with set) and requires recursive parsing of objects, and excludes JSON.stringify replaces for some cases, so this RP treats Maps as objects and Sets as arrays when nested in logger.log call