### PR TITLE
chore: gRPC server does not need to calling start method

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -84,7 +84,6 @@ export class ServerGrpc extends Server implements CustomTransportStrategy {
 
   public async start(callback?: () => void) {
     await this.bindEvents();
-    this.grpcClient.start();
     callback();
   }
 

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -51,31 +51,11 @@ describe('ServerGrpc', () => {
       await server.close();
       expect(bindEventsStub.called).to.be.true;
     });
-    it('should call "client.start"', async () => {
-      const client = { start: sinon.spy() };
-      sinon.stub(server, 'createClient').callsFake(async () => client);
 
-      await server.listen(callback);
-      expect(client.start.called).to.be.true;
-    });
     it('should call callback', async () => {
       await server.listen(callback);
       await server.close();
       expect(callback.called).to.be.true;
-    });
-    describe('when "start" throws an exception', () => {
-      it('should call callback with a thrown error as an argument', async () => {
-        const error = new Error('random error');
-
-        const callbackSpy = sinon.spy();
-        sinon.stub(server, 'createClient').callsFake(async () => null);
-
-        sinon.stub(server, 'start').callsFake(() => {
-          throw error;
-        });
-        await server.listen(callbackSpy);
-        expect(callbackSpy.calledWith(error)).to.be.true;
-      });
     });
   });
 
@@ -94,12 +74,6 @@ describe('ServerGrpc', () => {
       await serverMulti.listen(callback);
       await serverMulti.close();
       expect(bindEventsStub.called).to.be.true;
-    });
-    it('should call "client.start"', async () => {
-      const client = { start: sinon.spy() };
-      sinon.stub(serverMulti, 'createClient').callsFake(async () => client);
-      await serverMulti.listen(callback);
-      expect(client.start.called).to.be.true;
     });
     it('should call callback', async () => {
       await serverMulti.listen(callback);


### PR DESCRIPTION
gRPC server does not need to start( ) anymore.
Calling start is deprecated.