### PR TITLE
fix: add date to ignored metatypes

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -179,7 +179,7 @@ export class ValidationPipe implements PipeTransform<any> {
     if (type === 'custom' && !this.validateCustomDecorators) {
       return false;
     }
-    const types = [String, Boolean, Number, Array, Object, Buffer];
+    const types = [String, Boolean, Number, Array, Object, Buffer, Date];
     return !types.some(t => metatype === t) && !isNil(metatype);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If a parameter decorator with the metatype `Date` is used, with the `ValidationPipe` with at least one validation option, then the parameter will be transformed into a date object, even if `transform: false` is set. 

Issue Number: #12647 


## What is the new behavior?

`Date` specific parameters are now ignored, just as `Array`, `Object`, `String`, and `Number` are, for consistency

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
_Technically_ yes, but it's fixing what is a bug.

## Other information