### PR TITLE
feat(core): display module's name on `.select(module)` errors

### DIFF
--- a/packages/common/decorators/core/controller.decorator.ts
+++ b/packages/common/decorators/core/controller.decorator.ts
@@ -158,15 +158,15 @@ export function Controller(
   )
     ? [defaultPath, undefined, undefined, undefined]
     : isString(prefixOrOptions) || Array.isArray(prefixOrOptions)
-    ? [prefixOrOptions, undefined, undefined, undefined]
-    : [
-        prefixOrOptions.path || defaultPath,
-        prefixOrOptions.host,
-        { scope: prefixOrOptions.scope, durable: prefixOrOptions.durable },
-        Array.isArray(prefixOrOptions.version)
-          ? Array.from(new Set(prefixOrOptions.version))
-          : prefixOrOptions.version,
-      ];
+      ? [prefixOrOptions, undefined, undefined, undefined]
+      : [
+          prefixOrOptions.path || defaultPath,
+          prefixOrOptions.host,
+          { scope: prefixOrOptions.scope, durable: prefixOrOptions.durable },
+          Array.isArray(prefixOrOptions.version)
+            ? Array.from(new Set(prefixOrOptions.version))
+            : prefixOrOptions.version,
+        ];
 
   return (target: object) => {
     Reflect.defineMetadata(CONTROLLER_WATERMARK, true, target);

--- a/packages/core/errors/exceptions/unknown-module.exception.ts
+++ b/packages/core/errors/exceptions/unknown-module.exception.ts
@@ -1,9 +1,11 @@
 import { RuntimeException } from './runtime.exception';
 
 export class UnknownModuleException extends RuntimeException {
-  constructor() {
+  constructor(moduleName?: string) {
     super(
-      'Nest could not select the given module (it does not exist in current context)',
+      `Nest could not select the given module (${
+        moduleName ? `"${moduleName}"` : 'it'
+      } does not exist in current context).`,
     );
   }
 }

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -99,7 +99,7 @@ export class NestApplicationContext<
 
     const selectedModule = modulesContainer.get(token);
     if (!selectedModule) {
-      throw new UnknownModuleException();
+      throw new UnknownModuleException(type.name);
     }
     return new NestApplicationContext(
       this.container,

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -326,8 +326,8 @@ export class NestFactoryStatic {
           return result instanceof Promise
             ? result.then(mapToProxy)
             : result instanceof NestApplication
-            ? proxy
-            : result;
+              ? proxy
+              : result;
         };
 
         if (!(prop in receiver) && prop in adapter) {

--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -48,8 +48,8 @@ export class RouterResponseController {
       result && result.statusCode
         ? result.statusCode
         : redirectResponse.statusCode
-        ? redirectResponse.statusCode
-        : HttpStatus.FOUND;
+          ? redirectResponse.statusCode
+          : HttpStatus.FOUND;
     const url = result && result.url ? result.url : redirectResponse.url;
     this.applicationRef.redirect(response, statusCode, url);
   }

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -153,7 +153,11 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       (msg: Record<string, any>) => this.handleMessage(msg, channel),
       {
         noAck: this.noAck,
-        consumerTag: this.getOptionsProp(this.options, 'consumerTag', undefined)
+        consumerTag: this.getOptionsProp(
+          this.options,
+          'consumerTag',
+          undefined,
+        ),
       },
     );
     callback();

--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -23,8 +23,8 @@ export class IoAdapter extends AbstractWsAdapter {
     return server && isFunction(server.of)
       ? server.of(namespace)
       : namespace
-      ? this.createIOServer(port, opt).of(namespace)
-      : this.createIOServer(port, opt);
+        ? this.createIOServer(port, opt).of(namespace)
+        : this.createIOServer(port, opt);
   }
 
   public createIOServer(port: number, options?: any): any {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

when calling `app.select()` over modules that weren't registered, we will see the following error message:

![image](https://github.com/nestjs/nest/assets/13461315/7a7d0fef-07e0-454b-b695-23f2797513e4)

## What is the new behavior?

now we'll see module's name:

![image](https://github.com/nestjs/nest/assets/13461315/5c4a601e-72ee-472c-80fe-fc3b6fe020f8)

It works for dynamic modules as well

The code used in my tests:

![image](https://github.com/nestjs/nest/assets/13461315/611103d9-b25c-4e5a-8df1-77ae65e93c09)

This will help us to find which `.select` is broken

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I also ran `npm run format` (commit [aad263a](https://github.com/nestjs/nest/pull/12905/commits/aad263a92cd1cac78123cfa892c19147eb74f21c))