### PR TITLE
chore(deps): remove caret sign from @fastify/cors

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@codechecks/client": "0.1.12",
     "@commitlint/cli": "17.6.1",
     "@commitlint/config-angular": "17.6.1",
-    "@fastify/cors": "^8.0.0",
+    "@fastify/cors": "8.2.1",
     "@fastify/formbody": "7.4.0",
     "@fastify/middie": "8.1.0",
     "@fastify/multipart": "7.6.0",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the `package.json` file the `@fastify/cors` dependency has a caret sign before it which is not true for all other dependencies. 


## What is the new behavior?
Hardcoded `@fastify/cors` dependency version to `8.2.1`. That is the current version in the lock file of the main branch anyway.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->