### PR TITLE
feat(core): added unique dynamic module factory

### DIFF
--- a/packages/core/injector/compiler.ts
+++ b/packages/core/injector/compiler.ts
@@ -26,17 +26,17 @@ export class ModuleCompiler {
     metatype: Type<any> | ForwardReference | DynamicModule,
   ): {
     type: Type<any>;
-    dynamicMetadata?: Partial<DynamicModule> | undefined;
+    dynamicMetadata?: DynamicModule | undefined;
   } {
     if (!this.isDynamicModule(metatype)) {
       return {
         type: (metatype as ForwardReference)?.forwardRef
           ? (metatype as ForwardReference).forwardRef()
           : metatype,
+        dynamicMetadata: undefined,
       };
     }
-    const { module: type, ...dynamicMetadata } = metatype;
-    return { type, dynamicMetadata };
+    return { type: metatype.module, dynamicMetadata: metatype };
   }
 
   public isDynamicModule(

--- a/packages/core/injector/index.ts
+++ b/packages/core/injector/index.ts
@@ -4,3 +4,4 @@ export { ContextId, HostComponentInfo } from './instance-wrapper';
 export * from './lazy-module-loader/lazy-module-loader';
 export * from './module-ref';
 export * from './modules-container';
+export { UniqueDynamicModuleFactory } from './unique-dynamic-module-factory';

--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -2,6 +2,10 @@ import { DynamicModule, Logger } from '@nestjs/common';
 import { Type } from '@nestjs/common/interfaces/type.interface';
 import { randomStringGenerator } from '@nestjs/common/utils/random-string-generator.util';
 import { isFunction, isSymbol } from '@nestjs/common/utils/shared.utils';
+import {
+  getUniqueDynamicModuleId,
+  isUniqueDynamicModule,
+} from './unique-dynamic-module-factory';
 import { createHash } from 'crypto';
 import stringify from 'fast-safe-stringify';
 import { performance } from 'perf_hooks';
@@ -18,8 +22,12 @@ export class ModuleTokenFactory {
 
   public create(
     metatype: Type<unknown>,
-    dynamicModuleMetadata?: Partial<DynamicModule> | undefined,
+    dynamicModuleMetadata?: DynamicModule | undefined,
   ): string {
+    if (isUniqueDynamicModule(dynamicModuleMetadata)) {
+      return getUniqueDynamicModuleId(dynamicModuleMetadata);
+    }
+
     const moduleId = this.getModuleId(metatype);
 
     if (!dynamicModuleMetadata) {

--- a/packages/core/injector/unique-dynamic-module-factory.ts
+++ b/packages/core/injector/unique-dynamic-module-factory.ts
@@ -1,0 +1,63 @@
+import { DynamicModule, Type } from '@nestjs/common';
+import { RuntimeException } from '@nestjs/core/errors/exceptions';
+
+const kUniqueModuleId = Symbol('kUniqueModuleId');
+
+export class UniqueDynamicModuleFactory {
+  protected static readonly uniqueMap = new Map<string, string>();
+
+  /**
+   * You can use this method to avoid the hash algorithm during the DI compilation.
+   *
+   * Imagine you have a module that exports a provider, and that provider is
+   * imported using `MyModule.forRoot('myToken')`, and you can get the reference of this provider using
+   * injected using @Inject('myToken'). If you import this module twice, with different arguments on `.forRoot`,
+   * in order to register both modules, we need to serialize and hash the dynamic module created by `.forRoot`.
+   * Otherwise, it overrides the providers defined in the first import with the providers declared on the second import.
+   *
+   * This function tells the algorithm to skip the hash and directly use the `staticUniqueId`, and
+   *you are responsible for making it unique.
+   *
+   * @param staticUniqueId The unique ID across all modules.
+   * @param dynamicModule The dynamic module.
+   *
+   * @throws RuntimeException If the ID is already registered, an error will occur.
+   */
+  static wrap(staticUniqueId: string, dynamicModule: DynamicModule) {
+    if (!this.uniqueMap.has(staticUniqueId)) {
+      dynamicModule[
+        kUniqueModuleId
+      ] = `${dynamicModule.module.name}_${staticUniqueId}`;
+      this.uniqueMap.set(staticUniqueId, dynamicModule.module.name);
+      return dynamicModule;
+    }
+
+    throw new RuntimeException(
+      `A module with this ID was already added before for "${
+        this.uniqueMap.get(staticUniqueId).split('_')[0]
+      }".`,
+    );
+  }
+}
+
+/**
+ * Check if the given dynamic module was marked as unique.
+ *
+ * @param dynamicModule The dynamic module
+ */
+export function isUniqueDynamicModule(
+  dynamicModule: DynamicModule | Type<any> | undefined,
+): boolean {
+  return dynamicModule && dynamicModule[kUniqueModuleId] !== undefined;
+}
+
+/**
+ * Get the stored unique dynamic module id.
+ *
+ * @param dynamicModule The dynamic module
+ */
+export function getUniqueDynamicModuleId(
+  dynamicModule: DynamicModule | Type<any>,
+): string | undefined {
+  return dynamicModule[kUniqueModuleId];
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Today, we don't have any way to skip the hashing algorithm of `ModuleTokenFactory`.

Refs: #12719
Refs: https://github.com/nestjs/nest/pull/12753#issuecomment-1816278717

## What is the new behavior?

In this new way, we have this new module that we can use to avoid the serialization of `ModuleTokenFactory`:

```ts
class MyDynamicModule {
  static forRoot(customProvider: string, customText: string) {
    return {
      module: MyDynamicModule,
      providers: [
        {
          provide: customProvider,
          useValue: customText,
        },
      ],
      exports: [customProvider],
    } satisfies DynamicModule;
  }
}

@Injectable()
export class AppService {
  constructor(
    @Inject('123') protected readonly myDynamicText1: string,
    @Inject('456') protected readonly myDynamicText2: string,
  ) {}

  getHello(): string {
    return `From Inject: ${this.myDynamicText1} ${this.myDynamicText2}`;
  }
}

@Controller()
export class AppController {
  constructor(private readonly appService: AppService) {}

  @Get()
  getHello(): string {
    return this.appService.getHello();
  }
}

@Module({
  imports: [
    UniqueModuleFactory.wrap('myFirstDynamic', MyDynamicModule.forRoot('123', 'hello')),
    UniqueModuleFactory.wrap('mySecondDynamic', MyDynamicModule.forRoot('456', 'world')),
  ],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {}
```

This also solves the issue on https://github.com/nestjs/nest/issues/12719, just adds `.wrap` to that module.

### Why do you need the `staticUniqueId`?

Because of the following comment: https://github.com/nestjs/nest/issues/10844#issuecomment-1401487447

If we didn't have to maintain the same ID, we could drop the `staticModuleId`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I opened it as a draft because I want to get some feedback about this API before starting to write tests.

/cc @micalevisk @jmcdo29