### PR TITLE
fix(microservices): send rmq nack without matching message handler

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -44,7 +44,12 @@ export const RQM_NO_EVENT_HANDLER = (
   text: TemplateStringsArray,
   pattern: string,
 ) =>
-  `An unsupported event was received. It has been acknowledged, so it will not be re-delivered. Pattern: ${pattern}`;
+  `An unsupported event was received. It has been negative acknowledged, so it will not be re-delivered. Pattern: ${pattern}`;
+export const RQM_NO_MESSAGE_HANDLER = (
+  text: TemplateStringsArray,
+  pattern: string,
+) =>
+  `An unsupported message was received. It has been negative acknowledged, so it will not be re-delivered. Pattern: ${pattern}`;
 export const GRPC_DEFAULT_PROTO_LOADER = '@grpc/proto-loader';
 
 export const NO_EVENT_HANDLER = (text: TemplateStringsArray, pattern: string) =>

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -18,6 +18,7 @@ import {
   RQM_DEFAULT_QUEUE_OPTIONS,
   RQM_DEFAULT_URL,
   RQM_NO_EVENT_HANDLER,
+  RQM_NO_MESSAGE_HANDLER,
 } from '../constants';
 import { RmqContext } from '../ctx-host';
 import { Transport } from '../enums';
@@ -184,6 +185,10 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     const handler = this.getHandlerByPattern(pattern);
 
     if (!handler) {
+      if (!this.noAck) {
+        this.logger.warn(RQM_NO_MESSAGE_HANDLER`${pattern}`);
+        this.channel.nack(rmqContext.getMessage(), false, false);
+      }
       const status = 'error';
       const noHandlerPacket = {
         id: (packet as IncomingRequest).id,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

Same problem as descibed in [issue 11641](https://github.com/nestjs/nest/issues/11641) but for messages (not events).

With RMQ Options:
  * prefetchCount: 1
  * noAck: false

When you send a message (using `client.send()`) with an unknown pattern, the server does not send an acknowledgment. The message remains unacknowledged. Application reaches prefetch count and freezes.

Minimum reproduction code - https://github.com/toxol/nest-rmq-nack

## What is the new behavior?

When RMQ server receives a message for which there is no handler, it will send a negative acknowledgment without retrying.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information