### PR TITLE
feat(core): add options parameter to repl

### DIFF
--- a/packages/core/repl/repl.ts
+++ b/packages/core/repl/repl.ts
@@ -7,7 +7,12 @@ import { ReplContext } from './repl-context';
 import { ReplLogger } from './repl-logger';
 import { defineDefaultCommandsOnRepl } from './repl-native-commands';
 
-export async function repl(module: Type | DynamicModule) {
+import type { ReplOptions } from 'repl';
+
+export async function repl(
+  module: Type | DynamicModule,
+  replOptions: ReplOptions = {},
+) {
   const app = await NestFactory.createApplicationContext(module, {
     abortOnError: false,
     logger: new ReplLogger(),
@@ -21,6 +26,7 @@ export async function repl(module: Type | DynamicModule) {
   const replServer = _repl.start({
     prompt: clc.green('> '),
     ignoreUndefined: true,
+    ...replOptions,
   });
   assignToObject(replServer.context, replContext.globalScope);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The `nestjs/core/repl` function that runs `node:repl` does not allow the consumers to provide `node:repl`'s option (`ReplOptions`).

Issue Number: https://github.com/nestjs/nest/issues/12916

## What is the new behavior?

This PR allows passing `ReplOptions` to the `nestjs/core/repl` function. Current implemented behavior will also override default options `prompt` / `ignoreUndefined` if they are provided. If required, I can change the PR to not override this default options.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- I don't know if a test for this is required or not (we are just adding a new paramter whose type is defined within node typings itself). If a test is expected for this, it would be nice to have an hint of exactly "what" to test for to avoid writing uncessary code/tests.