### PR TITLE
fix: typings for fastify `enableCors` method

### DIFF
--- a/integration/cors/e2e/fastify.spec.ts
+++ b/integration/cors/e2e/fastify.spec.ts
@@ -38,10 +38,12 @@ describe.skip('Fastify Cors', () => {
         );
 
         let requestId = 0;
-        const configDelegation = function (req, cb) {
-          const config = configs[requestId];
-          requestId++;
-          cb(null, config);
+        const configDelegation = {
+          delegator: function (req, cb) {
+            const config = configs[requestId];
+            requestId++;
+            cb(null, config);
+          },
         };
         app.enableCors(configDelegation);
 

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -1,10 +1,6 @@
 import { RequestMethod } from '../../enums';
-import {
-  CorsOptions,
-  CorsOptionsDelegate,
-} from '../../interfaces/external/cors-options.interface';
 import { NestApplicationOptions } from '../../interfaces/nest-application-options.interface';
-import { VersioningOptions, VersionValue } from '../version-options.interface';
+import { VersionValue, VersioningOptions } from '../version-options.interface';
 
 export type ErrorHandler<TRequest = any, TResponse = any> = (
   error: any,
@@ -77,7 +73,7 @@ export interface HttpServer<
   getRequestUrl?(request: TRequest): string;
   getInstance(): ServerInstance;
   registerParserMiddleware(...args: any[]): any;
-  enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>): any;
+  enableCors(options: any): any;
   getHttpServer(): any;
   initHttpServer(options: NestApplicationOptions): void;
   close(): any;

--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -1,7 +1,3 @@
-import {
-  CorsOptions,
-  CorsOptionsDelegate,
-} from './external/cors-options.interface';
 import { CanActivate } from './features/can-activate.interface';
 import { NestInterceptor } from './features/nest-interceptor.interface';
 import { GlobalPrefixOptions } from './global-prefix-options.interface';
@@ -30,13 +26,6 @@ export interface INestApplication<TServer = any>
    * @returns {this}
    */
   use(...args: any[]): this;
-
-  /**
-   * Enables CORS (Cross-Origin Resource Sharing)
-   *
-   * @returns {void}
-   */
-  enableCors(options?: CorsOptions | CorsOptionsDelegate<any>): void;
 
   /**
    * Enables Versioning for the application.

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -1,9 +1,5 @@
 import { HttpServer, RequestMethod, VersioningOptions } from '@nestjs/common';
 import { RequestHandler, VersionValue } from '@nestjs/common/interfaces';
-import {
-  CorsOptions,
-  CorsOptionsDelegate,
-} from '@nestjs/common/interfaces/external/cors-options.interface';
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
 
 /**
@@ -123,10 +119,7 @@ export abstract class AbstractHttpAdapter<
   // TODO remove optional signature (v11)
   abstract appendHeader?(response: any, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
-  abstract enableCors(
-    options: CorsOptions | CorsOptionsDelegate<TRequest>,
-    prefix?: string,
-  );
+  abstract enableCors(options?: any, prefix?: string);
   abstract createMiddlewareFactory(
     requestMethod: RequestMethod,
   ):

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -15,10 +15,6 @@ import {
   GlobalPrefixOptions,
   NestApplicationOptions,
 } from '@nestjs/common/interfaces';
-import {
-  CorsOptions,
-  CorsOptionsDelegate,
-} from '@nestjs/common/interfaces/external/cors-options.interface';
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import {
@@ -129,9 +125,7 @@ export class NestApplication
     if (!passCustomOptions) {
       return this.enableCors();
     }
-    return this.enableCors(
-      this.appOptions.cors as CorsOptions | CorsOptionsDelegate<any>,
-    );
+    return this.enableCors(this.appOptions.cors);
   }
 
   public createServer<T = any>(): T {
@@ -279,7 +273,7 @@ export class NestApplication
     return this;
   }
 
-  public enableCors(options?: CorsOptions | CorsOptionsDelegate<any>): void {
+  public enableCors(options?: any): void {
     this.httpAdapter.enableCors(options);
   }
 

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -1,7 +1,11 @@
-import { INestApplication, HttpServer } from '@nestjs/common';
+import { HttpServer, INestApplication } from '@nestjs/common';
+import type {
+  CorsOptions,
+  CorsOptionsDelegate,
+} from '@nestjs/common/interfaces/external/cors-options.interface';
+import type { Express } from 'express';
 import type { Server as CoreHttpServer } from 'http';
 import type { Server as CoreHttpsServer } from 'https';
-import type { Express } from 'express';
 import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface';
 import { NestExpressBodyParserType } from './nest-express-body-parser.interface';
 import { ServeStaticOptions } from './serve-static-options.interface';
@@ -85,6 +89,8 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   useStaticAssets(path: string, options?: ServeStaticOptions): this;
+
+  enableCors(options?: CorsOptions | CorsOptionsDelegate<any>): void;
 
   /**
    * Register Express body parsers on the fly. Will respect

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -1,3 +1,4 @@
+import { FastifyCorsOptions } from '@fastify/cors';
 import {
   HttpStatus,
   Logger,
@@ -9,10 +10,6 @@ import {
   VersioningType,
 } from '@nestjs/common';
 import { VersionValue } from '@nestjs/common/interfaces';
-import {
-  CorsOptions,
-  CorsOptionsDelegate,
-} from '@nestjs/common/interfaces/external/cors-options.interface';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { isString, isUndefined } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
@@ -47,15 +44,15 @@ import {
 import * as pathToRegexp from 'path-to-regexp';
 // `querystring` is used internally in fastify for registering urlencoded body parser.
 import { parse as querystringParse } from 'querystring';
+import {
+  FASTIFY_ROUTE_CONFIG_METADATA,
+  FASTIFY_ROUTE_CONSTRAINTS_METADATA,
+} from '../constants';
 import { NestFastifyBodyParserOptions } from '../interfaces';
 import {
   FastifyStaticOptions,
   FastifyViewOptions,
 } from '../interfaces/external';
-import {
-  FASTIFY_ROUTE_CONFIG_METADATA,
-  FASTIFY_ROUTE_CONSTRAINTS_METADATA,
-} from '../constants';
 
 type FastifyHttp2SecureOptions<
   Server extends http2.Http2SecureServer,
@@ -492,7 +489,7 @@ export class FastifyAdapter<
     return this.getRequestOriginalUrl(request.raw || request);
   }
 
-  public enableCors(options: CorsOptions | CorsOptionsDelegate<TRequest>) {
+  public enableCors(options?: FastifyCorsOptions) {
     this.register(
       import('@fastify/cors') as Parameters<TInstance['register']>[0],
       options,

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -1,4 +1,5 @@
-import { INestApplication, HttpServer } from '@nestjs/common';
+import { FastifyCorsOptions } from '@fastify/cors';
+import { HttpServer, INestApplication } from '@nestjs/common';
 import {
   FastifyBodyParser,
   FastifyInstance,
@@ -6,14 +7,14 @@ import {
   FastifyPluginCallback,
   FastifyPluginOptions,
   FastifyRegisterOptions,
-  FastifyRequest,
   FastifyReply,
+  FastifyRequest,
   RawServerBase,
   RawServerDefault,
 } from 'fastify';
 import {
-  Chain as LightMyRequestChain,
   InjectOptions,
+  Chain as LightMyRequestChain,
   Response as LightMyRequestResponse,
 } from 'light-my-request';
 import { FastifyStaticOptions, FastifyViewOptions } from './external';
@@ -73,6 +74,13 @@ export interface NestFastifyApplication<
    * @returns {this}
    */
   useStaticAssets(options: FastifyStaticOptions): this;
+
+  /**
+   * Enables CORS (Cross-Origin Resource Sharing)
+   *
+   * @returns {void}
+   */
+  enableCors(options?: FastifyCorsOptions): void;
 
   /**
    * Sets a view engine for templates (views), for example: `pug`, `handlebars`, or `ejs`.


### PR DESCRIPTION
Fastify adapter uses typings from `@fastify/cors` package for `enableCors` method

Fix nestjs/nest#13234

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] ~Docs have been added / updated (for bug fixes / features)~ I do not think it is needed, [documentation](https://docs.nestjs.com/security/cors) already refers to `@fastfy/cors` options


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/13234


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No (well, it could be for fastify, because typings have been changed...)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'm not sure I've got the architecture right. My understanding is that the adapter should be platform-independent, and if there is a platform-specific implementation of the adapter then not. I took inspiration from `useStaticAssets` method for example, i.e. a universal adapter has `any` types and then the individual types are applied to the adapter (fastify, express) implementations.