### PR TITLE
feat(microservices): add type for rmq connection options

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -44,7 +44,7 @@ type ChannelWrapper = any;
 type ConsumeMessage = any;
 type AmqpConnectionManager = any;
 
-let rqmPackage: any = {};
+let rmqPackage: any = {};
 
 const REPLY_QUEUE = 'amq.rabbitmq.reply-to';
 
@@ -81,7 +81,7 @@ export class ClientRMQ extends ClientProxy {
       this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
 
     loadPackage('amqplib', ClientRMQ.name, () => require('amqplib'));
-    rqmPackage = loadPackage('amqp-connection-manager', ClientRMQ.name, () =>
+    rmqPackage = loadPackage('amqp-connection-manager', ClientRMQ.name, () =>
       require('amqp-connection-manager'),
     );
 
@@ -133,7 +133,7 @@ export class ClientRMQ extends ClientProxy {
 
   public createClient(): AmqpConnectionManager {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
-    return rqmPackage.connect(this.urls, {
+    return rmqPackage.connect(this.urls, {
       connectionOptions: socketOptions,
     });
   }

--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -1,3 +1,6 @@
+import { ConnectionOptions } from 'tls';
+import { TcpSocketConnectOpts } from 'net';
+
 /**
  * @publicApi
  */
@@ -18,6 +21,26 @@ interface ClientProperties {
   [key: string]: any;
 }
 
+type AmqpConnectionOptions = (ConnectionOptions | TcpSocketConnectOpts) & {
+  noDelay?: boolean;
+  timeout?: number;
+  keepAlive?: boolean;
+  keepAliveDelay?: number;
+  clientProperties?: any;
+  credentials?:
+    | {
+        mechanism: string;
+        username: string;
+        password: string;
+        response: () => Buffer;
+      }
+    | {
+        mechanism: string;
+        response: () => Buffer;
+      }
+    | undefined;
+};
+
 /**
  * @publicApi
  */
@@ -25,7 +48,7 @@ export interface AmqpConnectionManagerSocketOptions {
   reconnectTimeInSeconds?: number;
   heartbeatIntervalInSeconds?: number;
   findServers?: () => string | string[];
-  connectionOptions?: any;
+  connectionOptions?: AmqpConnectionOptions;
   clientProperties?: ClientProperties;
   [key: string]: any;
 }

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -31,7 +31,7 @@ import {
 import { RmqRecordSerializer } from '../serializers/rmq-record.serializer';
 import { Server } from './server';
 
-let rqmPackage: any = {};
+let rmqPackage: any = {};
 
 const INFINITE_CONNECTION_ATTEMPTS = -1;
 
@@ -67,7 +67,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
 
     this.loadPackage('amqplib', ServerRMQ.name, () => require('amqplib'));
-    rqmPackage = this.loadPackage(
+    rmqPackage = this.loadPackage(
       'amqp-connection-manager',
       ServerRMQ.name,
       () => require('amqp-connection-manager'),
@@ -136,7 +136,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
 
   public createClient<T = any>(): T {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
-    return rqmPackage.connect(this.urls, {
+    return rmqPackage.connect(this.urls, {
       connectionOptions: socketOptions,
       heartbeatIntervalInSeconds: socketOptions?.heartbeatIntervalInSeconds,
       reconnectTimeInSeconds: socketOptions?.reconnectTimeInSeconds,


### PR DESCRIPTION
change socketOptions.connectionOptions type from any to amqp-manager's AmqpConnectionOptions which allows to specify not only mTLS but also External auth

Closes https://github.com/nestjs/nest/issues/13071

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently in RabbitMq client options `socketOptions.connectionOptions` type is `any`
Issue Number: https://github.com/nestjs/nest/issues/13071


## What is the new behavior?

- RabbitMq client options `socketOptions.connectionOptions` type is now `AmqpConnectionOptions`
- In `server-rmq.ts` and `client-rmq.ts` local variable `rqmPackage` has been renamed to `rmqPackage`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information