### PR TITLE
fix(express): remove body-parser types and ship these types our own

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -26,8 +26,6 @@ import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
 import { RouterMethodFactory } from '@nestjs/core/helpers/router-method-factory';
 import {
   json as bodyParserJson,
-  OptionsJson,
-  OptionsUrlencoded,
   urlencoded as bodyParserUrlencoded,
 } from 'body-parser';
 import * as bodyparser from 'body-parser';
@@ -37,6 +35,7 @@ import * as http from 'http';
 import * as https from 'https';
 import { Duplex, pipeline } from 'stream';
 import { NestExpressBodyParserOptions } from '../interfaces/nest-express-body-parser-options.interface';
+import { NestExpressBodyParserType } from '../interfaces/nest-express-body-parser.interface';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface';
 import { getBodyParserOptions } from './utils/get-body-parser-options.util';
 
@@ -236,11 +235,10 @@ export class ExpressAdapter extends AbstractHttpAdapter {
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
-    const bodyParserJsonOptions = getBodyParserOptions<OptionsJson>(rawBody);
-    const bodyParserUrlencodedOptions = getBodyParserOptions<OptionsUrlencoded>(
-      rawBody,
-      { extended: true },
-    );
+    const bodyParserJsonOptions = getBodyParserOptions(rawBody);
+    const bodyParserUrlencodedOptions = getBodyParserOptions(rawBody, {
+      extended: true,
+    });
 
     const parserMiddleware = {
       jsonParser: bodyParserJson(bodyParserJsonOptions),
@@ -251,12 +249,12 @@ export class ExpressAdapter extends AbstractHttpAdapter {
       .forEach(parserKey => this.use(parserMiddleware[parserKey]));
   }
 
-  public useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
-    type: keyof bodyparser.BodyParser,
+  public useBodyParser<Options = NestExpressBodyParserOptions>(
+    type: NestExpressBodyParserType,
     rawBody: boolean,
-    options?: NestExpressBodyParserOptions<Options>,
+    options?: Omit<Options, 'verify'>,
   ): this {
-    const parserOptions = getBodyParserOptions(rawBody, options || {});
+    const parserOptions = getBodyParserOptions<Options>(rawBody, options);
     const parser = bodyparser[type](parserOptions);
 
     this.use(parser);

--- a/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
+++ b/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
@@ -1,6 +1,6 @@
 import type { RawBodyRequest } from '@nestjs/common';
-import type { Options } from 'body-parser';
 import type { IncomingMessage, ServerResponse } from 'http';
+import type { NestExpressBodyParserOptions } from '../../interfaces';
 
 const rawBodyParser = (
   req: RawBodyRequest<IncomingMessage>,
@@ -13,11 +13,11 @@ const rawBodyParser = (
   return true;
 };
 
-export function getBodyParserOptions<ParserOptions extends Options>(
+export function getBodyParserOptions<Options = NestExpressBodyParserOptions>(
   rawBody: boolean,
-  options?: ParserOptions | undefined,
-): ParserOptions {
-  let parserOptions: ParserOptions = options ?? ({} as ParserOptions);
+  options?: Omit<Options, 'verify'> | undefined,
+): Options {
+  let parserOptions: Options = (options || {}) as Options;
 
   if (rawBody === true) {
     parserOptions = {

--- a/packages/platform-express/interfaces/index.ts
+++ b/packages/platform-express/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './nest-express-application.interface';
-export * from './nest-express-body-parser-options.interface';
+export { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
+export * from './nest-express-body-parser.interface';

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,8 +1,8 @@
 import { Server } from 'http';
 import { INestApplication } from '@nestjs/common';
-import * as bodyparser from 'body-parser';
 import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
 import { ServeStaticOptions } from './serve-static-options.interface';
+import { NestExpressBodyParserType } from './nest-express-body-parser.interface';
 
 /**
  * Interface describing methods on NestExpressApplication.
@@ -88,9 +88,9 @@ export interface NestExpressApplication extends INestApplication {
    *
    * @returns {this}
    */
-  useBodyParser<Options extends bodyparser.Options = bodyparser.Options>(
-    parser: keyof bodyparser.BodyParser,
-    options?: NestExpressBodyParserOptions<Options>,
+  useBodyParser<Options = NestExpressBodyParserOptions>(
+    parser: NestExpressBodyParserType,
+    options?: Omit<Options, 'verify'>,
   ): this;
 
   /**

--- a/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage } from 'http';
 /**
  * Type alias to keep compatibility with @types/body-parser
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dcd1673c4fa18a15ea8cd8ff8af7d563bb6dc8e6/types/body-parser/index.d.ts#L48-L66#L48-L66
+ * @publicApi
  */
 export interface NestExpressBodyParserOptions {
   /** When set to true, then deflated (compressed) bodies will be inflated; when false, deflated bodies are rejected. Defaults to true. */

--- a/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
@@ -1,6 +1,25 @@
-import type { Options } from 'body-parser';
+import type { IncomingMessage } from 'http';
 
-export type NestExpressBodyParserOptions<T extends Options = Options> = Omit<
-  T,
-  'verify'
->;
+/**
+ * Type alias to keep compatibility with @types/body-parser
+ * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dcd1673c4fa18a15ea8cd8ff8af7d563bb6dc8e6/types/body-parser/index.d.ts#L48-L66#L48-L66
+ */
+export interface NestExpressBodyParserOptions {
+  /** When set to true, then deflated (compressed) bodies will be inflated; when false, deflated bodies are rejected. Defaults to true. */
+  inflate?: boolean | undefined;
+
+  /**
+   * Controls the maximum request body size. If this is a number,
+   * then the value specifies the number of bytes; if it is a string,
+   * the value is passed to the bytes library for parsing. Defaults to '100kb'.
+   */
+  limit?: number | string | undefined;
+
+  /**
+   * The type option is used to determine what media type the middleware will parse
+   */
+  type?: string | string[] | ((req: IncomingMessage) => any) | undefined;
+
+  // Catch-all for body-parser type specific options
+  [key: string]: unknown;
+}

--- a/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
@@ -1,0 +1,4 @@
+/**
+ * Interface defining possible body parser types, to be used with `NestExpressApplication.useBodyParser()`.
+ */
+export type NestExpressBodyParserType = 'json' | 'urlencoded' | 'text' | 'raw';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11302

We were depending on `@types/body-parser` in this new feature, as `body-parser` does not ship its own types. But this breaks when using `skipLibsCheck: false` in `tsconfig.json`.

## What is the new behavior?

I moved the `@types/body-parser` interface we use over to `@nestjs/platform-express`. We already have our own `NestExpressBodyParserOptions` which we can use to type ourselves. So this should not be a breaking change.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information