### PR TITLE
feat(common)!: type narrowing allowed injection tokens for `@Inject()`

### DIFF
--- a/.circleci/install-wrk.sh
+++ b/.circleci/install-wrk.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 
 cd /tmp/
 sudo apt-get install build-essential libssl-dev git -y
-git clone https://github.com/wg/wrk.git wrk
+git clone --depth=1 https://github.com/wg/wrk.git wrk
 cd wrk
 sudo make
 # move the executable to somewhere in your PATH, ex:

--- a/packages/common/decorators/core/inject.decorator.ts
+++ b/packages/common/decorators/core/inject.decorator.ts
@@ -2,6 +2,7 @@ import {
   PROPERTY_DEPS_METADATA,
   SELF_DECLARED_DEPS_METADATA,
 } from '../../constants';
+import { ForwardReference, InjectionToken } from '../../interfaces';
 import { isUndefined } from '../../utils/shared.utils';
 
 /**
@@ -33,8 +34,8 @@ import { isUndefined } from '../../utils/shared.utils';
  *
  * @publicApi
  */
-export function Inject<T = any>(
-  token?: T,
+export function Inject(
+  token?: InjectionToken | ForwardReference,
 ): PropertyDecorator & ParameterDecorator {
   return (target: object, key: string | symbol | undefined, index?: number) => {
     const type = token || Reflect.getMetadata('design:type', target, key);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

we can pass anything to `@Inject()` decorator factory


## What is the new behavior?

now we can only pass injection tokens (same type for `provide` on custom providers)

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information