### PR TITLE
fix(microservices): fix rabbitmq no-assert not being applied correctly

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -78,7 +78,9 @@ export class ClientRMQ extends ClientProxy {
     this.persistent =
       this.getOptionsProp(this.options, 'persistent') || RQM_DEFAULT_PERSISTENT;
     this.noAssert =
-      this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
+      this.getOptionsProp(this.options, 'noAssert') ??
+      this.queueOptions.noAssert ??
+      RQM_DEFAULT_NO_ASSERT;
 
     loadPackage('amqplib', ClientRMQ.name, () => require('amqplib'));
     rmqPackage = loadPackage('amqp-connection-manager', ClientRMQ.name, () =>
@@ -187,7 +189,7 @@ export class ClientRMQ extends ClientProxy {
       this.getOptionsProp(this.options, 'isGlobalPrefetchCount') ||
       RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT;
 
-    if (!this.queueOptions.noAssert) {
+    if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
     await channel.prefetch(prefetchCount, isGlobalPrefetchCount);

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -65,7 +65,9 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
       this.getOptionsProp(this.options, 'queueOptions') ||
       RQM_DEFAULT_QUEUE_OPTIONS;
     this.noAssert =
-      this.getOptionsProp(this.options, 'noAssert') || RQM_DEFAULT_NO_ASSERT;
+      this.getOptionsProp(this.options, 'noAssert') ??
+      this.queueOptions.noAssert ??
+      RQM_DEFAULT_NO_ASSERT;
 
     this.loadPackage('amqplib', ServerRMQ.name, () => require('amqplib'));
     rmqPackage = this.loadPackage(
@@ -145,7 +147,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   }
 
   public async setupChannel(channel: any, callback: Function) {
-    if (!this.queueOptions.noAssert) {
+    if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
     await channel.prefetch(this.prefetchCount, this.isGlobalPrefetchCount);

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -11,6 +11,19 @@ describe('ClientRMQ', function () {
 
   let client: ClientRMQ;
 
+  describe('constructor', () => {
+    it(`should fallback to queueOptions.noAssert when 'noAssert' is undefined`, () => {
+      const queueOptions = {
+        noAssert: true,
+      };
+      const instance = new ClientRMQ({
+        queueOptions,
+      });
+
+      expect(instance).property('noAssert').to.eq(queueOptions.noAssert);
+    });
+  });
+
   describe('connect', () => {
     let createClientStub: sinon.SinonStub;
     let handleErrorsSpy: sinon.SinonSpy;
@@ -135,9 +148,17 @@ describe('ClientRMQ', function () {
     afterEach(() => {
       consumeStub.restore();
     });
-    it('should call "assertQueue" with queue and queue options', async () => {
+    it('should call "assertQueue" with queue and queue options when noAssert is false', async () => {
+      client['noAssert'] = false;
+
       await client.setupChannel(channel, () => null);
       expect(channel.assertQueue.calledWith(queue, queueOptions)).to.be.true;
+    });
+    it('should not call "assertQueue" when noAssert is true', async () => {
+      client['noAssert'] = true;
+
+      await client.setupChannel(channel, () => null);
+      expect(channel.assertQueue.called).not.to.be.true;
     });
     it('should call "prefetch" with prefetchCount and "isGlobalPrefetchCount"', async () => {
       await client.setupChannel(channel, () => null);

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -14,6 +14,20 @@ describe('ServerRMQ', () => {
   beforeEach(() => {
     server = new ServerRMQ({});
   });
+
+  describe('constructor', () => {
+    it(`should fallback to queueOptions.noAssert when 'noAssert' is undefined`, () => {
+      const queueOptions = {
+        noAssert: true,
+      };
+      const instance = new ServerRMQ({
+        queueOptions,
+      });
+
+      expect(instance).property('noAssert').to.eq(queueOptions.noAssert);
+    });
+  });
+
   describe('listen', () => {
     let createClient: sinon.SinonStub;
     let onStub: sinon.SinonStub;
@@ -196,9 +210,17 @@ describe('ServerRMQ', () => {
         consume: sinon.spy(),
       };
     });
-    it('should call "assertQueue" with queue and queue options', async () => {
+    it('should call "assertQueue" with queue and queue options when noAssert is false', async () => {
+      server['noAssert' as any] = false;
+
       await server.setupChannel(channel, () => null);
       expect(channel.assertQueue.calledWith(queue, queueOptions)).to.be.true;
+    });
+    it('should not call "assertQueue" when noAssert is true', async () => {
+      server['noAssert' as any] = true;
+
+      await server.setupChannel(channel, () => null);
+      expect(channel.assertQueue.called).not.to.be.true;
     });
     it('should call "prefetch" with prefetchCount and "isGlobalPrefetchCount"', async () => {
       await server.setupChannel(channel, () => null);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `noAssert` flag is a state property on the `ServerRMQ` and `ClientRMQ` classes but it's not being used.

Instead, the `queueOptions.noAssert` is used to determine if the `assertQueue` should be called or not (can be seen [here for server](https://github.com/nestjs/nest/blob/7f00840c074ba5a5f233f73ef6c8456115abd7c1/packages/microservices/server/server-rmq.ts#L148) and [here for client](https://github.com/nestjs/nest/blob/7f00840c074ba5a5f233f73ef6c8456115abd7c1/packages/microservices/client/client-rmq.ts#L190))

This means that the `noAssert` flag is not used, at all.

## What is the new behavior?

This PR  makes sure to use the `noAssert` property of the class, instead of reading it from the `queueOptions`

The current workaround (without this PR) is to pass in the `noAssert` flag in the `queueOptions` like this:

```ts
app.connectMicroservice<MicroserviceOptions>({
  transport: Transport.RMQ,
  options: {
    urls: ['some-url'],
    queue: 'some-queue',
    prefetchCount: 1,
    noAck: false,
    queueOptions: {
      noAssert: false, // current workaround
    },
    noAssert: true // this has no effect currently
  },
});
```

In order to remain completely backward compatible, I've introduced a fallback on `queueOptions.noAssert`, so if `noAssert` is not provided, it falls back to `queueOptions.noAssert` before using the default value.

Please let me know if you don't agree with this fallback mechanism, I'd be more than happy to change the PR accordingly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information