### PR TITLE
Be able to use a random port for the TCP server

### DIFF
--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -40,7 +40,7 @@ export class ServerTCP extends Server implements CustomTransportStrategy {
 
   constructor(private readonly options: TcpOptions['options']) {
     super();
-    this.port = this.getOptionsProp(options, 'port') || TCP_DEFAULT_PORT;
+    this.port = this.getOptionsProp(options, 'port', TCP_DEFAULT_PORT);
     this.host = this.getOptionsProp(options, 'host') || TCP_DEFAULT_HOST;
     this.socketClass =
       this.getOptionsProp(options, 'socketClass') || JsonSocket;

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -41,9 +41,9 @@ export class ServerTCP extends Server implements CustomTransportStrategy {
   constructor(private readonly options: TcpOptions['options']) {
     super();
     this.port = this.getOptionsProp(options, 'port', TCP_DEFAULT_PORT);
-    this.host = this.getOptionsProp(options, 'host') || TCP_DEFAULT_HOST;
+    this.host = this.getOptionsProp(options, 'host', TCP_DEFAULT_HOST);
     this.socketClass =
-      this.getOptionsProp(options, 'socketClass') || JsonSocket;
+      this.getOptionsProp(options, 'socketClass', JsonSocket);
     this.tlsOptions = this.getOptionsProp(options, 'tlsOptions');
 
     this.init();


### PR DESCRIPTION
In the [docs from Node net server](https://nodejs.org/api/net.html#serverlisten):
> If port is omitted or is 0, the operating system will assign an arbitrary unused port, which can be retrieved by using server.address().port after the ['listening'](https://nodejs.org/api/net.html#event-listening) event has been emitted.

In the current code `0` is handled as a falsey value, which means the TCP server uses the `TCP_DEFAULT_PORT` value (`3000`) instead of letting the OS determine a random port.

Using a random free port is especially handy when running tests.

To get the port I am currently using the following function:
```ts
export const getAppTcpAddress = (app: INestMicroservice) => {
  const serverTcp = (app as NestMicroservice)?.['server']
  if (!(serverTcp instanceof ServerTCP)) return null

  const server = serverTcp?.['server']
  if (!(server instanceof Server)) return null

  return server.address()
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information