### PR TITLE
fix(express): sanity checking 'content-type' prior treating its value as string

### DIFF
--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -6,7 +6,7 @@ export class AppController {
   @Sse('sse')
   sse(): Observable<MessageEvent> {
     return interval(1000).pipe(
-      map(_ => ({ data: { hello: 'world' } } as MessageEvent)),
+      map(_ => ({ data: { hello: 'world' } }) as MessageEvent),
     );
   }
 }

--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -51,7 +51,8 @@ export interface ConfigurableModuleBuilderOptions {
 export class ConfigurableModuleBuilder<
   ModuleOptions,
   StaticMethodKey extends string = typeof DEFAULT_METHOD_KEY,
-  FactoryClassMethodKey extends string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
+  FactoryClassMethodKey extends
+    string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
   ExtraModuleDefinitionOptions = {},
 > {
   protected staticMethodKey: StaticMethodKey;

--- a/packages/common/module-utils/interfaces/configurable-module-async-options.interface.ts
+++ b/packages/common/module-utils/interfaces/configurable-module-async-options.interface.ts
@@ -28,7 +28,8 @@ export type ConfigurableModuleOptionsFactory<
  */
 export interface ConfigurableModuleAsyncOptions<
   ModuleOptions,
-  FactoryClassMethodKey extends string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
+  FactoryClassMethodKey extends
+    string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
 > extends Pick<ModuleMetadata, 'imports'> {
   /**
    * Injection token resolving to an existing provider. The provider must implement

--- a/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
+++ b/packages/common/module-utils/interfaces/configurable-module-cls.interface.ts
@@ -15,7 +15,8 @@ import { ConfigurableModuleAsyncOptions } from './configurable-module-async-opti
 export type ConfigurableModuleCls<
   ModuleOptions,
   MethodKey extends string = typeof DEFAULT_METHOD_KEY,
-  FactoryClassMethodKey extends string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
+  FactoryClassMethodKey extends
+    string = typeof DEFAULT_FACTORY_CLASS_METHOD_KEY,
   ExtraModuleDefinitionOptions = {},
 > = {
   new (): any;

--- a/packages/common/pipes/file/file-validator.interface.ts
+++ b/packages/common/pipes/file/file-validator.interface.ts
@@ -16,7 +16,9 @@ export abstract class FileValidator<
    * Indicates if this file should be considered valid, according to the options passed in the constructor.
    * @param file the file from the request object
    */
-  abstract isValid(file?: TFile | TFile[] | Record<string, TFile[]>): boolean | Promise<boolean>;
+  abstract isValid(
+    file?: TFile | TFile[] | Record<string, TFile[]>,
+  ): boolean | Promise<boolean>;
 
   /**
    * Builds an error message in case the validation fails.

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -83,9 +83,8 @@ export class NestContainer {
     if (!metatype) {
       throw new UndefinedForwardRefException(scope);
     }
-    const { type, dynamicMetadata, token } = await this.moduleCompiler.compile(
-      metatype,
-    );
+    const { type, dynamicMetadata, token } =
+      await this.moduleCompiler.compile(metatype);
     if (this.modules.has(token)) {
       return {
         moduleRef: this.modules.get(token),
@@ -124,9 +123,8 @@ export class NestContainer {
     }
 
     const { token } = await this.moduleCompiler.compile(metatypeToReplace);
-    const { type, dynamicMetadata } = await this.moduleCompiler.compile(
-      newMetatype,
-    );
+    const { type, dynamicMetadata } =
+      await this.moduleCompiler.compile(newMetatype);
 
     return {
       moduleRef: await this.setModule(
@@ -220,9 +218,8 @@ export class NestContainer {
       return;
     }
     const moduleRef = this.modules.get(token);
-    const { token: relatedModuleToken } = await this.moduleCompiler.compile(
-      relatedModule,
-    );
+    const { token: relatedModuleToken } =
+      await this.moduleCompiler.compile(relatedModule);
     const related = this.modules.get(relatedModuleToken);
     moduleRef.addImport(related);
   }

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -33,7 +33,8 @@ import { RouteInfoPathExtractor } from './route-info-path-extractor';
 import { RoutesMapper } from './routes-mapper';
 
 export class MiddlewareModule<
-  TAppOptions extends NestApplicationContextOptions = NestApplicationContextOptions,
+  TAppOptions extends
+    NestApplicationContextOptions = NestApplicationContextOptions,
 > {
   private readonly routerProxy = new RouterProxy();
   private readonly exceptionFiltersCache = new WeakMap();

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -36,7 +36,8 @@ import { Module } from './injector/module';
  * @publicApi
  */
 export class NestApplicationContext<
-    TOptions extends NestApplicationContextOptions = NestApplicationContextOptions,
+    TOptions extends
+      NestApplicationContextOptions = NestApplicationContextOptions,
   >
   extends AbstractInstanceResolver
   implements INestApplicationContext

--- a/packages/core/test/exceptions/external-exception-filter-context.spec.ts
+++ b/packages/core/test/exceptions/external-exception-filter-context.spec.ts
@@ -37,7 +37,7 @@ describe('ExternalExceptionFilterContext', () => {
       it('should return plain ExceptionHandler object', () => {
         const filter = exceptionFilter.create(
           new EmptyMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.be.empty;
@@ -50,7 +50,7 @@ describe('ExternalExceptionFilterContext', () => {
       it('should return ExceptionHandler object with exception filters', () => {
         const filter = exceptionFilter.create(
           new WithMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.not.be.empty;
@@ -105,7 +105,7 @@ describe('ExternalExceptionFilterContext', () => {
           .callsFake(() => scopedFilterWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(exceptionFilter.getGlobalMetadata({ id: 3 })).to.contains(
           instance,

--- a/packages/core/test/guards/guards-context-creator.spec.ts
+++ b/packages/core/test/guards/guards-context-creator.spec.ts
@@ -154,7 +154,7 @@ describe('GuardsContextCreator', () => {
           .callsFake(() => scopedGuardWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(guardsContextCreator.getGlobalMetadata({ id: 3 })).to.contains(
           instance,

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -32,7 +32,10 @@ describe('Injector', () => {
     class MainTest {
       @Inject() property: DependencyOne;
 
-      constructor(public one: DependencyOne, public two: DependencyTwo) {}
+      constructor(
+        public one: DependencyOne,
+        public two: DependencyTwo,
+      ) {}
     }
 
     let moduleDeps: Module;
@@ -743,7 +746,7 @@ describe('Injector', () => {
 
       const loadInstanceStub = sinon
         .stub(injector, 'loadInstance')
-        .callsFake(async () => ({} as any));
+        .callsFake(async () => ({}) as any);
 
       await injector.loadEnhancersPerContext(wrapper, STATIC_CONTEXT);
       expect(loadInstanceStub.calledTwice).to.be.true;

--- a/packages/core/test/interceptors/interceptors-context-creator.spec.ts
+++ b/packages/core/test/interceptors/interceptors-context-creator.spec.ts
@@ -160,7 +160,7 @@ describe('InterceptorsContextCreator', () => {
           .callsFake(() => scopedInterceptorWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(
           interceptorsContextCreator.getGlobalMetadata({ id: 3 }),

--- a/packages/core/test/pipes/pipes-context-creator.spec.ts
+++ b/packages/core/test/pipes/pipes-context-creator.spec.ts
@@ -111,7 +111,7 @@ describe('PipesContextCreator', () => {
           .callsFake(() => scopedPipeWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(creator.getGlobalMetadata({ id: 3 })).to.contains(
           instance,

--- a/packages/core/test/router/router-exception-filters.spec.ts
+++ b/packages/core/test/router/router-exception-filters.spec.ts
@@ -35,7 +35,7 @@ describe('RouterExceptionFilters', () => {
       it('should return plain ExceptionHandler object', () => {
         const filter = exceptionFilter.create(
           new EmptyMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.be.empty;
@@ -48,7 +48,7 @@ describe('RouterExceptionFilters', () => {
       it('should return ExceptionHandler object with exception filters', () => {
         const filter = exceptionFilter.create(
           new WithMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.not.be.empty;
@@ -97,7 +97,7 @@ describe('RouterExceptionFilters', () => {
           .callsFake(() => scopedFilterWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(exceptionFilter.getGlobalMetadata({ id: 3 })).to.contains(
           instance,

--- a/packages/core/test/router/router-explorer.spec.ts
+++ b/packages/core/test/router/router-explorer.spec.ts
@@ -175,7 +175,7 @@ describe('RouterExplorer', () => {
         () =>
           ({
             next: nextSpy,
-          } as any),
+          }) as any,
       );
     });
 

--- a/packages/microservices/interfaces/message-handler.interface.ts
+++ b/packages/microservices/interfaces/message-handler.interface.ts
@@ -4,9 +4,10 @@ import { Observable } from 'rxjs';
  * @publicApi
  */
 export interface MessageHandler<TInput = any, TContext = any, TResult = any> {
-  (data: TInput, ctx?: TContext):
-    | Promise<Observable<TResult>>
-    | Promise<TResult>;
+  (
+    data: TInput,
+    ctx?: TContext,
+  ): Promise<Observable<TResult>> | Promise<TResult>;
   next?: (
     data: TInput,
     ctx?: TContext,

--- a/packages/microservices/microservices-module.ts
+++ b/packages/microservices/microservices-module.ts
@@ -22,7 +22,8 @@ import { ListenersController } from './listeners-controller';
 import { Server } from './server/server';
 
 export class MicroservicesModule<
-  TAppOptions extends NestApplicationContextOptions = NestApplicationContextOptions,
+  TAppOptions extends
+    NestApplicationContextOptions = NestApplicationContextOptions,
 > {
   private readonly clientsContainer = new ClientsContainer();
   private listenersController: ListenersController;

--- a/packages/microservices/record-builders/rmq.record-builder.ts
+++ b/packages/microservices/record-builders/rmq.record-builder.ts
@@ -17,7 +17,10 @@ export interface RmqRecordOptions {
 }
 
 export class RmqRecord<TData = any> {
-  constructor(public readonly data: TData, public options?: RmqRecordOptions) {}
+  constructor(
+    public readonly data: TData,
+    public options?: RmqRecordOptions,
+  ) {}
 }
 
 export class RmqRecordBuilder<TData> {

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -255,7 +255,7 @@ describe('ClientMqtt', () => {
           ({
             addListener: () => ({}),
             removeListener: () => ({}),
-          } as any),
+          }) as any,
       );
       handleErrorsSpy = sinon.spy(client, 'handleError');
       connect$Stub = sinon.stub(client, 'connect$' as any).callsFake(() => ({

--- a/packages/microservices/test/client/client-nats.spec.ts
+++ b/packages/microservices/test/client/client-nats.spec.ts
@@ -241,7 +241,7 @@ describe('ClientNats', () => {
     beforeEach(async () => {
       createClientSpy = sinon
         .stub(client, 'createClient')
-        .callsFake(() => ({} as any));
+        .callsFake(() => ({}) as any);
       handleStatusUpdatesSpy = sinon.spy(client, 'handleStatusUpdates');
 
       await client.connect();

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -221,7 +221,7 @@ describe('ClientRedis', () => {
           ({
             addListener: () => null,
             removeListener: () => null,
-          } as any),
+          }) as any,
       );
       handleErrorsSpy = sinon.spy(client, 'handleError');
 

--- a/packages/microservices/test/context/exception-filters-context.spec.ts
+++ b/packages/microservices/test/context/exception-filters-context.spec.ts
@@ -33,7 +33,7 @@ describe('ExceptionFiltersContext', () => {
       it('should return plain ExceptionHandler object', () => {
         const filter = exceptionFilter.create(
           new EmptyMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.be.empty;
@@ -46,7 +46,7 @@ describe('ExceptionFiltersContext', () => {
       it('should return ExceptionHandler object with exception filters', () => {
         const filter = exceptionFilter.create(
           new WithMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           undefined,
         );
         expect((filter as any).filters).to.not.be.empty;
@@ -76,7 +76,7 @@ describe('ExceptionFiltersContext', () => {
           .callsFake(() => scopedFilterWrappers);
         sinon
           .stub(instanceWrapper, 'getInstanceByContextId')
-          .callsFake(() => ({ instance } as any));
+          .callsFake(() => ({ instance }) as any);
 
         expect(exceptionFilter.getGlobalMetadata({ id: 3 })).to.contains(
           instance,

--- a/packages/microservices/test/listeners-controller.spec.ts
+++ b/packages/microservices/test/listeners-controller.spec.ts
@@ -87,7 +87,7 @@ describe('ListenersController', () => {
     ];
 
     beforeEach(() => {
-      sinon.stub(container, 'getModuleByKey').callsFake(() => ({} as any));
+      sinon.stub(container, 'getModuleByKey').callsFake(() => ({}) as any);
     });
     it(`should call "addHandler" method of server for each pattern handler`, () => {
       explorer.expects('explore').returns(handlers);
@@ -203,12 +203,12 @@ describe('ListenersController', () => {
         () =>
           ({
             handle: handleSpy,
-          } as any),
+          }) as any,
       );
 
       sinon
         .stub((instance as any).container, 'registerRequestProvider')
-        .callsFake(() => ({} as any));
+        .callsFake(() => ({}) as any);
     });
 
     describe('when "loadPerContext" resolves', () => {

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -126,7 +126,7 @@ describe('ServerKafka', () => {
     it('should call "bindEvents"', async () => {
       bindEventsStub = sinon
         .stub(server, 'bindEvents')
-        .callsFake(() => ({} as any));
+        .callsFake(() => ({}) as any);
       await server.listen(callback);
       expect(bindEventsStub.called).to.be.true;
     });

--- a/packages/microservices/test/server/server-redis.spec.ts
+++ b/packages/microservices/test/server/server-redis.spec.ts
@@ -134,13 +134,13 @@ describe('ServerRedis', () => {
     });
     it('should call "handleEvent" if identifier is not present', async () => {
       const handleEventSpy = sinon.spy(server, 'handleEvent');
-      sinon.stub(server, 'parseMessage').callsFake(() => ({ data } as any));
+      sinon.stub(server, 'parseMessage').callsFake(() => ({ data }) as any);
 
       await server.handleMessage(channel, JSON.stringify({}), null, channel);
       expect(handleEventSpy.called).to.be.true;
     });
     it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {
-      sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data } as any));
+      sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data }) as any);
       await server.handleMessage(
         channel,
         JSON.stringify({ id }),
@@ -160,7 +160,7 @@ describe('ServerRedis', () => {
       (server as any).messageHandlers = objectToMap({
         [channel]: handler,
       });
-      sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data } as any));
+      sinon.stub(server, 'parseMessage').callsFake(() => ({ id, data }) as any);
 
       await server.handleMessage(channel, {}, null, channel);
       expect(handler.calledWith(data)).to.be.true;

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -29,7 +29,7 @@ describe('ServerRMQ', () => {
       createChannelStub = sinon.stub().callsFake(({ setup }) => setup());
       setupChannelStub = sinon
         .stub(server, 'setupChannel')
-        .callsFake(() => ({} as any));
+        .callsFake(() => ({}) as any);
 
       client = {
         on: onStub,

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -101,9 +101,10 @@ export class ExpressAdapter extends AbstractHttpAdapter<
         },
       );
     }
+    const responseContentType = response.getHeader('Content-Type');
     if (
-      response.getHeader('Content-Type') !== undefined &&
-      !response.getHeader('Content-Type').startsWith('application/json') &&
+      typeof responseContentType === 'string' &&
+      !responseContentType.startsWith('application/json') &&
       body?.statusCode >= HttpStatus.BAD_REQUEST
     ) {
       this.logger.warn(

--- a/packages/platform-express/multer/interceptors/any-files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/any-files.interceptor.ts
@@ -17,8 +17,8 @@ import { transformException } from '../multer/multer.utils';
 type MulterInstance = any;
 
 /**
- * @param localOptions 
- * 
+ * @param localOptions
+ *
  * @publicApi
  */
 export function AnyFilesInterceptor(

--- a/packages/platform-express/multer/interceptors/file-fields.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/file-fields.interceptor.ts
@@ -20,8 +20,8 @@ import { transformException } from '../multer/multer.utils';
 type MulterInstance = any;
 
 /**
- * @param uploadFields 
- * @param localOptions 
+ * @param uploadFields
+ * @param localOptions
  * @publicApi
  */
 export function FileFieldsInterceptor(

--- a/packages/platform-express/multer/interceptors/file.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/file.interceptor.ts
@@ -17,9 +17,9 @@ import { transformException } from '../multer/multer.utils';
 type MulterInstance = any;
 
 /**
- * @param fieldName 
- * @param localOptions 
- * 
+ * @param fieldName
+ * @param localOptions
+ *
  * @publicApi
  */
 export function FileInterceptor(

--- a/packages/platform-express/multer/interceptors/files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/files.interceptor.ts
@@ -17,12 +17,12 @@ import { transformException } from '../multer/multer.utils';
 type MulterInstance = any;
 
 /**
- * 
- * @param fieldName 
- * @param maxCount 
- * @param localOptions 
- * 
- * @publicApi 
+ *
+ * @param fieldName
+ * @param maxCount
+ * @param localOptions
+ *
+ * @publicApi
  */
 export function FilesInterceptor(
   fieldName: string,

--- a/packages/platform-express/multer/interceptors/no-files.interceptor.ts
+++ b/packages/platform-express/multer/interceptors/no-files.interceptor.ts
@@ -17,8 +17,8 @@ import { transformException } from '../multer/multer.utils';
 type MulterInstance = any;
 
 /**
- * 
- * @param localOptions 
+ *
+ * @param localOptions
  * @publicApi
  */
 export function NoFilesInterceptor(

--- a/packages/platform-express/multer/interfaces/files-upload-module.interface.ts
+++ b/packages/platform-express/multer/interfaces/files-upload-module.interface.ts
@@ -10,7 +10,6 @@ export interface MulterOptionsFactory {
   createMulterOptions(): Promise<MulterModuleOptions> | MulterModuleOptions;
 }
 
-
 /**
  * @publicApi
  */

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -101,7 +101,8 @@ type FastifyRawRequest<TServer extends RawServerBase> =
 export class FastifyAdapter<
   TServer extends RawServerBase = RawServerDefault,
   TRawRequest extends FastifyRawRequest<TServer> = FastifyRawRequest<TServer>,
-  TRawResponse extends RawReplyDefaultExpression<TServer> = RawReplyDefaultExpression<TServer>,
+  TRawResponse extends
+    RawReplyDefaultExpression<TServer> = RawReplyDefaultExpression<TServer>,
   TRequest extends FastifyRequest<
     RequestGenericInterface,
     TServer,

--- a/packages/platform-fastify/decorators/route-config.decorator.ts
+++ b/packages/platform-fastify/decorators/route-config.decorator.ts
@@ -3,7 +3,7 @@ import { FASTIFY_ROUTE_CONFIG_METADATA } from '../constants';
 
 /**
  * @publicApi
- * 
+ *
  * @param config See {@link https://fastify.dev/docs/latest/Reference/Routes/#config}
  */
 export const RouteConfig = (config: any) =>

--- a/packages/websockets/socket-module.ts
+++ b/packages/websockets/socket-module.ts
@@ -25,7 +25,8 @@ import { WebSocketsController } from './web-sockets-controller';
 
 export class SocketModule<
   THttpServer = any,
-  TAppOptions extends NestApplicationContextOptions = NestApplicationContextOptions,
+  TAppOptions extends
+    NestApplicationContextOptions = NestApplicationContextOptions,
 > {
   private readonly socketsContainer = new SocketsContainer();
   private applicationConfig: ApplicationConfig;

--- a/packages/websockets/test/context/exception-filters.context.spec.ts
+++ b/packages/websockets/test/context/exception-filters.context.spec.ts
@@ -28,7 +28,7 @@ describe('ExceptionFiltersContext', () => {
       it('should return plain ExceptionHandler object', () => {
         const filter = exceptionFilter.create(
           new EmptyMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           '',
         );
         expect((filter as any).filters).to.be.empty;
@@ -41,7 +41,7 @@ describe('ExceptionFiltersContext', () => {
       it('should return ExceptionHandler object with exception filters', () => {
         const filter = exceptionFilter.create(
           new WithMetadata(),
-          () => ({} as any),
+          () => ({}) as any,
           '',
         );
         expect((filter as any).filters).to.not.be.empty;

--- a/packages/websockets/test/context/ws-proxy.spec.ts
+++ b/packages/websockets/test/context/ws-proxy.spec.ts
@@ -18,8 +18,10 @@ describe('WsProxy', () => {
 
   describe('create', () => {
     it('should method return thunk', async () => {
-      const proxy = await routerProxy.create(async (client, data) => {},
-      handler);
+      const proxy = await routerProxy.create(
+        async (client, data) => {},
+        handler,
+      );
       expect(typeof proxy === 'function').to.be.true;
     });
 

--- a/sample/02-gateways/e2e/events-gateway/gateway.e2e-spec.ts
+++ b/sample/02-gateways/e2e/events-gateway/gateway.e2e-spec.ts
@@ -16,7 +16,7 @@ describe('EventsGateway', () => {
     await app.listen(3000);
   });
 
-  beforeEach((done) => {
+  beforeEach(done => {
     socket = io('http://localhost:3000');
     socket.on('connect', () => {
       done();

--- a/sample/19-auth-jwt/src/auth/auth.guard.ts
+++ b/sample/19-auth-jwt/src/auth/auth.guard.ts
@@ -12,7 +12,10 @@ import { IS_PUBLIC_KEY } from './decorators/public.decorator';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private jwtService: JwtService, private reflector: Reflector) {}
+  constructor(
+    private jwtService: JwtService,
+    private reflector: Reflector,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [

--- a/sample/28-sse/src/app.controller.ts
+++ b/sample/28-sse/src/app.controller.ts
@@ -17,7 +17,7 @@ export class AppController {
   @Sse('sse')
   sse(): Observable<MessageEvent> {
     return interval(1000).pipe(
-      map((_) => ({ data: { hello: 'world' } } as MessageEvent)),
+      map((_) => ({ data: { hello: 'world' } }) as MessageEvent),
     );
   }
 }

--- a/tools/benchmarks/check-benchmarks.ts
+++ b/tools/benchmarks/check-benchmarks.ts
@@ -12,9 +12,8 @@ export default async function checkBenchmarks() {
   if (!codechecks.isPr()) {
     return;
   }
-  const baselineBenchmarks = await codechecks.getValue<Benchmarks>(
-    benchmarksKey,
-  );
+  const baselineBenchmarks =
+    await codechecks.getValue<Benchmarks>(benchmarksKey);
   const report = getCodechecksReport(currentBenchmarks, baselineBenchmarks);
   await codechecks.report(report);
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #12412


## What is the new behavior?

handle cases where `response.getHeader('Content-Type')` is returning `null` as well as `undefined` before invoking `.startsWith()` method on it

Also, I've ran `npm run format`. That's why a bunch of files was touched. I can revert that commit tho.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information