### PR TITLE
fix(core): when filtering routes ending with slash to apply a nestjs middleware

### DIFF
--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -108,10 +108,10 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
           ),
         }));
       return routes.filter(route => {
-        const isOverlapped = (v: { path: string; regex: RegExp }) => {
+        const isOverlapped = (v: { path: string; regex: RegExp }): boolean => {
           const normalizedRoutePath = stripEndSlash(route.path);
           return (
-            normalizedRoutePath !== v.path && normalizedRoutePath.match(v.regex)
+            normalizedRoutePath !== v.path && v.regex.test(normalizedRoutePath)
           );
         };
         const routeMatch = routesWithRegex.find(isOverlapped);

--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -1,3 +1,4 @@
+import { stripEndSlash } from '@nestjs/common/utils/shared.utils';
 import { flatten } from '@nestjs/common/decorators/core/dependencies.decorator';
 import {
   HttpServer,
@@ -108,12 +109,15 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
         }));
       return routes.filter(route => {
         const isOverlapped = (v: { path: string; regex: RegExp }) => {
-          return route.path !== v.path && route.path.match(v.regex);
+          const normalizedRoutePath = stripEndSlash(route.path);
+          return (
+            normalizedRoutePath !== v.path && normalizedRoutePath.match(v.regex)
+          );
         };
         const routeMatch = routesWithRegex.find(isOverlapped);
 
         if (routeMatch === undefined) {
-         return route;
+          return route;
         }
       });
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #11833


## What is the new behavior?

dot not exclude routes ending with slash

but I'm not 100% sure on this fix although it works for the mentioned Issue (I tested it locally)

@rychardvale could you please review this?

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information