### PR TITLE
fix: add options param when converting to class in serializer

### DIFF
--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -94,7 +94,7 @@ export class ClassSerializerInterceptor implements NestInterceptor {
     if (plainOrClass instanceof options.type) {
       return classTransformer.classToPlain(plainOrClass, options);
     }
-    const instance = classTransformer.plainToClass(options.type, plainOrClass);
+    const instance = classTransformer.plainToClass(options.type, plainOrClass, options);
     return classTransformer.classToPlain(instance, options);
   }
 


### PR DESCRIPTION
Missing options params to function plainToClass would miss groups rules
Fixes: https://github.com/nestjs/nest/issues/13160

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 13160


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information