### PR TITLE
sample(mongoose): change mongoose model type

### DIFF
--- a/sample/06-mongoose/src/cats/cats.service.ts
+++ b/sample/06-mongoose/src/cats/cats.service.ts
@@ -2,13 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { CreateCatDto } from './dto/create-cat.dto';
-import { Cat, CatDocument } from './schemas/cat.schema';
+import { Cat } from './schemas/cat.schema';
 
 @Injectable()
 export class CatsService {
-  constructor(
-    @InjectModel(Cat.name) private readonly catModel: Model<CatDocument>,
-  ) {}
+  constructor(@InjectModel(Cat.name) private readonly catModel: Model<Cat>) {}
 
   async create(createCatDto: CreateCatDto): Promise<Cat> {
     const createdCat = await this.catModel.create(createCatDto);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Change Mongoose sample code

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current example uses `Model<CatDocument>` as a Mongoose model type. The result model type doesn't match the plain Mongoose model type. It wasn't a problem in v6. But the `Model` interface was changed in v7 and now `Model<>` doesn't accept `Document` types. It leads to some type mismatch problems if we use `Document` in generic.

For example, lean documents still have document properties and methods when they shouldn't.

```typescript
// Mongoose v6
type CatDocumentModel = Model<CatDocument>
// Model<Document<unknown, any, Cat> & Cat & { _id: Types.ObjectId }, {}, {}, {}, any>
type CatModel = Model<Cat>
// Model<Cat, {}, {}, {}, any>

// ref: https://mongoosejs.com/docs/6.x/docs/typescript.html#creating-your-first-document
const mongooseCatModel = model<Cat>('Cat', catSchema)
// Model<Cat, {}, {}, {}, any>


// Mongoose v7
type CatDocumentModel = Model<CatDocument>
// Model<Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, {}, {}, {}, Document<unknown, {}, Document<unknown, {}, Cat> & Omit<...>> & Omit<...>, any>
type CatModel = Model<Cat>
// Model<Cat, {}, {}, {}, Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, any>

// ref: https://mongoosejs.com/docs/typescript.html#creating-your-first-document
const mongooseCatModel = model<Cat>('Cat', catSchema)
// Model<Cat, {}, {}, {}, Document<unknown, {}, Cat> & Omit<Cat & { _id: Types.ObjectId }, never>, any>
```


## What is the new behavior?

The Mongoose model type in the example uses `Model<Cat>`. It matches the plain Mongoose model type and provides proper typing.

refs:
https://mongoosejs.com/docs/migrating_to_7.html#removed-leandocument-and-support-for-extends-document
https://github.com/Automattic/mongoose/pull/12924/files#diff-ea95265448afcd58460d834ad313d09f7147696fbaa96a31629e3d4b9bb12585

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR is related to https://github.com/nestjs/docs.nestjs.com/pull/2684