### PR TITLE
fix(sample) NestJS TypeOrm compatibility with reflect-metadata 0.2.1

### DIFF
--- a/sample/05-sql-typeorm/package.json
+++ b/sample/05-sql-typeorm/package.json
@@ -24,7 +24,7 @@
     "@nestjs/platform-express": "10.3.8",
     "@nestjs/typeorm": "10.0.1",
     "mysql2": "3.9.7",
-    "reflect-metadata": "0.2.1",
+    "reflect-metadata": "0.2.2",
     "rimraf": "5.0.5",
     "rxjs": "7.8.1",
     "typeorm": "0.3.20"


### PR DESCRIPTION
"@nestjs/typeorm": "10.0.1" is not compatible with "reflect-metadata": "0.2.1". We had to bump version to 0.2.2

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information