### PR TITLE
feat(microservices): kafka instrumentation events

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -9,6 +9,10 @@ import {
   KafkaConfig,
   ProducerConfig,
   ProducerRecord,
+  AdminEvents,
+  ProducerEvents,
+  ConsumerEvents,
+  InstrumentationEvent,
 } from '../external/kafka.interface';
 import { MqttClientOptions, QoS } from '../external/mqtt-options.interface';
 import { IORedisOptions } from '../external/redis.interface';
@@ -17,6 +21,19 @@ import { TcpSocket } from '../helpers';
 import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
+
+export type ValueOf<T> = T[keyof T];
+
+export type InstrumentationEventToRegister<T> = {
+  eventName: ValueOf<T>;
+  listener: (event: InstrumentationEvent<any>) => void;
+};
+
+export type InstrumentationEventsToRegister = {
+  consumerEvents?: InstrumentationEventToRegister<ConsumerEvents>[];
+  producerEvents?: InstrumentationEventToRegister<ProducerEvents>[];
+  adminEvents?: InstrumentationEventToRegister<AdminEvents>[];
+};
 
 export type MicroserviceOptions =
   | GrpcOptions
@@ -247,5 +264,6 @@ export interface KafkaOptions {
     deserializer?: Deserializer;
     parser?: KafkaParserConfig;
     producerOnlyMode?: boolean;
+    instrumentationEvents?: InstrumentationEventsToRegister;
   };
 }


### PR DESCRIPTION
add the ability to subscribe to kafka instrumentations events

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently there is no way to subscribe to kafka instrumentation events other than consumer and only very specific ones

Issue Number: Resolves #11616


## What is the new behavior?
Adds the ability to listen to kafka instrumentation events

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information