### PR TITLE
fix(common): type def for cors delegated callback function option

### DIFF
--- a/packages/common/interfaces/external/cors-options.interface.ts
+++ b/packages/common/interfaces/external/cors-options.interface.ts
@@ -56,7 +56,7 @@ export interface CorsOptions {
 }
 
 export interface CorsOptionsCallback {
-  (error: Error, options: CorsOptions): void;
+  (error: Error | null, options: CorsOptions): void;
 }
 export interface CorsOptionsDelegate<T> {
   (req: T, cb: CorsOptionsCallback): void;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #12816 

## What is the new behavior?

we can now supply `null` to the callback as the [`cors` docs](https://www.npmjs.com/package/cors) suggests

A better definition would be:

```ts
export interface CorsOptionsCallback {
  (error: Error): void;
  (error: null, options: CorsOptions): void;
}
```

but I believe this would introduce a breaking change

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information