### PR TITLE
feat(common): Support JSON format in ConsoleLogger

### DIFF
--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -539,6 +539,60 @@ describe('Logger', () => {
       });
     });
 
+    describe('when the default logger is used and global context is set and asJSON enabled', () => {
+      const globalContext = 'GlobalContext';
+
+      const logger = new ConsoleLogger(globalContext, { asJSON: true });
+
+      let processStdoutWriteSpy: sinon.SinonSpy;
+      let processStderrWriteSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        processStdoutWriteSpy = sinon.spy(process.stdout, 'write');
+        processStderrWriteSpy = sinon.spy(process.stderr, 'write');
+      });
+
+      afterEach(() => {
+        processStdoutWriteSpy.restore();
+        processStderrWriteSpy.restore();
+      });
+
+      it('should print error with stack as JSON to the console', () => {
+        const errorMessage = 'error message';
+        const error = new Error(errorMessage);
+
+        logger.error(error.message, error.stack);
+
+        const json = JSON.parse(processStderrWriteSpy.firstCall?.firstArg);
+
+        expect(json.logLevel).to.equal('error');
+        expect(json.context).to.equal(globalContext);
+        expect(json.message).to.equal(errorMessage);
+      });
+      it('should log out to stdout as JSON', () => {
+        const message = 'message 1';
+
+        logger.log(message);
+
+        const json = JSON.parse(processStdoutWriteSpy.firstCall?.firstArg);
+
+        expect(json.logLevel).to.equal('log');
+        expect(json.context).to.equal(globalContext);
+        expect(json.message).to.equal(message);
+      });
+      it('should log out an error to stderr as JSON', () => {
+        const message = 'message 1';
+
+        logger.error(message);
+
+        const json = JSON.parse(processStderrWriteSpy.firstCall?.firstArg);
+
+        expect(json.logLevel).to.equal('error');
+        expect(json.context).to.equal(globalContext);
+        expect(json.message).to.equal(message);
+      });
+    });
+
     describe('when logging is disabled', () => {
       const logger = new Logger();
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

`ConsoleLoggerOptions` interface has the new option `asJSON` with a JSDoc comment

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, there is no way to make `ConsoleLogger` log JSON strings

Issue Number: N/A


## What is the new behavior?
Now there is a option to log as JSON string

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

There is this issue https://github.com/nestjs/nest/issues/10342 that is closed, but  still there is no support for JSON string format.

We are in a need of JSON string logs - it's easier to parse in Google Cloud and there are less problems with newlines.

Some projects that handle this issue exists:
- https://github.com/igrek8/gc-json-logger-nestjs
- https://github.com/marciopd/json-logger-service
but they doesn't seems to be updated. And I think a basic form of this functionality should be provided without external library.