### PR TITLE
Add consumerTag param on rmq microservice config

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -205,6 +205,7 @@ export interface RmqOptions {
     queueOptions?: any; // AmqplibQueueOptions;
     socketOptions?: any; // AmqpConnectionManagerSocketOptions;
     noAck?: boolean;
+    consumerTag?: string;
     serializer?: Serializer;
     deserializer?: Deserializer;
     replyQueue?: string;

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -48,6 +48,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   protected readonly queueOptions: any;
   protected readonly isGlobalPrefetchCount: boolean;
   protected readonly noAssert: boolean;
+  protected readonly consumerTag: string;
 
   constructor(protected readonly options: RmqOptions['options']) {
     super();
@@ -58,6 +59,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       this.getOptionsProp(this.options, 'prefetchCount') ||
       RQM_DEFAULT_PREFETCH_COUNT;
     this.noAck = this.getOptionsProp(this.options, 'noAck', RQM_DEFAULT_NOACK);
+    this.consumerTag = this.getOptionsProp(this.options, 'consumerTag', undefined);
     this.isGlobalPrefetchCount =
       this.getOptionsProp(this.options, 'isGlobalPrefetchCount') ||
       RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT;
@@ -154,6 +156,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       (msg: Record<string, any>) => this.handleMessage(msg, channel),
       {
         noAck: this.noAck,
+        consumerTag: this.consumerTag
       },
     );
     callback();

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -48,8 +48,6 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   protected readonly queueOptions: any;
   protected readonly isGlobalPrefetchCount: boolean;
   protected readonly noAssert: boolean;
-  protected readonly consumerTag: string;
-
   constructor(protected readonly options: RmqOptions['options']) {
     super();
     this.urls = this.getOptionsProp(this.options, 'urls') || [RQM_DEFAULT_URL];
@@ -59,7 +57,6 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       this.getOptionsProp(this.options, 'prefetchCount') ||
       RQM_DEFAULT_PREFETCH_COUNT;
     this.noAck = this.getOptionsProp(this.options, 'noAck', RQM_DEFAULT_NOACK);
-    this.consumerTag = this.getOptionsProp(this.options, 'consumerTag', undefined);
     this.isGlobalPrefetchCount =
       this.getOptionsProp(this.options, 'isGlobalPrefetchCount') ||
       RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT;
@@ -156,7 +153,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       (msg: Record<string, any>) => this.handleMessage(msg, channel),
       {
         noAck: this.noAck,
-        consumerTag: this.consumerTag
+        consumerTag: this.getOptionsProp(this.options, 'consumerTag', undefined)
       },
     );
     callback();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently Rmq microservice config params does not accept consumerTag parameter.  
Issue Number: N/A


## What is the new behavior?
Microservice options should now accept consumerTag param while configuring the rabbitmq microservice app.  

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information