### PR TITLE
fix(microservices): support client cancel grpc request in unary stream

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -226,7 +226,7 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
                     return;
                   }
                 }
-              return observer.error(this.serializeError(error));
+                return observer.error(this.serializeError(error));
               }
               observer.next(data);
               observer.complete();

--- a/packages/microservices/test/client/client-grpc.spec.ts
+++ b/packages/microservices/test/client/client-grpc.spec.ts
@@ -393,8 +393,8 @@ describe('ClientGrpcProxy', () => {
         };
 
         (obj[methodName] as any).requestStream = true;
-        let upstream: Subject<unknown> = new Subject();
-        let stream$: Observable<any> = client.createUnaryServiceMethod(
+        const upstream: Subject<unknown> = new Subject();
+        const stream$: Observable<any> = client.createUnaryServiceMethod(
           obj,
           methodName,
         )(upstream);

--- a/packages/microservices/test/client/client-grpc.spec.ts
+++ b/packages/microservices/test/client/client-grpc.spec.ts
@@ -384,8 +384,8 @@ describe('ClientGrpcProxy', () => {
         };
   
         (obj[methodName] as any).requestStream = true;
-        let upstream: Subject<unknown> = new Subject();
-        let stream$: Observable<any> = client.createUnaryServiceMethod(obj, methodName)(upstream);
+        const upstream: Subject<unknown> = new Subject();
+        const stream$: Observable<any> = client.createUnaryServiceMethod(obj, methodName)(upstream);
 
         const upstreamSubscribe = sinon.spy(upstream, 'subscribe');
         stream$.subscribe({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Unsubscribe unary request with client upstream do nothing:
- Not cancel grpc call
- Request keep connection


Issue Number: #12023


## What is the new behavior?
When unsubscribe unary request with client upstream:
- Check grpc call is finished or not
- If not, call `call.cancel()` to cancel request & release resource



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information