### PR TITLE
feat: Implement getHeader and appendHeader methods in adapters

### DIFF
--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -117,7 +117,11 @@ export abstract class AbstractHttpAdapter<
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   abstract isHeadersSent(response: any);
+  // TODO remove optional signature (v11)
+  abstract getHeader?(response: any, name: string, value: string);
   abstract setHeader(response: any, name: string, value: string);
+  // TODO remove optional signature (v11)
+  abstract appendHeader?(response: any, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
   abstract enableCors(
     options: CorsOptions | CorsOptionsDelegate<TRequest>,

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -118,7 +118,7 @@ export abstract class AbstractHttpAdapter<
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   abstract isHeadersSent(response: any);
   // TODO remove optional signature (v11)
-  abstract getHeader?(response: any, name: string, value: string);
+  abstract getHeader?(response: any, name: string);
   abstract setHeader(response: any, name: string, value: string);
   // TODO remove optional signature (v11)
   abstract appendHeader?(response: any, name: string, value: string);

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -21,7 +21,9 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   setErrorHandler(handler: Function, prefix = '/'): any {}
   setNotFoundHandler(handler: Function, prefix = '/'): any {}
   isHeadersSent(response: any): any {}
+  getHeader?(response: any, name: string) {}
   setHeader(response: any, name: string, value: string): any {}
+  appendHeader?(response: any, name: string, value: string) {}
   registerParserMiddleware(): any {}
   enableCors(options: any): any {}
   createMiddlewareFactory(requestMethod: RequestMethod): any {}

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -143,8 +143,16 @@ export class ExpressAdapter extends AbstractHttpAdapter<
     return response.headersSent;
   }
 
+  public getHeader?(response: any, name: string) {
+    return response.get(name);
+  }
+
   public setHeader(response: any, name: string, value: string) {
     return response.set(name, value);
+  }
+
+  public appendHeader?(response: any, name: string, value: string) {
+    return response.append(name, value);
   }
 
   public listen(port: string | number, callback?: () => void): Server;

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -466,8 +466,16 @@ export class FastifyAdapter<
     return response.sent;
   }
 
+  public getHeader?(response: any, name: string, value: string) {
+    return response.getHeader(name, value);
+  }
+
   public setHeader(response: TReply, name: string, value: string) {
     return response.header(name, value);
+  }
+
+  public appendHeader?(response: any, name: string, value: string) {
+    response.header(name, value);
   }
 
   public getRequestHostname(request: TRequest): string {

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -466,8 +466,8 @@ export class FastifyAdapter<
     return response.sent;
   }
 
-  public getHeader?(response: any, name: string, value: string) {
-    return response.getHeader(name, value);
+  public getHeader?(response: any, name: string) {
+    return response.getHeader(name);
   }
 
   public setHeader(response: TReply, name: string, value: string) {


### PR DESCRIPTION
The setHeader method would replace a header, while there can be multiple headers with the same name

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Talking about cookie headers, you can have more than one header with the same key (two Set-Cookie headers). With the existing setHeader method, a header in Express could not be appended with the same key, just in Fastify platform, because Fastify handles this problem, unlikely Express.

Issue Number: N/A


## What is the new behavior?
I ended up adding a getHeader() and an appendHeader() method. The appendHeader() Express implementation calls `response.append(name, value)`, and the Fastify implementation calls `response.header(name, value). Now, you can have more than one Set-Cookie header in Express.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
