### PR TITLE
fix(packages/microservices): pass inboxPrefix as argument to createInbox

### DIFF
--- a/packages/microservices/client/client-nats.ts
+++ b/packages/microservices/client/client-nats.ts
@@ -127,7 +127,7 @@ export class ClientNats extends ClientProxy {
       const packet = this.assignPacketId(partialPacket);
       const channel = this.normalizePattern(partialPacket.pattern);
       const serializedPacket: NatsRecord = this.serializer.serialize(packet);
-      const inbox = natsPackage.createInbox();
+      const inbox = natsPackage.createInbox(this.options.inboxPrefix);
 
       const subscriptionHandler = this.createSubscriptionHandler(
         packet,


### PR DESCRIPTION
Pretty simple fix to correctly prepend the `inboxPrefix` to the NATS inbox ID

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
https://github.com/nestjs/nest/issues/13150

Issue Number: 13150


## What is the new behavior?
The inbox prefix being added to the inbox ID

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information