### PR TITLE
feat(common): adding the fieldname to validation errors

### DIFF
--- a/packages/common/pipes/parse-array.pipe.ts
+++ b/packages/common/pipes/parse-array.pipe.ts
@@ -10,7 +10,6 @@ import { HttpErrorByCode } from '../utils/http-error-by-code.util';
 import { isNil, isUndefined, isString } from '../utils/shared.utils';
 import { ValidationPipe, ValidationPipeOptions } from './validation.pipe';
 
-const VALIDATION_ERROR_MESSAGE = 'Validation failed (parsable array expected)';
 const DEFAULT_ARRAY_SEPARATOR = ',';
 
 /**
@@ -62,21 +61,27 @@ export class ParseArrayPipe implements PipeTransform {
    */
   async transform(value: any, metadata: ArgumentMetadata): Promise<any> {
     if (!value && !this.options.optional) {
-      throw this.exceptionFactory(VALIDATION_ERROR_MESSAGE);
+      throw this.exceptionFactory(
+        this.getValidationErrorMessage(metadata.data),
+      );
     } else if (isNil(value) && this.options.optional) {
       return value;
     }
 
     if (!Array.isArray(value)) {
       if (!isString(value)) {
-        throw this.exceptionFactory(VALIDATION_ERROR_MESSAGE);
+        throw this.exceptionFactory(
+          this.getValidationErrorMessage(metadata.data),
+        );
       } else {
         try {
           value = value
             .trim()
             .split(this.options.separator || DEFAULT_ARRAY_SEPARATOR);
         } catch {
-          throw this.exceptionFactory(VALIDATION_ERROR_MESSAGE);
+          throw this.exceptionFactory(
+            this.getValidationErrorMessage(metadata.data),
+          );
         }
       }
     }
@@ -133,6 +138,10 @@ export class ParseArrayPipe implements PipeTransform {
       }
     }
     return value;
+  }
+
+  protected getValidationErrorMessage(field: string) {
+    return `Validation failed (parsable array expected in "${field}")`;
   }
 
   protected isExpectedTypePrimitive(): boolean {

--- a/packages/common/pipes/parse-bool.pipe.ts
+++ b/packages/common/pipes/parse-bool.pipe.ts
@@ -63,7 +63,7 @@ export class ParseBoolPipe
       return false;
     }
     throw this.exceptionFactory(
-      'Validation failed (boolean string is expected)',
+      `Validation failed (boolean string is expected in "${metadata.data}")`,
     );
   }
 

--- a/packages/common/pipes/parse-enum.pipe.ts
+++ b/packages/common/pipes/parse-enum.pipe.ts
@@ -57,7 +57,7 @@ export class ParseEnumPipe<T = any> implements PipeTransform<T> {
     }
     if (!this.isEnum(value)) {
       throw this.exceptionFactory(
-        'Validation failed (enum string is expected)',
+        `Validation failed (enum string is expected in "${metadata.data}")`,
       );
     }
     return value;

--- a/packages/common/pipes/parse-float.pipe.ts
+++ b/packages/common/pipes/parse-float.pipe.ts
@@ -50,7 +50,7 @@ export class ParseFloatPipe implements PipeTransform<string> {
     }
     if (!this.isNumeric(value)) {
       throw this.exceptionFactory(
-        'Validation failed (numeric string is expected)',
+        `Validation failed (numeric string is expected in "${metadata.data}")`,
       );
     }
     return parseFloat(value);

--- a/packages/common/pipes/parse-int.pipe.ts
+++ b/packages/common/pipes/parse-int.pipe.ts
@@ -54,7 +54,7 @@ export class ParseIntPipe implements PipeTransform<string> {
     }
     if (!this.isNumeric(value)) {
       throw this.exceptionFactory(
-        'Validation failed (numeric string is expected)',
+        `Validation failed (numeric string is expected in "${metadata.data}")`,
       );
     }
     return parseInt(value, 10);

--- a/packages/common/pipes/parse-uuid.pipe.ts
+++ b/packages/common/pipes/parse-uuid.pipe.ts
@@ -61,7 +61,7 @@ export class ParseUUIDPipe implements PipeTransform<string> {
       throw this.exceptionFactory(
         `Validation failed (uuid${
           this.version ? ` v ${this.version}` : ''
-        } is expected)`,
+        } is expected in ${metadata.data})`,
       );
     }
     return value;

--- a/packages/common/pipes/parse-uuid.pipe.ts
+++ b/packages/common/pipes/parse-uuid.pipe.ts
@@ -61,7 +61,7 @@ export class ParseUUIDPipe implements PipeTransform<string> {
       throw this.exceptionFactory(
         `Validation failed (uuid${
           this.version ? ` v ${this.version}` : ''
-        } is expected in ${metadata.data})`,
+        } is expected in "${metadata.data}")`,
       );
     }
     return value;

--- a/packages/common/test/pipes/parse-array.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-array.pipe.spec.ts
@@ -43,6 +43,11 @@ describe('ParseArrayPipe', () => {
       beforeEach(() => {
         target = new ParseArrayPipe();
       });
+      it('should mention the field name in the error', async () => {
+        return expect(
+          target.transform(true, { data: 'foo' } as ArgumentMetadata),
+        ).to.be.rejectedWith(/.*Validation failed.*"foo".*/);
+      });
       it('should throw an exception (boolean)', async () => {
         return expect(
           target.transform(true, {} as ArgumentMetadata),

--- a/packages/common/test/pipes/parse-bool.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-bool.pipe.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseBoolPipe } from '../../pipes/parse-bool.pipe';
+import { BadRequestException } from '../../exceptions';
 
 describe('ParseBoolPipe', () => {
   let target: ParseBoolPipe;
@@ -27,8 +28,14 @@ describe('ParseBoolPipe', () => {
     });
     describe('when validation fails', () => {
       it('should throw an error', async () => {
-        return expect(target.transform('123abc', {} as ArgumentMetadata)).to.be
-          .rejected;
+        return expect(
+          target.transform('123abc', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(BadRequestException);
+      });
+      it('should mention the field name in the error', async () => {
+        return expect(
+          target.transform('123abc', { data: 'foo' } as ArgumentMetadata),
+        ).to.be.rejectedWith(/.*Validation failed.*"foo".*/);
       });
     });
   });

--- a/packages/common/test/pipes/parse-uuid.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-uuid.pipe.spec.ts
@@ -56,6 +56,13 @@ describe('ParseUUIDPipe', () => {
         ).to.be.rejectedWith(TestException);
       });
 
+      it('should mention the field name in the error', async () => {
+        target = new ParseUUIDPipe();
+        await expect(
+          target.transform('123a', { data: 'foo' } as ArgumentMetadata),
+        ).to.be.rejectedWith(/.*Validation failed.*"foo".*/);
+      });
+
       it('should throw an error - not a string', async () => {
         target = new ParseUUIDPipe({ exceptionFactory });
         await expect(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12357

It's impossible to know based on the BadRequest response payload which field is causing problems

## What is the new behavior?

The error message contains the field name

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information