### PR TITLE
fix(microservice) Delete unnecessary call of grpcClient.start

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -81,7 +81,6 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
 
   public async start(callback?: () => void) {
     await this.bindEvents();
-    this.grpcClient.start();
     callback();
   }
 

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -51,13 +51,6 @@ describe('ServerGrpc', () => {
       await server.close();
       expect(bindEventsStub.called).to.be.true;
     });
-    it('should call "client.start"', async () => {
-      const client = { start: sinon.spy() };
-      sinon.stub(server, 'createClient').callsFake(async () => client);
-
-      await server.listen(callback);
-      expect(client.start.called).to.be.true;
-    });
     it('should call callback', async () => {
       await server.listen(callback);
       await server.close();
@@ -94,12 +87,6 @@ describe('ServerGrpc', () => {
       await serverMulti.listen(callback);
       await serverMulti.close();
       expect(bindEventsStub.called).to.be.true;
-    });
-    it('should call "client.start"', async () => {
-      const client = { start: sinon.spy() };
-      sinon.stub(serverMulti, 'createClient').callsFake(async () => client);
-      await serverMulti.listen(callback);
-      expect(client.start.called).to.be.true;
     });
     it('should call callback', async () => {
       await serverMulti.listen(callback);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

> (node:66623) DeprecationWarning: Calling start() is no longer necessary. It can be safely omitted.
    at ServerGrpc.start (\<PATH\>/node_modules/@nestjs/microservices/server/server-grpc.js:39:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ServerGrpc.listen (\<PATH\>/node_modules/@nestjs/microservices/server/server-grpc.js:31:13)

The above warning message appeared, so even if I deleted `this.grpcClient.start();` and ran it, it worked normally.
