### PR TITLE
fix(platform-express): wrong type def for `NestExpressApplication#listen`

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -1,4 +1,4 @@
-import type { Server } from 'net';
+import type { Server } from 'http';
 import {
   HttpStatus,
   InternalServerErrorException,

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,4 +1,4 @@
-import { Server } from 'net';
+import { Server } from 'http';
 import { INestApplication } from '@nestjs/common';
 import * as bodyparser from 'body-parser';
 import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #11279

I just tested that `server` from `app.listen` is an instance of `http.Server`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No