### PR TITLE
feat(core): add response provider to injectables

### DIFF
--- a/integration/injector/e2e/scoped-instances.spec.ts
+++ b/integration/injector/e2e/scoped-instances.spec.ts
@@ -1,4 +1,4 @@
-import { createContextId } from '@nestjs/core';
+import { ContextIdFactory, createContextId } from '@nestjs/core';
 import { InvalidClassScopeException } from '@nestjs/core/errors/exceptions/invalid-class-scope.exception';
 import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
@@ -57,10 +57,8 @@ describe('Scoped Instances', () => {
 
     const ctxId = { id: 1 };
     const requestProvider = { host: 'localhost' };
-    const responseProvider = { id: ctxId, msg: 'response' };
 
     testingModule.registerRequestByContextId(requestProvider, ctxId);
-    testingModule.registerResponseByContextId(responseProvider, ctxId);
 
     const request3 = await testingModule.resolve(ScopedService, ctxId);
     const requestFactory = await testingModule.resolve(REQUEST_SCOPED_FACTORY);
@@ -70,7 +68,6 @@ describe('Scoped Instances', () => {
     expect(request3).to.not.be.equal(request2);
     expect(requestFactory).to.be.true;
     expect(request3.request).to.be.equal(requestProvider);
-    expect(request3.response).to.be.equal(responseProvider);
   });
 
   it('should dynamically resolve request-scoped controller', async () => {
@@ -97,5 +94,15 @@ describe('Scoped Instances', () => {
     } catch (err) {
       expect(err).to.be.instanceOf(InvalidClassScopeException);
     }
+  });
+
+  it('should dynamically resolve request-scoped response provider', async () => {
+    const ctxId = ContextIdFactory.create();
+    const response = { host: 'localhost' };
+
+    testingModule.registerResponseByContextId(response, ctxId);
+    const request3 = await testingModule.resolve(ScopedService, ctxId);
+
+    expect(request3.response).to.be.equal(response);
   });
 });

--- a/integration/injector/e2e/scoped-instances.spec.ts
+++ b/integration/injector/e2e/scoped-instances.spec.ts
@@ -57,7 +57,10 @@ describe('Scoped Instances', () => {
 
     const ctxId = { id: 1 };
     const requestProvider = { host: 'localhost' };
+    const responseProvider = { id: ctxId, msg: 'response' };
+
     testingModule.registerRequestByContextId(requestProvider, ctxId);
+    testingModule.registerResponseByContextId(responseProvider, ctxId);
 
     const request3 = await testingModule.resolve(ScopedService, ctxId);
     const requestFactory = await testingModule.resolve(REQUEST_SCOPED_FACTORY);
@@ -67,6 +70,7 @@ describe('Scoped Instances', () => {
     expect(request3).to.not.be.equal(request2);
     expect(requestFactory).to.be.true;
     expect(request3.request).to.be.equal(requestProvider);
+    expect(request3.response).to.be.equal(responseProvider);
   });
 
   it('should dynamically resolve request-scoped controller', async () => {

--- a/integration/injector/src/scoped/scoped.service.ts
+++ b/integration/injector/src/scoped/scoped.service.ts
@@ -1,7 +1,10 @@
 import { Inject, Injectable, Scope } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
+import { REQUEST, RESPONSE } from '@nestjs/core';
 
 @Injectable({ scope: Scope.REQUEST })
 export class ScopedService {
-  constructor(@Inject(REQUEST) public readonly request) {}
+  constructor(
+    @Inject(REQUEST) public readonly request,
+    @Inject(RESPONSE) public readonly response,
+  ) {}
 }

--- a/packages/common/interfaces/nest-application-context.interface.ts
+++ b/packages/common/interfaces/nest-application-context.interface.ts
@@ -114,6 +114,15 @@ export interface INestApplicationContext {
   ): void;
 
   /**
+   * Registers the request/context object for a given context ID (DI container sub-tree).
+   * @returns {void}
+   */
+  registerResponseByContextId<T = any>(
+    response: T,
+    contextId: { id: number },
+  ): void;
+
+  /**
    * Terminates the application
    * @returns {Promise<void>}
    */

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -12,7 +12,7 @@ import {
 } from '../errors/exceptions';
 import { InitializeOnPreviewAllowlist } from '../inspector/initialize-on-preview.allowlist';
 import { SerializedGraph } from '../inspector/serialized-graph';
-import { REQUEST } from '../router/request/request-constants';
+import { REQUEST, RESPONSE } from '../router/request/request-constants';
 import { ModuleCompiler } from './compiler';
 import { ContextId } from './instance-wrapper';
 import { InternalCoreModule } from './internal-core-module/internal-core-module';
@@ -254,6 +254,14 @@ export class NestContainer {
     const wrapper = this.internalCoreModule.getProviderByKey(REQUEST);
     wrapper.setInstanceByContextId(contextId, {
       instance: request,
+      isResolved: true,
+    });
+  }
+
+  public registerResponseProvider<T = any>(response: T, contextId: ContextId) {
+    const wrapper = this.internalCoreModule.getProviderByKey(RESPONSE);
+    wrapper.setInstanceByContextId(contextId, {
+      instance: response,
       isResolved: true,
     });
   }

--- a/packages/core/injector/internal-core-module/internal-core-module.ts
+++ b/packages/core/injector/internal-core-module/internal-core-module.ts
@@ -4,7 +4,10 @@ import {
   FactoryProvider,
   ValueProvider,
 } from '@nestjs/common/interfaces';
-import { requestProvider } from '../../router/request/request-providers';
+import {
+  requestProvider,
+  responseProvider,
+} from '../../router/request/request-providers';
 import { Reflector } from '../../services';
 import { inquirerProvider } from '../inquirer/inquirer-providers';
 
@@ -19,12 +22,14 @@ const ReflectorAliasProvider = {
     Reflector,
     ReflectorAliasProvider,
     requestProvider,
+    responseProvider,
     inquirerProvider,
   ],
   exports: [
     Reflector,
     ReflectorAliasProvider,
     requestProvider,
+    responseProvider,
     inquirerProvider,
   ],
 })

--- a/packages/core/inspector/serialized-graph.ts
+++ b/packages/core/inspector/serialized-graph.ts
@@ -6,7 +6,7 @@ import { INQUIRER } from '../injector/inquirer/inquirer-constants';
 import { LazyModuleLoader } from '../injector/lazy-module-loader/lazy-module-loader';
 import { ModuleRef } from '../injector/module-ref';
 import { ModulesContainer } from '../injector/modules-container';
-import { REQUEST } from '../router/request/request-constants';
+import { REQUEST, RESPONSE } from '../router/request/request-constants';
 import { Reflector } from '../services/reflector.service';
 import { DeterministicUuidRegistry } from './deterministic-uuid-registry';
 import { Edge } from './interfaces/edge.interface';
@@ -41,6 +41,7 @@ export class SerializedGraph {
     HttpAdapterHost.name,
     Reflector.name,
     REQUEST,
+    RESPONSE,
     INQUIRER,
   ];
 

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -257,7 +257,7 @@ export class MiddlewareModule<
         next: () => void,
       ) => {
         try {
-          const contextId = this.getContextId(req, isTreeDurable);
+          const contextId = this.getContextId(req, res, isTreeDurable);
           const contextInstance = await this.injector.loadPerContext(
             instance,
             moduleRef,
@@ -329,7 +329,11 @@ export class MiddlewareModule<
     paths.forEach(path => router(path, middlewareFunction));
   }
 
-  private getContextId(request: unknown, isTreeDurable: boolean): ContextId {
+  private getContextId(
+    request: unknown,
+    response: unknown,
+    isTreeDurable: boolean,
+  ): ContextId {
     const contextId = ContextIdFactory.getByRequest(request);
     if (!request[REQUEST_CONTEXT_ID]) {
       Object.defineProperty(request, REQUEST_CONTEXT_ID, {
@@ -341,6 +345,7 @@ export class MiddlewareModule<
 
       const requestProviderValue = isTreeDurable ? contextId.payload : request;
       this.container.registerRequestProvider(requestProviderValue, contextId);
+      this.container.registerResponseProvider(response, contextId);
     }
     return contextId;
   }

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -224,6 +224,17 @@ export class NestApplicationContext<
   }
 
   /**
+   * Registers the response/context object for a given context ID (DI container sub-tree).
+   * @returns {void}
+   */
+  public registerResponseByContextId<T = any>(
+    response: T,
+    contextId: ContextId,
+  ) {
+    this.container.registerResponseProvider(response, contextId);
+  }
+
+  /**
    * Initializes the Nest application.
    * Calls the Nest lifecycle events.
    *

--- a/packages/core/router/request/index.ts
+++ b/packages/core/router/request/index.ts
@@ -1,1 +1,1 @@
-export { REQUEST } from './request-constants';
+export { REQUEST, RESPONSE } from './request-constants';

--- a/packages/core/router/request/request-constants.ts
+++ b/packages/core/router/request/request-constants.ts
@@ -1,2 +1,4 @@
 export const REQUEST = 'REQUEST';
 export const REQUEST_CONTEXT_ID = Symbol('REQUEST_CONTEXT_ID');
+
+export const RESPONSE = 'RESPONSE';

--- a/packages/core/router/request/request-providers.ts
+++ b/packages/core/router/request/request-providers.ts
@@ -1,10 +1,16 @@
 import { Provider, Scope } from '@nestjs/common';
-import { REQUEST } from './request-constants';
+import { REQUEST, RESPONSE } from './request-constants';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 export const requestProvider: Provider = {
   provide: REQUEST,
+  scope: Scope.REQUEST,
+  useFactory: noop,
+};
+
+export const responseProvider: Provider = {
+  provide: RESPONSE,
   scope: Scope.REQUEST,
   useFactory: noop,
 };

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -414,13 +414,6 @@ export class RouterExplorer {
         configurable: false,
       });
 
-      Object.defineProperty(response, REQUEST_CONTEXT_ID, {
-        value: contextId,
-        enumerable: false,
-        writable: false,
-        configurable: false,
-      });
-
       const requestProviderValue = isTreeDurable ? contextId.payload : request;
       this.container.registerRequestProvider(requestProviderValue, contextId);
       this.container.registerResponseProvider(response, contextId);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11278


## What is the new behavior?
Resolves #11278

You can inject response to request-scoped-provider
```ts
import { RESPONSE } from '@nestjs/core'
import { Injectable,Scope } from '@nestjs/common'

@Injectable({ scope: Scope.REQUEST })
export class SomeRequestService {
 constructor(@Inject(RESPONSE) response) {}
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information