### PR TITLE
feat(core): add option to have router module path before version

### DIFF
--- a/integration/versioning/e2e/uri-versioning.spec.ts
+++ b/integration/versioning/e2e/uri-versioning.spec.ts
@@ -174,6 +174,50 @@ describe('URI Versioning', () => {
       });
     });
 
+    describe('GET /internal-api/internal-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/v2/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/internal-api/v2/internal-resource')
+          .expect(404);
+      });
+    });
+
+    describe('GET /public-api/public-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/public-api/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/public-api/v2/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/v2/public-api/public-resource')
+          .expect(404);
+      });
+    });
+
     after(async () => {
       await app.close();
     });
@@ -348,6 +392,50 @@ describe('URI Versioning', () => {
       });
     });
 
+    describe('GET /internal-api/internal-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/v1/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/v2/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/internal-api/v2/internal-resource')
+          .expect(404);
+      });
+    });
+
+    describe('GET /public-api/public-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/public-api/v1/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/public-api/v2/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/v2/public-api/public-resource')
+          .expect(404);
+      });
+    });
+
     after(async () => {
       await app.close();
     });
@@ -411,6 +499,50 @@ describe('URI Versioning', () => {
 
       it('No Version', () => {
         return request(app.getHttpServer()).get('/foo/bar').expect(404);
+      });
+    });
+
+    describe('GET /internal-api/internal-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/api/v1/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/api/v2/internal-api/internal-resource')
+          .expect(200)
+          .expect('Internal Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/api/internal-api/v2/internal-resource')
+          .expect(404);
+      });
+    });
+
+    describe('GET /public-api/public-resource', () => {
+      it('No Version', () => {
+        return request(app.getHttpServer())
+          .get('/api/public-api/v1/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 1');
+      });
+
+      it('V2', () => {
+        return request(app.getHttpServer())
+          .get('/api/public-api/v2/public-resource')
+          .expect(200)
+          .expect('Public Resource Version 2');
+      });
+
+      it('V2 - wrong version position', () => {
+        return request(app.getHttpServer())
+          .get('/api/v2/public-api/public-resource')
+          .expect(404);
       });
     });
 

--- a/integration/versioning/src/app.module.ts
+++ b/integration/versioning/src/app.module.ts
@@ -9,9 +9,26 @@ import { VersionNeutralController } from './neutral.controller';
 import { NoVersioningController } from './no-versioning.controller';
 import { OverridePartialController } from './override-partial.controller';
 import { OverrideController } from './override.controller';
+import { RouterModule } from '@nestjs/core';
+import { InternalApiModule } from './internal-api.module';
+import { PublicApiModule } from './public-api.module';
 
 @Module({
-  imports: [],
+  imports: [
+    PublicApiModule,
+    InternalApiModule,
+    RouterModule.register([
+      {
+        path: 'public-api',
+        pathBeforeVersion: true,
+        module: PublicApiModule,
+      },
+      {
+        path: 'internal-api',
+        module: InternalApiModule,
+      },
+    ]),
+  ],
   controllers: [
     AppV1Controller,
     AppV2Controller,

--- a/integration/versioning/src/internal-api.controller.ts
+++ b/integration/versioning/src/internal-api.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Version } from '@nestjs/common';
+
+@Controller('internal-resource')
+export class InternalApiController {
+  @Get()
+  resource() {
+    return 'Internal Resource Version 1';
+  }
+
+  @Version('2')
+  @Get()
+  resourceV2() {
+    return 'Internal Resource Version 2';
+  }
+}

--- a/integration/versioning/src/internal-api.module.ts
+++ b/integration/versioning/src/internal-api.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { InternalApiController } from './internal-api.controller';
+
+@Module({
+  controllers: [InternalApiController],
+})
+export class InternalApiModule {}

--- a/integration/versioning/src/public-api.controller.ts
+++ b/integration/versioning/src/public-api.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get, Version } from '@nestjs/common';
+
+@Controller('public-resource')
+export class PublicApiController {
+  @Get()
+  resource() {
+    return 'Public Resource Version 1';
+  }
+
+  @Version('2')
+  @Get()
+  resourceV2() {
+    return 'Public Resource Version 2';
+  }
+}

--- a/integration/versioning/src/public-api.module.ts
+++ b/integration/versioning/src/public-api.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { PublicApiController } from './public-api.controller';
+
+@Module({
+  controllers: [PublicApiController],
+})
+export class PublicApiModule {}

--- a/packages/common/constants.ts
+++ b/packages/common/constants.ts
@@ -36,6 +36,7 @@ export type EnhancerSubtype =
 export const RENDER_METADATA = '__renderTemplate__';
 export const HTTP_CODE_METADATA = '__httpCode__';
 export const MODULE_PATH = '__module_path__';
+export const MODULE_PATH_BEFORE_VERSION = '__modulePathBeforeVersion__';
 export const HEADERS_METADATA = '__headers__';
 export const REDIRECT_METADATA = '__redirect__';
 export const RESPONSE_PASSTHROUGH_METADATA = '__responsePassthrough__';

--- a/packages/core/router/interfaces/route-path-metadata.interface.ts
+++ b/packages/core/router/interfaces/route-path-metadata.interface.ts
@@ -23,6 +23,11 @@ export interface RoutePathMetadata {
   modulePath?: string;
 
   /**
+   * Option to put the route version after the module-level path.
+   */
+  modulePathBeforeVersion?: boolean;
+
+  /**
    * Controller-level version (e.g., @Controller({ version: '1.0' }) = "1.0").
    */
   controllerVersion?: VersionValue;

--- a/packages/core/router/interfaces/routes.interface.ts
+++ b/packages/core/router/interfaces/routes.interface.ts
@@ -2,6 +2,7 @@ import { Type } from '@nestjs/common';
 
 export interface RouteTree {
   path: string;
+  pathBeforeVersion?: boolean;
   module?: Type<any>;
   children?: (RouteTree | Type<any>)[];
 }

--- a/packages/core/router/route-path-factory.ts
+++ b/packages/core/router/route-path-factory.ts
@@ -24,6 +24,10 @@ export class RoutePathFactory {
   ): string[] {
     let paths = [''];
 
+    if (metadata.modulePathBeforeVersion) {
+      paths = this.appendToAllIfDefined(paths, metadata.modulePath);
+    }
+
     const versionOrVersions = this.getVersion(metadata);
     if (
       versionOrVersions &&
@@ -52,7 +56,9 @@ export class RoutePathFactory {
       }
     }
 
-    paths = this.appendToAllIfDefined(paths, metadata.modulePath);
+    if (!metadata.modulePathBeforeVersion) {
+      paths = this.appendToAllIfDefined(paths, metadata.modulePath);
+    }
     paths = this.appendToAllIfDefined(paths, metadata.ctrlPath);
     paths = this.appendToAllIfDefined(paths, metadata.methodPath);
 

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -1,5 +1,8 @@
 import { DynamicModule, Inject, Module, Type } from '@nestjs/common';
-import { MODULE_PATH } from '@nestjs/common/constants';
+import {
+  MODULE_PATH,
+  MODULE_PATH_BEFORE_VERSION,
+} from '@nestjs/common/constants';
 import { normalizePath } from '@nestjs/common/utils/shared.utils';
 import { Module as ModuleClass } from '../injector/module';
 import { ModulesContainer } from '../injector/modules-container';
@@ -60,6 +63,10 @@ export class RouterModule {
     flattenedRoutes.forEach(route => {
       const modulePath = normalizePath(route.path);
       this.registerModulePathMetadata(route.module, modulePath);
+      this.registerModulePathBeforeVersionMetadata(
+        route.module,
+        route.pathBeforeVersion,
+      );
       this.updateTargetModulesCache(route.module);
     });
   }
@@ -71,6 +78,17 @@ export class RouterModule {
     Reflect.defineMetadata(
       MODULE_PATH + this.modulesContainer.applicationId,
       modulePath,
+      moduleCtor,
+    );
+  }
+
+  private registerModulePathBeforeVersionMetadata(
+    moduleCtor: Type<unknown>,
+    modulePathBeforeVersion = false,
+  ) {
+    Reflect.defineMetadata(
+      MODULE_PATH_BEFORE_VERSION + this.modulesContainer.applicationId,
+      modulePathBeforeVersion,
       moduleCtor,
     );
   }

--- a/packages/core/router/utils/flatten-route-paths.util.ts
+++ b/packages/core/router/utils/flatten-route-paths.util.ts
@@ -1,11 +1,19 @@
 import { normalizePath, isString } from '@nestjs/common/utils/shared.utils';
 import { Routes } from '../interfaces/routes.interface';
 
-export function flattenRoutePaths(routes: Routes) {
+export function flattenRoutePaths(
+  routes: Routes,
+  parentPathBeforeVersion?: boolean,
+) {
   const result = [];
   routes.forEach(item => {
+    const pathBeforeVersion = item.pathBeforeVersion ?? parentPathBeforeVersion;
     if (item.module && item.path) {
-      result.push({ module: item.module, path: item.path });
+      result.push({
+        module: item.module,
+        path: item.path,
+        pathBeforeVersion,
+      });
     }
     if (item.children) {
       const childrenRef = item.children as Routes;
@@ -15,10 +23,14 @@ export function flattenRoutePaths(routes: Routes) {
             normalizePath(item.path) + normalizePath(child.path),
           );
         } else {
-          result.push({ path: item.path, module: child });
+          result.push({
+            path: item.path,
+            pathBeforeVersion,
+            module: child,
+          });
         }
       });
-      result.push(...flattenRoutePaths(childrenRef));
+      result.push(...flattenRoutePaths(childrenRef, pathBeforeVersion));
     }
   });
   return result;

--- a/packages/core/test/router/routes-resolver.spec.ts
+++ b/packages/core/test/router/routes-resolver.spec.ts
@@ -104,11 +104,19 @@ describe('RoutesResolver', () => {
       sinon
         .stub((routesResolver as any).routerExplorer, 'extractRouterPath')
         .callsFake(() => ['']);
-      routesResolver.registerRouters(routes, moduleName, '', '', appInstance);
+      routesResolver.registerRouters(
+        routes,
+        moduleName,
+        '',
+        '',
+        false,
+        appInstance,
+      );
 
       const routePathMetadata = {
         ctrlPath: '',
         modulePath: '',
+        modulePathBeforeVersion: false,
         globalPrefix: '',
         controllerVersion: undefined,
         versioningOptions: undefined,
@@ -146,11 +154,19 @@ describe('RoutesResolver', () => {
       sinon
         .stub((routesResolver as any).routerExplorer, 'extractRouterPath')
         .callsFake(() => ['']);
-      routesResolver.registerRouters(routes, moduleName, '', '', appInstance);
+      routesResolver.registerRouters(
+        routes,
+        moduleName,
+        '',
+        '',
+        false,
+        appInstance,
+      );
 
       const routePathMetadata = {
         ctrlPath: '',
         modulePath: '',
+        modulePathBeforeVersion: false,
         globalPrefix: '',
         controllerVersion: undefined,
         versioningOptions: undefined,
@@ -200,11 +216,19 @@ describe('RoutesResolver', () => {
       sinon
         .stub((routesResolver as any).routerExplorer, 'extractRouterPath')
         .callsFake(() => ['']);
-      routesResolver.registerRouters(routes, moduleName, '', '', appInstance);
+      routesResolver.registerRouters(
+        routes,
+        moduleName,
+        '',
+        '',
+        true,
+        appInstance,
+      );
 
       const routePathMetadata = {
         ctrlPath: '',
         modulePath: '',
+        modulePathBeforeVersion: true,
         globalPrefix: '',
         controllerVersion: '1',
         versioningOptions: {

--- a/packages/core/test/router/utils/flat-routes.spec.ts
+++ b/packages/core/test/router/utils/flat-routes.spec.ts
@@ -39,6 +39,7 @@ describe('flattenRoutePaths', () => {
       {
         path: '/parent',
         module: ParentModule,
+        pathBeforeVersion: true,
         children: [
           {
             path: '/child',
@@ -77,27 +78,49 @@ describe('flattenRoutePaths', () => {
       { path: '/v3', children: [AuthModule3, CatsModule3] },
     ];
     const expectedRoutes = [
-      { path: '/parent', module: ParentModule },
-      { path: '/parent/child', module: ChildModule },
-      { path: '/parent/child/child2', module: ChildModule2 },
-      { path: '/parent/child/parentchild', module: ParentChildModule },
+      { path: '/parent', pathBeforeVersion: true, module: ParentModule },
+      {
+        path: '/parent/child',
+        pathBeforeVersion: true,
+        module: ChildModule,
+      },
+      {
+        path: '/parent/child/child2',
+        pathBeforeVersion: true,
+        module: ChildModule2,
+      },
+      {
+        path: '/parent/child/parentchild',
+        pathBeforeVersion: true,
+        module: ParentChildModule,
+      },
       {
         path: '/parent/child/parentchild/childchild',
+        pathBeforeVersion: true,
         module: ChildChildModule,
       },
       {
         path: '/parent/child/parentchild/childchild/child2child',
+        pathBeforeVersion: true,
         module: ChildChildModule2,
       },
-      { path: '/parent/child2', module: ChildModule4 },
-      { path: '/parent/child2/child', module: ChildModule3 },
-      { path: '/v1', module: AuthModule },
-      { path: '/v1', module: CatsModule },
-      { path: '/v1', module: DogsModule },
-      { path: '/v2', module: AuthModule2 },
-      { path: '/v2', module: CatsModule2 },
-      { path: '/v3', module: AuthModule3 },
-      { path: '/v3', module: CatsModule3 },
+      {
+        path: '/parent/child2',
+        pathBeforeVersion: true,
+        module: ChildModule4,
+      },
+      {
+        path: '/parent/child2/child',
+        pathBeforeVersion: true,
+        module: ChildModule3,
+      },
+      { path: '/v1', pathBeforeVersion: undefined, module: AuthModule },
+      { path: '/v1', pathBeforeVersion: undefined, module: CatsModule },
+      { path: '/v1', pathBeforeVersion: undefined, module: DogsModule },
+      { path: '/v2', pathBeforeVersion: undefined, module: AuthModule2 },
+      { path: '/v2', pathBeforeVersion: undefined, module: CatsModule2 },
+      { path: '/v3', pathBeforeVersion: undefined, module: AuthModule3 },
+      { path: '/v3', pathBeforeVersion: undefined, module: CatsModule3 },
     ];
     expect(flattenRoutePaths(routes)).to.be.eql(expectedRoutes);
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using `RouterModule` along with URI versioning, you cannot affect the order of path parts. It is always like this:
`/{globalAppPrefix}/{version}/{modulePath}/{controllerPath}/{methodPath}`

I'm using `RouterModule` to separate public facing and internal routes like this:
```ts
// app.module.ts
@Module({
  imports: [
    PublicApiModule,
    InternalApiModule,
    RouterModule.register([
      {
        path: 'public',
        module: PublicApiModule,
      },
      {
        path: 'internal',
        module: InternalApiModule,
      },
    ]),
  ],
})
export class AppModule {}

// main.ts
app.setGlobalPrefix('api')
app.enableVersioning({type: VersioningType.URI})
```
So my routes are `/api/public/...` and `/api/internal/...`.
When I enable URI versioning my routes are `/api/v1/public/...` and `/api/v1/internal/...` which breaks my proxy which enables any requests starting with `/api/public/*` to pass in.

Issue Number: N/A


## What is the new behavior?

After adding `pathBeforeVersion: true`, the module path and version parts are swapped like so:
`/{globalAppPrefix}/{modulePath}/{version}/{controllerPath}/{methodPath}`

```ts
@Module({
  imports: [
    PublicApiModule,
    InternalApiModule,
    RouterModule.register([
      {
        path: 'public',
        pathBeforeVersion: true,
        module: PublicApiModule,
      },
      {
        path: 'internal',
        pathBeforeVersion: true,
        module: InternalApiModule,
      },
    ]),
  ],
})
export class AppModule {}
```

My routes are now `/api/public/v1/...` and `/api/internal/v1/...` and my proxy still works.

Setting the `pathBeforeVersion: false` or omitting the parameter doesn't introduce any change.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information