### PR TITLE
fix(core): merge request context with tenant context payload in the request singleton

### DIFF
--- a/integration/scopes/e2e/durable-providers.spec.ts
+++ b/integration/scopes/e2e/durable-providers.spec.ts
@@ -84,6 +84,25 @@ describe('Durable providers', () => {
       );
       expect(result.body).deep.equal({ tenantId: '3' });
     });
+
+    it(`should return the same tenantId both from durable request scoped service and non-durable request scoped service`, async () => {
+      let result: request.Response;
+      result = await new Promise<request.Response>(resolve =>
+        performHttpCall(1, resolve, '/durable/request-context'),
+      );
+      expect(result.body).deep.equal({
+        durableService: '1',
+        nonDurableService: '1',
+      });
+
+      result = await new Promise<request.Response>(resolve =>
+        performHttpCall(2, resolve, '/durable/request-context'),
+      );
+      expect(result.body).deep.equal({
+        durableService: '2',
+        nonDurableService: '2',
+      });
+    });
   });
 
   after(async () => {

--- a/integration/scopes/src/durable/durable-context-id.strategy.ts
+++ b/integration/scopes/src/durable/durable-context-id.strategy.ts
@@ -1,6 +1,10 @@
 import { ContextId, ContextIdStrategy, HostComponentInfo } from '@nestjs/core';
 import { Request } from 'express';
 
+export type TenantContext = {
+  tenantId: string;
+};
+
 const tenants = new Map<string, ContextId>();
 
 export class DurableContextIdStrategy implements ContextIdStrategy {
@@ -17,7 +21,7 @@ export class DurableContextIdStrategy implements ContextIdStrategy {
     return {
       resolve: (info: HostComponentInfo) =>
         info.isTreeDurable ? tenantSubTreeId : contextId,
-      payload: { tenantId },
+      payload: { tenantId } satisfies TenantContext,
     };
   }
 }

--- a/integration/scopes/src/durable/durable.controller.ts
+++ b/integration/scopes/src/durable/durable.controller.ts
@@ -1,9 +1,13 @@
 import { Controller, Get } from '@nestjs/common';
 import { DurableService } from './durable.service';
+import { NonDurableService } from './non-durable.service';
 
 @Controller('durable')
 export class DurableController {
-  constructor(private readonly durableService: DurableService) {}
+  constructor(
+    private readonly durableService: DurableService,
+    private readonly nonDurableService: NonDurableService,
+  ) {}
 
   @Get()
   greeting(): string {
@@ -12,6 +16,16 @@ export class DurableController {
 
   @Get('echo')
   echo() {
-    return this.durableService.requestPayload;
+    return {
+      tenantId: this.durableService.getTenantId(),
+    };
+  }
+
+  @Get('request-context')
+  getRequestContext() {
+    return {
+      durableService: this.durableService.getTenantId(),
+      nonDurableService: this.nonDurableService.getTenantId(),
+    };
   }
 }

--- a/integration/scopes/src/durable/durable.module.ts
+++ b/integration/scopes/src/durable/durable.module.ts
@@ -3,11 +3,13 @@ import { APP_GUARD } from '@nestjs/core';
 import { DurableController } from './durable.controller';
 import { DurableGuard } from './durable.guard';
 import { DurableService } from './durable.service';
+import { NonDurableService } from './non-durable.service';
 
 @Module({
   controllers: [DurableController],
   providers: [
     DurableService,
+    NonDurableService,
     {
       provide: APP_GUARD,
       useClass: DurableGuard,

--- a/integration/scopes/src/durable/non-durable.service.ts
+++ b/integration/scopes/src/durable/non-durable.service.ts
@@ -2,18 +2,11 @@ import { Inject, Injectable, Scope } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { TenantContext } from './durable-context-id.strategy';
 
-@Injectable({ scope: Scope.REQUEST, durable: true })
-export class DurableService {
-  public instanceCounter = 0;
-
+@Injectable()
+export class NonDurableService {
   constructor(
     @Inject(REQUEST) private readonly requestPayload: TenantContext,
   ) {}
-
-  greeting() {
-    ++this.instanceCounter;
-    return `Hello world! Counter: ${this.instanceCounter}`;
-  }
 
   getTenantId() {
     return this.requestPayload.tenantId;

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -346,7 +346,9 @@ export class MiddlewareModule<
         configurable: false,
       });
 
-      const requestProviderValue = isTreeDurable ? contextId.payload : request;
+      const requestProviderValue = isTreeDurable
+        ? contextId.payload
+        : Object.assign(request, contextId.payload);
       this.container.registerRequestProvider(requestProviderValue, contextId);
     }
     return contextId;

--- a/packages/core/router/router-explorer.ts
+++ b/packages/core/router/router-explorer.ts
@@ -418,7 +418,9 @@ export class RouterExplorer {
         configurable: false,
       });
 
-      const requestProviderValue = isTreeDurable ? contextId.payload : request;
+      const requestProviderValue = isTreeDurable
+        ? contextId.payload
+        : Object.assign(request, contextId.payload);
       this.container.registerRequestProvider(requestProviderValue, contextId);
     }
     return contextId;

--- a/packages/microservices/listeners-controller.ts
+++ b/packages/microservices/listeners-controller.ts
@@ -308,7 +308,9 @@ export class ListenersController {
         configurable: false,
       });
 
-      const requestProviderValue = isTreeDurable ? contextId.payload : request;
+      const requestProviderValue = isTreeDurable
+        ? contextId.payload
+        : Object.assign(request, contextId.payload);
       this.container.registerRequestProvider(requestProviderValue, contextId);
     }
     return contextId;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Doesn't create the request singleton with the contextId payload when the first request isn't to a durable tree. 


Issue Number: #13477 


## What is the new behavior?
The payload generated by the contextIdFactory will be always merged to the request singleton, not matter if the the tree is durable or not.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I would like to know which tests should I updated, if needed.

Also the patch doesn't merge payload from the contextIdFactory in the request passed to canActivate method for AuthGuard and exception filter.

To patch the case above:

`packages/core/router/router-explorer.ts` lines 389 and 402

```ts
  public createRequestScopedHandler(
    instanceWrapper: InstanceWrapper,
    requestMethod: RequestMethod,
    moduleRef: Module,
    moduleKey: string,
    methodName: string,
  ) {
    const { instance } = instanceWrapper;
    const collection = moduleRef.controllers;

    const isTreeDurable = instanceWrapper.isDependencyTreeDurable();

    return async <TRequest extends Record<any, any>, TResponse>(
      req: TRequest,
      res: TResponse,
      next: () => void,
    ) => {
      try {
        const contextId = this.getContextId(req, isTreeDurable);
        const contextInstance = await this.injector.loadPerContext(
          instance,
          moduleRef,
          collection,
          contextId,
        );
        await this.createCallbackProxy(
          contextInstance,
          contextInstance[methodName],
          methodName,
          moduleKey,
          requestMethod,
          contextId,
          instanceWrapper.id,
        )(req, res, next);
      } catch (err) {
        let exceptionFilter = this.exceptionFiltersCache.get(
          instance[methodName],
        );
        if (!exceptionFilter) {
          exceptionFilter = this.exceptionsFilter.create(
            instance,
            instance[methodName],
            moduleKey,
          );
          this.exceptionFiltersCache.set(instance[methodName], exceptionFilter);
        }
        const host = new ExecutionContextHost([req, res, next]);
        exceptionFilter.next(err, host);
      }
    };
  }
```

`
        ...,
          instanceWrapper.id,
        )(req, res, next);
`

should be replace by 

`
        ...,
          instanceWrapper.id,
        )(Object.assign(req, contextId.payload), res, next);
`

and

`const host = new ExecutionContextHost([req, res, next]);`

should be replace by 

`const host = new ExecutionContextHost([Object.assign(req, contextId.payload), res, next]);`


But I don't want to do it on my own since I would like a quick fix first, moreover maybe it will imply edge-case, I don't know the code base well 🤷‍♂️ 

