### PR TITLE
docs(common): remove incorrect constructor signature of HttpException

### DIFF
--- a/packages/common/exceptions/http.exception.ts
+++ b/packages/common/exceptions/http.exception.ts
@@ -28,7 +28,6 @@ export class HttpException extends Error {
    * Instantiate a plain HTTP Exception.
    *
    * @example
-   * throw new HttpException()
    * throw new HttpException('message', HttpStatus.BAD_REQUEST)
    * throw new HttpException('custom message', HttpStatus.BAD_REQUEST, {
    *  cause: new Error('Cause Error'),


### PR DESCRIPTION
HttpException cannot be instantiated with zero arguments. The provided first example is misleading.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Documentation correction

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a misleading example of the usage of HttpException's constructor. It cannot be instantiated with zero arguments.

Issue Number: N/A


## What is the new behavior?
Removed incorrect example.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information