### PR TITLE
fix(microservices): handle error thrown in the stream gRPC controller

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -3,7 +3,7 @@ import {
   isString,
   isUndefined,
 } from '@nestjs/common/utils/shared.utils';
-import { EMPTY, fromEvent, lastValueFrom, Subject } from 'rxjs';
+import {defaultIfEmpty, EMPTY, fromEvent, lastValueFrom, Subject} from 'rxjs';
 import { catchError, takeUntil } from 'rxjs/operators';
 import {
   CANCEL_EVENT,
@@ -289,6 +289,7 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
               callback(err, null);
               return EMPTY;
             }),
+            defaultIfEmpty(undefined),
           ),
         );
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When error is thrown in Streamed GRPC controller, the application crashed

Issue Number: https://github.com/nestjs/nest/issues/12187


## What is the new behavior?
Any errors thrown inside GrpcStreamMethod should be handle correctly without crashing the app.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information