### PR TITLE
fix: allow for filters to be aware of the pattern for websockets

### DIFF
--- a/integration/websockets/e2e/gateway.spec.ts
+++ b/integration/websockets/e2e/gateway.spec.ts
@@ -82,5 +82,21 @@ describe('WebSocketGateway', () => {
     );
   });
 
+  it(`should be able to get the pattern in a filter (when the error comes from a known handler)`, async () => {
+    app = await createNestApp(ApplicationGateway);
+    await app.listen(3000);
+
+    ws = io('http://localhost:8080');
+    ws.emit('getClientWithError', {
+      test: 'test',
+    });
+    await new Promise<void>(resolve =>
+      ws.on('exception', data => {
+        expect(data.pattern).to.be.eql('getClientWithError');
+        resolve();
+      }),
+    );
+  });
+
   afterEach(() => app.close());
 });

--- a/integration/websockets/src/app.gateway.ts
+++ b/integration/websockets/src/app.gateway.ts
@@ -1,10 +1,13 @@
-import { UseInterceptors } from '@nestjs/common';
+import { UseFilters, UseInterceptors } from '@nestjs/common';
 import {
   MessageBody,
   SubscribeMessage,
   WebSocketGateway,
+  WsException,
 } from '@nestjs/websockets';
 import { RequestInterceptor } from './request.interceptor';
+import { throwError } from 'rxjs';
+import { RequestFilter } from './request.filter';
 
 @WebSocketGateway(8080)
 export class ApplicationGateway {
@@ -23,5 +26,11 @@ export class ApplicationGateway {
       event: 'popClient',
       data: { ...data, path: client.pattern },
     };
+  }
+
+  @UseFilters(RequestFilter)
+  @SubscribeMessage('getClientWithError')
+  getPathCalledWithError() {
+    return throwError(() => new WsException('This is an error'));
   }
 }

--- a/integration/websockets/src/request.filter.ts
+++ b/integration/websockets/src/request.filter.ts
@@ -1,0 +1,12 @@
+import { ArgumentsHost, Catch, ExceptionFilter } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+
+@Catch(WsException)
+export class RequestFilter implements ExceptionFilter {
+  catch(exception: WsException, host: ArgumentsHost) {
+    const wsCtx = host.switchToWs();
+    const pattern = wsCtx.getPattern();
+    const client = wsCtx.getClient();
+    client.emit('exception', { pattern, message: exception.message });
+  }
+}

--- a/packages/websockets/context/ws-proxy.ts
+++ b/packages/websockets/context/ws-proxy.ts
@@ -7,8 +7,10 @@ export class WsProxy {
   public create(
     targetCallback: (...args: unknown[]) => Promise<any>,
     exceptionsHandler: WsExceptionsHandler,
+    targetPattern?: string,
   ): (...args: unknown[]) => Promise<any> {
     return async (...args: unknown[]) => {
+      args = [...args, targetPattern ?? 'unknown'];
       try {
         const result = await targetCallback(...args);
         return !isObservable(result)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, websocket exception filters are not aware of the value from `getPattern()` due to the way the args get passed around between the [`WsContextCreator`](https://github.com/nestjs/nest/blob/67951ff2e9b7f4803856ab8169e23350e49d7dfc/packages/websockets/context/ws-context-creator.ts#L112) and the [`WsProxy`](https://github.com/nestjs/nest/blob/67951ff2e9b7f4803856ab8169e23350e49d7dfc/packages/websockets/context/ws-proxy.ts#L11) classes.

Issue Number: #12380


## What is the new behavior?

By adding a new parameter to the `WsProxy#create` method, we're able to pass the found `targetPattern` from the `WsContextCreator` to the `WsProxy` class so that it can be properly passed on the the `handleError` method and pushed to the [`new ExecutionContextHost(args)`](https://github.com/nestjs/nest/blob/67951ff2e9b7f4803856ab8169e23350e49d7dfc/packages/websockets/context/ws-proxy.ts#L33) line where this error is, essentially, originating from. 

Due to the fact that we're using spread operators, the original `args.push()` is not propagating into the parent call which is why the `handleError` isn't getting the pattern added to it.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
 
To my knowledge, this is a completely internal class, and should not result in a breaking API change anywhere. If that's not the case, let me know, but as it's not referenced in the public `index.ts` anyone who is using this is technically using private API and should be aware that breaks can happen to _that_ without warning.


## Other information