### PR TITLE
feat(common): Make ValidationPipe aware of WebSocket context

### DIFF
--- a/integration/websockets/e2e/gateway-validation-pipe.spec.ts
+++ b/integration/websockets/e2e/gateway-validation-pipe.spec.ts
@@ -1,0 +1,103 @@
+import { INestApplication } from '@nestjs/common';
+import { WsAdapter } from '@nestjs/platform-ws';
+import { Test } from '@nestjs/testing';
+import * as WebSocket from 'ws';
+import { ValidationPipeGateway } from '../src/validation-pipe.gateway';
+import { expect } from 'chai';
+import { ApplicationGateway } from '../src/app.gateway';
+
+async function createNestApp(...gateways): Promise<INestApplication> {
+  const testingModule = await Test.createTestingModule({
+    providers: gateways,
+  }).compile();
+  const app = testingModule.createNestApplication();
+  app.useWebSocketAdapter(new WsAdapter(app) as any);
+  return app;
+}
+
+const testBody = { ws: null, app: null };
+
+async function prepareGatewayAndClientForResponseAction(
+  gateway: typeof ValidationPipeGateway | ApplicationGateway,
+  action: () => void,
+) {
+  testBody.app = await createNestApp(gateway);
+  await testBody.app.listen(3000);
+
+  testBody.ws = new WebSocket('ws://localhost:8080');
+  await new Promise(resolve => testBody.ws.on('open', resolve));
+
+  testBody.ws.send(
+    JSON.stringify({
+      event: 'push',
+      data: {
+        stringProp: 123,
+      },
+    }),
+  );
+
+  action();
+}
+
+const UNCAUGHT_EXCEPTION = 'uncaughtException';
+
+type WsExceptionWithWrappedValidationError = {
+  getError: () => {
+    response: {
+      message: string[];
+    };
+  };
+};
+
+function prepareToHandleExpectedUncaughtException() {
+  const listeners = process.listeners(UNCAUGHT_EXCEPTION);
+  process.removeAllListeners(UNCAUGHT_EXCEPTION);
+
+  process.on(
+    UNCAUGHT_EXCEPTION,
+    (err: WsExceptionWithWrappedValidationError) => {
+      expect(err.getError().response.message[0]).to.equal(
+        'stringProp must be a string',
+      );
+      reattachUncaughtExceptionListeners(listeners);
+    },
+  );
+}
+
+function reattachUncaughtExceptionListeners(
+  listeners: NodeJS.UncaughtExceptionListener[],
+) {
+  process.removeAllListeners(UNCAUGHT_EXCEPTION);
+  for (const listener of listeners) {
+    process.on(UNCAUGHT_EXCEPTION, listener);
+  }
+}
+
+describe('WebSocketGateway with ValidationPipe', () => {
+  it(`should throw WsException`, async () => {
+    prepareToHandleExpectedUncaughtException();
+
+    await prepareGatewayAndClientForResponseAction(
+      ValidationPipeGateway,
+      () => {
+        testBody.ws.once('message', () => {});
+      },
+    );
+  });
+
+  it('should return message normally', async () => {
+    await new Promise<void>(resolve =>
+      prepareGatewayAndClientForResponseAction(ApplicationGateway, async () => {
+        testBody.ws.once('message', msg => {
+          expect(JSON.parse(msg).data.stringProp).to.equal(123);
+          resolve();
+        });
+      }),
+    );
+  });
+
+  afterEach(function (done) {
+    testBody.ws.close();
+    testBody.app.close().then(() => done());
+  });
+});

--- a/integration/websockets/src/validation-pipe.gateway.ts
+++ b/integration/websockets/src/validation-pipe.gateway.ts
@@ -1,0 +1,40 @@
+import {
+  ArgumentsHost,
+  Catch,
+  UseFilters,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  BaseWsExceptionFilter,
+  MessageBody,
+  SubscribeMessage,
+  WebSocketGateway,
+} from '@nestjs/websockets';
+import { IsString } from 'class-validator';
+
+class TestModel {
+  @IsString()
+  stringProp: string;
+}
+
+@Catch()
+export class AllExceptionsFilter extends BaseWsExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost) {
+    throw exception;
+  }
+}
+
+@WebSocketGateway(8080)
+@UsePipes(new ValidationPipe())
+@UseFilters(new AllExceptionsFilter())
+export class ValidationPipeGateway {
+  @SubscribeMessage('push')
+  onPush(@MessageBody() data: TestModel) {
+    console.log('received msg');
+    return {
+      event: 'push',
+      data,
+    };
+  }
+}

--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -45,3 +45,4 @@ export const INJECTABLE_WATERMARK = '__injectable__';
 export const CONTROLLER_WATERMARK = '__controller__';
 export const CATCH_WATERMARK = '__catch__';
 export const ENTRY_PROVIDER_WATERMARK = '__entryProvider__';
+export const GATEWAY_METADATA = 'websockets:is_gateway';

--- a/packages/common/decorators/core/use-pipes.decorator.ts
+++ b/packages/common/decorators/core/use-pipes.decorator.ts
@@ -3,6 +3,7 @@ import { PipeTransform } from '../../interfaces/index';
 import { extendArrayMetadata } from '../../utils/extend-metadata.util';
 import { isFunction } from '../../utils/shared.utils';
 import { validateEach } from '../../utils/validate-each.util';
+import { isTargetAware } from '../../interfaces/features/target-aware-pipe.interface';
 
 /**
  * Decorator that binds pipes to the scope of the controller or method,
@@ -43,6 +44,12 @@ export function UsePipes(
       return descriptor;
     }
     validateEach(target, pipes, isPipeValid, '@UsePipes', 'pipe');
+
+    const pipesWithSetTarget = pipes.filter(pipe => isTargetAware(pipe));
+    pipesWithSetTarget.forEach(pipeWithSetTarget =>
+      pipeWithSetTarget['setTarget'](target),
+    );
+
     extendArrayMetadata(PIPES_METADATA, pipes, target);
     return target;
   };

--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -20,3 +20,4 @@ export * from './gateway-timeout.exception';
 export * from './im-a-teapot.exception';
 export * from './precondition-failed.exception';
 export * from './misdirected.exception';
+export * from './ws-exception';

--- a/packages/common/exceptions/ws-exception.ts
+++ b/packages/common/exceptions/ws-exception.ts
@@ -1,0 +1,27 @@
+import { isObject, isString } from '../utils/shared.utils';
+
+export class WsException extends Error {
+  constructor(private readonly error: string | object) {
+    super();
+    this.initMessage();
+  }
+
+  public initMessage() {
+    if (isString(this.error)) {
+      this.message = this.error;
+    } else if (
+      isObject(this.error) &&
+      isString((this.error as Record<string, any>).message)
+    ) {
+      this.message = (this.error as Record<string, any>).message;
+    } else if (this.constructor) {
+      this.message = this.constructor.name
+        .match(/[A-Z][a-z]+|[0-9]+/g)
+        .join(' ');
+    }
+  }
+
+  public getError(): string | object {
+    return this.error;
+  }
+}

--- a/packages/common/interfaces/features/target-aware-pipe.interface.ts
+++ b/packages/common/interfaces/features/target-aware-pipe.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * Interface describing method to set the target of the pipe decorator
+ */
+export interface TargetAwarePipe {
+  isTargetAware: true;
+
+  setTarget(target: unknown): void;
+}
+
+export function isTargetAware(pipe: unknown): pipe is TargetAwarePipe {
+  return pipe['isTargetAware'];
+}

--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -24,7 +24,7 @@ import {
 } from '@nestjs/core/interceptors';
 import { PipesConsumer, PipesContextCreator } from '@nestjs/core/pipes';
 import { MESSAGE_METADATA, PARAM_ARGS_METADATA } from '../constants';
-import { WsException } from '../errors/ws-exception';
+import { WsException } from '@nestjs/common';
 import { WsParamsFactory } from '../factories/ws-params-factory';
 import { ExceptionFiltersContext } from './exception-filters-context';
 import { DEFAULT_CALLBACK_METADATA } from './ws-metadata-constants';

--- a/packages/websockets/errors/index.ts
+++ b/packages/websockets/errors/index.ts
@@ -1,1 +1,1 @@
-export * from './ws-exception';
+export { WsException } from '@nestjs/common/exceptions/ws-exception';

--- a/packages/websockets/errors/ws-exception.ts
+++ b/packages/websockets/errors/ws-exception.ts
@@ -1,27 +1,8 @@
-import { isObject, isString } from '@nestjs/common/utils/shared.utils';
+import { WsException as WSE } from '@nestjs/common/exceptions/ws-exception';
 
-export class WsException extends Error {
-  constructor(private readonly error: string | object) {
-    super();
-    this.initMessage();
-  }
+/**
+ * @deprecated WsException has been moved to @nestjs/common
+ */
+const WsException = WSE;
 
-  public initMessage() {
-    if (isString(this.error)) {
-      this.message = this.error;
-    } else if (
-      isObject(this.error) &&
-      isString((this.error as Record<string, any>).message)
-    ) {
-      this.message = (this.error as Record<string, any>).message;
-    } else if (this.constructor) {
-      this.message = this.constructor.name
-        .match(/[A-Z][a-z]+|[0-9]+/g)
-        .join(' ');
-    }
-  }
-
-  public getError(): string | object {
-    return this.error;
-  }
-}
+export { WsException };

--- a/packages/websockets/exceptions/base-ws-exception-filter.ts
+++ b/packages/websockets/exceptions/base-ws-exception-filter.ts
@@ -1,7 +1,7 @@
 import { ArgumentsHost, Logger, WsExceptionFilter } from '@nestjs/common';
 import { isObject } from '@nestjs/common/utils/shared.utils';
 import { MESSAGES } from '@nestjs/core/constants';
-import { WsException } from '../errors/ws-exception';
+import { WsException } from '@nestjs/common';
 
 /**
  * @publicApi

--- a/packages/websockets/exceptions/ws-exceptions-handler.ts
+++ b/packages/websockets/exceptions/ws-exceptions-handler.ts
@@ -3,7 +3,7 @@ import { ArgumentsHost } from '@nestjs/common';
 import { ExceptionFilterMetadata } from '@nestjs/common/interfaces/exceptions/exception-filter-metadata.interface';
 import { selectExceptionFilterMetadata } from '@nestjs/common/utils/select-exception-filter-metadata.util';
 import { InvalidExceptionFilterException } from '@nestjs/core/errors/exceptions/invalid-exception-filter.exception';
-import { WsException } from '../errors/ws-exception';
+import { WsException } from '@nestjs/common';
 import { BaseWsExceptionFilter } from './base-ws-exception-filter';
 
 /**


### PR DESCRIPTION
Extended logic of UsePipes and ValidationPipe decorators to give awareness of WebSocket context.

Closes #13190

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR makes the ValidationPipe aware of being used in a WebSocket context. It is now correctly throwing a WsException instead of an internal server error when validation fails. It also moved the WsException into the common package, which is being referenced from the websockets package now.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

[Issue 1390](https://github.com/nestjs/nest/issues/13190)

Issue Number: 13190


## What is the new behavior?

ValidationPipe now correctly returns WsException with validation error details when validation in WebSocket gateway is failing.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is my first open source contribution and I hope I adhered to all guidelines correctly.