### PR TITLE
refactor(common)!: drop deprecated misspelled constant `CUSTOM_ROUTE_AGRS_METADATA`

### DIFF
--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -17,10 +17,6 @@ export const SCOPE_OPTIONS_METADATA = 'scope:options';
 export const METHOD_METADATA = 'method';
 export const ROUTE_ARGS_METADATA = '__routeArguments__';
 export const CUSTOM_ROUTE_ARGS_METADATA = '__customRouteArgs__';
-/**
- * @deprecated Use `CUSTOM_ROUTE_ARGS_METADATA` instead
- */
-export const CUSTOM_ROUTE_AGRS_METADATA = CUSTOM_ROUTE_ARGS_METADATA;
 export const FILTER_CATCH_EXCEPTIONS = '__filterCatchExceptions__';
 
 export const PIPES_METADATA = '__pipes__';


### PR DESCRIPTION
I'm not sure if we will drop the deprecated methods on `core/metadata-scanner.ts` in v10

https://github.com/nestjs/nest/blob/bee462e031f9562210c65b9eb8e8a20cab1f301f/packages/core/metadata-scanner.ts#L12-L16

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No