### PR TITLE
fix: #13077 KafkaJs typing consistency

### DIFF
--- a/packages/microservices/external/kafka.interface.ts
+++ b/packages/microservices/external/kafka.interface.ts
@@ -38,13 +38,17 @@ type Authenticator = {
   authenticate: () => Promise<void>;
 };
 
+export type SaslAuthenticateArgs<ParseResult> = {
+  request: SaslAuthenticationRequest;
+  response?: SaslAuthenticationResponse<ParseResult>;
+};
+
 type AuthenticationProviderArgs = {
   host: string;
   port: number;
   logger: Logger;
   saslAuthenticate: <ParseResult>(
-    request: SaslAuthenticationRequest,
-    response?: SaslAuthenticationResponse<ParseResult>,
+    args: SaslAuthenticateArgs<ParseResult>,
   ) => Promise<ParseResult | void>;
 };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Incompatible typing between the KafkaJs and Nest Kafka Microservice types.

Issue Number: #13077 


## What is the new behavior?

This will change the SASL Mechanism to be compatible types.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

While technically this is a breaking change, since we Object.assign, the current signature actually won't work: https://github.com/edeesis/nest/blob/master/packages/microservices/server/server-kafka.ts#L114-L118.

The signature change was introduced in kafkajs 2.2.1.


## Other information