### PR TITLE
refactor(platform-fastify): use the route method to inject routes

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -32,11 +32,12 @@ import {
   RawServerBase,
   RawServerDefault,
   RequestGenericInterface,
+  RouteOptions,
+  RouteShorthandOptions,
   fastify,
 } from 'fastify';
 import * as Reply from 'fastify/lib/reply';
 import { kRouteContext } from 'fastify/lib/symbols';
-import { RouteShorthandMethod } from 'fastify/types/route';
 import * as http2 from 'http2';
 import * as https from 'https';
 import {
@@ -683,6 +684,13 @@ export class FastifyAdapter<
     const hasConfig = !isUndefined(routeConfig);
     const hasConstraints = !isUndefined(routeConstraints);
 
+    const routeToInject: RouteOptions<TServer, TRawRequest, TRawResponse> &
+      RouteShorthandOptions = {
+      method: routerMethodKey,
+      url: args[0],
+      handler: handlerRef,
+    };
+
     if (isVersioned || hasConstraints || hasConfig) {
       const isPathAndRouteTuple = args.length === 2;
       if (isPathAndRouteTuple) {
@@ -701,15 +709,12 @@ export class FastifyAdapter<
             },
           }),
         };
-        const path = args[0];
-        return this.instance[routerMethodKey](path, options, handlerRef);
+
+        const routeToInjectWithOptions = { ...routeToInject, ...options };
+
+        return this.instance.route(routeToInjectWithOptions);
       }
     }
-
-    return this.instance[routerMethodKey](
-      ...(args as Parameters<
-        RouteShorthandMethod<TServer, TRawRequest, TRawResponse>
-      >),
-    );
+    return this.instance.route(routeToInject);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Route injection is handled by the shorthands methods


## What is the new behavior?
As discussed here: https://github.com/fastify/fastify/issues/5412#issuecomment-2068657469

Fastify allows the user to decorate the instance with any name. This can cause problems if common words are used instead of HTTP methods.

The other advantage is that Nest will not depend on the implementation of shorthands methods on the fastify side.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Related to https://github.com/nestjs/nest/pull/13278