### PR TITLE
fix(core): dependencies not resolving for transient lazy providers

### DIFF
--- a/integration/lazy-modules/e2e/lazy-import-transient-providers.spec.ts
+++ b/integration/lazy-modules/e2e/lazy-import-transient-providers.spec.ts
@@ -1,0 +1,32 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { TransientLazyModule } from '../src/transient.module';
+import { LazyController } from '../src/lazy.controller';
+import * as chai from 'chai';
+import { expect } from 'chai';
+import * as request from 'supertest';
+
+describe('Lazy Transient providers', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [LazyController],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+  });
+
+  it('should not recreate dependencies for default scope', async () => {
+    const resultOne = await request(app.getHttpServer()).get('/lazy/transient');
+
+    const resultTwo = await request(app.getHttpServer()).get('/lazy/transient');
+
+    expect(resultOne.text).to.be.equal('Hi! Counter is 1');
+    expect(resultOne.statusCode).to.be.equal(200);
+
+    expect(resultTwo.text).to.be.equal('Hi! Counter is 2');
+    expect(resultTwo.statusCode).to.be.equal(200);
+  });
+});

--- a/integration/lazy-modules/src/eager.module.ts
+++ b/integration/lazy-modules/src/eager.module.ts
@@ -3,7 +3,13 @@ import { GlobalService } from './global.module';
 
 @Injectable()
 export class EagerService {
+  private counter = 0;
   constructor(public globalService: GlobalService) {}
+
+  sayHello() {
+    this.counter++;
+    return 'Hi! Counter is ' + this.counter;
+  }
 }
 
 @Module({

--- a/integration/lazy-modules/src/lazy.controller.ts
+++ b/integration/lazy-modules/src/lazy.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get } from '@nestjs/common';
+import { LazyModuleLoader } from '@nestjs/core';
+
+@Controller('lazy')
+export class LazyController {
+  constructor(private lazyLoadModule: LazyModuleLoader) {}
+
+  @Get('transient')
+  async exec() {
+    const { TransientLazyModule } = await import('./transient.module');
+    const moduleRef = await this.lazyLoadModule.load(() => TransientLazyModule);
+
+    const { TransientService } = await import('./transient.service');
+    const _service = await moduleRef.resolve(TransientService);
+
+    return _service.eager();
+  }
+}

--- a/integration/lazy-modules/src/transient.module.ts
+++ b/integration/lazy-modules/src/transient.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GlobalService } from './global.module';
+import { EagerService } from './eager.module';
+import { TransientService } from './transient.service';
+
+@Module({
+  imports: [],
+  providers: [TransientService, GlobalService, EagerService],
+  exports: [TransientService],
+})
+export class TransientLazyModule {}

--- a/integration/lazy-modules/src/transient.service.ts
+++ b/integration/lazy-modules/src/transient.service.ts
@@ -1,0 +1,11 @@
+import { Injectable, Scope } from '@nestjs/common';
+import { EagerService } from './eager.module';
+
+@Injectable({ scope: Scope.TRANSIENT })
+export class TransientService {
+  constructor(private eagerService: EagerService) {}
+
+  eager() {
+    return this.eagerService.sayHello();
+  }
+}

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -297,9 +297,8 @@ export class Module {
     );
   }
 
-  public isTransientProvider(provider: Provider): boolean {
-    const metadata = Reflect.getMetadata('scope:options', provider);
-    return metadata && metadata?.scope === Scope.TRANSIENT;
+  private isTransientProvider(provider: Type<any>): boolean {
+    return getClassScope(provider) === Scope.TRANSIENT;
   }
 
   public addCustomProvider(

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -12,6 +12,7 @@ import {
   InjectionToken,
   NestModule,
   Provider,
+  Scope,
   Type,
   ValueProvider,
 } from '@nestjs/common/interfaces';
@@ -253,6 +254,10 @@ export class Module {
       return this.addCustomProvider(provider, this._providers, enhancerSubtype);
     }
 
+    if (this.isTransientProvider(provider) && this.getProviderByKey(provider)) {
+      return provider;
+    }
+
     this._providers.set(
       provider,
       new InstanceWrapper({
@@ -290,6 +295,11 @@ export class Module {
           | ExistingProvider
       ).provide,
     );
+  }
+
+  public isTransientProvider(provider: Provider): boolean {
+    const metadata = Reflect.getMetadata('scope:options', provider);
+    return metadata && metadata?.scope === Scope.TRANSIENT;
   }
 
   public addCustomProvider(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: Closes #13761 

When a lazy module resolver a lazy provider marked as transient the singleton dependencies are recreated for the new requests in same context.

## What is the new behavior?
Skipping creation of new providers if they are marked as transient and have annotation in the score of module.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information