### PR TITLE
fix(integration): change mysql connection host to 127.0.0.1

### DIFF
--- a/integration/typeorm/ormconfig.json
+++ b/integration/typeorm/ormconfig.json
@@ -1,6 +1,6 @@
 {
   "type": "mysql",
-  "host": "localhost",
+  "host": "127.0.0.1",
   "port": 3306,
   "username": "root",
   "password": "root",

--- a/integration/typeorm/src/app.module.ts
+++ b/integration/typeorm/src/app.module.ts
@@ -7,7 +7,7 @@ import { PhotoModule } from './photo/photo.module';
   imports: [
     TypeOrmModule.forRoot({
       type: 'mysql',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       username: 'root',
       password: 'root',

--- a/integration/typeorm/src/async-class-options.module.ts
+++ b/integration/typeorm/src/async-class-options.module.ts
@@ -11,7 +11,7 @@ class ConfigService implements TypeOrmOptionsFactory {
   createTypeOrmOptions(): TypeOrmModuleOptions {
     return {
       type: 'mysql',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       username: 'root',
       password: 'root',

--- a/integration/typeorm/src/async-existing-options.module.ts
+++ b/integration/typeorm/src/async-existing-options.module.ts
@@ -11,7 +11,7 @@ class ConfigService implements TypeOrmOptionsFactory {
   createTypeOrmOptions(): TypeOrmModuleOptions {
     return {
       type: 'mysql',
-      host: 'localhost',
+      host: '127.0.0.1',
       port: 3306,
       username: 'root',
       password: 'root',

--- a/integration/typeorm/src/async-options.module.ts
+++ b/integration/typeorm/src/async-options.module.ts
@@ -8,7 +8,7 @@ import { PhotoModule } from './photo/photo.module';
     TypeOrmModule.forRootAsync({
       useFactory: () => ({
         type: 'mysql',
-        host: 'localhost',
+        host: '127.0.0.1',
         port: 3306,
         username: 'root',
         password: 'root',

--- a/integration/typeorm/src/database.module.ts
+++ b/integration/typeorm/src/database.module.ts
@@ -11,7 +11,7 @@ export class DatabaseModule {
       imports: [
         TypeOrmModule.forRoot({
           type: 'mysql',
-          host: 'localhost',
+          host: '127.0.0.1',
           port: 3306,
           username: 'root',
           password: 'root',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

related #11648
This PR changes mysql connection host to '127.0.0.1'
Because nodejs prefers IPv6 addresses over IPv4 after 17 version.

I confirmed that this change solves typeorm test failure in integration test.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The following error occurred in node 18.14.0 version
```
  28) TypeOrm (async configuration)
       "before each" hook for "should return created entity":
     Error: connect ECONNREFUSED ::1:3306
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
      at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

  29) TypeOrm (async configuration)
       "after each" hook for "should return created entity":
     TypeError: Cannot read properties of undefined (reading 'close')
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-class.spec.ts:27:15
      at Generator.next (<anonymous>)
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-class.spec.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (integration/typeorm/e2e/typeorm-async-class.spec.ts:4:12)
      at Context.<anonymous> (integration/typeorm/e2e/typeorm-async-class.spec.ts:26:24)
      at processImmediate (node:internal/timers:476:21)
      at process.topLevelDomainCallback (node:domain:161:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24)

  30) TypeOrm (async configuration)
       "before each" hook for "should return created entity":
     Error: connect ECONNREFUSED ::1:3306
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
      at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

  31) TypeOrm (async configuration)
       "after each" hook for "should return created entity":
     TypeError: Cannot read properties of undefined (reading 'close')
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-existing.spec.ts:27:15
      at Generator.next (<anonymous>)
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-existing.spec.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (integration/typeorm/e2e/typeorm-async-existing.spec.ts:4:12)
      at Context.<anonymous> (integration/typeorm/e2e/typeorm-async-existing.spec.ts:26:24)
      at processImmediate (node:internal/timers:476:21)
      at process.topLevelDomainCallback (node:domain:161:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24)

  32) TypeOrm (async configuration)
       "before each" hook for "should return created entity":
     Error: connect ECONNREFUSED ::1:3306
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
      at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

  33) TypeOrm (async configuration)
       "after each" hook for "should return created entity":
     TypeError: Cannot read properties of undefined (reading 'close')
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-options.spec.ts:27:15
      at Generator.next (<anonymous>)
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async-options.spec.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (integration/typeorm/e2e/typeorm-async-options.spec.ts:4:12)
      at Context.<anonymous> (integration/typeorm/e2e/typeorm-async-options.spec.ts:26:24)
      at processImmediate (node:internal/timers:476:21)
      at process.topLevelDomainCallback (node:domain:161:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24)

  34) TypeOrm (async configuration)
       "before each" hook for "should return created entity":
     Error: connect ECONNREFUSED ::1:3306
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
      at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

  35) TypeOrm (async configuration)
       "after each" hook for "should return created entity":
     TypeError: Cannot read properties of undefined (reading 'close')
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async.spec.ts:27:15
      at Generator.next (<anonymous>)
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm-async.spec.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (integration/typeorm/e2e/typeorm-async.spec.ts:4:12)
      at Context.<anonymous> (integration/typeorm/e2e/typeorm-async.spec.ts:26:24)
      at processImmediate (node:internal/timers:476:21)
      at process.topLevelDomainCallback (node:domain:161:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24)

  36) TypeOrm
       "before each" hook for "should return created entity":
     Error: connect ECONNREFUSED ::1:3306
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1494:16)
      at TCPConnectWrap.callbackTrampoline (node:internal/async_hooks:130:17)

  37) TypeOrm
       "after each" hook for "should return created entity":
     TypeError: Cannot read properties of undefined (reading 'close')
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm.spec.ts:27:15
      at Generator.next (<anonymous>)
      at /Users/day1/Documents/git/nest/integration/typeorm/e2e/typeorm.spec.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (integration/typeorm/e2e/typeorm.spec.ts:4:12)
      at Context.<anonymous> (integration/typeorm/e2e/typeorm.spec.ts:26:24)
      at processImmediate (node:internal/timers:476:21)
      at process.topLevelDomainCallback (node:domain:161:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24)
```