### PR TITLE
refactor(microservices): change isNotKafkaMessage validation condition

### DIFF
--- a/packages/microservices/serializers/kafka-request.serializer.ts
+++ b/packages/microservices/serializers/kafka-request.serializer.ts
@@ -21,9 +21,7 @@ export class KafkaRequestSerializer
 {
   serialize(value: any) {
     const isNotKafkaMessage =
-      isNil(value) ||
-      !isObject(value) ||
-      (!('key' in value) && !('value' in value));
+      isNil(value) || !isObject(value) || !('key' in value && 'value' in value);
 
     if (isNotKafkaMessage) {
       value = { value };

--- a/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
+++ b/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
@@ -103,6 +103,19 @@ describe('KafkaRequestSerializer', () => {
       });
     });
 
+    it('kafka message without value', async () => {
+      expect(
+        await instance.serialize({
+          key: 'string',
+        }),
+      ).to.deep.eq({
+        headers: {},
+        value: JSON.stringify({
+          key: 'string',
+        }),
+      });
+    });
+
     it('kafka message with key', async () => {
       expect(
         await instance.serialize({

--- a/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
+++ b/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
@@ -97,7 +97,9 @@ describe('KafkaRequestSerializer', () => {
         }),
       ).to.deep.eq({
         headers: {},
-        value: 'string',
+        value: JSON.stringify({
+          value: 'string',
+        }),
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [  ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If either `key` or `value` is included in the object, it will be treated as a Kafka message.

Issue Number: #12886

## What is the new behavior?
Objects containing both `key` and `value` attributes will be treated as Kafka messages. 

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If concerns about breaking changes arise, it might be necessary to utilize an options object.