### PR TITLE
feat(validation.pipe): implicit parse query

### DIFF
--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -6,6 +6,7 @@ import {
   IsArray,
   IsBoolean,
   IsDefined,
+  IsNumber,
   IsOptional,
   IsString,
   ValidateNested,
@@ -246,6 +247,32 @@ describe('ValidationPipe', () => {
               type: 'param',
             }),
           ).to.be.true;
+        });
+      });
+      describe('when input is a query parameter (Object)', () => {
+        class TestModelQuery {
+          @IsString()
+          public prop1: string;
+
+          @IsNumber()
+          public prop2: number;
+
+          @IsBoolean()
+          public prop3: boolean;
+
+          @IsOptional()
+          @IsString()
+          public optionalProp: string;
+        }
+        it('should return value follows a given instance', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = { prop1: 'value1', prop2: '34', prop3: 'false' };
+          const result = await target.transform(value, {
+            metatype: TestModelQuery,
+            data: 'test',
+            type: 'query',
+          });
+          expect(result).to.eql({ prop1: 'value1', prop2: 34, prop3: false });
         });
       });
       describe('when validation strips', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Parse query string implicitly based on class type definition. 

For Example: if the given string is `?prop1=value1&prop2=34&prop3=false`,
with the query data needs to satisfy class 
```typescript
  class TestModelQuery {
    @IsString()
    public prop1: string;

    @IsNumber()
    public prop2: number;

    @IsBoolean()
    public prop3: boolean;

    @IsOptional()
    @IsString()
    public optionalProp: string;
  }
```
The result data transforms to `{ prop1: "value1", prop2: 34, prop3: false }`. 


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information