### PR TITLE
fix: deal with status code that are not valid http status

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -86,6 +86,13 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
    * @param err error object
    */
   public isHttpError(err: any): err is { statusCode: number; message: string } {
-    return err?.statusCode && err?.message;
+    const statusCodes = Object.values(HttpStatus);
+
+    return (
+      err?.statusCode &&
+      typeof err.statusCode === 'number' &&
+      statusCodes.includes(err.statusCode) &&
+      err?.message
+    );
   }
 }

--- a/packages/core/test/exceptions/base-exception-filter-context.spec.ts
+++ b/packages/core/test/exceptions/base-exception-filter-context.spec.ts
@@ -1,0 +1,73 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { BaseExceptionFilterContext } from '../../exceptions/base-exception-filter-context';
+import { NestContainer } from '../../injector/container';
+
+export class Filter {}
+
+describe('BaseExceptionFilterContext', () => {
+  let filter: BaseExceptionFilterContext;
+  let container: NestContainer;
+
+  beforeEach(() => {
+    container = new NestContainer();
+    filter = new BaseExceptionFilterContext(container);
+  });
+
+  describe('getFilterInstance', () => {
+    describe('when param is an object', () => {
+      it('should return instance', () => {
+        const instance = { catch: () => null };
+        expect(filter.getFilterInstance(instance)).to.be.eql(instance);
+      });
+    });
+    describe('when param is a constructor', () => {
+      it('should pick instance from container', () => {
+        const wrapper = {
+          instance: 'test',
+          getInstanceByContextId: () => wrapper,
+        };
+        sinon
+          .stub(filter, 'getInstanceByMetatype')
+          .callsFake(() => wrapper as any);
+        expect(filter.getFilterInstance(Filter)).to.be.eql(wrapper.instance);
+      });
+      it('should return null', () => {
+        sinon.stub(filter, 'getInstanceByMetatype').callsFake(() => null);
+        expect(filter.getFilterInstance(Filter)).to.be.eql(null);
+      });
+    });
+  });
+
+  describe('getInstanceByMetatype', () => {
+    describe('when "moduleContext" is nil', () => {
+      it('should return undefined', () => {
+        (filter as any).moduleContext = undefined;
+        expect(filter.getInstanceByMetatype(null)).to.be.undefined;
+      });
+    });
+    describe('when "moduleContext" is not nil', () => {
+      beforeEach(() => {
+        (filter as any).moduleContext = 'test';
+      });
+
+      describe('and when module exists', () => {
+        it('should return undefined', () => {
+          sinon.stub(container.getModules(), 'get').callsFake(() => undefined);
+          expect(filter.getInstanceByMetatype(null)).to.be.undefined;
+        });
+      });
+
+      describe('and when module does not exist', () => {
+        it('should return instance', () => {
+          const instance = { test: true };
+          const module = { injectables: { get: () => instance } };
+          sinon
+            .stub(container.getModules(), 'get')
+            .callsFake(() => module as any);
+          expect(filter.getInstanceByMetatype(class {})).to.be.eql(instance);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Nestjs will break if someone throws an error containing statusCode lesser than 0. 

A quick way to reproduce that is to create an error as:

```typescript
class CustomError extends Error {
  statusCode = -1;
}
```

and a controller throws that error

```typescript 
@Controller()
export class ErrorController() {

  @Get()
  error() {
    throws new CustomError("Breaking stuff")
  }
}
```

This will produce the following error:

```
RangeError: Invalid status code: -1
    at new NodeError (node:internal/errors:399:5)
    at ServerResponse.writeHead (node:_http_server:344:11)
    at ServerResponse._implicitHeader (node:_http_server:335:8)
    at write_ (node:_http_outgoing:912:9)
    at ServerResponse.end (node:_http_outgoing:1019:5)
```


Issue Number: N/A


## What is the new behavior?

If the statusCode is not included in the HttpStatus it will just assume that we can't use that statusCode and use an internal server error instead.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information