### PR TITLE
fix(ws): close existing connections

### DIFF
--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -158,6 +158,16 @@ export class WsAdapter extends AbstractWsAdapter {
     client.on(CLOSE_EVENT, callback);
   }
 
+  public async close(server: any) {
+    const closeEventSignal = new Promise((resolve, reject) =>
+      server.close(err => (err ? reject(err) : resolve(undefined))),
+    );
+    for (const ws of server.clients) {
+      ws.terminate();
+    }
+    await closeEventSignal;
+  }
+
   public async dispose() {
     const closeEventSignals = Array.from(this.httpServersRegistry)
       .filter(([port]) => port !== UNDERLYING_HTTP_SERVER_PORT)


### PR DESCRIPTION
Close all existing websocket connections to ensure a graceful shutdown.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: closes #13534

Existing connections are not closed automatically, according to https://github.com/websockets/ws/blob/master/doc/ws.md#serverclosecallback.

Application shutdown hangs when shutdown hooks are enabled and there are existing websocket connections. This is because the server.close callback that is awaited only resolves after all connections are closed. This is the call chain:
1. [process.cleanup](https://github.com/nestjs/nest/blob/master/packages/core/nest-application-context.ts#L326)
2. [NestApplication.dispose](https://github.com/nestjs/nest/blob/master/packages/core/nest-application.ts#L98)
3. [SocketModule.close](https://github.com/nestjs/nest/blob/master/packages/websockets/socket-module.ts#L96)
4. [WsAdapter.close](https://github.com/nestjs/nest/blob/master/packages/websockets/adapters/ws-adapter.ts#L37)
5. [server.close](https://github.com/nestjs/nest/blob/master/packages/websockets/adapters/ws-adapter.ts#L39)

## What is the new behavior?
All existing websocket connections are closed to ensure a graceful shutdown.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information