### PR TITLE
fix(core): when the discoverable decorator was not used on calling `getProviders`/`getControllers`

### DIFF
--- a/integration/discovery/e2e/discover-by-meta.spec.ts
+++ b/integration/discovery/e2e/discover-by-meta.spec.ts
@@ -1,15 +1,21 @@
-import { Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DiscoveryService } from '@nestjs/core';
 import { expect } from 'chai';
 import { AppModule } from '../src/app.module';
 import { WebhooksExplorer } from '../src/webhooks.explorer';
+import { NonAppliedDecorator } from '../src/decorators/non-applied.decorator';
 
 describe('DiscoveryModule', () => {
-  it('should discover all providers & handlers with corresponding annotations', async () => {
-    const builder = Test.createTestingModule({
+  let moduleRef: TestingModule;
+
+  beforeEach(async () => {
+    moduleRef = await Test.createTestingModule({
       imports: [AppModule],
-    });
-    const testingModule = await builder.compile();
-    const webhooksExplorer = testingModule.get(WebhooksExplorer);
+    }).compile();
+  });
+
+  it('should discover all providers & handlers with corresponding annotations', async () => {
+    const webhooksExplorer = moduleRef.get(WebhooksExplorer);
 
     expect(webhooksExplorer.getWebhooks()).to.be.eql([
       {
@@ -31,5 +37,23 @@ describe('DiscoveryModule', () => {
         name: 'flush',
       },
     ]);
+  });
+
+  it('should return an empty array if no providers were found for a given discoverable decorator', () => {
+    const discoveryService = moduleRef.get(DiscoveryService);
+
+    const providers = discoveryService.getProviders({
+      metadataKey: NonAppliedDecorator.KEY,
+    });
+    expect(providers).to.be.eql([]);
+  });
+
+  it('should return an empty array if no controllers were found for a given discoverable decorator', () => {
+    const discoveryService = moduleRef.get(DiscoveryService);
+
+    const controllers = discoveryService.getControllers({
+      metadataKey: NonAppliedDecorator.KEY,
+    });
+    expect(controllers).to.be.eql([]);
   });
 });

--- a/integration/discovery/src/decorators/non-applied.decorator.ts
+++ b/integration/discovery/src/decorators/non-applied.decorator.ts
@@ -1,0 +1,9 @@
+import { DiscoveryService } from '@nestjs/core';
+
+/**
+ * This decorator must not be used anywhere!
+ *
+ * This will be used to test the scenario where we are trying to retrieving
+ * metadata for a discoverable decorator that was not applied to any class.
+ */
+export const NonAppliedDecorator = DiscoveryService.createDecorator();

--- a/packages/core/discovery/discoverable-meta-host-collection.ts
+++ b/packages/core/discovery/discoverable-meta-host-collection.ts
@@ -94,7 +94,7 @@ export class DiscoverableMetaHostCollection {
     metaKey: string,
   ): Set<InstanceWrapper> {
     const wrappersByMetaKey = this.providersByMetaKey.get(hostContainerRef);
-    return wrappersByMetaKey.get(metaKey);
+    return wrappersByMetaKey?.get(metaKey) ?? new Set<InstanceWrapper>();
   }
 
   public static getControllersByMetaKey(
@@ -102,7 +102,7 @@ export class DiscoverableMetaHostCollection {
     metaKey: string,
   ): Set<InstanceWrapper> {
     const wrappersByMetaKey = this.controllersByMetaKey.get(hostContainerRef);
-    return wrappersByMetaKey.get(metaKey);
+    return wrappersByMetaKey?.get(metaKey) ?? new Set<InstanceWrapper>();
   }
 
   private static inspectInstanceWrapper(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #12518 


## What is the new behavior?

returns an empty Set - a null object, kinda (although I dislike the ideia of initializing a new empty object every time)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information