### PR TITLE
chore: add notice about closing unreproducible issues to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -38,7 +38,9 @@ body:
       required: true
     attributes:
       label: "Minimum reproduction code"
-      description: "An URL to some Git repository/[StackBlitz](https://stackblitz.com/fork/github/nestjs/typescript-starter)/[CodeSandbox](https://codesandbox.io/s/github/nestjs/typescript-starter/tree/master) project that reproduces your issue. [Wtf is a minimum reproduction?](https://jmcdo29.github.io/wtf-is-a-minimum-reproduction)"
+      description: |
+        An URL to some Git repository/[StackBlitz](https://stackblitz.com/fork/github/nestjs/typescript-starter)/[CodeSandbox](https://codesandbox.io/s/github/nestjs/typescript-starter/tree/master) project that reproduces your issue. [What is a minimum reproduction?](https://jmcdo29.github.io/wtf-is-a-minimum-reproduction)  
+        :warning: **NOTE:** We can close this issue if we don't manage to reproduce your potential bug. [Here](https://antfu.me/posts/why-reproductions-are-required) is why.
       placeholder: "https://github.com/..."
 
   - type: textarea


### PR DESCRIPTION
A minor change to the bug report issue template form to better align with contributions expectations. I'm using [this](https://antfu.me/posts/why-reproductions-are-required) great article to clarify why we need a reproduction. This is my attempt to decrease the amount of bugs report without reproductions when they clearly need one

## then

![image](https://github.com/nestjs/nest/assets/13461315/ecd63438-1a78-45a6-9686-e66d9be89256)

## now

![image](https://github.com/nestjs/nest/assets/13461315/368fb3a0-330b-496f-a2cb-38850737bba5)
