### PR TITLE
Updated excluded path in 24-serve-static example

### DIFF
--- a/sample/24-serve-static/src/app.module.ts
+++ b/sample/24-serve-static/src/app.module.ts
@@ -7,7 +7,7 @@ import { AppController } from './app.controller';
   imports: [
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', 'client'),
-      exclude: ['/api*'],
+      exclude: ['/api/(.*)'],
     }),
   ],
   controllers: [AppController],


### PR DESCRIPTION
Updated path specification to working one #92.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Problem with [example 24](sample/24-serve-static/src/app.module.ts) is, that exclude isn't working, it still redirects to static content if API path does not exist.


## What is the new behavior?

Works as expected. If API path not found, it returns HTTP 404.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information