### PR TITLE
fix(core): auto flush logs on synchronous internal errors

### DIFF
--- a/packages/core/errors/exceptions-zone.ts
+++ b/packages/core/errors/exceptions-zone.ts
@@ -9,7 +9,7 @@ export class ExceptionsZone {
   public static run(
     callback: () => void,
     teardown: (err: any) => void = DEFAULT_TEARDOWN,
-    autoFlushLogs?: boolean,
+    autoFlushLogs: boolean,
   ) {
     try {
       callback();
@@ -25,7 +25,7 @@ export class ExceptionsZone {
   public static async asyncRun(
     callback: () => Promise<void>,
     teardown: (err: any) => void = DEFAULT_TEARDOWN,
-    autoFlushLogs?: boolean,
+    autoFlushLogs: boolean,
   ) {
     try {
       await callback();

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -269,9 +269,13 @@ export class NestFactoryStatic {
 
     return (...args: unknown[]) => {
       let result: unknown;
-      ExceptionsZone.run(() => {
-        result = receiver[prop](...args);
-      }, teardown);
+      ExceptionsZone.run(
+        () => {
+          result = receiver[prop](...args);
+        },
+        teardown,
+        this.autoFlushLogs,
+      );
 
       return result;
     };

--- a/packages/core/test/errors/test/exceptions-zone.spec.ts
+++ b/packages/core/test/errors/test/exceptions-zone.spec.ts
@@ -13,7 +13,7 @@ describe('ExceptionsZone', () => {
       callback = sinon.spy();
     });
     it('should call callback', () => {
-      ExceptionsZone.run(callback as any, rethrow);
+      ExceptionsZone.run(callback as any, rethrow, false);
       expect(callback.called).to.be.true;
     });
     describe('when callback throws exception', () => {
@@ -29,7 +29,9 @@ describe('ExceptionsZone', () => {
         const throwsCallback = () => {
           throw new Error('');
         };
-        expect(() => ExceptionsZone.run(throwsCallback, rethrow)).to.throws();
+        expect(() =>
+          ExceptionsZone.run(throwsCallback, rethrow, false),
+        ).to.throws();
         expect(handleSpy.called).to.be.true;
       });
     });
@@ -40,7 +42,7 @@ describe('ExceptionsZone', () => {
       callback = sinon.spy();
     });
     it('should call callback', async () => {
-      await ExceptionsZone.asyncRun(callback as any, rethrow);
+      await ExceptionsZone.asyncRun(callback as any, rethrow, false);
       expect(callback.called).to.be.true;
     });
     describe('when callback throws exception', () => {
@@ -56,8 +58,8 @@ describe('ExceptionsZone', () => {
         const throwsCallback = () => {
           throw new Error('');
         };
-        expect(ExceptionsZone.asyncRun(throwsCallback, rethrow)).to.eventually
-          .be.rejected;
+        expect(ExceptionsZone.asyncRun(throwsCallback, rethrow, false)).to
+          .eventually.be.rejected;
       });
     });
   });

--- a/packages/core/test/errors/test/exceptions-zone.spec.ts
+++ b/packages/core/test/errors/test/exceptions-zone.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
+import { Logger } from '@nestjs/common';
 import { ExceptionsZone } from '../../../errors/exceptions-zone';
 
 describe('ExceptionsZone', () => {
@@ -21,21 +22,47 @@ describe('ExceptionsZone', () => {
         handle: () => {},
       };
       let handleSpy: sinon.SinonSpy;
+      let LoggerFlushSpy: sinon.SinonSpy;
       before(() => {
         (ExceptionsZone as any).exceptionHandler = exceptionHandler;
         handleSpy = sinon.spy(exceptionHandler, 'handle');
+        LoggerFlushSpy = sinon.spy(Logger, 'flush');
       });
-      it('should call "handle" method of exceptionHandler and rethrows', () => {
-        const throwsCallback = () => {
-          throw new Error('');
-        };
-        expect(() =>
-          ExceptionsZone.run(throwsCallback, rethrow, false),
-        ).to.throws();
-        expect(handleSpy.called).to.be.true;
+      after(() => {
+        LoggerFlushSpy.restore();
+      });
+      describe('when callback throws exception and autoFlushLogs is false', () => {
+        it('should call "handle" method of exceptionHandler and rethrows and not flush logs', () => {
+          const throwsCallback = () => {
+            throw new Error('');
+          };
+          expect(() =>
+            ExceptionsZone.run(throwsCallback, rethrow, false),
+          ).to.throws();
+
+          expect(handleSpy.called).to.be.true;
+
+          expect(LoggerFlushSpy.called).to.be.false;
+        });
+      });
+
+      describe('when callback throws exception and autoFlushLogs is true', () => {
+        it('should call "handle" method of exceptionHandler and rethrows and flush logs', () => {
+          const throwsCallback = () => {
+            throw new Error('');
+          };
+          expect(() =>
+            ExceptionsZone.run(throwsCallback, rethrow, true),
+          ).to.throws();
+
+          expect(handleSpy.called).to.be.true;
+
+          expect(LoggerFlushSpy.called).to.be.true;
+        });
       });
     });
   });
+
   describe('asyncRun', () => {
     let callback: sinon.SinonSpy;
     beforeEach(() => {
@@ -50,16 +77,40 @@ describe('ExceptionsZone', () => {
         handle: () => {},
       };
       let handleSpy: sinon.SinonSpy;
+      let LoggerFlushSpy: sinon.SinonSpy;
       before(() => {
         (ExceptionsZone as any).exceptionHandler = exceptionHandler;
         handleSpy = sinon.spy(exceptionHandler, 'handle');
+        LoggerFlushSpy = sinon.spy(Logger, 'flush');
       });
-      it('should call "handle" method of exceptionHandler and rethrows error', async () => {
-        const throwsCallback = () => {
-          throw new Error('');
-        };
-        expect(ExceptionsZone.asyncRun(throwsCallback, rethrow, false)).to
-          .eventually.be.rejected;
+      after(() => {
+        LoggerFlushSpy.restore();
+      });
+      describe('when callback throws exception and autoFlushLogs is false', () => {
+        it('should call "handle" method of exceptionHandler and rethrows error and not flush logs', async () => {
+          const throwsCallback = () => {
+            throw new Error('');
+          };
+          expect(ExceptionsZone.asyncRun(throwsCallback, rethrow, false)).to
+            .eventually.be.rejected;
+
+          expect(handleSpy.called).to.be.true;
+
+          expect(LoggerFlushSpy.called).to.be.false;
+        });
+      });
+      describe('when callback throws exception and autoFlushLogs is true', () => {
+        it('should call "handle" method of exceptionHandler and rethrows error and flush logs', async () => {
+          const throwsCallback = () => {
+            throw new Error('');
+          };
+          expect(ExceptionsZone.asyncRun(throwsCallback, rethrow, true)).to
+            .eventually.be.rejected;
+
+          expect(handleSpy.called).to.be.true;
+
+          expect(LoggerFlushSpy.called).to.be.true;
+        });
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #13400


## What is the new behavior?

For the following code

```ts
import { NestFactory } from '@nestjs/core'
import { AppModule } from './app.module' // no-op module

async function bootstrap() {
  const app = await NestFactory.create(AppModule, {
    bufferLogs: true,
    autoFlushLogs: true,
  });
  app.get('foo')
  await app.listen(3000);
}

bootstrap();
```

we'll see the following error:

![image](https://github.com/nestjs/nest/assets/13461315/830a455c-d7c2-4ffc-bb34-114524ff4657)

Do note that if `autoFlushLogs` is `false`, no logs will be shown for the above code.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
