### PR TITLE
perf(common): In case of an expensive log, allow to pass a function

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, Optional } from '../decorators/core';
 import { clc, yellow } from '../utils/cli-colors.util';
-import { isPlainObject, isString, isUndefined } from '../utils/shared.utils';
+import {
+  isFunction,
+  isPlainObject,
+  isString,
+  isUndefined,
+} from '../utils/shared.utils';
 import { LoggerService, LogLevel } from './logger.service';
 import { isLogLevelEnabled } from './utils';
 
@@ -221,7 +226,10 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {
-    return isPlainObject(message) || Array.isArray(message)
+    // If the message is a function, call it and re-resolve its value.
+    return isFunction(message)
+      ? this.stringifyMessage(message(), logLevel)
+      : isPlainObject(message) || Array.isArray(message)
       ? `${this.colorize('Object:', logLevel)}\n${JSON.stringify(
           message,
           (key, value) =>

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -256,6 +256,34 @@ describe('Logger', () => {
       loggerWithContext.resetContext();
       expect(loggerWithContext['context']).to.equal('context');
     });
+
+    describe('functions for message', () => {
+      let processStdoutWriteSpy: sinon.SinonSpy;
+      const logger = new ConsoleLogger();
+      const message = 'Hello World';
+
+      beforeEach(() => {
+        processStdoutWriteSpy = sinon.spy(process.stdout, 'write');
+      });
+      afterEach(() => {
+        processStdoutWriteSpy.restore();
+      });
+
+      it('works', () => {
+        logger.log(() => message);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include(message);
+        // Ensure we didn't serialize the function itself.
+        expect(processStdoutWriteSpy.firstCall.firstArg).not.to.include(' => ');
+        expect(processStdoutWriteSpy.firstCall.firstArg).not.to.include(
+          'function',
+        );
+        expect(processStdoutWriteSpy.firstCall.firstArg).not.to.include(
+          'Function',
+        );
+      });
+    });
   });
 
   describe('[instance methods]', () => {

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -41,7 +41,8 @@ export const normalizePath = (path?: string): string =>
 export const stripEndSlash = (path: string) =>
   path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;
 
-export const isFunction = (val: any): boolean => typeof val === 'function';
+export const isFunction = (val: any): val is Function =>
+  typeof val === 'function';
 export const isString = (val: any): val is string => typeof val === 'string';
 export const isNumber = (val: any): val is number => typeof val === 'number';
 export const isConstructor = (val: any): boolean => val === 'constructor';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
In certain case, it is very expensive to log some values. Instead of checking if certain level is enabled, allow the users to pass in a function that is only called if we need to stringify the log value.

This keeps the API small, while still allowing expensive logging to be called when needed, and skipped when not.

e.g. instead of

```javascript
// This check is technically done twice.
if (this.logger.isLevelEnabled('debug')) {
  this.logger.debug(this.generateAsciiArtFromJpeg());
}
```

the customer could use:

```javascript
this.logger.debug(() => this.generateAsciiArtFromJpeg());
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information