### PR TITLE
fix(core): always bind global modules when scan for modules

### DIFF
--- a/packages/core/injector/lazy-module-loader/lazy-module-loader.ts
+++ b/packages/core/injector/lazy-module-loader/lazy-module-loader.ts
@@ -28,6 +28,9 @@ export class LazyModuleLoader {
     const moduleClassOrDynamicDefinition = await loaderFn();
     const moduleInstances = await this.dependenciesScanner.scanForModules(
       moduleClassOrDynamicDefinition,
+      [],
+      [],
+      true,
     );
     if (moduleInstances.length === 0) {
       // The module has been loaded already. In this case, we must

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -90,9 +90,13 @@ export class DependenciesScanner {
       | Promise<DynamicModule>,
     scope: Type<unknown>[] = [],
     ctxRegistry: (ForwardReference | DynamicModule | Type<unknown>)[] = [],
+    bindGlobal = false,
   ): Promise<Module[]> {
     const moduleInstance = await this.insertModule(moduleDef, scope);
-    this.container.bindGlobalsToImports(moduleInstance);
+
+    if (bindGlobal) {
+      this.container.bindGlobalsToImports(moduleInstance);
+    }
 
     ctxRegistry.push(await moduleDef);
 
@@ -128,6 +132,7 @@ export class DependenciesScanner {
         innerModule,
         [].concat(scope, moduleDef),
         ctxRegistry,
+        bindGlobal,
       );
       registeredModuleRefs = registeredModuleRefs.concat(moduleRefs);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #12879 


## What is the new behavior?
Scanning for modules always bound for global modules,

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This branch is based on 9.4.3. Hence should not be merged into master.