### PR TITLE
refactor(microservices): prevent grpc write promise from throwing

### DIFF
--- a/integration/microservices/src/grpc/grpc.controller.ts
+++ b/integration/microservices/src/grpc/grpc.controller.ts
@@ -10,7 +10,7 @@ import {
   RpcException,
 } from '@nestjs/microservices';
 import { join } from 'path';
-import { Observable, of, catchError } from 'rxjs';
+import { Observable, of, catchError, from, mergeMap } from 'rxjs';
 
 class ErrorHandlingProxy extends ClientGrpcProxy {
   serializeError(err) {
@@ -105,6 +105,17 @@ export class GrpcController {
     return {
       result: request.dividend / request.divisor,
     };
+  }
+
+  // contrived example meant to show when an error is encountered, like dividing by zero, the
+  // application does not crash and the error is returned appropriately to the client
+  @GrpcMethod('Math', 'StreamDivide')
+  streamDivide({
+    data,
+  }: {
+    data: { dividend: number; divisor: number }[];
+  }): Observable<any> {
+    return from(data).pipe(mergeMap(request => this.divide(request)));
   }
 
   @GrpcMethod('Math2')

--- a/integration/microservices/src/grpc/math.proto
+++ b/integration/microservices/src/grpc/math.proto
@@ -7,7 +7,9 @@ service Math {
   rpc SumStream(stream RequestSum) returns(stream SumResult);
   rpc SumStreamPass(stream RequestSum) returns(stream SumResult);
   rpc Divide (RequestDivide) returns (DivideResult);
-  rpc StreamLargeMessages(Empty) returns (stream BackpressureData) {}
+  rpc StreamLargeMessages(Empty) returns (stream BackpressureData);
+  /* Given a series of dividend and divisor, stream back the division results for each */
+  rpc StreamDivide (StreamDivideRequest) returns (stream StreamDivideResponse);
 }
 
 message BackpressureData {
@@ -32,4 +34,12 @@ message RequestDivide {
 
 message DivideResult {
   int32 result = 1;
+}
+
+message StreamDivideRequest {
+  repeated RequestDivide data = 1;
+}
+
+message StreamDivideResponse {
+  DivideResult data = 1;
 }

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -375,6 +375,7 @@ describe('ServerGrpc', () => {
       const fn = server.createStreamServiceMethod(sinon.spy());
       expect(fn).to.be.a('function');
     });
+
     describe('on call', () => {
       it('should call native method', async () => {
         const call = {
@@ -390,6 +391,26 @@ describe('ServerGrpc', () => {
         expect(native.called).to.be.true;
         expect(call.on.calledWith('cancelled')).to.be.true;
         expect(call.off.calledWith('cancelled')).to.be.true;
+      });
+
+      it('should handle error thrown in handler', async () => {
+        const call = {
+          write: sinon.spy(() => true),
+          end: sinon.spy(),
+          on: sinon.spy(),
+          off: sinon.spy(),
+          emit: sinon.spy(),
+        };
+
+        const callback = sinon.spy();
+        const error = new Error('handler threw');
+        const native = sinon.spy(() => throwError(() => error));
+
+        // implicit assertion that this will never throw when call.emit emits an error event
+        await server.createStreamServiceMethod(native)(call, callback);
+        expect(native.called).to.be.true;
+        expect(call.emit.calledWith('error', error)).to.be.ok;
+        expect(call.end.called).to.be.true;
       });
 
       it(`should close the result observable when receiving an 'cancelled' event from the client`, async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
currently the Observable that wraps ServerStreaming calls to write data out to the gRPC call object can reject which needs to be caught, even though the `call.emit` in the catch handler won't do anything because `call.end()` happens before that catch block can run, thanks to the `unsubscribe` call in the Subscription cleanup functions used inside `writeObservableToGrpc`

Issue Number: N/A

## What is the new behavior?
This promise should just never reject in the first place. The Promise is just used to signal when writing has completed and the call has ended. The error signal is handled exclusively by emitting `error` on the `Call`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
A series of changes recently outlined here https://github.com/nestjs/nest/issues/13360 resulted in a bug where streaming server calls that replied with errors, would crash the application with an `unhandledRejection`. This PR also adds a test case in the integration test for asserting that that doesn't happen again. 

I renamed the integration test from `sum` because it no longer only tests sum-related endpoints, but the `Math` grpc service, so it should be called that instead (the other integration files probably should also). I piggybacked off the existing `Divide` function to showcase this behavior by providing a request that will result in an error on the streaming response. 