### PR TITLE
refactor(common,core): support read-only arrays on module metadata

### DIFF
--- a/packages/common/interfaces/modules/module-metadata.interface.ts
+++ b/packages/common/interfaces/modules/module-metadata.interface.ts
@@ -16,7 +16,7 @@ export interface ModuleMetadata {
    * Optional list of imported modules that export the providers which are
    * required in this module.
    */
-  imports?: Array<
+  imports?: ReadonlyArray<
     Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference
   >;
   /**
@@ -33,7 +33,7 @@ export interface ModuleMetadata {
    * Optional list of the subset of providers that are provided by this module
    * and should be available in other modules which import this module.
    */
-  exports?: Array<
+  exports?: ReadonlyArray<
     | DynamicModule
     | Promise<DynamicModule>
     | string

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -173,7 +173,10 @@ export class NestContainer {
     await this.addDynamicModules(imports, scope);
   }
 
-  public async addDynamicModules(modules: any[], scope: Type<any>[]) {
+  public async addDynamicModules(
+    modules: ReadonlyArray<any>,
+    scope: Type<any>[],
+  ) {
     if (!modules) {
       return;
     }

--- a/packages/core/test/injector/container.spec.ts
+++ b/packages/core/test/injector/container.spec.ts
@@ -210,6 +210,16 @@ describe('NestContainer', () => {
         expect(addModuleSpy.called).to.be.true;
       });
     });
+    describe('when array is readonly', () => {
+      it('should call "addModule"', () => {
+        const addModuleSpy = sinon.spy(container, 'addModule');
+
+        const readonlyModules: ReadonlyArray<any> = Object.freeze([Test]);
+        container.addDynamicModules(readonlyModules, []);
+
+        expect(addModuleSpy.called).to.be.true;
+      });
+    });
   });
 
   describe('get applicationConfig', () => {


### PR DESCRIPTION
Add support for ModuleMetadata to accept ReadOnlyArray. This allows developers to use TypeScript const assertions for module definitions.

There are no breaking changes with this commit and this change is discussed in #13326.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13326


## What is the new behavior?

ReadOnlyArray is not supported to better support using TypeScript const assertions in module definitions.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information