### PR TITLE
refactor(core): env variable to control slow threshold of token factory

### DIFF
--- a/packages/core/injector/module-token-factory.ts
+++ b/packages/core/injector/module-token-factory.ts
@@ -9,6 +9,10 @@ import { performance } from 'perf_hooks';
 const CLASS_STR = 'class ';
 const CLASS_STR_LEN = CLASS_STR.length;
 
+const slowThresholdMs = Number(
+  +process.env.NEST_TOKEN_FACTORY_SLOW_THRESHOLD_MS || 10,
+);
+
 export class ModuleTokenFactory {
   private readonly moduleTokenCache = new Map<string, string>();
   private readonly moduleIdsCache = new WeakMap<Type<unknown>, string>();
@@ -34,10 +38,10 @@ export class ModuleTokenFactory {
     const opaqueTokenString = this.getStringifiedOpaqueToken(opaqueToken);
     const timeSpentInMs = performance.now() - start;
 
-    if (timeSpentInMs > 10) {
+    if (timeSpentInMs > slowThresholdMs) {
       const formattedTimeSpent = timeSpentInMs.toFixed(2);
       this.logger.warn(
-        `The module "${opaqueToken.module}" is taking ${formattedTimeSpent}ms to serialize, this may be caused by larger objects statically assigned to the module. More details: https://github.com/nestjs/nest/issues/12738`,
+        `The module "${opaqueToken.module}" is taking ${formattedTimeSpent}ms to serialize, this may be caused by larger objects statically assigned to the module. To ignore, increase the threshold using env variable NEST_TOKEN_FACTORY_SLOW_THRESHOLD_MS. More details: https://github.com/nestjs/nest/issues/12738`,
       );
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Today, there's no way to change the threshold we added for slow serialization.

Refs: https://github.com/nestjs/nest/issues/12738#issuecomment-2232426283

## What is the new behavior?

Now, we can control the amount of time in MS using `NEST_TOKEN_FACTORY_SLOW_THRESHOLD_MS`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information