### PR TITLE
feat(core): allow using modules and nested route trees in parallel

### DIFF
--- a/packages/core/router/interfaces/routes.interface.ts
+++ b/packages/core/router/interfaces/routes.interface.ts
@@ -3,7 +3,7 @@ import { Type } from '@nestjs/common';
 export interface RouteTree {
   path: string;
   module?: Type<any>;
-  children?: Routes | Type<any>[];
+  children?: (RouteTree | Type<any>)[];
 }
 
 export type Routes = RouteTree[];

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -39,7 +39,7 @@ export class RouterModule {
   }
 
   private deepCloneRoutes(
-    routes: Routes | Type<any>[],
+    routes: (RouteTree | Type<any>)[],
   ): Routes | Array<Type<any>> {
     return routes.map((routeOrType: Type<any> | RouteTree) => {
       if (typeof routeOrType === 'function') {

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -40,7 +40,7 @@ export class RouterModule {
 
   private deepCloneRoutes(
     routes: (RouteTree | Type<any>)[],
-  ): Routes | Array<Type<any>> {
+  ): (RouteTree | Type<any>)[] {
     return routes.map((routeOrType: Type<any> | RouteTree) => {
       if (typeof routeOrType === 'function') {
         return routeOrType;
@@ -52,7 +52,7 @@ export class RouterModule {
         };
       }
       return { ...routeOrType };
-    }) as Routes | Array<Type<any>>;
+    });
   }
 
   private initialize() {

--- a/packages/core/test/router/utils/flat-routes.spec.ts
+++ b/packages/core/test/router/utils/flat-routes.spec.ts
@@ -65,7 +65,7 @@ describe('flattenRoutePaths', () => {
             children: [
               {
                 path: 'child',
-                ChildModule3,
+                module: ChildModule3,
               },
               ChildModule4,
             ],

--- a/packages/core/test/router/utils/flat-routes.spec.ts
+++ b/packages/core/test/router/utils/flat-routes.spec.ts
@@ -13,6 +13,10 @@ describe('flattenRoutePaths', () => {
     @Module({})
     class ChildModule2 {}
     @Module({})
+    class ChildModule3 {}
+    @Module({})
+    class ChildModule4 {}
+    @Module({})
     class ParentChildModule {}
     @Module({})
     class ChildChildModule2 {}
@@ -56,6 +60,16 @@ describe('flattenRoutePaths', () => {
               },
             ],
           },
+          {
+            path: '/child2',
+            children: [
+              {
+                path: 'child',
+                ChildModule3,
+              },
+              ChildModule4,
+            ],
+          },
         ],
       },
       { path: '/v1', children: [AuthModule, CatsModule, DogsModule] },
@@ -75,6 +89,8 @@ describe('flattenRoutePaths', () => {
         path: '/parent/child/parentchild/childchild/child2child',
         module: ChildChildModule2,
       },
+      { path: '/parent/child2', module: ChildModule4 },
+      { path: '/parent/child2/child', module: ChildModule3 },
       { path: '/v1', module: AuthModule },
       { path: '/v1', module: CatsModule },
       { path: '/v1', module: DogsModule },


### PR DESCRIPTION
change type of RouteTree.children to accept both RouteTree and Type<any> in junction

fixes #12700

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12700 


## What is the new behavior?
Instead of only allowing either an array of `RouteTree` OR `Type<any>`, both can now be used in junction to reduce code for simple nested routes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
SImple Type Change, no further changes required