### PR TITLE
refactor(microservices): modify rmq options interface

### DIFF
--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -13,7 +13,7 @@ export interface RmqUrl {
   vhost?: string;
 }
 
-interface clientProperties {
+interface ClientProperties {
   connectionName?: string;
   [key: string]: any;
 }
@@ -26,7 +26,7 @@ export interface AmqpConnectionManagerSocketOptions {
   heartbeatIntervalInSeconds?: number;
   findServers?: () => string | string[];
   connectionOptions?: any;
-  clientProperties?: clientProperties;
+  clientProperties?: ClientProperties;
   [key: string]: any;
 }
 

--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -13,6 +13,11 @@ export interface RmqUrl {
   vhost?: string;
 }
 
+interface clientProperties {
+  connectionName?: string;
+  [key: string]: any;
+}
+
 /**
  * @publicApi
  */
@@ -21,6 +26,8 @@ export interface AmqpConnectionManagerSocketOptions {
   heartbeatIntervalInSeconds?: number;
   findServers?: () => string | string[];
   connectionOptions?: any;
+  clientProperties?: clientProperties;
+  [key: string]: any;
 }
 
 /**
@@ -36,4 +43,5 @@ export interface AmqplibQueueOptions {
   deadLetterRoutingKey?: string;
   maxLength?: number;
   maxPriority?: number;
+  [key: string]: any;
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -12,7 +12,11 @@ import {
 } from '../external/kafka.interface';
 import { MqttClientOptions, QoS } from '../external/mqtt-options.interface';
 import { IORedisOptions } from '../external/redis.interface';
-import { RmqUrl } from '../external/rmq-url.interface';
+import {
+  AmqpConnectionManagerSocketOptions,
+  AmqplibQueueOptions,
+  RmqUrl,
+} from '../external/rmq-url.interface';
 import { TcpSocket } from '../helpers';
 import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
@@ -202,8 +206,8 @@ export interface RmqOptions {
     queue?: string;
     prefetchCount?: number;
     isGlobalPrefetchCount?: boolean;
-    queueOptions?: any; // AmqplibQueueOptions;
-    socketOptions?: any; // AmqpConnectionManagerSocketOptions;
+    queueOptions?: AmqplibQueueOptions;
+    socketOptions?: AmqpConnectionManagerSocketOptions;
     noAck?: boolean;
     consumerTag?: string;
     serializer?: Serializer;


### PR DESCRIPTION
remove the comments from the types of the rmq options interface to get types and modify the types
previous behavior: queueOptions and socketOptions fields type is any

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ v ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ v ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
any type for socketOptions and queueOptions fields in RMQ microservice options

Issue Number: N/A


## What is the new behavior?
get autocomplete for socketOptions  and queueOptions fields in RMQ microservice options because of the types

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information