### PR TITLE
Guard undefined Redis options

### DIFF
--- a/packages/microservices/server/server-redis.ts
+++ b/packages/microservices/server/server-redis.ts
@@ -64,7 +64,7 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
 
   public bindEvents(subClient: Redis, pubClient: Redis) {
     subClient.on(
-      this.options.wildcards ? 'pmessage' : MESSAGE_EVENT,
+      this.options?.wildcards ? 'pmessage' : MESSAGE_EVENT,
       this.getMessageHandler(pubClient).bind(this),
     );
     const subscribePatterns = [...this.messageHandlers.keys()];
@@ -75,7 +75,7 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
         ? pattern
         : this.getRequestPattern(pattern);
 
-      if (this.options.wildcards) {
+      if (this.options?.wildcards) {
         subClient.psubscribe(channel);
       } else {
         subClient.subscribe(channel);
@@ -99,7 +99,7 @@ export class ServerRedis extends Server implements CustomTransportStrategy {
   }
 
   public getMessageHandler(pub: Redis) {
-    return this.options.wildcards
+    return this.options?.wildcards
       ? (channel: string, pattern: string, buffer: string | any) =>
           this.handleMessage(channel, buffer, pub, pattern)
       : (channel: string, buffer: string | any) =>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently the following code

```ts
app.connectMicroservice<RedisOptions>({
    transport: Transport.REDIS,
});
```
will throw the following error
```
/.../server/node_modules/@nestjs/microservices/server/server-redis.js:42
        subClient.on(this.options.wildcards ? 'pmessage' : constants_1.MESSAGE_EVENT, this.getMessageHandler(pubClient).bind(this));
                                  ^
TypeError: Cannot read properties of undefined (reading 'wildcards')
    at ServerRedis.bindEvents (/.../server/node_modules/@nestjs/microservices/server/server-redis.js:42:35)
    at /.../server/node_modules/@nestjs/microservices/server/server-redis.js:35:18
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```


## What is the new behavior?
I chose to fix the bind function where the `options` were referenced, however if we want to require `options` to be defined for the `RedisOptions` type that would be another option.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
