### PR TITLE
feat(common): support empty `@Inject()` on constructor-based injection

### DIFF
--- a/packages/common/decorators/core/inject.decorator.ts
+++ b/packages/common/decorators/core/inject.decorator.ts
@@ -1,4 +1,5 @@
 import {
+  PARAMTYPES_METADATA,
   PROPERTY_DEPS_METADATA,
   SELF_DECLARED_DEPS_METADATA,
 } from '../../constants';
@@ -36,8 +37,14 @@ import { isUndefined } from '../../utils/shared.utils';
 export function Inject<T = any>(
   token?: T,
 ): PropertyDecorator & ParameterDecorator {
+  const injectCallHasArguments = arguments.length > 0;
+
   return (target: object, key: string | symbol | undefined, index?: number) => {
-    const type = token || Reflect.getMetadata('design:type', target, key);
+    let type = token || Reflect.getMetadata('design:type', target, key);
+    // Try to infer the token in a constructor-based injection
+    if (!type && !injectCallHasArguments) {
+      type = Reflect.getMetadata(PARAMTYPES_METADATA, target, key)?.[index];
+    }
 
     if (!isUndefined(index)) {
       let dependencies =

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -34,7 +34,7 @@ describe('Injector', () => {
 
       constructor(
         public one: DependencyOne,
-        public two: DependencyTwo,
+        @Inject() public two: DependencyTwo,
       ) {}
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #13426


## What is the new behavior?

We can use `@Inject()` (ie., no token supplied) on constructor-based injections. It works just like property-based injection

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

