### PR TITLE
fix(common): when passing class functions to logger methods

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -245,10 +245,18 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {
-    // If the message is a function, call it and re-resolve its value.
-    return isFunction(message)
-      ? this.stringifyMessage(message(), logLevel)
-      : isPlainObject(message) || Array.isArray(message)
+    if (isFunction(message)) {
+      const messageAsStr = Function.prototype.toString.call(message);
+      const isClass = messageAsStr.startsWith('class ');
+      if (isClass) {
+        // If the message is a class, we will display the class name.
+        return this.stringifyMessage(message.name, logLevel);
+      }
+      // If the message is a non-class function, call it and re-resolve its value.
+      return this.stringifyMessage(message(), logLevel);
+    }
+
+    return isPlainObject(message) || Array.isArray(message)
       ? `${this.colorize('Object:', logLevel)}\n${JSON.stringify(
           message,
           (key, value) =>

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -298,6 +298,34 @@ describe('Logger', () => {
         );
       });
     });
+
+    describe('classes for message', () => {
+      let processStdoutWriteSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        processStdoutWriteSpy = sinon.spy(process.stdout, 'write');
+      });
+      afterEach(() => {
+        processStdoutWriteSpy.restore();
+      });
+
+      it("should display class's name or empty for anonymous classes", () => {
+        const logger = new ConsoleLogger();
+
+        // in-line anonymous class
+        logger.log(class {});
+
+        // named class
+        class Test {
+          #privateField = 'private field';
+          publicField = 'public field';
+        }
+        logger.log(Test);
+
+        expect(processStdoutWriteSpy.firstCall.firstArg).to.include('');
+        expect(processStdoutWriteSpy.secondCall.firstArg).to.include(Test.name);
+      });
+    });
   });
 
   describe('[instance methods]', () => {

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -39,7 +39,6 @@ import { CONTROLLER_ID_KEY } from './constants';
 import { NestContainer } from './container';
 import { ContextId, InstanceWrapper } from './instance-wrapper';
 import { ModuleRef, ModuleRefGetOrResolveOpts } from './module-ref';
-import { Injector } from './injector';
 
 export class Module {
   private readonly _id: string;

--- a/packages/core/middleware/routes-mapper.ts
+++ b/packages/core/middleware/routes-mapper.ts
@@ -87,28 +87,27 @@ export class RoutesMapper {
       version === VERSION_NEUTRAL ? undefined : version;
 
     const toRouteInfo = (item: RouteDefinition, prefix: string) =>
-      item.path
-        ?.flatMap(p => {
-          let endpointPath = modulePath ?? '';
-          endpointPath += this.normalizeGlobalPath(prefix) + addLeadingSlash(p);
+      item.path?.flatMap(p => {
+        let endpointPath = modulePath ?? '';
+        endpointPath += this.normalizeGlobalPath(prefix) + addLeadingSlash(p);
 
-          const routeInfo: RouteInfo = {
-            path: endpointPath,
-            method: item.requestMethod,
-          };
-          const version = item.version ?? controllerVersion;
-          if (version && versioningConfig) {
-            if (typeof version !== 'string' && Array.isArray(version)) {
-              return version.map(v => ({
-                ...routeInfo,
-                version: toUndefinedIfNeural(v),
-              }));
-            }
-            routeInfo.version = toUndefinedIfNeural(version);
+        const routeInfo: RouteInfo = {
+          path: endpointPath,
+          method: item.requestMethod,
+        };
+        const version = item.version ?? controllerVersion;
+        if (version && versioningConfig) {
+          if (typeof version !== 'string' && Array.isArray(version)) {
+            return version.map(v => ({
+              ...routeInfo,
+              version: toUndefinedIfNeural(v),
+            }));
           }
+          routeInfo.version = toUndefinedIfNeural(version);
+        }
 
-          return routeInfo;
-        });
+        return routeInfo;
+      });
 
     return []
       .concat(routePath)

--- a/packages/microservices/server/server-mqtt.ts
+++ b/packages/microservices/server/server-mqtt.ts
@@ -189,7 +189,7 @@ export class ServerMqtt extends Server implements CustomTransportStrategy {
     if (this.messageHandlers.has(route)) {
       return this.messageHandlers.get(route) || null;
     }
-  
+
     for (const [key, value] of this.messageHandlers) {
       const keyWithoutSharedPrefix = this.removeHandlerKeySharedPrefix(key);
       if (this.matchMqttPattern(keyWithoutSharedPrefix, route)) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

this a fix for the regression introduced by PR #11281

For example:

```ts
import { Logger } from '@nestjs/common'

class Foo {}

function foo() {
  return 'foobar'
}

const logger = new Logger()
logger.log(foo)
logger.log(Foo)
logger.log(class {})
```

You'll see:

```
/tmp/nestjs-app/node_modules/@nestjs/common/services/console-logger.service.js:150
            ? this.stringifyMessage(message(), logLevel)
                                    ^
TypeError: Class constructor Foo cannot be invoked without 'new'
    at ConsoleLogger.stringifyMessage (/tmp/nestjs-app/node_modules/@nestjs/common/services/console-logger.service.js:150:37)
    at ConsoleLogger.formatMessage (/tmp/nestjs-app/node_modules/@nestjs/common/services/console-logger.service.js:142:29)
    at /tmp/nestjs-app/node_modules/@nestjs/common/services/console-logger.service.js:131:43
```

## What is the new behavior?

for the above code you will get this now:

![image](https://github.com/nestjs/nest/assets/13461315/0a47aa43-e01f-4dff-9cd5-e1b0cc3582af)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No ~ in the past (nest v9) we would see the whole class serialized. As this was broken since v10.0.0, I don't think that changing the format is a breaking change for v10 but I might be wrong. I can change the display format tho

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


