### PR TITLE
feat(fastify): add type for http options

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -40,6 +40,7 @@ import * as Reply from 'fastify/lib/reply';
 import { kRouteContext } from 'fastify/lib/symbols';
 import * as http2 from 'http2';
 import * as https from 'https';
+import * as http from 'http';
 import {
   InjectOptions,
   Chain as LightMyRequestChain,
@@ -86,6 +87,13 @@ type FastifyHttpsOptions<
   Logger extends FastifyBaseLogger = FastifyBaseLogger,
 > = FastifyAdapterBaseOptions<Server, Logger> & {
   https: https.ServerOptions;
+};
+
+type FastifyHttpOptions<
+  Server extends http.Server,
+  Logger extends FastifyBaseLogger = FastifyBaseLogger,
+> = FastifyAdapterBaseOptions<Server, Logger> & {
+  http: http.ServerOptions;
 };
 
 type VersionedRoute<TRequest, TResponse> = ((
@@ -217,6 +225,7 @@ export class FastifyAdapter<
       | FastifyHttp2Options<any>
       | FastifyHttp2SecureOptions<any>
       | FastifyHttpsOptions<any>
+      | FastifyHttpOptions<any>
       | FastifyAdapterBaseOptions<TServer>,
   ) {
     super();


### PR DESCRIPTION
Fastify has support for http options through the fastify function call which was not officially included in the nest adapter. Currently passing an object with a http field works, but gives the developer no type hinting about the `http` field.

First time open source contributor so please let me know what is not correct.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently creating an http server we cannot pass any http options without fooling the typescript type system. So this works, but in my opinion more magical than explicit.

```typescript
const serverOptions: ServerOptions = {
  // Increase max header size from default ~16kb
  maxHeaderSize: 32768,
};
const options = {
  logger: undefined,
  http: serverOptions,
};

const adapter = new FastifyAdapter(options);
```

I use a property from the type `FastifyServerOptions` so it makes Typescript happy but also pass another property called http which will be used by fastify to create a server.

## What is the new behavior?

With addition of the new type you can now do this (likewise the https property):

```typescript
new FastifyAdapter({
  http: {
    maxHeaderSize: 32768
  }
})
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
