### PR TITLE
fix(sample) NestJS compatibility with nest/swagger 7.2.0

### DIFF
--- a/sample/11-swagger/package.json
+++ b/sample/11-swagger/package.json
@@ -22,7 +22,7 @@
     "@nestjs/common": "10.3.2",
     "@nestjs/core": "10.3.2",
     "@nestjs/platform-express": "10.3.8",
-    "@nestjs/swagger": "7.2.0",
+    "@nestjs/swagger": "7.3.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "reflect-metadata": "0.2.1",


### PR DESCRIPTION
In this sample next/swagger 7.2.0 is used as a dependency, but its no more compatible with the latest version so bumping to 7.3.0

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information