### PR TITLE
fix(express,fastify): return type of `#listen` method

### DIFF
--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,7 +1,6 @@
 import { INestApplication, HttpServer } from '@nestjs/common';
 import type { Server as CoreHttpServer } from 'http';
 import type { Server as CoreHttpsServer } from 'https';
-import type { Server } from 'net';
 import type { Express } from 'express';
 import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
 import { NestExpressBodyParserType } from './nest-express-body-parser.interface';
@@ -32,12 +31,12 @@ export interface NestExpressApplication<
    * @param {Function} [callback] Optional callback
    * @returns {Promise} A Promise that, when resolved, is a reference to the underlying HttpServer.
    */
-  listen(port: number | string, callback?: () => void): Promise<Server>;
+  listen(port: number | string, callback?: () => void): Promise<TServer>;
   listen(
     port: number | string,
     hostname: string,
     callback?: () => void,
-  ): Promise<Server>;
+  ): Promise<TServer>;
 
   /**
    * A wrapper function around native `express.set()` method.

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -96,16 +96,16 @@ export interface NestFastifyApplication<
   listen(
     port: number | string,
     callback?: (err: Error, address: string) => void,
-  ): Promise<any>;
+  ): Promise<TServer>;
   listen(
     port: number | string,
     address: string,
     callback?: (err: Error, address: string) => void,
-  ): Promise<any>;
+  ): Promise<TServer>;
   listen(
     port: number | string,
     address: string,
     backlog: number,
     callback?: (err: Error, address: string) => void,
-  ): Promise<any>;
+  ): Promise<TServer>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the return type of `#listen` when defining the type arg for `NestFactory.create` isn't correct. See:

![image](https://github.com/nestjs/nest/assets/13461315/bf4ea79b-6c93-4976-bc8a-d4c13466d8c1)


## What is the new behavior?

- express
> ![image](https://github.com/nestjs/nest/assets/13461315/c182d0dd-7133-4e84-ba83-da9851bf60ea)

- fastify
> ![image](https://github.com/nestjs/nest/assets/13461315/c033fde0-9b1a-4c47-b73d-c90247b1b4c7)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
