### PR TITLE
feat(core): add factory-provider circular dependency check

### DIFF
--- a/integration/injector/e2e/circular-factory-providers.spec.ts
+++ b/integration/injector/e2e/circular-factory-providers.spec.ts
@@ -1,0 +1,35 @@
+import { Test } from '@nestjs/testing';
+import { Assertion, expect } from 'chai';
+import {
+  CircularFactoryProvidersModule,
+  NonCircularFactoryProvidersModule,
+} from '../src/circular-factory-providers/circular.module';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { CircularDependencyFactoryProviderException } from '@nestjs/core/errors/exceptions/circular-dependency-factory-provider.exception';
+import { Logger } from '@nestjs/common';
+
+chai.use(chaiAsPromised);
+
+describe('Circular Factory Provider Dependency', () => {
+  it('should log an Error when a Circular Dependency between Factory Providers is detected', async () => {
+    const builder = Test.createTestingModule({
+      imports: [CircularFactoryProvidersModule],
+    }).setLogger(new Logger());
+
+    await expect(builder.compile())
+      .to.eventually.be.rejected.and.be.an.instanceOf(
+        CircularDependencyFactoryProviderException,
+      )
+      .and.property('message')
+      .to.include('PROVIDER3 -> PROVIDER1 -> PROVIDER2 -> PROVIDER3');
+
+    it('should log no Error when no Circular Dependency between Factory Providers is detected', async () => {
+      const builder = Test.createTestingModule({
+        imports: [NonCircularFactoryProvidersModule],
+      });
+
+      await expect(builder.compile()).to.eventually.be.fulfilled;
+    });
+  });
+});

--- a/integration/injector/src/circular-factory-providers/circular-factory-providers.ts
+++ b/integration/injector/src/circular-factory-providers/circular-factory-providers.ts
@@ -1,0 +1,48 @@
+export const dynamicProvider1 = {
+  provide: 'PROVIDER1',
+  useFactory: (provider2: any) => {
+    return {
+      name: 'provider 1',
+    };
+  },
+  inject: ['PROVIDER2'],
+};
+
+export const dynamicProvider2 = {
+  provide: 'PROVIDER2',
+  useFactory: (provider3: any) => {
+    return {
+      name: 'provider 2',
+    };
+  },
+  inject: ['PROVIDER3'],
+};
+
+export const dynamicProvider3 = {
+  provide: 'PROVIDER3',
+  useFactory: (provider1: any) => {
+    return {
+      name: 'provider 3',
+    };
+  },
+  inject: ['PROVIDER1'],
+};
+
+export const dynamicProvider4 = {
+  provide: 'PROVIDER4',
+  useFactory: (provider5: any) => {
+    return {
+      name: 'provider 4',
+    };
+  },
+  inject: ['PROVIDER5'],
+};
+
+export const dynamicProvider5 = {
+  provide: 'PROVIDER5',
+  useFactory: () => {
+    return {
+      name: 'provider 5',
+    };
+  },
+};

--- a/integration/injector/src/circular-factory-providers/circular.module.ts
+++ b/integration/injector/src/circular-factory-providers/circular.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import {
+  dynamicProvider1,
+  dynamicProvider2,
+  dynamicProvider3,
+  dynamicProvider4,
+  dynamicProvider5,
+} from './circular-factory-providers';
+
+@Module({
+  imports: [],
+  providers: [dynamicProvider1, dynamicProvider2, dynamicProvider3],
+})
+export class CircularFactoryProvidersModule {}
+
+@Module({
+  imports: [],
+  providers: [dynamicProvider4, dynamicProvider5],
+})
+export class NonCircularFactoryProvidersModule {}

--- a/packages/core/errors/exceptions/circular-dependency-factory-provider.exception.ts
+++ b/packages/core/errors/exceptions/circular-dependency-factory-provider.exception.ts
@@ -1,0 +1,11 @@
+import { RuntimeException } from './runtime.exception';
+
+export class CircularDependencyFactoryProviderException extends RuntimeException {
+  constructor(injectionPath: string[]) {
+    super(
+      `A circular dependency has been detected between factory providers. The injection path is: ${injectionPath.join(
+        ' -> ',
+      )}. Circular factory providers are not supported.`,
+    );
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #11093 

Currently the nest application won't start when there is a circular dependency between factory providers

## What is the new behavior?

A descriptive error will be thrown when a circular dependency is detected.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Continuation of #11126