### PR TITLE
feat(core): add generic type for transformed value in decorators factory

### DIFF
--- a/packages/core/test/services/reflector.service.spec.ts
+++ b/packages/core/test/services/reflector.service.spec.ts
@@ -1,12 +1,22 @@
 import { expect } from 'chai';
 import { Reflector } from '../../services/reflector.service';
 
+const transformDecorator = Reflector.createDecorator<string[], number>({
+  transform: value => value.length,
+});
+
 describe('Reflector', () => {
   let reflector: Reflector;
+
   class Test {}
+
+  @transformDecorator(['a', 'b', 'c'])
+  class TestTransform {}
+
   beforeEach(() => {
     reflector = new Reflector();
   });
+
   describe('get', () => {
     it('should reflect metadata by key', () => {
       const key = 'key';
@@ -14,6 +24,7 @@ describe('Reflector', () => {
       Reflect.defineMetadata(key, value, Test);
       expect(reflector.get(key, Test)).to.eql(value);
     });
+
     it('should reflect metadata by decorator', () => {
       const decorator = Reflector.createDecorator<string>();
       const value = 'value';
@@ -36,6 +47,19 @@ describe('Reflector', () => {
 
       // @ts-expect-error 'value' is not assignable to parameter of type 'string[]'
       reflectedValue = true;
+    });
+
+    it('should reflect metadata by decorator (with transform option)', () => {
+      let reflectedValue = reflector.get(transformDecorator, TestTransform);
+      expect(reflectedValue).to.eql(3);
+
+      // @ts-expect-error 'value' is not assignable to type 'number'
+      reflectedValue = [];
+    });
+
+    it('should require transform option when second generic type is provided', () => {
+      // @ts-expect-error Property 'transform' is missing in type {} but required in type
+      const decorator = Reflector.createDecorator<string[], number>({});
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the return type of `Reflector.get(ReflectableDecorator)` resolves incorrectly if the `transform` option is used with the `Reflector.createDecorator` call and the transformed value has a different type than the input.

Issue Number: https://github.com/nestjs/nest/issues/12264


## What is the new behavior?
Add a second optional generic param on Reflector.createDecorator to describe the transformed value type as following:

```typescript
const Roles = Reflector.createDecorator<string[], number>({
  key: 'roles',
  transform: (roles: string[]): string[] => roles.length, // Must return type number
});


const roles = this.reflector.get(Roles, context.getHandler()) // Will resolve as type number
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information