### PR TITLE
fix(microservices): migrate from deprecated kafka subscribe usage

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -163,12 +163,13 @@ export class ClientKafka extends ClientProxy {
     }
 
     const consumerSubscribeOptions = this.options.subscribe || {};
-    const subscribeTo = async (responsePattern: string) =>
-      this.consumer.subscribe({
-        topic: responsePattern,
+
+    if (this.responsePatterns.length > 0) {
+      await this.consumer.subscribe({
         ...consumerSubscribeOptions,
+        topics: this.responsePatterns,
       });
-    await Promise.all(this.responsePatterns.map(subscribeTo));
+    }
 
     await this.consumer.run(
       Object.assign(this.options.run || {}, {

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -122,12 +122,13 @@ export class ServerKafka extends Server implements CustomTransportStrategy {
   public async bindEvents(consumer: Consumer) {
     const registeredPatterns = [...this.messageHandlers.keys()];
     const consumerSubscribeOptions = this.options.subscribe || {};
-    const subscribeToPattern = async (pattern: string) =>
-      consumer.subscribe({
-        topic: pattern,
+
+    if (registeredPatterns.length > 0) {
+      await this.consumer.subscribe({
         ...consumerSubscribeOptions,
+        topics: registeredPatterns,
       });
-    await Promise.all(registeredPatterns.map(subscribeToPattern));
+    }
 
     const consumerRunOptions = Object.assign(this.options.run || {}, {
       eachMessage: this.getMessageHandler(),

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -435,7 +435,7 @@ describe('ClientKafka', () => {
       expect(subscribe.calledOnce).to.be.true;
       expect(
         subscribe.calledWith({
-          topic: replyTopic,
+          topics: [replyTopic],
         }),
       ).to.be.true;
       expect(run.calledOnce).to.be.true;
@@ -452,7 +452,7 @@ describe('ClientKafka', () => {
       expect(subscribe.calledOnce).to.be.true;
       expect(
         subscribe.calledWith({
-          topic: replyTopic,
+          topics: [replyTopic],
           fromBeginning: true,
         }),
       ).to.be.true;

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -190,7 +190,7 @@ describe('ServerKafka', () => {
       expect(subscribe.called).to.be.true;
       expect(
         subscribe.calledWith({
-          topic: pattern,
+          topics: [pattern],
         }),
       ).to.be.true;
 
@@ -214,7 +214,7 @@ describe('ServerKafka', () => {
       expect(subscribe.called).to.be.true;
       expect(
         subscribe.calledWith({
-          topic: pattern,
+          topics: [pattern],
           fromBeginning: true,
         }),
       ).to.be.true;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

currently, Kafka is subscribing to topics one by one, which is deprecated

https://github.com/nestjs/nest/blob/8399c68b20cd76d766cd25790f662ef211e810ff/packages/microservices/external/kafka.interface.ts#L1034-L1045

## What is the new behavior?

Use the correct way to subscribe to topics using a single call as described in [their docs](https://kafka.js.org/docs/consuming)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information