### PR TITLE
fix(common): when transforming undefined numeric values

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -203,6 +203,12 @@ export class ValidationPipe implements PipeTransform<any> {
       return value === true || value === 'true';
     }
     if (metatype === Number) {
+      if (isUndefined(value)) {
+        // This is a workaround to deal with optional numeric values since
+        // optional numerics shouldn't be parsed to a valid number when
+        // they were not defined
+        return undefined;
+      }
       return +value;
     }
     return value;

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -205,6 +205,18 @@ describe('ValidationPipe', () => {
             }),
           ).to.be.equal(+value);
         });
+        it('should parse undefined to undefined', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = undefined;
+
+          expect(
+            await target.transform(value, {
+              metatype: Number,
+              data: 'test',
+              type: 'query',
+            }),
+          ).to.be.undefined;
+        });
       });
       describe('when input is a path parameter (number)', () => {
         it('should parse to number', async () => {
@@ -218,6 +230,18 @@ describe('ValidationPipe', () => {
               type: 'param',
             }),
           ).to.be.equal(+value);
+        });
+        it('should parse undefined to undefined', async () => {
+          target = new ValidationPipe({ transform: true });
+          const value = undefined;
+
+          expect(
+            await target.transform(value, {
+              metatype: Number,
+              data: 'test',
+              type: 'param',
+            }),
+          ).to.be.undefined;
         });
       });
       describe('when input is a query parameter (boolean)', () => {


### PR DESCRIPTION
Transforming numeric values in validationpipe is incorrect when value is undefined

closes #12864

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
This issue occurs when using ValidationPipe with `transform: true` option set.
When this option is set and query/param arguments on an endpoint are used that are optional/have a default value, when no value/invalid value is passed to this query/URL param, it results in a NaN value, instead of the default value or having it be set to undefined in case it's an optional param.

Issue Number: #12864 

## What is the new behavior?
Values of the sort mentioned will now be parsed as undefined and converted to undefined.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No