### PR TITLE
feat(core): disambiguate string-based providers from class-based providers on error message

### DIFF
--- a/integration/injector/e2e/optional-factory-provider-dep.spec.ts
+++ b/integration/injector/e2e/optional-factory-provider-dep.spec.ts
@@ -118,14 +118,14 @@ describe('Optional factory provider deps', () => {
       } catch (err) {
         expect(err).to.be.instanceOf(UnknownDependenciesException);
         expect(err.message).to
-          .equal(`Nest can't resolve dependencies of the POSSIBLY_MISSING_DEP (?). Please make sure that the argument MISSING_DEP at index [0] is available in the RootTestModule context.
+          .equal(`Nest can't resolve dependencies of the POSSIBLY_MISSING_DEP (?). Please make sure that the argument "MISSING_DEP" at index [0] is available in the RootTestModule context.
 
 Potential solutions:
 - Is RootTestModule a valid NestJS module?
-- If MISSING_DEP is a provider, is it part of the current RootTestModule?
-- If MISSING_DEP is exported from a separate @Module, is that module imported within RootTestModule?
+- If "MISSING_DEP" is a provider, is it part of the current RootTestModule?
+- If "MISSING_DEP" is exported from a separate @Module, is that module imported within RootTestModule?
   @Module({
-    imports: [ /* the Module containing MISSING_DEP */ ]
+    imports: [ /* the Module containing "MISSING_DEP" */ ]
   })
 `);
       }

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -57,6 +57,28 @@ describe('Error Messages', () => {
 
       expect(actualMessage).to.equal(expectedResult);
     });
+    it('should display the provide token as double-quoted string for string-based tokens', () => {
+      const expectedResult =
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?). Please make sure that the argument "FooRepository" at index [0] is available in the current context.
+
+      Potential solutions:
+      - If "FooRepository" is a provider, is it part of the current Module?
+      - If "FooRepository" is exported from a separate @Module, is that module imported within Module?
+      @Module({
+      imports: [ /* the Module containing "FooRepository" */ ]
+      })
+      `);
+
+      const actualMessage = stringCleaner(
+        new UnknownDependenciesException('CatService', {
+          index: 0,
+          dependencies: ['FooRepository'],
+          name: 'FooRepository',
+        }).message,
+      );
+
+      expect(actualMessage).to.equal(expectedResult);
+    });
     it('should display the function name', () => {
       const expectedResult =
         stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatFunction). Please make sure that the argument dependency at index [0] is available in the current context.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) -- I'll update the docs as well if thi get merged


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when some provider registered with a string token is missing, the error message is the same as the ones registered with classes

I believe this confuse people sometimes specially when the token is created by 3rd-party libs and, on the consumer side, there is a class with the same name

For example:

![image](https://github.com/nestjs/nest/assets/13461315/99369c45-49e0-4ac9-9462-4f4a99d7b375)
![image](https://github.com/nestjs/nest/assets/13461315/8d7fc4dc-abdb-42db-ac78-2a441b9161a3)


## What is the new behavior?

![image](https://github.com/nestjs/nest/assets/13461315/18e991ff-fdd4-4ccf-abf8-b9ada019259e)


I believe that this minor change would decrease the debugging time spent of resolving such errors. But I don't know if not having quotes around provider's name was intentional in first place.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No(?)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

