### PR TITLE
feat: cache method decorator

### DIFF
--- a/packages/common/cache/decorators/cache-method.decorator.ts
+++ b/packages/common/cache/decorators/cache-method.decorator.ts
@@ -9,14 +9,19 @@ import { Cache } from 'cache-manager';
  * `@CacheMethod()`
  *
  * @param {object} options configuration object specifying:
- * - `key` - string naming the field to be used as a cache key
+ * - `prefix` - string naming the field to be used as a prefix key
  * - `ttl` - number set the cache expiration time
+ * - `transform` - function set the define key by arguments
  *
  * @see [Caching](https://docs.nestjs.com/techniques/caching)
  *
  * @publicApi
  */
-export const CacheMethod = (opts?: { key?: string; ttl?: number }) => {
+export const CacheMethod = (opts?: {
+  prefix?: string;
+  ttl?: number;
+  transform?: (args: unknown[]) => string;
+}) => {
   const injector = Inject(CACHE_MANAGER);
 
   return (
@@ -33,7 +38,9 @@ export const CacheMethod = (opts?: { key?: string; ttl?: number }) => {
     const originalMethod = descriptor.value;
 
     descriptor.value = async function (...args: unknown[]) {
-      const cacheKey = [key, opts?.key, ...args].filter(Boolean).join(':');
+      const cacheKey = opts?.transform
+        ? opts.transform(args)
+        : [key, opts?.prefix, ...args].filter(Boolean).join(':');
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       const cacheManager = this.cacheManager as Cache;

--- a/packages/common/cache/decorators/cache-method.decorator.ts
+++ b/packages/common/cache/decorators/cache-method.decorator.ts
@@ -1,0 +1,54 @@
+import { CACHE_MANAGER } from '../';
+import { Inject } from '../../decorators';
+import { Cache } from 'cache-manager';
+
+/**
+ * Cache Method Decorator that manage per method name and arguments
+ *
+ * For example:
+ * `@CacheMethod()`
+ *
+ * @param {object} options configuration object specifying:
+ * - `key` - string naming the field to be used as a cache key
+ * - `ttl` - number set the cache expiration time
+ *
+ * @see [Caching](https://docs.nestjs.com/techniques/caching)
+ *
+ * @publicApi
+ */
+export const CacheMethod = (opts?: { key?: string; ttl?: number }) => {
+  const injector = Inject(CACHE_MANAGER);
+
+  return (
+    target: Object,
+    key?: string | symbol,
+    descriptor?: PropertyDescriptor,
+  ) => {
+    injector(target, 'cacheManager');
+
+    if (!descriptor) {
+      return;
+    }
+
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: unknown[]) {
+      const cacheKey = [key, opts?.key, ...args].filter(Boolean).join(':');
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      const cacheManager = this.cacheManager as Cache;
+      const store = await cacheManager.get(cacheKey);
+
+      if (store) {
+        return store;
+      }
+      const value = await originalMethod.apply(this, args);
+      if (value) {
+        await cacheManager.set(cacheKey, value, opts?.ttl);
+      }
+      return value;
+    };
+
+    return descriptor;
+  };
+};

--- a/packages/common/cache/decorators/index.ts
+++ b/packages/common/cache/decorators/index.ts
@@ -1,2 +1,3 @@
 export * from './cache-key.decorator';
 export * from './cache-ttl.decorator';
+export * from './cache-method.decorator';

--- a/packages/common/test/decorators/cache.decorator.spec.ts
+++ b/packages/common/test/decorators/cache.decorator.spec.ts
@@ -61,6 +61,13 @@ describe('@Cache', () => {
           resolve({ name, now: Date.now() });
         });
       }
+
+      @CacheMethod({ transform: (args: unknown[]) => `${+args[0] % 3}` })
+      async transformTest(num: number): Promise<{ num: number; now: number }> {
+        return new Promise(resolve => {
+          resolve({ num, now: Date.now() });
+        });
+      }
     }
 
     let testService: TestService;
@@ -82,6 +89,19 @@ describe('@Cache', () => {
 
         const newRequest = await testService.findOne(`test-${i}`);
         expect(newRequest.now).not.equal(first.now);
+      }
+    });
+
+    it('should be set the transform function', async () => {
+      const zeroKey = await testService.transformTest(3);
+      for (let i = 0; i < 10; i++) {
+        const cached = await testService.transformTest(i);
+        if (i % 3 === 0) {
+          expect(cached.num).equal(3);
+          expect(cached.now).equal(zeroKey.now);
+        } else {
+          expect(cached.num).not.equal(3);
+        }
       }
     });
   });

--- a/packages/common/test/decorators/cache.decorator.spec.ts
+++ b/packages/common/test/decorators/cache.decorator.spec.ts
@@ -1,10 +1,17 @@
+import { Test, TestingModule } from '@nestjs/testing';
 import { expect } from 'chai';
-import { CacheKey, CacheInterceptor, CacheTTL } from '../../cache';
+import {
+  CacheKey,
+  CacheInterceptor,
+  CacheTTL,
+  CacheModule,
+  CacheMethod,
+} from '../../cache';
 import {
   CACHE_KEY_METADATA,
   CACHE_TTL_METADATA,
 } from '../../cache/cache.constants';
-import { UseInterceptors } from '../../decorators';
+import { Injectable, Module, UseInterceptors } from '../../decorators';
 import { Controller } from '../../decorators/core/controller.decorator';
 
 describe('@Cache', () => {
@@ -43,5 +50,39 @@ describe('@Cache', () => {
     expect(Reflect.getMetadata(CACHE_KEY_METADATA, TestKey)).to.be.eql(
       '/a_different_cache_key',
     );
+  });
+
+  describe('CacheMethod', () => {
+    @Injectable()
+    class TestService {
+      @CacheMethod()
+      async findOne(name: string): Promise<{ name: string; now: number }> {
+        return new Promise(resolve => {
+          resolve({ name, now: Date.now() });
+        });
+      }
+    }
+
+    let testService: TestService;
+    beforeEach(async () => {
+      const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [CacheModule.register()],
+        providers: [TestService],
+      }).compile();
+      const app = moduleFixture.createNestApplication();
+      testService = app.get<TestService>(TestService);
+    });
+
+    it('should be used cache for the same request', async () => {
+      const first = await testService.findOne('test');
+      for (let i = 0; i < 10; i++) {
+        await new Promise(r => setTimeout(r, 10));
+        const cached = await testService.findOne('test');
+        expect(cached.now).equal(first.now);
+
+        const newRequest = await testService.findOne(`test-${i}`);
+        expect(newRequest.now).not.equal(first.now);
+      }
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

in method, cache should be implemented every time.

`CacheKey` decorator exists but does not fit this usage.

```
@Injectable()
export class TestService {
    constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}

    async findOneByHostname(hostname: string): Promise<TestEntity | null> {
        const cacheKey = this.cacheKey(hostname);
        const cache = await this.cacheManager.get<ProxyEntity>(cacheKey);
        if (cache) {
            return cache;
        }

        const testEntity = await this.findOne(xxx);
        if (testEntity) {
            await this.cacheManager.set(cacheKey, testEntity);
        }
        return testEntity;
    }

    private cacheKey(name: string) {
        return ['proxy', name].join('::');
    }
}
```


## What is the new behavior?

The 'CacheMethod' decorator can be easily applied to the cache manager in the `method`.

The `CacheMethod` decorator manages the store by each argument in the method.

```
    @Injectable()
    class TestService {
      @CacheMethod()
      async findOne(name: string): Promise<{ name: string; now: number }> {
        return new Promise(resolve => {
          resolve({ name, now: Date.now() });
        });
      }
    }
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

```
  @Cache
    ✔ should override global defaults for CacheKey and CacheTTL
    ✔ should override only the TTL
    ✔ should override only the Key
    CacheMethod
      ✔ should be used cache for the same request (107ms)
```