### PR TITLE
add payment required exception to the list of built in exceptions in Nest

### DIFF
--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -20,4 +20,4 @@ export * from './gateway-timeout.exception';
 export * from './im-a-teapot.exception';
 export * from './precondition-failed.exception';
 export * from './misdirected.exception';
-export * from './payment-required.exception.ts';
+export * from './payment-required.exception';

--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -20,3 +20,4 @@ export * from './gateway-timeout.exception';
 export * from './im-a-teapot.exception';
 export * from './precondition-failed.exception';
 export * from './misdirected.exception';
+export * from './payment-required.exception.ts';

--- a/packages/common/exceptions/payment-required.exception.ts
+++ b/packages/common/exceptions/payment-required.exception.ts
@@ -41,8 +41,8 @@ export class PaymentRequiredException extends HttpException {
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
-      HttpException.createBody(objectOrError, description, HttpStatus.PaymentRequiredException),
-      HttpStatus.PaymentRequiredException,
+      HttpException.createBody(objectOrError, description, HttpStatus.PAYMENT_REQUIRED),
+      HttpStatus.PAYMENT_REQUIRED,
       httpExceptionOptions,
     );
   }

--- a/packages/common/exceptions/payment-required.exception.ts
+++ b/packages/common/exceptions/payment-required.exception.ts
@@ -1,0 +1,49 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { HttpException, HttpExceptionOptions } from './http.exception';
+
+/**
+ * Defines an HTTP exception for *Payment required exception* type errors.
+ *
+ * @see [Built-in HTTP exceptions](https://docs.nestjs.com/exception-filters#built-in-http-exceptions)
+ *
+ * @publicApi
+ */
+export class PaymentRequiredException extends HttpException {
+  /**
+   * Instantiate a `PaymentRequiredException` Exception.
+   *
+   * @example
+   * `throw new PaymentRequiredException()`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 402.
+   * - The `objectOrError` argument defines the JSON response body or the message string.
+   * - The `descriptionOrOptions` argument contains either a short description of the HTTP error or an options object used to provide an underlying error cause.
+   *
+   * By default, the JSON response body contains two properties:
+   * - `statusCode`: this will be the value 402.
+   * - `message`: the string `'PaymentRequiredException'` by default; override this by supplying
+   * a string in the `objectOrError` parameter.
+   *
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, with a short description of the HTTP error. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
+   *
+   * @param objectOrError string or object describing the error condition.
+   * @param descriptionOrOptions either a short description of the HTTP error or an options object used to provide an underlying error cause
+   */
+  constructor(
+    objectOrError?: string | object | any,
+    descriptionOrOptions: string | HttpExceptionOptions = 'PaymentRequiredException',
+  ) {
+    const { description, httpExceptionOptions } =
+      HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
+    super(
+      HttpException.createBody(objectOrError, description, HttpStatus.PaymentRequiredException),
+      HttpStatus.PaymentRequiredException,
+      httpExceptionOptions,
+    );
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
add a new exception ([Payment required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)  status code 402) to the list of supported exceptions
 

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [* ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
the way I use it to create a payment required exception 
```
throw new HttpException(
            'payment required',
            HttpStatus.PAYMENT_REQUIRED,
          );
```


Issue Number: N/A


## What is the new behavior?
example usage 
```
throw new PaymentRequiredException();
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [ *] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information