### PR TITLE
fix(common): right generic type arg constraint for `FileValidator#isValid` method

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -16,12 +16,15 @@ export type FileTypeValidatorOptions = {
  *
  * @publicApi
  */
-export class FileTypeValidator extends FileValidator<FileTypeValidatorOptions> {
+export class FileTypeValidator extends FileValidator<
+  FileTypeValidatorOptions,
+  IFile
+> {
   buildErrorMessage(): string {
     return `Validation failed (expected type is ${this.validationOptions.fileType})`;
   }
 
-  isValid<TFile extends IFile = any>(file?: TFile): boolean {
+  isValid(file?: IFile): boolean {
     if (!this.validationOptions) {
       return true;
     }

--- a/packages/common/pipes/file/file-validator.interface.ts
+++ b/packages/common/pipes/file/file-validator.interface.ts
@@ -6,16 +6,17 @@ import { IFile } from './interfaces';
  * @see {ParseFilePipe}
  * @publicApi
  */
-export abstract class FileValidator<TValidationOptions = Record<string, any>> {
+export abstract class FileValidator<
+  TValidationOptions = Record<string, any>,
+  TFile extends IFile = IFile,
+> {
   constructor(protected readonly validationOptions: TValidationOptions) {}
 
   /**
    * Indicates if this file should be considered valid, according to the options passed in the constructor.
    * @param file the file from the request object
    */
-  abstract isValid<TFile extends IFile = any>(
-    file?: TFile,
-  ): boolean | Promise<boolean>;
+  abstract isValid(file?: TFile): boolean | Promise<boolean>;
 
   /**
    * Builds an error message in case the validation fails.

--- a/packages/common/pipes/file/max-file-size.validator.ts
+++ b/packages/common/pipes/file/max-file-size.validator.ts
@@ -13,7 +13,10 @@ export type MaxFileSizeValidatorOptions = {
  *
  * @publicApi
  */
-export class MaxFileSizeValidator extends FileValidator<MaxFileSizeValidatorOptions> {
+export class MaxFileSizeValidator extends FileValidator<
+  MaxFileSizeValidatorOptions,
+  IFile
+> {
   buildErrorMessage(): string {
     if ('message' in this.validationOptions) {
       if (typeof this.validationOptions.message === 'function') {
@@ -26,7 +29,7 @@ export class MaxFileSizeValidator extends FileValidator<MaxFileSizeValidatorOpti
     return `Validation failed (expected size is less than ${this.validationOptions.maxSize})`;
   }
 
-  public isValid<TFile extends IFile = any>(file?: TFile): boolean {
+  public isValid(file?: IFile): boolean {
     if (!this.validationOptions || !file) {
       return true;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #12019


## What is the new behavior?

the only way to proper narrowing the type of the first arg of `FileValidator#isValid` method AFIAK is via generic type arg instead of the method-based one which was introduced in PR #11040

![image](https://github.com/nestjs/nest/assets/13461315/2476fcc1-52e8-4b0c-85ec-a6b83bd094dd)

![image](https://github.com/nestjs/nest/assets/13461315/553536b9-22c3-46ef-8265-a8509d736440)

![image](https://github.com/nestjs/nest/assets/13461315/4cc6b40f-6669-4453-a920-95c47ce8f849)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information