### PR TITLE
feat: allow for custom logger with streamable files

### DIFF
--- a/packages/common/file-stream/streamable-file.ts
+++ b/packages/common/file-stream/streamable-file.ts
@@ -3,6 +3,7 @@ import { types } from 'util';
 import { HttpStatus } from '../enums';
 import { isFunction } from '../utils/shared.utils';
 import { StreamableFileOptions, StreamableHandlerResponse } from './interfaces';
+import { Logger } from '../services';
 
 /**
  * @see [Streaming files](https://docs.nestjs.com/techniques/streaming-files)
@@ -11,6 +12,7 @@ import { StreamableFileOptions, StreamableHandlerResponse } from './interfaces';
  */
 export class StreamableFile {
   private readonly stream: Readable;
+  protected logger = new Logger('StreamableFile');
 
   protected handleError: (
     err: Error,
@@ -26,6 +28,10 @@ export class StreamableFile {
 
     res.statusCode = HttpStatus.BAD_REQUEST;
     res.send(err.message);
+  };
+
+  protected logError: (err: Error) => void = (err: Error) => {
+    this.logger.error(err.message, err.stack);
   };
 
   constructor(buffer: Uint8Array, options?: StreamableFileOptions);
@@ -72,6 +78,15 @@ export class StreamableFile {
     handler: (err: Error, response: StreamableHandlerResponse) => void,
   ) {
     this.handleError = handler;
+    return this;
+  }
+
+  get errorLogger() {
+    return this.logError;
+  }
+
+  setErrorLogger(handler: (err: Error) => void) {
+    this.logError = handler;
     return this;
   }
 }

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -96,7 +96,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
         response,
         (err: Error) => {
           if (err) {
-            this.logger.error(err.message, err.stack);
+            body.errorLogger(err);
           }
         },
       );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When the StreamableFile handle has an error, it uses the built in `this.logger.error()` handler to log the error. This works, but can cause a lot of noise with the stack trace that gets printed.

Issue Number: #12542


## What is the new behavior?

Devs are now able to do `new StreamableFile().setErrorLogger((err) => this.logger.error(err.message))` to only log the message and not the stack trace, or whatever other custom logging they want to use

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information