### PR TITLE
feat: add multer error fieldname to the exception message

### DIFF
--- a/packages/platform-express/multer/multer/multer.utils.ts
+++ b/packages/platform-express/multer/multer/multer.utils.ts
@@ -19,6 +19,11 @@ export function transformException(error: Error | undefined) {
     case multerExceptions.LIMIT_UNEXPECTED_FILE:
     case multerExceptions.LIMIT_PART_COUNT:
     case multerExceptions.MISSING_FIELD_NAME:
+      //@ts-expect-error: Multer may attach the fieldname to the error object
+      if (error.field) {
+        //@ts-expect-error: Multer may attach the fieldname to the error object
+        return new BadRequestException(`${error.message} - ${error.field}`);
+      }
       return new BadRequestException(error.message);
     case busboyExceptions.MULTIPART_BOUNDARY_NOT_FOUND:
       return new BadRequestException(error.message);

--- a/packages/platform-express/multer/multer/multer.utils.ts
+++ b/packages/platform-express/multer/multer/multer.utils.ts
@@ -5,7 +5,11 @@ import {
 } from '@nestjs/common';
 import { multerExceptions, busboyExceptions } from './multer.constants';
 
-export function transformException(error: Error | undefined) {
+// Multer may add in a 'field' property to the error
+// https://github.com/expressjs/multer/blob/aa42bea6ac7d0cb8fcb279b15a7278cda805dc63/lib/multer-error.js#L19
+export function transformException(
+  error: (Error & { field?: string }) | undefined,
+) {
   if (!error || error instanceof HttpException) {
     return error;
   }
@@ -19,9 +23,7 @@ export function transformException(error: Error | undefined) {
     case multerExceptions.LIMIT_UNEXPECTED_FILE:
     case multerExceptions.LIMIT_PART_COUNT:
     case multerExceptions.MISSING_FIELD_NAME:
-      //@ts-expect-error: Multer may attach the fieldname to the error object
       if (error.field) {
-        //@ts-expect-error: Multer may attach the fieldname to the error object
         return new BadRequestException(`${error.message} - ${error.field}`);
       }
       return new BadRequestException(error.message);

--- a/packages/platform-express/test/multer/multer/multer.utils.spec.ts
+++ b/packages/platform-express/test/multer/multer/multer.utils.spec.ts
@@ -57,5 +57,16 @@ describe('transformException', () => {
         );
       });
     });
+    describe(`and has a 'field' property`, () => {
+      it('should return the field propery appended to the error message', () => {
+        const err = {
+          message: multerExceptions.LIMIT_UNEXPECTED_FILE,
+          field: 'foo',
+        };
+        expect(transformException(err as any).message).to.equal(
+          `${multerExceptions.LIMIT_UNEXPECTED_FILE} - foo`,
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When transforming a `MulterError` into a Nest error, the optional `field` property is dropped.

Issue Number: N/A


## What is the new behavior?
The `field` property is included in the error message, if applicable.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
If Multer throws an error, some identifying information is hidden from the error message. 

[https://github.com/expressjs/multer/blob/aa42bea6ac7d0cb8fcb279b15a7278cda805dc63/lib/multer-error.js#L19](https://github.com/expressjs/multer/blob/aa42bea6ac7d0cb8fcb279b15a7278cda805dc63/lib/multer-error.js#L19). This is where Multer adds the optional `field` property.