### PR TITLE
fix(sample): change mysql connection host to 127.0.0.1

### DIFF
--- a/sample/05-sql-typeorm/src/app.module.ts
+++ b/sample/05-sql-typeorm/src/app.module.ts
@@ -6,7 +6,7 @@ import { UsersModule } from './users/users.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'mysql',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       username: 'root',
       password: 'root',

--- a/sample/05-sql-typeorm/test/users/users.e2e-spec.ts
+++ b/sample/05-sql-typeorm/test/users/users.e2e-spec.ts
@@ -20,7 +20,7 @@ describe('Users - /users (e2e)', () => {
       imports: [
         TypeOrmModule.forRoot({
           type: 'mysql',
-          host: 'localhost',
+          host: '127.0.0.1',
           port: 3307,
           username: 'root',
           password: 'root',

--- a/sample/07-sequelize/src/app.module.ts
+++ b/sample/07-sequelize/src/app.module.ts
@@ -6,7 +6,7 @@ import { UsersModule } from './users/users.module';
   imports: [
     SequelizeModule.forRoot({
       dialect: 'mysql',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       username: 'root',
       password: 'root',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
This PR changes mysql connection host to '127.0.0.1'
Because nodejs prefers IPv6 addresses over IPv4 after 17 version.
I am using the LTS version and I found that the sample code gives error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
here is my local test log
### as-is
```
 day1@MacBook-Pro  ~/Documents/git/nest/sample/05-sql-typeorm   master  node -v
v18.14.0
 day1@MacBook-Pro  ~/Documents/git/nest/sample/05-sql-typeorm   master  npm start

> nest-typescript-starter@1.0.0 start
> nest start

[Nest] 43476  - 2023. 05. 22. 오후 6:58:30     LOG [NestFactory] Starting Nest application...
[Nest] 43476  - 2023. 05. 22. 오후 6:58:30     LOG [InstanceLoader] AppModule dependencies initialized +167ms
[Nest] 43476  - 2023. 05. 22. 오후 6:58:30     LOG [InstanceLoader] TypeOrmModule dependencies initialized +0ms
[Nest] 43476  - 2023. 05. 22. 오후 6:58:30   ERROR [TypeOrmModule] Unable to connect to the database. Retrying (1)...
Error: connect ECONNREFUSED ::1:3306
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
[Nest] 43476  - 2023. 05. 22. 오후 6:58:33   ERROR [TypeOrmModule] Unable to connect to the database. Retrying (2)...
Error: connect ECONNREFUSED ::1:3306
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
[Nest] 43476  - 2023. 05. 22. 오후 6:58:36   ERROR [TypeOrmModule] Unable to connect to the database. Retrying (3)...
Error: connect ECONNREFUSED ::1:3306
    at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
```

### to-be
```
 day1@MacBook-Pro  ~/Documents/git/nest/sample/05-sql-typeorm   fix/mysql-connection-host-sample  node -v
v18.14.0
 day1@MacBook-Pro  ~/Documents/git/nest/sample/05-sql-typeorm   fix/mysql-connection-host-sample  npm start

> nest-typescript-starter@1.0.0 start
> nest start

[Nest] 43144  - 2023. 05. 22. 오후 6:57:49     LOG [NestFactory] Starting Nest application...
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [InstanceLoader] AppModule dependencies initialized +162ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [InstanceLoader] TypeOrmModule dependencies initialized +0ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [InstanceLoader] TypeOrmCoreModule dependencies initialized +116ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [InstanceLoader] TypeOrmModule dependencies initialized +0ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [InstanceLoader] UsersModule dependencies initialized +2ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [RoutesResolver] UsersController {/users}: +21ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [RouterExplorer] Mapped {/users, POST} route +3ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [RouterExplorer] Mapped {/users, GET} route +1ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [RouterExplorer] Mapped {/users/:id, GET} route +1ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [RouterExplorer] Mapped {/users/:id, DELETE} route +0ms
[Nest] 43144  - 2023. 05. 22. 오후 6:57:50     LOG [NestApplication] Nest application successfully started +3ms
Application is running on: http://[::1]:3000
```