### PR TITLE
perf: prefer use factory instead of use value when possible

### DIFF
--- a/integration/inspector/e2e/fixtures/post-init-graph.json
+++ b/integration/inspector/e2e/fixtures/post-init-graph.json
@@ -60,10 +60,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "ExternalContextCreator"
+        "token": "ExternalContextCreator",
+        "initTime": 0
       }
     },
     "208171089": {
@@ -800,10 +800,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "ModulesContainer"
+        "token": "ModulesContainer",
+        "initTime": 0
       }
     },
     "-326832201": {
@@ -816,10 +816,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "HttpAdapterHost"
+        "token": "HttpAdapterHost",
+        "initTime": 0
       }
     },
     "-702581189": {
@@ -848,10 +848,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "SerializedGraph"
+        "token": "SerializedGraph",
+        "initTime": 0
       }
     },
     "-1251270035": {

--- a/integration/inspector/e2e/fixtures/pre-init-graph.json
+++ b/integration/inspector/e2e/fixtures/pre-init-graph.json
@@ -60,10 +60,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "ExternalContextCreator"
+        "token": "ExternalContextCreator",
+        "initTime": 0
       }
     },
     "208171089": {
@@ -784,10 +784,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "ModulesContainer"
+        "token": "ModulesContainer",
+        "initTime": 0
       }
     },
     "-326832201": {
@@ -800,10 +800,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "HttpAdapterHost"
+        "token": "HttpAdapterHost",
+        "initTime": 0
       }
     },
     "-702581189": {
@@ -832,10 +832,10 @@
         "sourceModuleName": "InternalCoreModule",
         "durable": false,
         "static": true,
-        "scope": 0,
         "transient": false,
         "exported": true,
-        "token": "SerializedGraph"
+        "token": "SerializedGraph",
+        "initTime": 0
       }
     },
     "-1251270035": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:dev": "mocha -w --watch-files \"packages\" packages/**/*.spec.ts",
     "pretest:cov": "npm run clean",
     "test:cov": "nyc mocha packages/**/*.spec.ts --reporter spec",
-    "test:integration": "mocha \"integration/*/{,!(node_modules)/**/}/*.spec.ts\"",
+    "test:integration": "mocha --reporter-option maxDiffSize=0 \"integration/*/{,!(node_modules)/**/}/*.spec.ts\"",
     "test:docker:up": "docker-compose -f integration/docker-compose.yml up -d",
     "test:docker:down": "docker-compose -f integration/docker-compose.yml down",
     "lint": "concurrently 'npm run lint:packages' 'npm run lint:integration' 'npm run lint:spec'",

--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -209,7 +209,7 @@ export class ConfigurableModuleBuilder<
         const providers: Array<Provider> = [
           {
             provide: self.options.optionsInjectionToken,
-            useValue: this.omitExtras(options, self.extras),
+            useFactory: () => this.omitExtras(options, self.extras),
           },
         ];
         if (self.options.alwaysTransient) {

--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -209,6 +209,8 @@ export class ConfigurableModuleBuilder<
         const providers: Array<Provider> = [
           {
             provide: self.options.optionsInjectionToken,
+            // useFactory is for performance reasons
+            // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
             useFactory: () => this.omitExtras(options, self.extras),
           },
         ];

--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -209,8 +209,6 @@ export class ConfigurableModuleBuilder<
         const providers: Array<Provider> = [
           {
             provide: self.options.optionsInjectionToken,
-            // useFactory is for performance reasons
-            // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
             useFactory: () => this.omitExtras(options, self.extras),
           },
         ];

--- a/packages/core/injector/internal-core-module/internal-core-module-factory.ts
+++ b/packages/core/injector/internal-core-module/internal-core-module-factory.ts
@@ -45,15 +45,15 @@ export class InternalCoreModuleFactory {
     return InternalCoreModule.register([
       {
         provide: ExternalContextCreator,
-        useValue: ExternalContextCreator.fromContainer(container),
+        useFactory: () => ExternalContextCreator.fromContainer(container),
       },
       {
         provide: ModulesContainer,
-        useValue: container.getModules(),
+        useFactory: () => container.getModules(),
       },
       {
         provide: HttpAdapterHost,
-        useValue: httpAdapterHost,
+        useFactory: () => httpAdapterHost,
       },
       {
         provide: LazyModuleLoader,
@@ -61,7 +61,7 @@ export class InternalCoreModuleFactory {
       },
       {
         provide: SerializedGraph,
-        useValue: container.serializedGraph,
+        useFactory: () => container.serializedGraph,
       },
     ]);
   }

--- a/packages/core/injector/internal-core-module/internal-core-module-factory.ts
+++ b/packages/core/injector/internal-core-module/internal-core-module-factory.ts
@@ -42,8 +42,6 @@ export class InternalCoreModuleFactory {
       );
     };
 
-    // useFactory is for performance reasons
-    // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
     return InternalCoreModule.register([
       {
         provide: ExternalContextCreator,

--- a/packages/core/injector/internal-core-module/internal-core-module-factory.ts
+++ b/packages/core/injector/internal-core-module/internal-core-module-factory.ts
@@ -42,6 +42,8 @@ export class InternalCoreModuleFactory {
       );
     };
 
+    // useFactory is for performance reasons
+    // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
     return InternalCoreModule.register([
       {
         provide: ExternalContextCreator,

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -32,7 +32,7 @@ export class RouterModule {
       providers: [
         {
           provide: ROUTES,
-          useValue: routes,
+          useFactory: () => routes,
         },
       ],
     };

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -32,6 +32,8 @@ export class RouterModule {
       providers: [
         {
           provide: ROUTES,
+          // useFactory is for performance reasons
+          // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
           useFactory: () => routes,
         },
       ],

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -32,8 +32,6 @@ export class RouterModule {
       providers: [
         {
           provide: ROUTES,
-          // useFactory is for performance reasons
-          // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
           useFactory: () => routes,
         },
       ],

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -32,7 +32,7 @@ export class RouterModule {
       providers: [
         {
           provide: ROUTES,
-          useFactory: () => routes,
+          useValue: routes,
         },
       ],
     };

--- a/packages/core/test/router/router-module.spec.ts
+++ b/packages/core/test/router/router-module.spec.ts
@@ -7,6 +7,7 @@ import {
   ROUTES,
   targetModulesByContainer,
 } from '../../router/router-module';
+import { FactoryProvider } from '@nestjs/common';
 
 class TestModuleClass {}
 
@@ -15,15 +16,12 @@ describe('RouterModule', () => {
 
   describe('register', () => {
     it('should return a dynamic module with routes registered as a provider', () => {
-      expect(RouterModule.register(routes)).to.deep.equal({
-        module: RouterModule,
-        providers: [
-          {
-            provide: ROUTES,
-            useValue: routes,
-          },
-        ],
-      });
+      const moduleRegistered = RouterModule.register(routes);
+      const provider = moduleRegistered.providers.find(
+        p => 'useFactory' in p && p.provide === ROUTES,
+      ) as FactoryProvider;
+      expect(provider).to.not.be.undefined;
+      expect(provider.useFactory()).to.be.eq(routes);
     });
   });
   describe('when instantiated', () => {

--- a/packages/core/test/router/router-module.spec.ts
+++ b/packages/core/test/router/router-module.spec.ts
@@ -16,12 +16,15 @@ describe('RouterModule', () => {
 
   describe('register', () => {
     it('should return a dynamic module with routes registered as a provider', () => {
-      const moduleRegistered = RouterModule.register(routes);
-      const provider = moduleRegistered.providers.find(
-        p => 'useFactory' in p && p.provide === ROUTES,
-      ) as FactoryProvider;
-      expect(provider).to.not.be.undefined;
-      expect(provider.useFactory()).to.be.eq(routes);
+      expect(RouterModule.register(routes)).to.deep.equal({
+        module: RouterModule,
+        providers: [
+          {
+            provide: ROUTES,
+            useValue: routes,
+          },
+        ],
+      });
     });
   });
   describe('when instantiated', () => {

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -19,8 +19,6 @@ export class ClientsModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
     const clients = (clientsOptions || []).map(item => ({
       provide: item.name,
-      // useFactory is for performance reasons
-      // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
       useFactory: () =>
         this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
     }));

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -17,11 +17,13 @@ import {
 export class ClientsModule {
   static register(options: ClientsModuleOptions): DynamicModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
-    const clients = (clientsOptions || []).map(item => ({
-      provide: item.name,
-      useFactory: () =>
-        this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
-    }));
+    const clients = (clientsOptions || []).map(item => {
+      return {
+        provide: item.name,
+        useFactory: () =>
+          this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
+      };
+    });
     return {
       module: ClientsModule,
       global: !Array.isArray(options) && options.isGlobal,

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -19,6 +19,8 @@ export class ClientsModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
     const clients = (clientsOptions || []).map(item => ({
       provide: item.name,
+      // useFactory is for performance reasons
+      // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
       useFactory: () =>
         this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
     }));

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -19,7 +19,8 @@ export class ClientsModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
     const clients = (clientsOptions || []).map(item => ({
       provide: item.name,
-      useValue: this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
+      useFactory: () =>
+        this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
     }));
     return {
       module: ClientsModule,

--- a/packages/microservices/test/module/clients.module.spec.ts
+++ b/packages/microservices/test/module/clients.module.spec.ts
@@ -21,14 +21,13 @@ describe('ClientsModule', () => {
       expect(dynamicModule.module).to.be.eql(ClientsModule);
     });
     it('should return an expected providers array', () => {
-      expect(dynamicModule.providers).to.be.deep.eq([
-        {
-          provide: 'test',
-          useValue: ClientsModule['assignOnAppShutdownHook'](
-            ClientProxyFactory.create({}),
-          ),
-        },
-      ]);
+      const provider = dynamicModule.providers.find(
+        p => 'useFactory' in p && p.provide === 'test',
+      ) as FactoryProvider;
+      expect(provider).to.not.be.undefined;
+      expect(provider.useFactory()).to.be.deep.eq(
+        ClientsModule['assignOnAppShutdownHook'](ClientProxyFactory.create({})),
+      );
     });
   });
   describe('registerAsync', () => {

--- a/packages/platform-express/multer/multer.module.ts
+++ b/packages/platform-express/multer/multer.module.ts
@@ -17,7 +17,7 @@ export class MulterModule {
     return {
       module: MulterModule,
       providers: [
-        { provide: MULTER_MODULE_OPTIONS, useValue: options },
+        { provide: MULTER_MODULE_OPTIONS, useFactory: () => options },
         {
           provide: MULTER_MODULE_ID,
           useValue: randomStringGenerator(),

--- a/packages/platform-express/multer/multer.module.ts
+++ b/packages/platform-express/multer/multer.module.ts
@@ -17,8 +17,6 @@ export class MulterModule {
     return {
       module: MulterModule,
       providers: [
-        // useFactory is for performance reasons
-        // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
         { provide: MULTER_MODULE_OPTIONS, useFactory: () => options },
         {
           provide: MULTER_MODULE_ID,

--- a/packages/platform-express/multer/multer.module.ts
+++ b/packages/platform-express/multer/multer.module.ts
@@ -17,6 +17,8 @@ export class MulterModule {
     return {
       module: MulterModule,
       providers: [
+        // useFactory is for performance reasons
+        // see more: https://github.com/nestjs/nest/issues/12738#issuecomment-1810987001
         { provide: MULTER_MODULE_OPTIONS, useFactory: () => options },
         {
           provide: MULTER_MODULE_ID,

--- a/packages/platform-express/test/multer/multer/multer.module.spec.ts
+++ b/packages/platform-express/test/multer/multer/multer.module.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { MULTER_MODULE_OPTIONS } from '../../../multer/files.constants';
 import { MulterModule } from '../../../multer/multer.module';
+import { FactoryProvider } from '@nestjs/common';
 
 describe('MulterModule', () => {
   describe('register', () => {
@@ -14,10 +15,12 @@ describe('MulterModule', () => {
       expect(dynamicModule.providers).to.have.length(2);
       expect(dynamicModule.imports).to.be.undefined;
       expect(dynamicModule.exports).to.include(MULTER_MODULE_OPTIONS);
-      expect(dynamicModule.providers).to.deep.include({
-        provide: MULTER_MODULE_OPTIONS,
-        useValue: options,
-      });
+
+      const moduleOptionsProvider = dynamicModule.providers.find(
+        p => 'useFactory' in p && p.provide === MULTER_MODULE_OPTIONS,
+      ) as FactoryProvider;
+      expect(moduleOptionsProvider).to.not.be.undefined;
+      expect(moduleOptionsProvider.useFactory()).to.be.eq(options);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Because of the nature of the `ModuleTokenFactory`, heavy objects will slow down the initialization, especially when using `.proto` files.

Issue Number: #12719
Closes #12719

## What is the new behavior?

Now, we defer the initialization of the `.proto` files by using `useFactory`, this will fix any initialization issue.

![image](https://github.com/nestjs/nest/assets/12551007/d126dc2b-187b-4f13-ae01-1b5f45a66622)

> The second run is with the fix.

I also updated almost all the references for `useValue`, so this can help avoid the same issue in other places.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No