### PR TITLE
feat(microservices): Allow RegExps in Patterns for Kafka

### DIFF
--- a/integration/microservices/e2e/sum-kafka.spec.ts
+++ b/integration/microservices/e2e/sum-kafka.spec.ts
@@ -96,7 +96,21 @@ describe.skip('Kafka transport', function () {
       .send()
       .end(() => {
         setTimeout(() => {
-          expect(KafkaController.IS_NOTIFIED).to.be.true;
+          expect(KafkaMessagesController.IS_NOTIFIED).to.be.true;
+          done();
+        }, 1000);
+      });
+  });
+
+  it(`/POST (async event notification)`, done => {
+    request(server)
+      .post('/notifyRegex')
+      .send()
+      .end(() => {
+        setTimeout(() => {
+          expect(KafkaMessagesController.IS_REGEX_NOTIFIED).to.be.eq(
+            'regex.notify.test-0',
+          );
           done();
         }, 1000);
       });

--- a/integration/microservices/src/kafka/kafka.controller.ts
+++ b/integration/microservices/src/kafka/kafka.controller.ts
@@ -15,7 +15,6 @@ import { UserDto } from './dtos/user.dto';
 @Controller()
 export class KafkaController implements OnModuleInit, OnModuleDestroy {
   protected readonly logger = new Logger(KafkaController.name);
-  static IS_NOTIFIED = false;
   static MATH_SUM = 0;
 
   @Client({
@@ -131,6 +130,11 @@ export class KafkaController implements OnModuleInit, OnModuleDestroy {
   @Post('notify')
   async sendNotification(): Promise<any> {
     return this.client.emit('notify', { notify: true });
+  }
+
+  @Post('notifyRegex')
+  async sendRegexNotification(): Promise<any> {
+    return this.client.emit('regex.notify.test-0', { notify: true });
   }
 
   // Complex data to send.

--- a/integration/microservices/src/kafka/kafka.messages.controller.ts
+++ b/integration/microservices/src/kafka/kafka.messages.controller.ts
@@ -1,5 +1,10 @@
 import { Controller, Logger } from '@nestjs/common';
-import { EventPattern, MessagePattern } from '@nestjs/microservices';
+import {
+  Ctx,
+  EventPattern,
+  KafkaContext,
+  MessagePattern,
+} from '@nestjs/microservices';
 import { BusinessDto } from './dtos/business.dto';
 import { UserDto } from './dtos/user.dto';
 import { BusinessEntity } from './entities/business.entity';
@@ -10,6 +15,7 @@ import { KafkaController } from './kafka.controller';
 export class KafkaMessagesController {
   protected readonly logger = new Logger(KafkaMessagesController.name);
   static IS_NOTIFIED = false;
+  static IS_REGEX_NOTIFIED: any = false;
 
   @MessagePattern('math.sum.sync.kafka.message')
   mathSumSyncKafkaMessage(data: any) {
@@ -53,7 +59,12 @@ export class KafkaMessagesController {
 
   @EventPattern('notify')
   eventHandler(data: any) {
-    KafkaController.IS_NOTIFIED = data.value.notify;
+    KafkaMessagesController.IS_NOTIFIED = data.value.notify;
+  }
+
+  @EventPattern(/regex\.notify\.test-[0-9]*/)
+  regexHandler(data: any, @Ctx() context: KafkaContext) {
+    KafkaMessagesController.IS_REGEX_NOTIFIED = context.getTopic();
   }
 
   // Complex data to send.

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -180,10 +180,26 @@ describe('ServerKafka', () => {
       await server.listen(callback);
 
       const pattern = 'test';
-      const handler = sinon.spy();
-      (server as any).messageHandlers = objectToMap({
-        [pattern]: handler,
-      });
+      (server as any).registeredPatterns = [pattern];
+
+      await server.bindEvents((server as any).consumer);
+
+      expect(subscribe.called).to.be.true;
+      expect(
+        subscribe.calledWith({
+          topics: [pattern],
+        }),
+      ).to.be.true;
+
+      expect(run.called).to.be.true;
+      expect(connect.called).to.be.true;
+    });
+    it('should call subscribe and run on consumer when there are RegExp messageHandlers', async () => {
+      (server as any).logger = new NoopLogger();
+      await server.listen(callback);
+
+      const pattern = /test/;
+      (server as any).registeredPatterns = [pattern];
 
       await server.bindEvents((server as any).consumer);
 
@@ -204,10 +220,7 @@ describe('ServerKafka', () => {
       await server.listen(callback);
 
       const pattern = 'test';
-      const handler = sinon.spy();
-      (server as any).messageHandlers = objectToMap({
-        [pattern]: handler,
-      });
+      (server as any).registeredPatterns = [pattern];
 
       await server.bindEvents((server as any).consumer);
 


### PR DESCRIPTION
closes #3083

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
RegExps could be added and the Typescript would compile, but at runtime, you'd get an error: 

```
The request attempted to perform an operation on an invalid topic
KafkaJSProtocolError: The request attempted to perform an operation on an invalid topic
```

because normalizePattern in Server.ts would map a RegExp to the string "{}"

Issue Number: #3083 


## What is the new behavior?

Now RegExp is allowed for Kafka, and the same handler can be used for multiple topics that match the pattern.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

N/A