### PR TITLE
fix(microservices): pass rmq connection options correctly to amqp-con…

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -136,7 +136,7 @@ export class ClientRMQ extends ClientProxy {
   public createClient(): AmqpConnectionManager {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
     return rmqPackage.connect(this.urls, {
-      connectionOptions: socketOptions,
+      connectionOptions: socketOptions?.connectionOptions,
     });
   }
 

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -140,7 +140,7 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
   public createClient<T = any>(): T {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
     return rmqPackage.connect(this.urls, {
-      connectionOptions: socketOptions,
+      connectionOptions: socketOptions?.connectionOptions,
       heartbeatIntervalInSeconds: socketOptions?.heartbeatIntervalInSeconds,
       reconnectTimeInSeconds: socketOptions?.reconnectTimeInSeconds,
     });


### PR DESCRIPTION
Correct the link between nestjs/microservices to amqp-connection-manager, to pass `socketOptions.connectionOptions` from nestjs/microservices configuration to `AmqpConnectionManagerOptions.connectionOptions`.

Closes: #13429

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently in RabbitMQ options, client options `socketOptions.connectionOptions` are not passed correctly to amqp-connection-manager.
Issue Number: #13429


## What is the new behavior?
- Pass Rabbitmq `socketOptions.connectionOptions` defined in nestjs/microservices config at the connectionOptions of amqp-connection-manager.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information