### PR TITLE
fix(core): break reference chain to instance object

### DIFF
--- a/packages/core/helpers/context-utils.ts
+++ b/packages/core/helpers/context-utils.ts
@@ -89,15 +89,11 @@ export class ContextUtils {
     instance?: object,
     callback?: Function,
   ): (args: unknown[]) => ExecutionContextHost {
-    const contextFactory = (args: unknown[]) => {
-      const ctx = new ExecutionContextHost(
-        args,
-        instance && (instance.constructor as Type<unknown>),
-        callback,
-      );
+    const type = instance && (instance.constructor as Type<unknown>);
+    return (args: unknown[]) => {
+      const ctx = new ExecutionContextHost(args, type, callback);
       ctx.setType(contextType);
       return ctx;
     };
-    return contextFactory;
   }
 }


### PR DESCRIPTION
Reference caused in getContextFactory, and it stored in handlerMetadataStorage in Map, that never be purged

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
[issue](https://github.com/nestjs/nest/issues/13365)

Issue Number: 13365


## What is the new behavior?
same, but without leak

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information