### PR TITLE
fix(microservices): grpc client closing

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -330,9 +330,11 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
   }
 
   public close() {
-    this.clients.forEach(
-      client => client && isFunction(client.close) && client.close(),
-    );
+    this.clients.forEach(client => {
+      if (client && isFunction(client.close)) {
+        client.close();
+      }
+    });
     this.clients.clear();
     this.grpcClients = [];
   }

--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -330,9 +330,10 @@ export class ClientGrpcProxy extends ClientProxy implements ClientGrpc {
   }
 
   public close() {
-    this.grpcClients
-      .filter(client => client && isFunction(client.close))
-      .forEach(client => client.close());
+    this.clients.forEach(
+      client => client && isFunction(client.close) && client.close(),
+    );
+    this.clients.clear();
     this.grpcClients = [];
   }
 

--- a/packages/microservices/test/client/client-grpc.spec.ts
+++ b/packages/microservices/test/client/client-grpc.spec.ts
@@ -462,10 +462,13 @@ describe('ClientGrpcProxy', () => {
   describe('close', () => {
     it('should call "close" method', () => {
       const grpcClient = { close: sinon.spy() };
-      (client as any).grpcClients[0] = grpcClient;
+      (client as any).clients.set('test', grpcClient);
+      (client as any).grpcClients[0] = {};
 
       client.close();
       expect(grpcClient.close.called).to.be.true;
+      expect((client as any).clients.size).to.be.eq(0);
+      expect((client as any).grpcClients.length).to.be.eq(0);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, using GRPC client created through `ClientProxyFactory`, it's not possible to close once initiated connection.

```ts
const client = ClientProxyFactory.create({
      transport: Transport.GRPC
    });

const service = client.getService('ServiceName')

await firstValueFrom(service.callSomething())

// do nothing with connection
client.close()

// workaround to close connection properly
client.getClientByServiceName<Client>('ServiceName').close();

```

That looks like a bug, as `close()` method of `ClientGrpcProxy` class trying to call corresponding method not from `Client` instance, created by `@grpc/grpc-js`, but from parsed proto package definition, loaded by `@grpc/proto-loader`:

```ts
  // ! there is packages definitions inside this.grpcClients, not a clients
  public close() {
    this.grpcClients
      .filter(client => client && isFunction(client.close))
      .forEach(client => client.close());
    this.grpcClients = [];
  }
```

As a result, network connection to GRPC server never ends, once initiated. 

Additionally, connections are not gratefully closing on app termination, using GRPC client via `ClientsModule`, as above described method set for `client.onApplicationShutdown` hook:

```ts
    static assignOnAppShutdownHook(client) {
        client.onApplicationShutdown =
            client.close;
        return client;
```

Issue Number: N/A


## What is the new behavior?

`public close()` method has been rewritten to properly close the network connection.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information