### PR TITLE
fix(core): prevent exclude method from overwriting previous calls

### DIFF
--- a/integration/hello-world/e2e/exclude-middleware.spec.ts
+++ b/integration/hello-world/e2e/exclude-middleware.spec.ts
@@ -45,6 +45,11 @@ class TestController {
   overviewById() {
     return RETURN_VALUE;
   }
+
+  @Get('multiple/exclude')
+  multipleExclude() {
+    return RETURN_VALUE;
+  }
 }
 
 @Module({
@@ -59,6 +64,7 @@ class TestModule {
         path: 'middleware',
         method: RequestMethod.POST,
       })
+      .exclude('multiple/exclude')
       .forRoutes('*');
   }
 }
@@ -107,6 +113,12 @@ describe('Exclude middleware', () => {
   it(`should exclude "/wildcard/overview" endpoint (by wildcard)`, () => {
     return request(app.getHttpServer())
       .get('/wildcard/overview')
+      .expect(200, RETURN_VALUE);
+  });
+
+  it(`should exclude "/multiple/exclude" endpoint`, () => {
+    return request(app.getHttpServer())
+      .get('/multiple/exclude')
       .expect(200, RETURN_VALUE);
   });
 

--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -58,8 +58,9 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
     public exclude(
       ...routes: Array<string | RouteInfo>
     ): MiddlewareConfigProxy {
-      this.excludedRoutes = this.getRoutesFlatList(routes).reduce(
-        (excludedRoutes, route) => {
+      this.excludedRoutes = [
+        ...this.excludedRoutes,
+        ...this.getRoutesFlatList(routes).reduce((excludedRoutes, route) => {
           for (const routePath of this.routeInfoPathExtractor.extractPathFrom(
             route,
           )) {
@@ -70,9 +71,8 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
           }
 
           return excludedRoutes;
-        },
-        [] as RouteInfo[],
-      );
+        }, [] as RouteInfo[]),
+      ];
 
       return this;
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Summary:

Previously, calling multiple `exclude` method in `MiddlewareConsumer` overwrote the previously excluded routes.

```typescript
configure(consumer: MiddlewareConsumer) {
    consumer
      .apply((req, res, next) => res.send(MIDDLEWARE_VALUE))
      .exclude('test', 'overview/:id', 'wildcard/(.*)', {
          path: 'middleware',
          method: RequestMethod.POST,
       }) // ignored
      .exclude('multiple/exclude')
      .forRoutes('*');
 }
```

It only worked well when using a single `exclude` method.

```typescript
configure(consumer: MiddlewareConsumer) {
    consumer
      .apply((req, res, next) => res.send(MIDDLEWARE_VALUE))
      .exclude('test', 'overview/:id', 'wildcard/(.*)', 'multiple/exclude', {
        path: 'middleware',
        method: RequestMethod.POST,
      })
      .forRoutes('*');
}
```

I created a minimum reproduction repository. 

- [Github](https://github.com/dragontaek-lee/middleware-exclude-method-overwrites)
- [CodeSandbox](https://codesandbox.io/p/devbox/exclude-overwrites-2jrz53)

Both repositories contain the same code. You can review the test code (`exclude-middleware.spec.ts`) and see the results by cloning or forking the repository and running `npm run test`.

## What is the new behavior?
This change ensures that the `exclude` method appends new routes to the existing excluded routes list instead of overwriting them. 
This preserves all previous exclude calls and maintains the intended behavior of accumulating excluded routes.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information