### PR TITLE
fix(core): pass application config to nest container when using application context

### DIFF
--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -164,7 +164,6 @@ export class NestFactoryStatic {
     this.setAbortOnError(options);
     this.registerLoggerConfiguration(options);
 
-    
     await this.initialize(
       moduleCls,
       container,

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -157,13 +157,14 @@ export class NestFactoryStatic {
     moduleCls: any,
     options?: NestApplicationContextOptions,
   ): Promise<INestApplicationContext> {
-    const container = new NestContainer();
+    const applicationConfig = new ApplicationConfig();
+    const container = new NestContainer(applicationConfig);
     const graphInspector = this.createGraphInspector(options, container);
 
     this.setAbortOnError(options);
     this.registerLoggerConfiguration(options);
 
-    const applicationConfig = undefined;
+    
     await this.initialize(
       moduleCls,
       container,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12165 #9017

NestContainer init w/o application config.
`NestFactory.initialize` take default value for application config. For that reason we got application config undefined and no global enhancers.

## What is the new behavior?
After bootstrap application allow to create fns via ExternalContextCreator with global enhancers. For that we need to pass ApplicationConfig to container.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information