### PR TITLE
docs(sample/31): fix wrong port number in README

### DIFF
--- a/sample/31-graphql-federation-code-first/README.md
+++ b/sample/31-graphql-federation-code-first/README.md
@@ -20,7 +20,7 @@ cd gateway && npm run start
 
 ## Access the graph
 
-You can reach the gateway under `http://localhost:3002/graphql`
+You can reach the gateway under `http://localhost:3001/graphql`
 
 ## Query a combined graph
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation update

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Following the README leads you to the wrong gateway link.


## What is the new behavior?
The link in the README is correct.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This was a regression after [this PR](https://github.com/nestjs/nest/pull/11950) fixed a version problem with sample 31.