### PR TITLE
feat(core): Modify BaseExceptionFilter to include error properties in error logging

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -91,6 +91,12 @@ export class ConsoleLogger implements LoggerService {
     const { messages, context, stack } =
       this.getContextAndStackAndMessagesToPrint([message, ...optionalParams]);
 
+    if (message instanceof Error) {
+      this.printMessages(messages, context, 'error', 'stderr');
+      this.printError(message);
+      return;
+    }
+
     this.printMessages(messages, context, 'error', 'stderr');
     this.printStackTrace(stack);
   }
@@ -276,6 +282,13 @@ export class ConsoleLogger implements LoggerService {
       return;
     }
     process.stderr.write(`${stack}\n`);
+  }
+
+  protected printError(error: Error) {
+    if (!error) {
+      return;
+    }
+    console.error(error);
   }
 
   protected updateAndGetTimestampDiff(): string {

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -129,6 +129,11 @@ export class Logger implements LoggerService {
   error(message: any, ...optionalParams: [...any, string?, string?]): void;
   @Logger.WrapBuffer
   error(message: any, ...optionalParams: any[]) {
+    if (message instanceof Error) {
+      this.localInstance.error(message);
+      return;
+    }
+
     optionalParams = this.context
       ? (optionalParams.length ? optionalParams : [undefined]).concat(
           this.context,

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -8,15 +8,18 @@ describe('Logger', () => {
     describe('when the default logger is used', () => {
       let processStdoutWriteSpy: sinon.SinonSpy;
       let processStderrWriteSpy: sinon.SinonSpy;
+      let consoleErrorSpy: sinon.SinonSpy;
 
       beforeEach(() => {
         processStdoutWriteSpy = sinon.spy(process.stdout, 'write');
         processStderrWriteSpy = sinon.spy(process.stderr, 'write');
+        consoleErrorSpy = sinon.spy(console, 'error');
       });
 
       afterEach(() => {
         processStdoutWriteSpy.restore();
         processStderrWriteSpy.restore();
+        consoleErrorSpy.restore();
       });
 
       it('should print one message to the console', () => {
@@ -111,10 +114,8 @@ describe('Logger', () => {
 
         Logger.error(error);
 
-        expect(processStderrWriteSpy.calledOnce).to.be.true;
-        expect(processStderrWriteSpy.firstCall.firstArg).to.include(
-          `Error: Random text here`,
-        );
+        expect(consoleErrorSpy.calledOnce).to.be.true;
+        expect(consoleErrorSpy.firstCall.firstArg).to.equal(error);
       });
 
       it('should serialise a plain JS object (as a message) without context to the console', () => {

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -68,12 +68,6 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
       applicationRef.end(response);
     }
 
-    if (this.isExceptionObject(exception)) {
-      return BaseExceptionFilter.logger.error(
-        exception.message,
-        exception.stack,
-      );
-    }
     return BaseExceptionFilter.logger.error(exception);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #13550

The class is defined as follows. This class includes the properties detail and code.

```typescript
export class MyCustomError extends Error {
  detail: any;
  code: string;

  constructor(message: string, detail: string, code: string) {
    super(message);
    this.detail = detail;
    this.code = code;
  }
}
```

If thrown like this, the `detail` of the error and the information about `42883` are not logged by the BaseExceptionFilter.

```typescript
@Get('/')
async helloWorld() {
  throw new MyCustomError('My custom error', 'Detail Error', '42883');
}
```

As shown in the image below:
<img width="1028" alt="image" src="https://github.com/nestjs/nest/assets/54374610/5a7d9c7a-ff73-4112-8307-9be6a938c1f9">

So, I created a protected method that logs the Error object to the console.

```typescript
protected printError(error: Error) {
  if (!error) {
    return;
  }
  console.error(error);
}
```

## What is the new behavior?

Now, all the properties of the `Error` object processed by the BaseExceptionFilter can be seen in the logs.

<img width="1025" alt="image" src="https://github.com/nestjs/nest/assets/54374610/b97ecc70-0a28-4d63-b562-22e1d548396e">

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The `error` method of the Logger class has been modified to log more than just the stack trace as a string when an Error object is passed. I'm not sure if this qualifies as a breaking change.


## Other information

I'm not sure if there's a specific reason why the console.error method shouldn't be used.

If it cannot be used, you can modify the handleUnknownError method in the BaseExceptionFilter as follows to check the properties of the error:
```typescript
if (this.isExceptionObject(exception)) {
  return BaseExceptionFilter.logger.error(
    exception.message,
    exception.stack + ' ' + JSON.stringify(exception, null, 2),
  );
}
```

However, this approach is not exactly the same as using console.error; it does not provide color coding or emphasis on the stack trace, as shown in the image below.

<img width="312" alt="image" src="https://github.com/nestjs/nest/assets/54374610/75a1a464-8d06-41b1-a7ab-9055df26a8ba">


If using the console.error method is not an option, we may need to manually create a string representation of the object to display as shown above.