### PR TITLE
fix(microservices): fix usage noassert flag in rabbitmq

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -187,7 +187,7 @@ export class ClientRMQ extends ClientProxy {
       this.getOptionsProp(this.options, 'isGlobalPrefetchCount') ||
       RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT;
 
-    if (!this.queueOptions.noAssert) {
+    if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
     await channel.prefetch(prefetchCount, isGlobalPrefetchCount);

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -145,7 +145,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   }
 
   public async setupChannel(channel: any, callback: Function) {
-    if (!this.queueOptions.noAssert) {
+    if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
     await channel.prefetch(this.prefetchCount, this.isGlobalPrefetchCount);

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -119,6 +119,7 @@ describe('ClientRMQ', function () {
     const prefetchCount = 10;
 
     let consumeStub: sinon.SinonStub;
+    let noAssertStub: sinon.SinonStub;
     let channel: any = {};
 
     beforeEach(() => {
@@ -131,13 +132,20 @@ describe('ClientRMQ', function () {
         prefetch: sinon.spy(),
       };
       consumeStub = sinon.stub(client, 'consumeChannel').callsFake(() => null);
+      noAssertStub = sinon.stub(client as any, 'noAssert').value(false);
     });
     afterEach(() => {
       consumeStub.restore();
+      noAssertStub.restore();
     });
     it('should call "assertQueue" with queue and queue options', async () => {
       await client.setupChannel(channel, () => null);
       expect(channel.assertQueue.calledWith(queue, queueOptions)).to.be.true;
+    });
+    it('should not call "assertQueue" when "noAssert" flag is true', async () => {
+      sinon.stub(client as any, 'noAssert').value(true);
+      await client.setupChannel(channel, () => null);
+      expect(channel.assertQueue.notCalled).to.be.true;
     });
     it('should call "prefetch" with prefetchCount and "isGlobalPrefetchCount"', async () => {
       await client.setupChannel(channel, () => null);

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -182,6 +182,7 @@ describe('ServerRMQ', () => {
     const isGlobalPrefetchCount = true;
     const prefetchCount = 10;
 
+    let noAssertStub: sinon.SinonStub;
     let channel: any = {};
 
     beforeEach(() => {
@@ -195,10 +196,19 @@ describe('ServerRMQ', () => {
         prefetch: sinon.spy(),
         consume: sinon.spy(),
       };
+      noAssertStub = sinon.stub(server as any, 'noAssert').value(false);
+    });
+    afterEach(() => {
+      noAssertStub.restore();
     });
     it('should call "assertQueue" with queue and queue options', async () => {
       await server.setupChannel(channel, () => null);
       expect(channel.assertQueue.calledWith(queue, queueOptions)).to.be.true;
+    });
+    it('should not call "assertQueue" when "noAssert" flag is true', async () => {
+      sinon.stub(server as any, 'noAssert').value(true);
+      await server.setupChannel(channel, () => null);
+      expect(channel.assertQueue.notCalled).to.be.true;
     });
     it('should call "prefetch" with prefetchCount and "isGlobalPrefetchCount"', async () => {
       await server.setupChannel(channel, () => null);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using the `ClientRMQ` module with the `noAssert` flag set to true, the `assertQueue` method still gets invoked.

## What is the new behavior?
After setting the `noAssert` flag to true, the `assertQueue` method is not triggered.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information