### PR TITLE
feat: allow extension of microservice event and message extras

### DIFF
--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -61,7 +61,14 @@ export const EventPattern: {
       descriptor.value,
     );
     Reflect.defineMetadata(TRANSPORT_METADATA, transport, descriptor.value);
-    Reflect.defineMetadata(PATTERN_EXTRAS_METADATA, extras, descriptor.value);
+    Reflect.defineMetadata(
+      PATTERN_EXTRAS_METADATA,
+      {
+        ...Reflect.getMetadata(PATTERN_EXTRAS_METADATA, descriptor.value),
+        ...extras,
+      },
+      descriptor.value,
+    );
     return descriptor;
   };
 };

--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -75,7 +75,14 @@ export const MessagePattern: {
       descriptor.value,
     );
     Reflect.defineMetadata(TRANSPORT_METADATA, transport, descriptor.value);
-    Reflect.defineMetadata(PATTERN_EXTRAS_METADATA, extras, descriptor.value);
+    Reflect.defineMetadata(
+      PATTERN_EXTRAS_METADATA,
+      {
+        ...Reflect.getMetadata(PATTERN_EXTRAS_METADATA, descriptor.value),
+        ...extras,
+      },
+      descriptor.value,
+    );
     return descriptor;
   };
 };

--- a/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
@@ -36,6 +36,8 @@ describe('@MessagePattern', () => {
   });
 
   describe('decorator overloads', () => {
+    const additionalExtras = { foo: 'bar' };
+
     class TestComponent1 {
       @MessagePattern(pattern)
       public static test() {}
@@ -50,6 +52,18 @@ describe('@MessagePattern', () => {
     }
     class TestComponent4 {
       @MessagePattern(pattern, Transport.TCP, extras)
+      public static test() {}
+    }
+    class TestComponent5 {
+      @MessagePattern(pattern, Transport.TCP, extras)
+      @((
+        (): MethodDecorator => (_target, _key, descriptor) =>
+          Reflect.defineMetadata(
+            PATTERN_EXTRAS_METADATA,
+            additionalExtras,
+            descriptor.value,
+          )
+      )())
       public static test() {}
     }
 
@@ -68,7 +82,7 @@ describe('@MessagePattern', () => {
       );
       expect(metadataArg).to.be.eql(pattern);
       expect(transportArg).to.be.undefined;
-      expect(extrasArg).to.be.undefined;
+      expect(extrasArg).to.be.eql({});
     });
 
     it(`should enhance method with ${PATTERN_METADATA}, ${TRANSPORT_METADATA} metadata`, () => {
@@ -86,7 +100,7 @@ describe('@MessagePattern', () => {
       );
       expect(metadataArg).to.be.eql(pattern);
       expect(transportArg).to.be.eql(Transport.TCP);
-      expect(extrasArg).to.be.undefined;
+      expect(extrasArg).to.be.eql({});
     });
 
     it(`should enhance method with ${PATTERN_METADATA}, ${PATTERN_EXTRAS_METADATA} metadata`, () => {
@@ -124,6 +138,27 @@ ${PATTERN_EXTRAS_METADATA} metadata`, () => {
       expect(metadataArg).to.be.eql(pattern);
       expect(transportArg).to.be.eql(Transport.TCP);
       expect(extrasArg).to.be.eql(extras);
+    });
+
+    it(`should merge with existing ${PATTERN_EXTRAS_METADATA} metadata`, () => {
+      const [metadataArg] = Reflect.getMetadata(
+        PATTERN_METADATA,
+        TestComponent5.test,
+      );
+      const transportArg = Reflect.getMetadata(
+        TRANSPORT_METADATA,
+        TestComponent5.test,
+      );
+      const extrasArg = Reflect.getMetadata(
+        PATTERN_EXTRAS_METADATA,
+        TestComponent5.test,
+      );
+      expect(metadataArg).to.be.eql(pattern);
+      expect(transportArg).to.be.eql(Transport.TCP);
+      expect(extrasArg).to.be.eql({
+        ...additionalExtras,
+        ...extras,
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Ran into this challenge when creating a custom transport strategy. As far as I can tell there's no way to read additional metadata off of our handlers within the strategy itself; we just have access to the `extras` object.

However, the extras object can only be set when using the `@MessagePattern` or `@EventPattern` decorator reliably because they will always override any existing extras.

Issue Number: N/A

## What is the new behavior?

With this change the `@MessagePattern` and `@EventPattern` decorators will merge their extras with any existing extras found.

In our custom transport framework we have multiple decorators which work the same way as the `@HttpCode` decorator does for an HTTP transport by adding additional metadata that is respected when handling the request. However for the transport technology we're using we need the metadata at binding time vs when the handler is executed, and the extras object is the only metadata available at binding time

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information