### PR TITLE
fix: port number being used insted of options

### DIFF
--- a/packages/websockets/decorators/socket-gateway.decorator.ts
+++ b/packages/websockets/decorators/socket-gateway.decorator.ts
@@ -19,7 +19,7 @@ export function WebSocketGateway<
 >(portOrOptions?: number | T, options?: T): ClassDecorator {
   const isPortInt = Number.isInteger(portOrOptions as number);
   // eslint-disable-next-line prefer-const
-  let [port, opt] = isPortInt ? [portOrOptions, options] : [0, portOrOptions];
+  let [port, opt] = isPortInt ? [portOrOptions, options] : [0, options];
 
   opt = opt || ({} as T);
   return (target: object) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
when the default port is used for the WebSocketGateway decorator the options passed are not applied
```
import { Injectable } from '@nestjs/common';
import { SubscribeMessage, WebSocketGateway, WebSocketServer, MessageBody, ConnectedSocket, OnGatewayDisconnect, } from '@nestjs/websockets';
import { Server, Socket } from 'socket.io';

@Injectable()
@WebSocketGateway(null, {
  cors: {
    origin: '*'  
  }
})
export class EventsGateway {

  @WebSocketServer()
  server: Server;
  socketId: string;


  afterInit() {
    console.log('Socket.io server initialized');
  }
}
```
Like in the above code i am trying to enable CORS for websocket as CORS apllied to the nest app do bot apply for socket.io 

![image](https://user-images.githubusercontent.com/74726248/230735477-0edbefb6-8379-4340-a709-379fbe898422.png)
Here as the `Access-Control-Allow-Origin` header is missing we can see that CORS was not appled the socket.io instance, even though the correct options are passed in

when the port number is explicitly defined tho it works. but connot use the same port as it will throw an error
```
@WebSocketGateway(3000, {
  cors: {
    origin: '*'  
  }
})
```

`[Nest] 28255  - 04/08/2023, 9:51:56 PM   ERROR [NestApplication] Error: listen EADDRINUSE: address already in use :::3000 +2ms`

<mark>I have identified the issue to be a minor mistake of using the portNumber insted of sockets options when port number is undefined</mark> (the naming is a bit confusing so understandable) [portOrOptions/options]

## What is the new behavior?
websockets work normally and I can pass in options too

finally can enable CORS for websockets on NestJS
![image](https://user-images.githubusercontent.com/74726248/230735370-c9447cf5-ea93-47e2-916a-d1860624a1e0.png)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


