### PR TITLE
fix(common): `ConsoleLogger` doesn't log stacktrace

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -281,6 +281,14 @@ export class ConsoleLogger implements LoggerService {
   }
 
   private getContextAndStackAndMessagesToPrint(args: unknown[]) {
+    if (args.length === 2) {
+      return {
+        messages: [args[0]],
+        stack: args[1] as string,
+        context: this.context,
+      };
+    }
+
     const { messages, context } = this.getContextAndMessagesToPrint(args);
     if (messages?.length <= 1) {
       return { messages, context };

--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -80,6 +80,7 @@ export class ConsoleLogger implements LoggerService {
    * Write an 'error' level log, if the configured level allows for it.
    * Prints to `stderr` with newline.
    */
+  error(message: any, stackOrContext?: string): void;
   error(message: any, stack?: string, context?: string): void;
   error(message: any, ...optionalParams: [...any, string?, string?]): void;
   error(message: any, ...optionalParams: any[]) {
@@ -282,11 +283,16 @@ export class ConsoleLogger implements LoggerService {
 
   private getContextAndStackAndMessagesToPrint(args: unknown[]) {
     if (args.length === 2) {
-      return {
-        messages: [args[0]],
-        stack: args[1] as string,
-        context: this.context,
-      };
+      return this.isStackFormat(args[1])
+        ? {
+            messages: [args[0]],
+            stack: args[1] as string,
+            context: this.context,
+          }
+        : {
+            messages: [args[0]],
+            context: args[1] as string,
+          };
     }
 
     const { messages, context } = this.getContextAndMessagesToPrint(args);
@@ -304,6 +310,14 @@ export class ConsoleLogger implements LoggerService {
       messages: messages.slice(0, messages.length - 1),
       context,
     };
+  }
+
+  private isStackFormat(stack: unknown) {
+    if (!isString(stack) && !isUndefined(stack)) {
+      return false;
+    }
+
+    return /^(.)+\n\s+at .+:\d+:\d+$/.test(stack);
   }
 
   private getColorByLogLevel(level: LogLevel) {

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -188,6 +188,7 @@ export class Logger implements LoggerService {
   /**
    * Write an 'error' level log.
    */
+  static error(message: any, stackOrContext?: string): void;
   static error(message: any, context?: string): void;
   static error(message: any, stack?: string, context?: string): void;
   static error(

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -70,19 +70,6 @@ describe('Logger', () => {
         );
       });
 
-      it('should print one error to the console', () => {
-        const message = 'random error';
-        const context = 'RandomContext';
-
-        Logger.error(message, context);
-
-        expect(processStderrWriteSpy.calledOnce).to.be.true;
-        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
-          `[${context}]`,
-        );
-        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
-      });
-
       it('should print one error without context to the console', () => {
         const message = 'random error without context';
 
@@ -114,6 +101,20 @@ describe('Logger', () => {
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(`Object:`);
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(
           `{\n  "randomError": true\n}`,
+        );
+      });
+
+      it('should print one error to the console with stacktrace and no context', () => {
+        const message = 'random error';
+        const stacktrace = 'stacktrace';
+
+        Logger.error(message, stacktrace);
+
+        expect(processStderrWriteSpy.calledTwice).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.not.include(`[]`);
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+        expect(processStderrWriteSpy.secondCall.firstArg).to.equal(
+          stacktrace + '\n',
         );
       });
 
@@ -354,17 +355,18 @@ describe('Logger', () => {
         );
       });
 
-      it('should print one error to the console', () => {
+      it('should print one error to the console with stacktrace and no context', () => {
         const message = 'random error';
-        const context = 'RandomContext';
+        const stacktrace = 'stacktrace';
 
-        logger.error(message, context);
+        logger.error(message, stacktrace);
 
-        expect(processStderrWriteSpy.calledOnce).to.be.true;
-        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
-          `[${context}]`,
-        );
+        expect(processStderrWriteSpy.calledTwice).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.not.include(`[]`);
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+        expect(processStderrWriteSpy.secondCall.firstArg).to.equal(
+          stacktrace + '\n',
+        );
       });
 
       it('should print one error without context to the console', () => {

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -70,6 +70,19 @@ describe('Logger', () => {
         );
       });
 
+      it('should print one error to the console', () => {
+        const message = 'random error';
+        const context = 'RandomContext';
+
+        Logger.error(message, undefined, context);
+
+        expect(processStderrWriteSpy.calledOnce).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
+          `[${context}]`,
+        );
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+      });
+
       it('should print one error without context to the console', () => {
         const message = 'random error without context';
 
@@ -353,6 +366,19 @@ describe('Logger', () => {
         expect(processStdoutWriteSpy.thirdCall.firstArg).to.include(
           messages[2],
         );
+      });
+
+      it('should print one error to the console', () => {
+        const message = 'random error';
+        const context = 'RandomContext';
+
+        logger.error(message, undefined, context);
+
+        expect(processStderrWriteSpy.calledOnce).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
+          `[${context}]`,
+        );
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
       });
 
       it('should print one error to the console with stacktrace and no context', () => {

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -70,17 +70,31 @@ describe('Logger', () => {
         );
       });
 
-      it('should print one error to the console', () => {
+      it('should print one error to the console with context', () => {
         const message = 'random error';
         const context = 'RandomContext';
 
-        Logger.error(message, undefined, context);
+        Logger.error(message, context);
 
         expect(processStderrWriteSpy.calledOnce).to.be.true;
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(
           `[${context}]`,
         );
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+      });
+
+      it('should print one error to the console with stacktrace', () => {
+        const message = 'random error';
+        const stacktrace = 'Error: message\n    at <anonymous>:1:2';
+
+        Logger.error(message, stacktrace);
+
+        expect(processStderrWriteSpy.calledTwice).to.be.true;
+        expect(processStderrWriteSpy.firstCall.firstArg).to.not.include(`[]`);
+        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
+        expect(processStderrWriteSpy.secondCall.firstArg).to.equal(
+          stacktrace + '\n',
+        );
       });
 
       it('should print one error without context to the console', () => {
@@ -114,20 +128,6 @@ describe('Logger', () => {
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(`Object:`);
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(
           `{\n  "randomError": true\n}`,
-        );
-      });
-
-      it('should print one error to the console with stacktrace and no context', () => {
-        const message = 'random error';
-        const stacktrace = 'stacktrace';
-
-        Logger.error(message, stacktrace);
-
-        expect(processStderrWriteSpy.calledTwice).to.be.true;
-        expect(processStderrWriteSpy.firstCall.firstArg).to.not.include(`[]`);
-        expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
-        expect(processStderrWriteSpy.secondCall.firstArg).to.equal(
-          stacktrace + '\n',
         );
       });
 
@@ -368,11 +368,11 @@ describe('Logger', () => {
         );
       });
 
-      it('should print one error to the console', () => {
+      it('should print one error to the console with context', () => {
         const message = 'random error';
         const context = 'RandomContext';
 
-        logger.error(message, undefined, context);
+        logger.error(message, context);
 
         expect(processStderrWriteSpy.calledOnce).to.be.true;
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(
@@ -381,9 +381,9 @@ describe('Logger', () => {
         expect(processStderrWriteSpy.firstCall.firstArg).to.include(message);
       });
 
-      it('should print one error to the console with stacktrace and no context', () => {
+      it('should print one error to the console with stacktrace', () => {
         const message = 'random error';
-        const stacktrace = 'stacktrace';
+        const stacktrace = 'Error: message\n    at <anonymous>:1:2';
 
         logger.error(message, stacktrace);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 The second parameter in `error` function must be a stack, but it logs context instead (if I pass 2 parameters to `error` function).

```
logger.error('message', 'stacktrace');
```

Log:
```
[Nest] 153  - 04/27/2023, 12:34:05 PM   ERROR [stacktrace] message
```

## What is the new behavior?
Log stack instead of context if passing 2 arguments to `error` function.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information