### PR TITLE
feat: allow for microservice options to come from the di container

### DIFF
--- a/integration/microservices/e2e/sum-rpc-async.spec.ts
+++ b/integration/microservices/e2e/sum-rpc-async.spec.ts
@@ -1,0 +1,98 @@
+import {
+  Controller,
+  INestMicroservice,
+  Injectable,
+  Module,
+} from '@nestjs/common';
+import {
+  AsyncOptions,
+  ClientTCP,
+  ClientsModule,
+  MessagePattern,
+  MicroserviceOptions,
+  Payload,
+  TcpClientOptions,
+  Transport,
+} from '@nestjs/microservices';
+import { expect } from 'chai';
+import { NestFactory } from '@nestjs/core';
+
+let port: number;
+
+do {
+  port = Math.round(Math.random() * 10000);
+} while (port < 1000);
+
+@Injectable()
+class RpcOptionsProvider {
+  getOptions(): TcpClientOptions {
+    return {
+      transport: Transport.TCP,
+      options: {
+        port,
+        host: '0.0.0.0',
+      },
+    };
+  }
+}
+
+@Controller()
+class RpcController {
+  @MessagePattern({ cmd: 'sum' })
+  sumPayload(@Payload() payload: number[]) {
+    return payload.reduce((a, b) => a + b, 0);
+  }
+}
+
+@Module({
+  imports: [
+    ClientsModule.register([
+      {
+        name: 'RPC_CLIENT',
+        transport: Transport.TCP,
+        options: {
+          port,
+          host: '0.0.0.0',
+        },
+      },
+    ]),
+  ],
+  controllers: [RpcController],
+  providers: [RpcOptionsProvider],
+})
+class RpcModule {}
+
+describe('RPC Async transport', () => {
+  let app: INestMicroservice;
+  let client: ClientTCP;
+
+  beforeEach(async () => {
+    app = await NestFactory.createMicroservice<
+      AsyncOptions<MicroserviceOptions>
+    >(RpcModule, {
+      logger: false,
+      inject: [RpcOptionsProvider],
+      useFactory: (optionsProvider: RpcOptionsProvider) =>
+        optionsProvider.getOptions(),
+    });
+
+    await app.listen();
+    client = app.get('RPC_CLIENT', { strict: false });
+  });
+
+  it(`/POST`, done => {
+    let retData = 0;
+    client.send({ cmd: 'sum' }, [1, 2, 3, 4, 5]).subscribe({
+      next: val => (retData += val),
+      error: done,
+      complete: () => {
+        expect(retData).to.eq(15);
+        done();
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+});

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -1,4 +1,4 @@
-import { Type } from '@nestjs/common';
+import { FactoryProvider, InjectionToken, Type } from '@nestjs/common';
 import { ConnectionOptions } from 'tls';
 import { Transport } from '../enums/transport.enum';
 import { ChannelOptions } from '../external/grpc-options.interface';
@@ -27,6 +27,16 @@ export type MicroserviceOptions =
   | RmqOptions
   | KafkaOptions
   | CustomStrategy;
+
+export type AsyncMicroserviceOptions = {
+  inject: InjectionToken[];
+  useFactory: (...args: any[]) => MicroserviceOptions;
+};
+
+export type AsyncOptions<T extends object> = {
+  inject: InjectionToken[];
+  useFactory: (...args: any[]) => T;
+};
 
 /**
  * @publicApi


### PR DESCRIPTION
Microservices are now able to be created by getting their options from within the DI container itself. This has been a long requested feature of developers and I finally had some time to work through how we could possibly let this happen.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

There is no way to apply the microservice config for a microservice server, by getting the configuration from within the DI container, like from the `ConfigService`

Issue Number:

* #12620
* #2343
* #4410 
* #5102
* #7108 

## What is the new behavior?

Microservices are now able to be configured via a provider that was registered within the DI tree, without creating a new `NestFactory.createApplicationContext()` first. Devs are now able to pass a `useFactory` and `inject` as a part of the options object passed to `NestFactory.createMicroservice()` which will allow for Nest to find the tokens in the inject and pass them to the `useFactory` to get the configuration for the microservice. E.g.:

```ts
const port = 4444;

@Injectable()
class RpcOptionsProvider {
  getOptions(): TcpClientOptions {
    return {
      transport: Transport.TCP,
      options: {
        port,
        host: '0.0.0.0',
      },
    };
  }
}

@Controller()
class RpcController {
  @MessagePattern({ cmd: 'sum' })
  sumPayload(@Payload() payload: number[]) {
    return payload.reduce((a, b) => a + b, 0);
  }
}

@Module({
  imports: [
    ClientsModule.register([
      {
        name: 'RPC_CLIENT',
        transport: Transport.TCP,
        options: {
          port,
          host: '0.0.0.0',
        },
      },
    ]),
  ],
  controllers: [RpcController],
  providers: [RpcOptionsProvider],
})
class RpcModule {}

const bootstrap = async () => {
  await NestFactory.createMicroservice<
    AsyncOptions<MicroserviceOptions>
  >(RpcModule, {
    logger: false,
    inject: [RpcOptionsProvider],
    useFactory: (optionsProvider: RpcOptionsProvider) =>
      optionsProvider.getOptions(),
  });
  await app.listen();
}
bootstrap();
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information