### PR TITLE
fix(express): Extend MulterOptions dest to match Multer's engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3245,6 +3245,15 @@
       "integrity": "sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==",
       "dev": true
     },
+    "@types/multer": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.7.tgz",
+      "integrity": "sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/node": {
       "version": "20.2.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/gulp": "4.0.11",
     "@types/http-errors": "2.0.1",
     "@types/mocha": "10.0.1",
+    "@types/multer": "^1.4.7",
     "@types/node": "20.2.5",
     "@types/sinon": "10.0.15",
     "@types/supertest": "2.0.12",

--- a/packages/platform-express/multer/interfaces/multer-options.interface.ts
+++ b/packages/platform-express/multer/interfaces/multer-options.interface.ts
@@ -1,8 +1,17 @@
 /**
  * @see https://github.com/expressjs/multer
  */
+import { Request } from 'express';
+
 export interface MulterOptions {
-  dest?: string;
+  dest?:
+    | string
+    | ((
+        req: Request,
+        file: Express.Multer.File,
+        callback: (error: Error | null, destination: string) => void,
+      ) => void)
+    | undefined;
   /** The storage engine to use for uploaded files. */
   storage?: any;
   /**


### PR DESCRIPTION
Fixes nestjs/nest#11607

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Incomplete type definition, `dest` in MulterOptions interface only allows string

Issue Number: #11607 


## What is the new behavior?
Type is extended to union and either accepts string and function that matches 
https://github.com/expressjs/multer/blob/master/storage/disk.js#L20
See also: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/ab674ff124cd19f3d4add271cbb919fe1d9821a8/types/multer/index.d.ts#L288


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information