### PR TITLE
fix(platform-fastify): search method not declared

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -306,6 +306,10 @@ export class FastifyAdapter<
     return this.injectRouteOptions('options', ...args);
   }
 
+  public search(...args: any[]) {
+    return this.injectRouteOptions('search', ...args);
+  }
+
   public applyVersionFilter(
     handler: Function,
     version: VersionValue,

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -34,6 +34,7 @@ import {
   RequestGenericInterface,
   RouteOptions,
   RouteShorthandOptions,
+  HTTPMethods,
   fastify,
 } from 'fastify';
 import * as Reply from 'fastify/lib/reply';
@@ -672,17 +673,7 @@ export class FastifyAdapter<
     return rawRequest.originalUrl || rawRequest.url;
   }
 
-  private injectRouteOptions(
-    routerMethodKey:
-      | 'get'
-      | 'post'
-      | 'put'
-      | 'delete'
-      | 'options'
-      | 'patch'
-      | 'head',
-    ...args: any[]
-  ) {
+  private injectRouteOptions(routerMethodKey: HTTPMethods, ...args: any[]) {
     const handlerRef = args[args.length - 1];
     const isVersioned =
       !isUndefined(handlerRef.version) &&


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
The usage of the @Search method with fastify was not properly declared

```ts
node_modules/@nestjs/core/adapters/http-adapter.js:59
        return this.instance.search(...args);
                             ^

TypeError: this.instance.search is not a function
    at FastifyAdapter.search (node_modules/@nestjs/core/adapters/http-adapter.js:59:30)
    at node_modules/@nestjs/core/router/router-explorer.js:105:17
    at Array.forEach (<anonymous>)
    at node_modules/@nestjs/core/router/router-explorer.js:90:29
    at Array.forEach (<anonymous>)
    at RouterExplorer.applyCallbackToRouter (node_modules/@nestjs/core/router/router-explorer.js:82:15)
    at node_modules/@nestjs/core/router/router-explorer.js:65:18
    at Array.forEach (<anonymous>)
    at RouterExplorer.applyPathsToRouterProxy (node_modules/@nestjs/core/router/router-explorer.js:62:34)
    at RouterExplorer.explore (node_modules/@nestjs/core/router/router-explorer.js:49:14)
```


## Does this PR introduce a breaking change?
- [x] No