### PR TITLE
fix(microservices): when postfixId is an empty string on kafka

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -64,7 +64,8 @@ export class ClientKafka extends ClientProxy {
       this.getOptionsProp(this.options, 'client') || ({} as KafkaConfig);
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
-    const postfixId = this.options['postfixId'] ?? '-client';
+    const postfixId =
+      this.getOptionsProp(this.options, 'consumer') ?? '-client';
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -283,6 +283,14 @@ export class ClientKafka extends ClientProxy {
     }
   }
 
+  public getGroupId() {
+    return this.groupId
+  }
+
+  public getClientId() {
+    return this.clientId
+  }
+
   protected getResponsePatternName(pattern: string): string {
     return `${pattern}.reply`;
   }

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -65,7 +65,7 @@ export class ClientKafka extends ClientProxy {
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
-      this.getOptionsProp(this.options, 'postfixId') ?? '-client';
+      this.getOptionsProp(this.options, 'postfixId', undefined, true) ?? '-client';
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -65,7 +65,7 @@ export class ClientKafka extends ClientProxy {
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
-      this.getOptionsProp(this.options, 'postfixId', undefined, true) ?? '-client';
+      this.getOptionsProp(this.options, 'postfixId', '-client', true);
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -65,7 +65,7 @@ export class ClientKafka extends ClientProxy {
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
     const postfixId =
-      this.getOptionsProp(this.options, 'consumer') ?? '-client';
+      this.getOptionsProp(this.options, 'postfixId') ?? '-client';
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -64,8 +64,7 @@ export class ClientKafka extends ClientProxy {
       this.getOptionsProp(this.options, 'client') || ({} as KafkaConfig);
     const consumerOptions =
       this.getOptionsProp(this.options, 'consumer') || ({} as ConsumerConfig);
-    const postfixId =
-      this.getOptionsProp(this.options, 'postfixId') ?? '-client';
+    const postfixId = this.options['postfixId'] ?? '-client';
     this.producerOnlyMode =
       this.getOptionsProp(this.options, 'producerOnlyMode') || false;
 

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -129,7 +129,7 @@ export abstract class ClientProxy {
   protected getOptionsProp<
     T extends ClientOptions['options'],
     K extends keyof T,
-  >(obj: T, prop: K, defaultValue: T[K] = undefined, nullishCoalesce = false) {
+  >(obj: T, prop: K, defaultValue: T[K] = undefined, nullishCoalesce: boolean = false) {
     if (nullishCoalesce) {
       return (obj && obj[prop]) ?? defaultValue;
     } else {

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -129,7 +129,7 @@ export abstract class ClientProxy {
   protected getOptionsProp<
     T extends ClientOptions['options'],
     K extends keyof T,
-  >(obj: T, prop: K, defaultValue: T[K] = undefined, nullishCoalesce: boolean = false) {
+  >(obj: T, prop: K, defaultValue: T[K] = undefined, nullishCoalesce = false) {
     if (nullishCoalesce) {
       return (obj && obj[prop]) ?? defaultValue;
     } else {

--- a/packages/microservices/client/client-proxy.ts
+++ b/packages/microservices/client/client-proxy.ts
@@ -129,8 +129,12 @@ export abstract class ClientProxy {
   protected getOptionsProp<
     T extends ClientOptions['options'],
     K extends keyof T,
-  >(obj: T, prop: K, defaultValue: T[K] = undefined) {
-    return (obj && obj[prop]) || defaultValue;
+  >(obj: T, prop: K, defaultValue: T[K] = undefined, nullishCoalesce = false) {
+    if (nullishCoalesce) {
+      return (obj && obj[prop]) ?? defaultValue;
+    } else {
+      return (obj && obj[prop]) || defaultValue;
+    }
   }
 
   protected normalizePattern(pattern: MsPattern): string {

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -227,7 +227,7 @@ describe('ClientKafka', () => {
       expect(client.getGroupId()).to.eq('nestjs-group');
     });
 
-    it('should postfix clientId and groupId with postfixId', async () => {
+    it('should postfix clientId and groupId with default postfixId', async () => {
       const client = new ClientKafka({});
       expect(client.getClientId()).to.eq('nestjs-consumer-client');
       expect(client.getGroupId()).to.eq('nestjs-group-client');

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -218,6 +218,24 @@ describe('ClientKafka', () => {
 
       expect(logCreatorSpy.called).to.be.true;
     });
+
+    it('should allow an empty postfixId', async () => {
+      const client = new ClientKafka({
+        postfixId: ''
+      })
+      // @ts-ignore: we need to see internal field
+      expect(client.clientId).to.eq('nestjs-consumer')
+      // @ts-ignore: we need to see internal field
+      expect(client.groupId).to.eq('nestjs-group')
+    });
+
+    it('should postfix clientId and groupId with postfixId', async () => {
+      const client = new ClientKafka({ })
+      // @ts-ignore: we need to see internal field
+      expect(client.clientId).to.eq('nestjs-consumer-client')
+      // @ts-ignore: we need to see internal field
+      expect(client.groupId).to.eq('nestjs-group-client')
+    });
   });
 
   describe('subscribeToResponseOf', () => {

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -222,19 +222,15 @@ describe('ClientKafka', () => {
     it('should allow an empty postfixId', async () => {
       const client = new ClientKafka({
         postfixId: ''
-      })
-      // @ts-ignore: we need to see internal field
-      expect(client.clientId).to.eq('nestjs-consumer')
-      // @ts-ignore: we need to see internal field
-      expect(client.groupId).to.eq('nestjs-group')
+      });
+      expect(client.getClientId()).to.eq('nestjs-consumer');
+      expect(client.getGroupId()).to.eq('nestjs-group');
     });
 
     it('should postfix clientId and groupId with postfixId', async () => {
-      const client = new ClientKafka({ })
-      // @ts-ignore: we need to see internal field
-      expect(client.clientId).to.eq('nestjs-consumer-client')
-      // @ts-ignore: we need to see internal field
-      expect(client.groupId).to.eq('nestjs-group-client')
+      const client = new ClientKafka({});
+      expect(client.getClientId()).to.eq('nestjs-consumer-client');
+      expect(client.getGroupId()).to.eq('nestjs-group-client');
     });
   });
 


### PR DESCRIPTION
`getOptionsProp` does an `||` with the passed value so empty strings end up being set as undefined

We may want to add a test for this since it doesn't seem like this behavior was covered.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Passing `postfixId: ''` does not do what you'd expect and instead continues to the use the default `postfixId` values

## What is the new behavior?
Passing `postfixId: ''` will now correctly unset the `postfixId` and disable that behavior

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Current behavior is a bug but users might be relying on the bug.

## Other information