### PR TITLE
feat(microservices): handle kafka consumer crashes

### DIFF
--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+
 import { ClientKafka } from '../../client/client-kafka';
 import { NO_MESSAGE_HANDLER } from '../../constants';
 import { KafkaHeaders } from '../../enums';
@@ -176,6 +177,7 @@ describe('ClientKafka', () => {
         run,
         events: {
           GROUP_JOIN: 'consumer.group_join',
+          CRASH: 'consumer.crash',
         },
         on,
       };
@@ -288,7 +290,7 @@ describe('ClientKafka', () => {
 
         expect(consumerStub.calledOnce).to.be.true;
 
-        expect(on.calledOnce).to.be.true;
+        expect(on.calledTwice).to.be.true;
         expect(client['consumerAssignments']).to.be.empty;
 
         expect(connect.calledTwice).to.be.true;

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { AssertionError, expect } from 'chai';
 import * as sinon from 'sinon';
+
 import { NO_MESSAGE_HANDLER } from '../../constants';
 import { KafkaHeaders } from '../../enums';
 import {
@@ -90,6 +91,7 @@ describe('ServerKafka', () => {
   let subscribe: sinon.SinonSpy;
   let run: sinon.SinonSpy;
   let send: sinon.SinonSpy;
+  let on: sinon.SinonSpy;
   let consumerStub: sinon.SinonStub;
   let producerStub: sinon.SinonStub;
   let client;
@@ -101,12 +103,17 @@ describe('ServerKafka', () => {
     subscribe = sinon.spy();
     run = sinon.spy();
     send = sinon.spy();
+    on = sinon.spy();
 
     consumerStub = sinon.stub(server as any, 'consumer').callsFake(() => {
       return {
         connect,
         subscribe,
         run,
+        events: {
+          CRASH: 'consumer.crash',
+        },
+        on,
       };
     });
     producerStub = sinon.stub(server as any, 'producer').callsFake(() => {


### PR DESCRIPTION
To be able to react to consumer crashes within kafkajs, which are not retryable, the ClientKafka and ServerKafka have to listen to CRASH events and act accordingly. Listen to CRASH events and throw an exception, if the crash is not retried.

Documentation: https://kafka.js.org/docs/instrumentation-events#a-name-consumer-a-consumer

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Whenever the kafka consumer crashes, the application will not cleanly shutdown. The rest of the application will still work as expected, but no messages from kafka will be consumed

Issue Number: N/A

Related Issue, but not solving it: https://github.com/nestjs/nest/issues/11616


## What is the new behavior?

Whenever a crash of the kafka consumer is not retriable, the handler will throw an exception to shutdown the nest application

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information