### PR TITLE
feat(express,fastify): expose request & response types from vendors

### DIFF
--- a/packages/platform-express/index.ts
+++ b/packages/platform-express/index.ts
@@ -5,6 +5,11 @@
  * MIT Licensed
  */
 
+export type {
+  Request as RequestExpress,
+  Response as ResponseExpress,
+} from 'express';
+
 export * from './adapters';
 export * from './interfaces';
 export * from './multer';

--- a/packages/platform-fastify/index.ts
+++ b/packages/platform-fastify/index.ts
@@ -5,5 +5,10 @@
  * MIT Licensed
  */
 
+export type {
+  FastifyRequest as RequestFastify,
+  FastifyReply as ResponseFastify,
+} from 'fastify';
+
 export * from './adapters';
 export * from './interfaces';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

This is my proposal to improve DX when dealing with objects from the underlying HTTP fw

From time to time people ask on which type they should use for `@Req()` or `@Res()` or just need some reference to the request/response object somewhere like in `RawBodyRequest` generics. I know that this is mentioned in the docs page but I found it a bit harder than it should be

For instance:

- using raw body request feature
> ![image](https://github.com/nestjs/nest/assets/13461315/fb810370-ed41-4786-8fc0-9a53205e3332)

- using fastify request object
> ![image](https://github.com/nestjs/nest/assets/13461315/fa1e783c-27c7-440c-b242-181649cd3d31)

- well-typed exception filters
> ![image](https://github.com/nestjs/nest/assets/13461315/bec13479-17fe-4971-8a4d-60a00abca898)

- nestjs middlewares
> ![image](https://github.com/nestjs/nest/assets/13461315/b7cbc489-2883-4d39-bd0f-3c3b417fc814)
> ![image](https://github.com/nestjs/nest/assets/13461315/f721d7fa-6352-4ddf-b239-34f8d29638f4)

for the above scenarios we should know beforehand that we'll import something from `express` or `fastify` packages. At same time, those packages are hard dependencies of `@nestjs/platform-express` and `@nestjs/platform-fastify`. So we're unlikely to have them listed in our `package.json`. I found this odd.

---

<details>
<summary>We can use this code in your side to have this feature already</summary>

```ts
import type { Request as Rq } from 'express'
import type { Response as Rs } from 'express'
declare module '@nestjs/platform-express' {
  export type RequestExpress = Rq
  export type ResponseExpress = Rs
}
```

</details>

## What is the new behavior?

`@nestjs/platform-express` and `@nestjs/platform-fastify` will now expose type aliaess for the request and response object types that NestJS uses for its abstractions like `@Res()` and `RawBodyRequest`

I'm suggesting different names that should be easy to recall. They are different because the value they represent aren't the same. Also, this leaves rooms for adding some abstraction for both of them under the same name in the future. 

I know that having that suffix seems redundant. The ideia was to make clear that such types are from the underlying fw.

Now we could write nestjs code like this:

![image](https://github.com/nestjs/nest/assets/13461315/355e45fa-a8cf-4d06-913a-b236f03f851a)
![image](https://github.com/nestjs/nest/assets/13461315/7cb99c55-6ce4-4d14-959d-a6124d7e4f7e)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If this get merged, I'll update the code snippets in docs to use those types instead.