### PR TITLE
Param metadata support

### DIFF
--- a/packages/common/decorators/core/set-metadata.decorator.ts
+++ b/packages/common/decorators/core/set-metadata.decorator.ts
@@ -32,13 +32,13 @@ export const SetMetadata = <K = string, V = any>(
 
     if (typeof descriptorOrIndex === "number") {
       const index = descriptorOrIndex;
-			const func = (target as any)[key] as Function;
-			let existingMetadata: V[] = Reflect.getMetadata(`param:${metadataKey}`, func) || [];
-			if (!Array.isArray(existingMetadata))
-				existingMetadata = [existingMetadata];
-			existingMetadata[index] = metadataValue;
-			Reflect.defineMetadata(`param:${metadataKey}`, existingMetadata, func);
-			return target;
+      const func = (target as any)[key] as Function;
+      let existingMetadata: V[] = Reflect.getMetadata(`param:${metadataKey}`, func) || [];
+      if (!Array.isArray(existingMetadata))
+        existingMetadata = [existingMetadata];
+      existingMetadata[index] = metadataValue;
+      Reflect.defineMetadata(`param:${metadataKey}`, existingMetadata, func);
+      return target;
     }
 
     Reflect.defineMetadata(metadataKey, metadataValue, target);

--- a/packages/core/services/reflector.service.ts
+++ b/packages/core/services/reflector.service.ts
@@ -137,7 +137,7 @@ export class Reflector {
   public getParam<T extends ReflectableDecorator<any>>(
     decorator: T,
     target: Function,
-  ): T extends ReflectableDecorator<any, infer R> ? R : unknown;
+  ): T extends ReflectableDecorator<any, infer R> ? R[] : unknown[];
 
   /**
    * Retrieve metadata for a specified key for a specified target function.
@@ -155,7 +155,7 @@ export class Reflector {
   public getParam<TResult = any, TKey = any>(
     metadataKey: TKey,
     target: Function,
-  ): TResult;
+  ): TResult[];
   
   /**
    * Retrieve metadata for a specified key or decorator for a specified target.

--- a/packages/core/services/reflector.service.ts
+++ b/packages/core/services/reflector.service.ts
@@ -120,6 +120,70 @@ export class Reflector {
     return Reflect.getMetadata(metadataKey, target);
   }
 
+
+  /**
+   * Retrieve metadata for a reflectable decorator for a specified target function.
+   * The metadata is returned as an array where each index corresponds to a parameter index in the method signature.
+   *
+   * @example
+   * `const roles = this.getParam(Roles, myFunction);`
+   *
+   * @param decorator reflectable decorator created through `SetMetadata`
+   * @param target context (decorated function) to retrieve metadata from
+   *
+   * @returns An array of metadata values, where each index in the array corresponds to a parameter index in the function. 
+   * Returns `undefined` if no such metadata exists.
+  */
+  public getParam<T extends ReflectableDecorator<any>>(
+    decorator: T,
+    target: Function,
+  ): T extends ReflectableDecorator<any, infer R> ? R : unknown;
+
+  /**
+   * Retrieve metadata for a specified key for a specified target function.
+   * The metadata is returned as an array where each index corresponds to a parameter index in the method signature.
+   *
+   * @example
+   * `const roles = this.getParam<string>('roles', myFunction);`
+   *
+   * @param metadataKey lookup key for metadata to retrieve
+   * @param target context (decorated function) to retrieve metadata from
+   *
+   * @returns An array of metadata values, where each index in the array corresponds to a parameter index in the function. 
+   * Returns `undefined` if no such metadata exists.
+  */
+  public getParam<TResult = any, TKey = any>(
+    metadataKey: TKey,
+    target: Function,
+  ): TResult;
+  
+  /**
+   * Retrieve metadata for a specified key or decorator for a specified target.
+   * This method returns an array where each index corresponds to a parameter index in the method signature.
+   *
+   * @example
+   * `const queryParam = this.getParam<string>('query', myFunction);`
+   * If `myFunction` was decorated for its parameters with metadata via
+   * `@SetMetadata('query', 'value1')`
+   * `@SetMetadata('query', 'value2')`
+   * Then `queryParam` would be an array like: ['value1', 'value2']
+   *
+   * @param metadataKeyOrDecorator lookup key or decorator for metadata to retrieve
+   * @param target context (decorated function) to retrieve metadata from
+   *
+   * @returns An array of metadata values, where each index in the array corresponds to a parameter index in the function.
+  */
+  public getParam<TResult = any, TKey = any>(
+    metadataKeyOrDecorator: TKey,
+    target: Function,
+  ): TResult[] {
+    const metadataKey =
+      (metadataKeyOrDecorator as ReflectableDecorator<unknown>).KEY ??
+      metadataKeyOrDecorator;
+
+    return Reflect.getMetadata(`param:${metadataKey}`, target);
+  }
+
   /**
    * Retrieve metadata for a specified decorator for a specified set of targets.
    *


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current implementation of `SetMetadata` and `Reflector` allows to attach metadata only to classes and methods. They do not natively support metadata annotation for function parameters.

Issue Number: #12368

## What is the new behavior?
The new implementation extends `SetMetadata` to allow annotation for function parameters. A corresponding method, `getParam`, is added to `Reflector` that retrieves metadata for parameters as an array. Each array index corresponds to the parameter index.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
One important detail to note is that the metadata keys for parameters are prefixed with `param:`. This is to prevent conflicts when using the same metadata key for both methods and parameters. Since metadata for both methods and parameters are attached to the method itself, using the same key without the prefix would result in metadata for method overriding that of the parameters. Therefore, the `param:` prefix is used to distinguish between them.