### PR TITLE
fix: appropriately handle backpressure

### DIFF
--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { expect } from 'chai';
 import { join } from 'path';
-import { of, ReplaySubject, throwError } from 'rxjs';
+import { Observable, of, ReplaySubject, Subject, throwError } from 'rxjs';
 import * as sinon from 'sinon';
 import { CANCEL_EVENT } from '../../constants';
 import { InvalidGrpcPackageException } from '../../errors/invalid-grpc-package.exception';
@@ -391,29 +391,39 @@ describe('ServerGrpc', () => {
         const call = {
           write: sinon.spy(),
           end: sinon.spy(),
-          addListener: sinon.spy(),
-          removeListener: sinon.spy(),
+          on: sinon.spy(),
+          off: sinon.spy(),
         };
         const callback = sinon.spy();
         const native = sinon.spy();
 
         await server.createStreamServiceMethod(native)(call, callback);
         expect(native.called).to.be.true;
-        expect(call.addListener.calledWith('cancelled')).to.be.true;
-        expect(call.removeListener.calledWith('cancelled')).to.be.true;
+        expect(call.on.calledWith('cancelled')).to.be.true;
+        expect(call.off.calledWith('cancelled')).to.be.true;
       });
 
       it(`should close the result observable when receiving an 'cancelled' event from the client`, async () => {
-        let cancelCb: () => void;
+        const et = new EventTarget();
+        let calls = 0;
         const call = {
-          write: sinon
-            .stub()
-            .onSecondCall()
-            .callsFake(() => cancelCb()),
+          write: sinon.spy((value: any) => {
+            calls++;
+            if (calls === 2) {
+              et.dispatchEvent(new Event('cancelled'));
+            }
+            // automatically drain the call stream
+            et.dispatchEvent(new Event('drain'));
+          }),
           end: sinon.spy(),
-          addListener: (name, cb) => (cancelCb = cb),
-          removeListener: sinon.spy(),
+          on: sinon.spy((name, cb) => {
+            et.addEventListener(name, cb);
+          }),
+          off: sinon.spy((name, cb) => {
+            et.removeEventListener(name, cb);
+          }),
         };
+
         const result$ = of(1, 2, 3);
         const callback = sinon.spy();
         const native = sinon
@@ -421,8 +431,13 @@ describe('ServerGrpc', () => {
           .returns(new Promise((resolve, reject) => resolve(result$)));
 
         await server.createStreamServiceMethod(native)(call, callback);
-        expect(call.write.calledTwice).to.be.true;
+        expect(call.write.callCount).to.equal(2);
         expect(call.end.called).to.be.true;
+
+        expect(call.on.calledWith('cancelled')).to.be.true;
+        expect(call.on.calledWith('drain')).to.be.true;
+        expect(call.off.calledWith('cancelled')).to.be.true;
+        expect(call.off.calledWith('drain')).to.be.true;
       });
     });
   });
@@ -500,6 +515,7 @@ describe('ServerGrpc', () => {
       expect(handler.called).to.be.true;
       expect(handler.args[0][1]).to.eq(call.metadata);
     });
+
     describe('when response is not a stream', () => {
       it('should call callback', async () => {
         const handler = async () => ({ test: true });
@@ -562,6 +578,211 @@ describe('ServerGrpc', () => {
 
           expect(call.write.called).to.be.true;
           expect(call.end.called).to.be.true;
+        });
+
+        it('should wait for a drain event from the GRPC call before writing more data from the observable', async () => {
+          const emitter = new EventTarget();
+
+          const drain = () => {
+            emitter.dispatchEvent(new Event('drain'));
+          };
+
+          const call = {
+            write: sinon.spy(),
+            end: sinon.spy(),
+            emit: sinon.spy(),
+            request: sinon.spy(),
+            metadata: sinon.spy(),
+            sendMetadata: sinon.spy(),
+            on: (name, cb) => {
+              emitter.addEventListener(name, cb);
+            },
+            off: (name, cb) => {
+              emitter.removeEventListener(name, cb);
+            },
+          };
+
+          const callback = sinon.spy();
+
+          const subject = new Subject<string>();
+          const handlerResult = Promise.resolve(subject);
+          const methodHandler = () => handlerResult;
+
+          const serviceMethod = await server.createRequestStreamMethod(
+            methodHandler,
+            true,
+          );
+
+          const result = serviceMethod(call, callback);
+
+          await handlerResult;
+
+          // Nothing has arrived from the observable yet.
+          expect(call.write.notCalled).to.be.true;
+
+          // When the observable emits the first value, it will
+          // write immediately, because the GRPC call is not being
+          // written to yet.
+          subject.next('a');
+          expect(call.write.calledOnce).to.be.true;
+
+          // The second emission from the observable will not cause
+          // a write yet, because the GRPC call has not been drained.
+          subject.next('b');
+          expect(call.write.calledOnce).to.be.true;
+
+          // Once we drain the GRPC call, "b" will be written
+          drain();
+          expect(call.write.calledTwice).to.be.true;
+
+          // After writing "b" drains, we shouldn't have written
+          // anything else yet, because we haven't gotten any more values.
+          drain();
+          expect(call.write.calledTwice).to.be.true;
+
+          // When the observable emits the third value, it will
+          // write immediately, because the GRPC call is not being
+          // written to yet.
+          subject.next('c');
+          expect(call.write.calledThrice).to.be.true;
+          drain();
+
+          // It shouldn't end until it's complete.
+          expect(call.end.notCalled).to.be.true;
+
+          subject.complete();
+          expect(call.end.called).to.be.true;
+          return result;
+        });
+
+        it('should end the subscription to the source if the call is cancelled', async () => {
+          const emitter = new EventTarget();
+
+          const drain = () => {
+            emitter.dispatchEvent(new Event('drain'));
+          };
+
+          const cancel = () => {
+            emitter.dispatchEvent(new Event(CANCEL_EVENT));
+          };
+
+          const call = {
+            write: sinon.spy(),
+            end: sinon.spy(),
+            emit: sinon.spy(),
+            request: sinon.spy(),
+            metadata: sinon.spy(),
+            sendMetadata: sinon.spy(),
+            on: (name, cb) => {
+              emitter.addEventListener(name, cb);
+            },
+            off: (name, cb) => {
+              emitter.removeEventListener(name, cb);
+            },
+          };
+
+          const callback = sinon.spy();
+
+          let cancelled = false;
+          const subject = new Observable<string>(subscriber => {
+            subscriber.next('a');
+            subscriber.next('b');
+            return () => {
+              cancelled = true;
+            };
+          });
+
+          const handlerResult = Promise.resolve(subject);
+          const methodHandler = () => handlerResult;
+
+          const serviceMethod = await server.createRequestStreamMethod(
+            methodHandler,
+            true,
+          );
+
+          const result = serviceMethod(call, callback);
+
+          await handlerResult;
+
+          // The first value is written because the GRPC call
+          // is not being written to yet.
+          expect(call.write.calledOnce).to.be.true; // a
+
+          // "b" can't be written until the GRPC call is drained.
+          drain();
+          expect(call.write.calledTwice).to.be.true; // b
+
+          // We shouldn't be cancelled yet.
+          expect(cancelled).to.be.false;
+
+          // Signal that the GRPC call is cancelled.
+          cancel();
+          // we should have only written twice at this point.
+          expect(call.write.calledTwice).to.be.true;
+          expect(cancelled).to.be.true;
+
+          return result;
+        });
+
+        it('should wait to end until all values from the source have been written', async () => {
+          const emitter = new EventTarget();
+
+          const drain = () => {
+            emitter.dispatchEvent(new Event('drain'));
+          };
+
+          const call = {
+            write: sinon.spy(),
+            end: sinon.spy(),
+            emit: sinon.spy(),
+            request: sinon.spy(),
+            metadata: sinon.spy(),
+            sendMetadata: sinon.spy(),
+            on: (name, cb) => {
+              emitter.addEventListener(name, cb);
+            },
+            off: (name, cb) => {
+              emitter.removeEventListener(name, cb);
+            },
+          };
+
+          const callback = sinon.spy();
+
+          const subject = new Subject<string>();
+          const handlerResult = Promise.resolve(subject);
+          const methodHandler = () => handlerResult;
+
+          const serviceMethod = await server.createRequestStreamMethod(
+            methodHandler,
+            true,
+          );
+
+          const result = serviceMethod(call, callback);
+
+          await handlerResult;
+
+          // Nothing has arrived from the observable yet.
+          expect(call.write.notCalled).to.be.true;
+
+          subject.next('a');
+          subject.next('b');
+          subject.next('c');
+          subject.complete();
+
+          expect(call.write.calledOnce).to.be.true; // a
+          expect(call.end.notCalled).to.be.true;
+
+          drain();
+          expect(call.write.calledTwice).to.be.true; // b
+          expect(call.end.notCalled).to.be.true;
+
+          drain();
+          expect(call.write.calledThrice).to.be.true; // c
+          expect(call.end.notCalled).to.be.true;
+
+          drain();
+          expect(call.end.called).to.be.true;
+          return result;
         });
       });
     });


### PR DESCRIPTION
Adds code to handle back pressure when writing output from Observable streams.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Docs are n/a.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when writing out observables to the GRPC Call writable stream, it's not waiting for the stream writer to be drained before writing the next bit of data. This means the service doesn't get a breather between each part.


## What is the new behavior?

The consumer of the observable will wait for the stream to drain before trying to write the next bit.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information