### PR TITLE
chore(): update interface deprecated for kafka

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -4,7 +4,7 @@ import { ChannelOptions } from '../external/grpc-options.interface';
 import {
   ConsumerConfig,
   ConsumerRunConfig,
-  ConsumerSubscribeTopic,
+  ConsumerSubscribeTopics,
   KafkaConfig,
   ProducerConfig,
   ProducerRecord,
@@ -234,7 +234,7 @@ export interface KafkaOptions {
     client?: KafkaConfig;
     consumer?: ConsumerConfig;
     run?: Omit<ConsumerRunConfig, 'eachBatch' | 'eachMessage'>;
-    subscribe?: Omit<ConsumerSubscribeTopic, 'topic'>;
+    subscribe?: Omit<ConsumerSubscribeTopics, 'topic'>;
     producer?: ProducerConfig;
     send?: Omit<ProducerRecord, 'topic' | 'messages'>;
     serializer?: Serializer;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Proposal:

- Updated the `ConsumerSubscribeTopic` interface with `ConsumerSubscribeTopics`, because `ConsumerSubscribeTopic` is deprecated.

<img width="753" alt="screenshot-interface-kafka" src="https://user-images.githubusercontent.com/11542387/229157187-498f132f-e194-4e90-a770-01b0ac9c993c.png">



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information