### PR TITLE
feat(microservices): add support for grpc reflection api

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -66,6 +66,7 @@ export interface GrpcOptions {
     protoLoader?: string;
     packageDefinition?: any;
     gracefulShutdown?: boolean;
+    disableReflection?: boolean;
     loader?: {
       keepCase?: boolean;
       alternateCommentMode?: boolean;

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -66,7 +66,6 @@ export interface GrpcOptions {
     protoLoader?: string;
     packageDefinition?: any;
     gracefulShutdown?: boolean;
-    disableReflection?: boolean;
     loader?: {
       keepCase?: boolean;
       alternateCommentMode?: boolean;

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -66,6 +66,7 @@ export interface GrpcOptions {
     protoLoader?: string;
     packageDefinition?: any;
     gracefulShutdown?: boolean;
+    onLoadPackageDefinition?: (pkg: any, server: any) => void;
     loader?: {
       keepCase?: boolean;
       alternateCommentMode?: boolean;

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -27,6 +27,7 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "*",
+    "@grpc/reflection": "^1.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/websockets": "^10.0.0",
@@ -42,6 +43,9 @@
   },
   "peerDependenciesMeta": {
     "@grpc/grpc-js": {
+      "optional": true
+    },
+    "@grpc/reflection": {
       "optional": true
     },
     "@nestjs/websockets": {

--- a/packages/microservices/package.json
+++ b/packages/microservices/package.json
@@ -27,7 +27,6 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "*",
-    "@grpc/reflection": "^1.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/websockets": "^10.0.0",
@@ -43,9 +42,6 @@
   },
   "peerDependenciesMeta": {
     "@grpc/grpc-js": {
-      "optional": true
-    },
-    "@grpc/reflection": {
       "optional": true
     },
     "@nestjs/websockets": {

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -509,6 +509,14 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         this.options,
         grpcProtoLoaderPackage,
       );
+
+      if (this.options.onLoadPackageDefinition) {
+        this.options.onLoadPackageDefinition(
+          packageDefinition,
+          this.grpcClient,
+        );
+      }
+
       return grpcPackage.loadPackageDefinition(packageDefinition);
     } catch (err) {
       const invalidProtoError = new InvalidProtoDefinitionException(err.path);

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -509,7 +509,6 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         this.options,
         grpcProtoLoaderPackage,
       );
-      this.addReflection(packageDefinition);
       return grpcPackage.loadPackageDefinition(packageDefinition);
     } catch (err) {
       const invalidProtoError = new InvalidProtoDefinitionException(err.path);
@@ -593,33 +592,5 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         await this.createService(definition.service, definition.name),
       );
     }
-  }
-
-  /** Optionally add gRPC Reflection support if the user has the `@grpc/reflection` package installed
-   *
-   * @param pkg - PackageDefinition returned by proto-loader.sync or equivalent
-   */
-  private addReflection(pkg): Promise<void> {
-    const disabled = this.getOptionsProp(
-      this.options,
-      'disableReflection',
-      false,
-    );
-    if (disabled) {
-      return;
-    }
-
-    try {
-      require('@grpc/reflection');
-    } catch {
-      this.logger.warn(
-        'Missing @grpc/reflection dependency. Disabling gRPC reflection functionality',
-      );
-      return;
-    }
-
-    const reflectionPackage = require('@grpc/reflection'); // eslint-disable-line @typescript-eslint/no-var-requires
-    const reflection = new reflectionPackage.ReflectionService(pkg);
-    reflection.addToServer(this.grpcClient);
   }
 }

--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -509,6 +509,7 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         this.options,
         grpcProtoLoaderPackage,
       );
+      this.addReflection(packageDefinition);
       return grpcPackage.loadPackageDefinition(packageDefinition);
     } catch (err) {
       const invalidProtoError = new InvalidProtoDefinitionException(err.path);
@@ -592,5 +593,33 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
         await this.createService(definition.service, definition.name),
       );
     }
+  }
+
+  /** Optionally add gRPC Reflection support if the user has the `@grpc/reflection` package installed
+   *
+   * @param pkg - PackageDefinition returned by proto-loader.sync or equivalent
+   */
+  private addReflection(pkg): Promise<void> {
+    const disabled = this.getOptionsProp(
+      this.options,
+      'disableReflection',
+      false,
+    );
+    if (disabled) {
+      return;
+    }
+
+    try {
+      require('@grpc/reflection');
+    } catch {
+      this.logger.warn(
+        'Missing @grpc/reflection dependency. Disabling gRPC reflection functionality',
+      );
+      return;
+    }
+
+    const reflectionPackage = require('@grpc/reflection'); // eslint-disable-line @typescript-eslint/no-var-requires
+    const reflection = new reflectionPackage.ReflectionService(pkg);
+    reflection.addToServer(this.grpcClient);
   }
 }

--- a/sample/04-grpc/package-lock.json
+++ b/sample/04-grpc/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@grpc/grpc-js": "1.10.0",
+        "@grpc/reflection": "1.0.3",
         "@nestjs/common": "10.3.2",
         "@nestjs/core": "10.3.2",
         "@nestjs/microservices": "10.3.2",
@@ -1037,6 +1038,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/reflection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@grpc/reflection/-/reflection-1.0.3.tgz",
+      "integrity": "sha512-Fe1F1HpBSbOb2v4DOnZa2TiQkUJrj0/7camKUNoH6OfOXw/GO82e0gA4Eihbsuga8dZxJYNBHsig/c58SG2c/g==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.10",
+        "protobufjs": "^7.2.5"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "^1.8.21"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -7744,9 +7757,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -10295,6 +10308,15 @@
         "long": "^5.0.0",
         "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
+      }
+    },
+    "@grpc/reflection": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@grpc/reflection/-/reflection-1.0.3.tgz",
+      "integrity": "sha512-Fe1F1HpBSbOb2v4DOnZa2TiQkUJrj0/7camKUNoH6OfOXw/GO82e0gA4Eihbsuga8dZxJYNBHsig/c58SG2c/g==",
+      "requires": {
+        "@grpc/proto-loader": "^0.7.10",
+        "protobufjs": "^7.2.5"
       }
     },
     "@humanwhocodes/config-array": {
@@ -15315,9 +15337,9 @@
       }
     },
     "protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/sample/04-grpc/package.json
+++ b/sample/04-grpc/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.10.0",
-    "@grpc/reflection": "1.0.1",
     "@nestjs/common": "10.3.2",
     "@nestjs/core": "10.3.2",
     "@nestjs/microservices": "10.3.2",

--- a/sample/04-grpc/package.json
+++ b/sample/04-grpc/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.10.0",
+    "@grpc/reflection": "1.0.3",
     "@nestjs/common": "10.3.2",
     "@nestjs/core": "10.3.2",
     "@nestjs/microservices": "10.3.2",

--- a/sample/04-grpc/package.json
+++ b/sample/04-grpc/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "1.10.0",
+    "@grpc/reflection": "1.0.1",
     "@nestjs/common": "10.3.2",
     "@nestjs/core": "10.3.2",
     "@nestjs/microservices": "10.3.2",

--- a/sample/04-grpc/src/grpc-client.options.ts
+++ b/sample/04-grpc/src/grpc-client.options.ts
@@ -1,3 +1,4 @@
+import { ReflectionService } from '@grpc/reflection';
 import { ClientOptions, Transport } from '@nestjs/microservices';
 import { join } from 'path';
 
@@ -6,5 +7,8 @@ export const grpcClientOptions: ClientOptions = {
   options: {
     package: 'hero', // ['hero', 'hero2']
     protoPath: join(__dirname, './hero/hero.proto'), // ['./hero/hero.proto', './hero/hero2.proto']
+    onLoadPackageDefinition: (pkg, server) => {
+      new ReflectionService(pkg).addToServer(server);
+    },
   },
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Automatically add support for the gRPC reflection API if the user has the `@grpc/reflection` package installed

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I currently maintain a Nest Module package (`nestjs-grpc-reflection`) which adds this capability to a user's app, but opening this PR as a discussion point for whether this makes sense to add to NestJS directly!

The [gRPC server reflection API](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) exposes information about a gRPC package so that clients can introspect it, this is gaining in popularity in developer tooling such as Postman, grpcui, ezy and so on as it removes the need for developers to manually manage proto file definitions and can instead rely on their client to fetch the correct definition automatically