### PR TITLE
fix(common): loosen http exception cause type

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -2,7 +2,8 @@ import { Logger } from '../services';
 import { isObject, isString } from '../utils/shared.utils';
 
 export interface HttpExceptionOptions {
-  cause?: Error;
+  /** original cause of the error */
+  cause?: unknown;
   description?: string;
 }
 
@@ -67,14 +68,13 @@ export class HttpException extends Error {
     this.initCause();
   }
 
-  public cause: Error | undefined;
+  public cause: unknown;
 
   /**
    * Configures error chaining support
    *
-   * See:
-   * - https://nodejs.org/en/blog/release/v16.9.0/#error-cause
-   * - https://github.com/microsoft/TypeScript/issues/45167
+   * @see https://nodejs.org/en/blog/release/v16.9.0/#error-cause
+   * @see https://github.com/microsoft/TypeScript/issues/45167
    */
   public initCause(): void {
     if (this.options?.cause) {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (existing coverage)
- [ ] ~Docs have been added / updated (N/A)~


## PR Type

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/11665


## What is the new behavior?

Loose `HttpExceptionOptions.cause` type from `Error` to `unknown`.

## Does this PR introduce a breaking change?

- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Per [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) it seems this property can by of any type (given you can throw anything in JavaScript), so internal conditional logic seems unnecessary.