### PR TITLE
feat: change updateAndGetTimestampDiff from private to protected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log
 /packages/graphql
 /benchmarks/memory
 build/config\.gypi
+
+.npmrc
+pnpm-lock.yaml

--- a/integration/graphql-schema-first/src/main.ts
+++ b/integration/graphql-schema-first/src/main.ts
@@ -1,8 +1,8 @@
 import { NestFactory } from '@nestjs/core';
-import { ApplicationModule } from './app.module';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(ApplicationModule);
+  const app = await NestFactory.create(AppModule);
   await app.listen(3000);
 }
 bootstrap();

--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -251,7 +251,7 @@ export class ConsoleLogger implements LoggerService {
     process.stderr.write(`${stack}\n`);
   }
 
-  private updateAndGetTimestampDiff(): string {
+  protected updateAndGetTimestampDiff(): string {
     const includeTimestamp =
       ConsoleLogger.lastTimestampAt && this.options?.timestamp;
     const result = includeTimestamp

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -253,7 +253,7 @@ export class Logger implements LoggerService {
 
   /**
    * Attach buffer.
-   * Turns on initialisation logs buffering.
+   * Turns on initialization logs buffering.
    */
   static attachBuffer() {
     this.isBufferAttached = true;
@@ -261,7 +261,7 @@ export class Logger implements LoggerService {
 
   /**
    * Detach buffer.
-   * Turns off initialisation logs buffering.
+   * Turns off initialization logs buffering.
    */
   static detachBuffer() {
     this.isBufferAttached = false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

ConsoleLogger.updateAndGetTimestampDiff can't be called in child class. 


## What is the new behavior?

ConsoleLogger.updateAndGetTimestampDiff can be called in child class. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
this PR is related to this discussion https://github.com/nestjs/nest/pull/11391