### PR TITLE
perf(ws): optimize message handler lookup

### DIFF
--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -111,10 +111,13 @@ export class WsAdapter extends AbstractWsAdapter {
     handlers: MessageMappingProperties[],
     transform: (data: any) => Observable<any>,
   ) {
+    const handlersMap = new Map<string, MessageMappingProperties>();
+    handlers.forEach(handler => handlersMap.set(handler.message, handler));
+
     const close$ = fromEvent(client, CLOSE_EVENT).pipe(share(), first());
     const source$ = fromEvent(client, 'message').pipe(
       mergeMap(data =>
-        this.bindMessageHandler(data, handlers, transform).pipe(
+        this.bindMessageHandler(data, handlersMap, transform).pipe(
           filter(result => !isNil(result)),
         ),
       ),
@@ -131,14 +134,12 @@ export class WsAdapter extends AbstractWsAdapter {
 
   public bindMessageHandler(
     buffer: any,
-    handlers: MessageMappingProperties[],
+    handlersMap: Map<string, MessageMappingProperties>,
     transform: (data: any) => Observable<any>,
   ): Observable<any> {
     try {
       const message = JSON.parse(buffer.data);
-      const messageHandler = handlers.find(
-        handler => handler.message === message.event,
-      );
+      const messageHandler = handlersMap.get(message.event);
       const { callback } = messageHandler;
       return transform(callback(message.data, message.event));
     } catch {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Each WebSocket request requires iterating through all message handlers to find the appropriate one now. When there are many message handlers, this is much less efficient than using a `Map` for lookup.

## What is the new behavior?

Using a `Map` for message handler lookup instead of traversing an array.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information