### PR TITLE
fix: @platform-express bodyparser types

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -252,7 +252,7 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
-    type: keyof bodyparser.BodyParser,
+    type: keyof bodyparser.Options,
     rawBody: boolean,
     options?: NestExpressBodyParserOptions<Options>,
   ): this {

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -89,7 +89,7 @@ export interface NestExpressApplication extends INestApplication {
    * @returns {this}
    */
   useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
-    parser: keyof bodyparser.BodyParser,
+    parser: keyof bodyparser.Options,
     options?: NestExpressBodyParserOptions<Options>,
   ): this;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
On the last version `9.3.9` when platform-express included to code, the typescript compiler is failing on some platform-express bodyparser types.
I think there was mistakenly added `bodyparser.BodyParser` where `BodyParser` property doesn't exist on `bodyparser` type and it should be `Options` instead.

Issue Number: N/A


## What is the new behavior?
Typescript compiler is working properly.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information