### PR TITLE
fix: allow @fastify/static v7

### DIFF
--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -27,7 +27,7 @@
     "tslib": "2.6.2"
   },
   "peerDependencies": {
-    "@fastify/static": "^6.0.0",
+    "@fastify/static": "^6.0.0 || ^7.0.0",
     "@fastify/view": "^7.0.0 || ^8.0.0",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0"


### PR DESCRIPTION
This change allows updating @fastify/static to v7.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
when updating @fastify/static you might get the error "Conflicting peer dependency".

Issue Number: N/A


## What is the new behavior?
allows updating @fastify/static

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information