### PR TITLE
fix(ws): fix incorrect host pattern on messages

### DIFF
--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -140,7 +140,7 @@ export class WsAdapter extends AbstractWsAdapter {
         handler => handler.message === message.event,
       );
       const { callback } = messageHandler;
-      return transform(callback(message.data));
+      return transform(callback(message.data, message.event));
     } catch {
       return EMPTY;
     }


### PR DESCRIPTION
function call was missing the second argument

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, when using `platform-ws` and calling `host.switchToWs().getPattern()` on `ArgumentsHost` given in exception filter, we don't get a pattern but we get a `data` object. For example for following message on the websocket:
```
{
    event: 'foo',
    data: {  test: 1  }
}
```
we would get `{  test: 1  }` as a "pattern"

Issue Number: N/A

## What is the new behavior?
When using `platform-ws` and calling `host.switchToWs().getPattern()` on `ArgumentsHost` given in exception filter we get correct pattern matched for this branch. For the following message on the websocket:
```
{
    event: 'foo',
    data: {  test: 1  }
}
```
we correctly get `'foo'` as a pattern

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
If I traced the code correctly, currect behaviour happens because the code always gets the last item from the list as a pattern, but on `platform-ws` the `message.event` was never added to that list.

I'm not yet fluent with writing for libraries of this size and I didn't see any tests for `platform-ws` or for `platform-socket.io`. That's why I didn't add a test myself. I did see there were some tests for `getPattern()`, but none of them caught this problem. Probably because they were more high-level than the change here.