### PR TITLE
fix: update broken link in SetMetadata decorator documentation

### DIFF
--- a/packages/common/decorators/core/set-metadata.decorator.ts
+++ b/packages/common/decorators/core/set-metadata.decorator.ts
@@ -15,7 +15,7 @@ export type CustomDecorator<TKey = string> = MethodDecorator &
  *
  * Example: `@SetMetadata('roles', ['admin'])`
  *
- * @see [Reflection](https://docs.nestjs.com/guards#reflection)
+ * @see [Reflection](https://docs.nestjs.com/fundamentals/execution-context#reflection-and-metadata)
  *
  * @publicApi
  */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:
   Documentation

## What is the current behavior?
The current behavior is that the link in the SetMetadata decorator documentation is broken and redirects to the wrong page.

## What is the new behavior?
The new behavior is that the broken link in the SetMetadata decorator documentation has been fixed to accurately direct users to the Reflection section within the Execution Context page of the NestJS fundamentals documentation.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information