### PR TITLE
feat(core): emit warning when serialization of module is slow

### DIFF
--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -1,4 +1,4 @@
-import { DynamicModule } from '@nestjs/common';
+import { DynamicModule, Logger } from '@nestjs/common';
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
@@ -12,6 +12,9 @@ const CLASS_STR_LEN = CLASS_STR.length;
 export class ModuleTokenFactory {
   private readonly moduleTokenCache = new Map<string, string>();
   private readonly moduleIdsCache = new WeakMap<Type<unknown>, string>();
+  private readonly logger = new Logger(ModuleTokenFactory.name, {
+    timestamp: true,
+  });
 
   public create(
     metatype: Type<unknown>,
@@ -32,10 +35,10 @@ export class ModuleTokenFactory {
     const timeSpentInMs = performance.now() - start;
 
     if (timeSpentInMs > 10) {
-      process.emitWarning(
-        `The module "${opaqueToken.module}" took ${timeSpentInMs.toFixed(
+      this.logger.warn(
+        `The module "${opaqueToken.module}" is taking ${timeSpentInMs.toFixed(
           2,
-        )}ms to serialize, consider reduce the size of the object. More details: https://github.com/nestjs/nest/issues/12738`,
+        )}ms to serialize, this may be caused by larger objects assigned to the module. More details: https://github.com/nestjs/nest/issues/12738`,
       );
     }
 

--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -4,6 +4,7 @@ import { randomStringGenerator } from '@nestjs/common/utils/random-string-genera
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
 import { createHash } from 'crypto';
 import stringify from 'fast-safe-stringify';
+import { performance } from 'perf_hooks';
 
 const CLASS_STR = 'class ';
 const CLASS_STR_LEN = CLASS_STR.length;
@@ -26,7 +27,17 @@ export class ModuleTokenFactory {
       module: this.getModuleName(metatype),
       dynamic: dynamicModuleMetadata,
     };
+    const start = performance.now();
     const opaqueTokenString = this.getStringifiedOpaqueToken(opaqueToken);
+    const timeSpentInMs = performance.now() - start;
+
+    if (timeSpentInMs > 10) {
+      process.emitWarning(
+        `The module "${opaqueToken.module}" took ${timeSpentInMs.toFixed(
+          2,
+        )}ms to serialize, consider reduce the size of the object. More details: https://github.com/nestjs/nest/issues/12738`,
+      );
+    }
 
     return this.hashString(opaqueTokenString);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The serialization can be slow and the user will never know about it.

Issue Number: #12738
Fixes #12738

## What is the new behavior?

Now we emit a warning using `process.emitWarning` when the serialization took more than `10ms`.

This is an arbitrary value, we can raise or lower this value depending on the real-world applications.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No