### PR TITLE
feat(websockets): multiple subscribe message per function

### DIFF
--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -132,7 +132,7 @@ export class WsContextCreator {
     return Reflect.getMetadata(PARAMTYPES_METADATA, instance, callback.name);
   }
 
-  public reflectCallbackPattern(callback: (...args: any[]) => any): string {
+  public reflectCallbackPattern(callback: (...args: any[]) => any): string[] {
     return Reflect.getMetadata(MESSAGE_METADATA, callback);
   }
 

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -109,7 +109,7 @@ export class WsContextCreator {
     };
 
     return this.wsProxy.create(async (...args: unknown[]) => {
-      args.push(this.reflectCallbackPattern(callback));
+      args.push(...this.reflectCallbackPattern(callback));
 
       const initialArgs = this.contextUtils.createNullArray(argsLength);
       fnCanActivate && (await fnCanActivate(args));
@@ -133,7 +133,7 @@ export class WsContextCreator {
   }
 
   public reflectCallbackPattern(callback: (...args: any[]) => any): string[] {
-    return Reflect.getMetadata(MESSAGE_METADATA, callback);
+    return Reflect.getMetadata(MESSAGE_METADATA, callback) || [];
   }
 
   public createGuardsFn<TContext extends string = ContextType>(

--- a/packages/websockets/context/ws-metadata-constants.ts
+++ b/packages/websockets/context/ws-metadata-constants.ts
@@ -1,6 +1,7 @@
 import { WsParamtype } from '../enums/ws-paramtype.enum';
 
 export const DEFAULT_CALLBACK_METADATA = {
+  [`${WsParamtype.MESSAGE}:2`]: { index: 2, data: undefined, pipes: [] },
   [`${WsParamtype.PAYLOAD}:1`]: { index: 1, data: undefined, pipes: [] },
   [`${WsParamtype.SOCKET}:0`]: { index: 0, data: undefined, pipes: [] },
 };

--- a/packages/websockets/decorators/index.ts
+++ b/packages/websockets/decorators/index.ts
@@ -3,3 +3,4 @@ export * from './gateway-server.decorator';
 export * from './message-body.decorator';
 export * from './socket-gateway.decorator';
 export * from './subscribe-message.decorator';
+export * from './message-name.decorator';

--- a/packages/websockets/decorators/message-name.decorator.ts
+++ b/packages/websockets/decorators/message-name.decorator.ts
@@ -1,0 +1,9 @@
+import { WsParamtype } from '../enums/ws-paramtype.enum';
+import { createWsParamDecorator } from '../utils/param.utils';
+
+/**
+ * @publicApi
+ */
+export const MessageName: () => ParameterDecorator = createWsParamDecorator(
+  WsParamtype.MESSAGE,
+);

--- a/packages/websockets/decorators/subscribe-message.decorator.ts
+++ b/packages/websockets/decorators/subscribe-message.decorator.ts
@@ -5,14 +5,22 @@ import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '../constants';
  *
  * @publicApi
  */
-export const SubscribeMessage = <T = string>(message: T): MethodDecorator => {
+export const SubscribeMessage = <T = string>(
+  ...messages: T[]
+): MethodDecorator => {
   return (
     target: object,
     key: string | symbol,
     descriptor: PropertyDescriptor,
   ) => {
     Reflect.defineMetadata(MESSAGE_MAPPING_METADATA, true, descriptor.value);
-    Reflect.defineMetadata(MESSAGE_METADATA, message, descriptor.value);
+    const currentMessages =
+      Reflect.getMetadata(MESSAGE_METADATA, descriptor.value) || [];
+    Reflect.defineMetadata(
+      MESSAGE_METADATA,
+      [...currentMessages, ...messages],
+      descriptor.value,
+    );
     return descriptor;
   };
 };

--- a/packages/websockets/enums/ws-paramtype.enum.ts
+++ b/packages/websockets/enums/ws-paramtype.enum.ts
@@ -1,4 +1,5 @@
 export enum WsParamtype {
   SOCKET = 0,
   PAYLOAD = 3,
+  MESSAGE = 4,
 }

--- a/packages/websockets/factories/ws-params-factory.ts
+++ b/packages/websockets/factories/ws-params-factory.ts
@@ -14,6 +14,8 @@ export class WsParamsFactory {
         return args[0];
       case WsParamtype.PAYLOAD:
         return data ? args[1]?.[data] : args[1];
+      case WsParamtype.MESSAGE:
+        return args[2];
       default:
         return null;
     }

--- a/packages/websockets/gateway-metadata-explorer.ts
+++ b/packages/websockets/gateway-metadata-explorer.ts
@@ -21,14 +21,14 @@ export class GatewayMetadataExplorer {
     const instancePrototype = Object.getPrototypeOf(instance);
     return this.metadataScanner
       .getAllMethodNames(instancePrototype)
-      .map(method => this.exploreMethodMetadata(instancePrototype, method))
+      .flatMap(method => this.exploreMethodMetadata(instancePrototype, method))
       .filter(metadata => metadata);
   }
 
   public exploreMethodMetadata(
     instancePrototype: object,
     methodName: string,
-  ): MessageMappingProperties {
+  ): MessageMappingProperties[] {
     const callback = instancePrototype[methodName];
     const isMessageMapping = Reflect.getMetadata(
       MESSAGE_MAPPING_METADATA,
@@ -37,12 +37,12 @@ export class GatewayMetadataExplorer {
     if (isUndefined(isMessageMapping)) {
       return null;
     }
-    const message = Reflect.getMetadata(MESSAGE_METADATA, callback);
-    return {
+    const messages = Reflect.getMetadata(MESSAGE_METADATA, callback) as any[];
+    return messages.map(message => ({
       callback,
       message,
       methodName,
-    };
+    }));
   }
 
   public *scanForServerHooks(instance: NestGateway): IterableIterator<string> {

--- a/packages/websockets/test/context/ws-context-creator.spec.ts
+++ b/packages/websockets/test/context/ws-context-creator.spec.ts
@@ -155,8 +155,9 @@ describe('WsContextCreator', () => {
       const metadata = {
         [WsParamtype.SOCKET]: { index: 0, data: 'test', pipes: [] },
         [WsParamtype.PAYLOAD]: { index: 2, data: 'test', pipes: [] },
+        [WsParamtype.MESSAGE]: { index: 3, data: 'test', pipes: [] },
         [`key${CUSTOM_ROUTE_ARGS_METADATA}`]: {
-          index: 3,
+          index: 4,
           data: 'custom',
           pipes: [],
         },
@@ -172,10 +173,12 @@ describe('WsContextCreator', () => {
       const expectedValues = [
         { index: 0, type: WsParamtype.SOCKET, data: 'test' },
         { index: 2, type: WsParamtype.PAYLOAD, data: 'test' },
-        { index: 3, type: `key${CUSTOM_ROUTE_ARGS_METADATA}`, data: 'custom' },
+        { index: 3, type: WsParamtype.MESSAGE, data: 'test' },
+        { index: 4, type: `key${CUSTOM_ROUTE_ARGS_METADATA}`, data: 'custom' },
       ];
       expect(values[0]).to.deep.include(expectedValues[0]);
       expect(values[1]).to.deep.include(expectedValues[1]);
+      expect(values[2]).to.deep.include(expectedValues[2]);
     });
   });
   describe('getParamValue', () => {

--- a/packages/websockets/test/decorators/message-name.decorator.spec.ts
+++ b/packages/websockets/test/decorators/message-name.decorator.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { PARAM_ARGS_METADATA } from '../../constants';
+import { MessageName } from '../../decorators';
+import { WsParamtype } from '../../enums/ws-paramtype.enum';
+
+class MessageNameTest {
+  public test(@MessageName() name: string) {}
+}
+
+describe('@MessageName', () => {
+  it('should enhance class with expected request metadata', () => {
+    const argsMetadata = Reflect.getMetadata(
+      PARAM_ARGS_METADATA,
+      MessageNameTest,
+      'test',
+    );
+    const expectedMetadata = {
+      [`${WsParamtype.MESSAGE}:0`]: {
+        data: undefined,
+        index: 0,
+        pipes: [],
+      },
+    };
+    expect(argsMetadata).to.be.eql(expectedMetadata);
+  });
+});

--- a/packages/websockets/test/factories/ws-params-factory.spec.ts
+++ b/packages/websockets/test/factories/ws-params-factory.spec.ts
@@ -10,9 +10,10 @@ describe('WsParamsFactory', () => {
   describe('exchangeKeyForValue', () => {
     const client = {};
     const data = { data: true };
+    const message = 'test';
 
     describe('when key is', () => {
-      const args = [client, data];
+      const args = [client, data, message];
       describe(`WsParamtype.PAYLOAD`, () => {
         it('should return a message payload object', () => {
           expect(
@@ -30,6 +31,13 @@ describe('WsParamsFactory', () => {
           expect(
             factory.exchangeKeyForValue(WsParamtype.SOCKET, null, args),
           ).to.be.eql(client);
+        });
+      });
+      describe(`WsParamtype.MESSAGE`, () => {
+        it('should return a message name', () => {
+          expect(
+            factory.exchangeKeyForValue(WsParamtype.MESSAGE, null, args),
+          ).to.be.eql(message);
         });
       });
     });

--- a/packages/websockets/test/gateway-metadata-explorer.spec.ts
+++ b/packages/websockets/test/gateway-metadata-explorer.spec.ts
@@ -60,9 +60,9 @@ describe('GatewayMetadataExplorer', () => {
       expect(metadata).to.eq(null);
     });
     it(`should return message mapping properties when "isMessageMapping" metadata is not undefined`, () => {
-      const metadata = instance.exploreMethodMetadata(test, 'test');
+      const [metadata] = instance.exploreMethodMetadata(test, 'test');
       expect(metadata).to.have.keys(['callback', 'message', 'methodName']);
-      expect(metadata.message).to.eql(message);
+      expect(metadata.message).to.deep.eq(message);
     });
   });
   describe('scanForServerHooks', () => {

--- a/packages/websockets/test/utils/subscribe-message.decorator.spec.ts
+++ b/packages/websockets/test/utils/subscribe-message.decorator.spec.ts
@@ -1,21 +1,53 @@
 import { expect } from 'chai';
-import { MESSAGE_MAPPING_METADATA } from '../../constants';
+import { MESSAGE_MAPPING_METADATA, MESSAGE_METADATA } from '../../constants';
 import { SubscribeMessage } from '../../decorators/subscribe-message.decorator';
 
 describe('@SubscribeMessage', () => {
+  const message = 'filter';
+  const secMessage = 'filter2';
+
   class TestGateway {
-    @SubscribeMessage('filter')
+    @SubscribeMessage(message)
     static fn() {}
+
+    @SubscribeMessage(message, secMessage)
+    static fnSec() {}
+
+    @SubscribeMessage(secMessage)
+    @SubscribeMessage(message)
+    static fnThi() {}
   }
 
-  it('should decorate transport with expected metadata', () => {
+  it('should decorate transport with expected metadata single decorator with single message', () => {
     const isMessageMapping = Reflect.getMetadata(
       MESSAGE_MAPPING_METADATA,
       TestGateway.fn,
     );
-    const message = Reflect.getMetadata('message', TestGateway.fn);
+    const messages = Reflect.getMetadata(MESSAGE_METADATA, TestGateway.fn);
 
     expect(isMessageMapping).to.be.true;
-    expect(message).to.be.eql('filter');
+    expect(messages).to.be.deep.eq([message]);
+  });
+
+  it('should decorate transport with expected metadata single decorator with multiple messages', () => {
+    const isMessageMapping = Reflect.getMetadata(
+      MESSAGE_MAPPING_METADATA,
+      TestGateway.fn,
+    );
+    const messages = Reflect.getMetadata(MESSAGE_METADATA, TestGateway.fnSec);
+
+    expect(isMessageMapping).to.be.true;
+    expect(messages).to.be.deep.eq([message, secMessage]);
+  });
+
+  it('should decorate transport with expected metadata double decorator with single messages', () => {
+    const isMessageMapping = Reflect.getMetadata(
+      MESSAGE_MAPPING_METADATA,
+      TestGateway.fn,
+    );
+    const messages = Reflect.getMetadata(MESSAGE_METADATA, TestGateway.fnThi);
+
+    expect(isMessageMapping).to.be.true;
+    expect(messages).to.be.deep.eq([message, secMessage]);
   });
 });


### PR DESCRIPTION
Release multiple SubscribeMessage logic

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

At the moment SubscribeMessage can only be used once per function.

Issue Number: N/A


## What is the new behavior?

Decorator SubscribeMessage can only be used multiple time per function.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Actually I want to route events for a single function without creating multiple functions