### PR TITLE
chore(deps): remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nestjs/core",
-  "version": "10.3.4",
+  "version": "10.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs/core",
-      "version": "10.3.4",
+      "version": "10.3.10",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -26,8 +26,7 @@
         "rxjs": "7.8.1",
         "socket.io": "4.7.5",
         "tslib": "2.6.3",
-        "uid": "2.0.2",
-        "uuid": "10.0.0"
+        "uid": "2.0.2"
       },
       "devDependencies": {
         "@apollo/server": "4.10.4",
@@ -108,7 +107,6 @@
         "multer": "1.4.4",
         "mysql2": "3.10.1",
         "nats": "2.27.0",
-        "nodemon": "3.1.4",
         "nyc": "14.1.1",
         "prettier": "3.3.2",
         "redis": "4.6.14",
@@ -13093,11 +13091,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/abbrev": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "dev": true,
@@ -24561,11 +24554,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/ignore-walk": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-6.0.5.tgz",
@@ -30449,203 +30437,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/nodemon": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.4.tgz",
-      "integrity": "sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==",
-      "dev": true,
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/anymatch": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/nodemon/node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nodemon/node_modules/braces": {
-      "version": "3.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nodemon/node_modules/chokidar": {
-      "version": "3.5.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/nodemon/node_modules/debug": {
-      "version": "4.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nodemon/node_modules/fill-range": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nodemon/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/nodemon/node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nodemon/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/nodemon/node_modules/normalize-path": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nodemon/node_modules/readdirp": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "7.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/nodemon/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "dev": true,
@@ -33362,11 +33153,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pump": {
       "version": "3.0.0",
       "dev": true,
@@ -35280,31 +35066,6 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/sinon": {
@@ -37517,17 +37278,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/touch": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "nopt": "~1.0.10"
-      },
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
-      }
-    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "dev": true,
@@ -39059,11 +38809,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undertaker": {
       "version": "1.2.1",
       "dev": true,
@@ -39378,18 +39123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "rxjs": "7.8.1",
     "socket.io": "4.7.5",
     "tslib": "2.6.3",
-    "uid": "2.0.2",
-    "uuid": "10.0.0"
+    "uid": "2.0.2"
   },
   "devDependencies": {
     "@apollo/server": "4.10.4",
@@ -156,7 +155,6 @@
     "multer": "1.4.4",
     "mysql2": "3.10.1",
     "nats": "2.27.0",
-    "nodemon": "3.1.4",
     "nyc": "14.1.1",
     "prettier": "3.3.2",
     "redis": "4.6.14",


### PR DESCRIPTION
- there's no occurrence on `uuid` and `nodemon` in the codebase, so I think we can remove those dependencies now
- bumps the lock file with the latest version of `package.json`