### PR TITLE
Allow Binding to Shared Topics Without Wildcards

### DIFF
--- a/packages/microservices/server/server-mqtt.ts
+++ b/packages/microservices/server/server-mqtt.ts
@@ -189,14 +189,8 @@ export class ServerMqtt extends Server implements CustomTransportStrategy {
     if (this.messageHandlers.has(route)) {
       return this.messageHandlers.get(route) || null;
     }
-
+  
     for (const [key, value] of this.messageHandlers) {
-      if (
-        !key.includes(MQTT_WILDCARD_SINGLE) &&
-        !key.includes(MQTT_WILDCARD_ALL)
-      ) {
-        continue;
-      }
       const keyWithoutSharedPrefix = this.removeHandlerKeySharedPrefix(key);
       if (this.matchMqttPattern(keyWithoutSharedPrefix, route)) {
         return value;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current behavior of the `getHandlerByPattern` method in the `ServerMqtt` class is to exclude patterns that do not contain wildcards when looking for message handlers. This means that binding to shared topics without wildcards is not supported.

Issue Number: [#12367](https://github.com/nestjs/nest/issues/12367)


## What is the new behavior?

The new behavior allows binding to shared topics without wildcards in the `getHandlerByPattern` method.



## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information