### PR TITLE
fix(core): when using forward references on `exports` array

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -38,10 +38,12 @@ body:
       required: true
     attributes:
       label: "Minimum reproduction code"
-      description: |
-        An URL to some Git repository/[StackBlitz](https://stackblitz.com/fork/github/nestjs/typescript-starter)/[CodeSandbox](https://codesandbox.io/s/github/nestjs/typescript-starter/tree/master) project that reproduces your issue. [What is a minimum reproduction?](https://jmcdo29.github.io/wtf-is-a-minimum-reproduction)  
-        :warning: **NOTE:** We can close this issue if we don't manage to reproduce your potential bug. [Here](https://antfu.me/posts/why-reproductions-are-required) is why.
       placeholder: "https://github.com/..."
+      description: |
+        An URL to some Git repository/[StackBlitz](https://stackblitz.com/fork/github/nestjs/typescript-starter)/[CodeSandbox](https://codesandbox.io/s/github/nestjs/typescript-starter/tree/master) project that reproduces your issue. [What is a minimum reproduction?](https://jmcdo29.github.io/wtf-is-a-minimum-reproduction)
+
+        > [!WARNING]
+        > We may close this Issue if we don't manage to reproduce the potential bug. [Read this](https://antfu.me/posts/why-reproductions-are-required) to understand why.
 
   - type: textarea
     attributes:

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -522,10 +522,14 @@ export class DependenciesScanner {
   }
 
   public insertExportedProvider(
-    exportedProvider: Type<Injectable>,
+    // TODO: improve the type definition bellow because it doesn't reflects the real usage of this method
+    exportedProvider: Type<Injectable> | ForwardReference,
     token: string,
   ) {
-    this.container.addExportedProvider(exportedProvider, token);
+    const fulfilledProvider = this.isForwardReference(exportedProvider)
+      ? exportedProvider.forwardRef()
+      : exportedProvider;
+    this.container.addExportedProvider(fulfilledProvider, token);
   }
 
   public insertController(controller: Type<Controller>, token: string) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the following code triggers the error because of the `forwardRef` on `exports` array

```ts
import { Module, forwardRef } from '@nestjs/common';

@Module({})
export class FooModule {
  onModuleInit() {
    console.log('oops')
  }
}

@Module({
  imports: [
    forwardRef(() => FooModule),
  ],
  exports: [forwardRef(() => FooModule)],
})
export class AppModule {}
```

![image](https://github.com/nestjs/nest/assets/13461315/4cf97f93-4bbd-4715-b009-f14bf15c2b96)

Which breaks the `ConditionModule` from `@nestjs/config` when we use a forward reference.

<details>

<summary>Do note that the same error happens when we supply a promise to <code>exports</code>:</summary>

![image](https://github.com/nestjs/nest/assets/13461315/fc261f0c-5fd4-47dd-b92e-e14c0ec37153)

but I didn't address this error in this PR because I'm not sure about the error handling for rejected promises and about the right place to resolve such promise.

</details>

## What is the new behavior?

we can now use `forwardRef` on `exports`, as its type definition tell us so.

I also made a tiny change to the issue template of bug reports. It will look like this:

![image](https://github.com/nestjs/nest/assets/13461315/270f418a-cc35-4681-8709-ff0f80712e51)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I can't tell for sure if this is bug or a feature because I don't know if this was supported. But since `exports` allow us to supply a `ForwardReference`, I'd say that this is a bug.

https://github.com/nestjs/nest/blob/15cb568e40f42fb3c40c4cb2ad432b23a5ec7bcd/packages/common/interfaces/modules/module-metadata.interface.ts#L36-L44