### PR TITLE
feat(core): print cause of uncaught errors in their stack trace

### DIFF
--- a/packages/core/errors/exception-handler.ts
+++ b/packages/core/errors/exception-handler.ts
@@ -1,14 +1,21 @@
-import { RuntimeException } from './exceptions/runtime.exception';
 import { Logger } from '@nestjs/common/services/logger.service';
+import { combineStackTrace } from '../helpers/combine-stack-trace';
+import { RuntimeException } from './exceptions/runtime.exception';
 
 export class ExceptionHandler {
   private static readonly logger = new Logger(ExceptionHandler.name);
 
   public handle(exception: RuntimeException | Error) {
     if (!(exception instanceof RuntimeException)) {
-      ExceptionHandler.logger.error(exception.message, exception.stack);
+      ExceptionHandler.logger.error(
+        exception.message,
+        combineStackTrace(exception),
+      );
       return;
     }
-    ExceptionHandler.logger.error(exception.what(), exception.stack);
+    ExceptionHandler.logger.error(
+      exception.what(),
+      combineStackTrace(exception),
+    );
   }
 }

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -11,6 +11,7 @@ import {
 import { isObject } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '../adapters';
 import { MESSAGES } from '../constants';
+import { combineStackTrace } from '../helpers/combine-stack-trace';
 import { HttpAdapterHost } from '../helpers/http-adapter-host';
 
 export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
@@ -71,7 +72,7 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
     if (this.isExceptionObject(exception)) {
       return BaseExceptionFilter.logger.error(
         exception.message,
-        exception.stack,
+        combineStackTrace(exception),
       );
     }
     return BaseExceptionFilter.logger.error(exception);

--- a/packages/core/exceptions/external-exception-filter.ts
+++ b/packages/core/exceptions/external-exception-filter.ts
@@ -1,11 +1,15 @@
 import { ArgumentsHost, HttpException, Logger } from '@nestjs/common';
+import { combineStackTrace } from '../helpers/combine-stack-trace';
 
 export class ExternalExceptionFilter<T = any, R = any> {
   private static readonly logger = new Logger('ExceptionsHandler');
 
   catch(exception: T, host: ArgumentsHost): R | Promise<R> {
     if (exception instanceof Error && !(exception instanceof HttpException)) {
-      ExternalExceptionFilter.logger.error(exception.message, exception.stack);
+      ExternalExceptionFilter.logger.error(
+        exception.message,
+        combineStackTrace(exception),
+      );
     }
     throw exception;
   }

--- a/packages/core/helpers/combine-stack-trace.ts
+++ b/packages/core/helpers/combine-stack-trace.ts
@@ -1,0 +1,22 @@
+/**
+ * Generates the full stack trace of an error, recursively including the stack
+ * traces of its causes. An error may specify a cause by passing an object with
+ * a `cause` property as the second argument to the `Error` constructor.
+ *
+ * @param error Error whose stack trace should be generated.
+ * @returns A string representation of the error's stack trace.
+ */
+export function combineStackTrace(error: Error): string {
+  let result = error.stack || '';
+  let errorCause = getErrorCause(error);
+  while (errorCause instanceof Error) {
+    result += '\nCaused by ' + errorCause.stack;
+    errorCause = getErrorCause(errorCause);
+  }
+  return result;
+}
+
+function getErrorCause(error: Error): unknown {
+  // @ts-expect-error - Error.cause has been introduced in ES2022.
+  return error.cause;
+}

--- a/packages/core/test/errors/test/exception-handler.spec.ts
+++ b/packages/core/test/errors/test/exception-handler.spec.ts
@@ -2,7 +2,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 import { ExceptionHandler } from '../../../errors/exception-handler';
 import { RuntimeException } from '../../../errors/exceptions/runtime.exception';
-import { InvalidMiddlewareException } from '../../../errors/exceptions/invalid-middleware.exception';
+import { combineStackTrace } from '../../../helpers/combine-stack-trace';
 
 describe('ExceptionHandler', () => {
   let instance: ExceptionHandler;
@@ -22,13 +22,16 @@ describe('ExceptionHandler', () => {
     it('when exception is instanceof RuntimeException', () => {
       const exception = new RuntimeException('msg');
       instance.handle(exception);
-      expect(errorSpy.calledWith(exception.message, exception.stack)).to.be
-        .true;
+      expect(
+        errorSpy.calledWith(exception.what(), combineStackTrace(exception)),
+      ).to.be.true;
     });
     it('when exception is not instanceof RuntimeException', () => {
-      const exception = new InvalidMiddlewareException('msg');
+      const exception = new Error('msg');
       instance.handle(exception);
-      expect(errorSpy.calledWith(exception.what(), exception.stack)).to.be.true;
+      expect(
+        errorSpy.calledWith(exception.message, combineStackTrace(exception)),
+      ).to.be.true;
     });
   });
 });

--- a/packages/core/test/helpers/combine-stack-trace.spec.ts
+++ b/packages/core/test/helpers/combine-stack-trace.spec.ts
@@ -1,0 +1,42 @@
+import { combineStackTrace } from '@nestjs/core/helpers/combine-stack-trace';
+import { expect } from 'chai';
+
+describe(combineStackTrace.name, () => {
+  it('returns error stack trace as-is when error has no cause', () => {
+    const error = new Error('Something went wrong');
+
+    const stack = combineStackTrace(error);
+
+    expect(stack).to.equal(error.stack);
+  });
+
+  it('appends error stack trace with that of its cause', () => {
+    const cause = new Error('Request failed with HTTP 400');
+    const error = errorWithCause('Something went wrong', cause);
+
+    const stack = combineStackTrace(error);
+
+    expect(stack.startsWith(error.stack)).to.be.true;
+    expect(stack.endsWith(cause.stack)).to.be.true;
+    expect(stack.includes('Caused by Error: Request failed with HTTP 400')).to
+      .be.true;
+  });
+
+  it('recursively appends stack traces', () => {
+    const cause = new Error('Request failed with HTTP 400');
+    const error = errorWithCause('Unable to retrieve data', cause);
+    const caught = errorWithCause('Something went wrong', error);
+
+    const stack = combineStackTrace(caught);
+
+    expect(stack.includes('Caused by Error: Unable to retrieve data')).to.be
+      .true;
+    expect(stack.includes('Caused by Error: Request failed with HTTP 400')).to
+      .be.true;
+  });
+});
+
+function errorWithCause(message: string, cause: unknown): Error {
+  // @ts-expect-error - Error options have been introduced in ES2022.
+  return new Error(message, { cause });
+}

--- a/packages/microservices/exceptions/base-rpc-exception-filter.ts
+++ b/packages/microservices/exceptions/base-rpc-exception-filter.ts
@@ -2,6 +2,7 @@
 import { ArgumentsHost, Logger, RpcExceptionFilter } from '@nestjs/common';
 import { isObject } from '@nestjs/common/utils/shared.utils';
 import { MESSAGES } from '@nestjs/core/constants';
+import { combineStackTrace } from '@nestjs/core/helpers/combine-stack-trace';
 import { Observable, throwError as _throw } from 'rxjs';
 import { RpcException } from './rpc-exception';
 
@@ -27,7 +28,7 @@ export class BaseRpcExceptionFilter<T = any, R = any>
     const errorMessage = MESSAGES.UNKNOWN_EXCEPTION_MESSAGE;
 
     const loggerArgs = this.isError(exception)
-      ? [exception.message, exception.stack]
+      ? [exception.message, combineStackTrace(exception)]
       : [exception];
     const logger = BaseRpcExceptionFilter.logger;
     logger.error.apply(logger, loggerArgs as any);

--- a/packages/websockets/exceptions/base-ws-exception-filter.ts
+++ b/packages/websockets/exceptions/base-ws-exception-filter.ts
@@ -1,6 +1,7 @@
 import { ArgumentsHost, Logger, WsExceptionFilter } from '@nestjs/common';
 import { isObject } from '@nestjs/common/utils/shared.utils';
 import { MESSAGES } from '@nestjs/core/constants';
+import { combineStackTrace } from '@nestjs/core/helpers/combine-stack-trace';
 import { WsException } from '../errors/ws-exception';
 
 /**
@@ -49,7 +50,7 @@ export class BaseWsExceptionFilter<TError = any>
     if (this.isExceptionObject(exception)) {
       return BaseWsExceptionFilter.logger.error(
         exception.message,
-        exception.stack,
+        combineStackTrace(exception),
       );
     }
     return BaseWsExceptionFilter.logger.error(exception);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #13550

When an uncaught error is thrown, NestJS handles it using the configured `ExceptionFilter`. If the default filter is not overridden, the error is logged under the `ExceptionsHandler` tag with its message and stack trace.

Since ECMAScript 2022, the `Error` constructor accepts a new `cause` parameter option. The cause of an `Error` is printed to the console when passed to `console.error`:

```typescript
const cause = new Error("The real cause of our problem");
const error = new Error("Something went wrong here", { cause })
const caught = new Error("An unexpected error occurred", { cause: exception });
console.error(caught);

// prints stack trace, recursively specifying the cause
Error: An unexpected error occurred
    at REPL3:1:14
    at ContextifyScript.runInThisContext (node:vm:136:12)
    ... 7 lines matching cause stack trace ...
    at [_line] [as _line] (node:internal/readline/interface:888:18) {
  [cause]: Error: Something went wrong here
      at REPL2:1:13
      at ContextifyScript.runInThisContext (node:vm:136:12)
      ... 7 lines matching cause stack trace ...
      at [_line] [as _line] (node:internal/readline/interface:888:18) {
    [cause]: Error: The real cause of our problem
        at REPL1:1:13
        at ContextifyScript.runInThisContext (node:vm:136:12)
        at REPLServer.defaultEval (node:repl:598:22)
        at bound (node:domain:432:15)
        at REPLServer.runBound [as eval] (node:domain:443:12)
        at REPLServer.onLine (node:repl:927:10)
        at REPLServer.emit (node:events:531:35)
        at REPLServer.emit (node:domain:488:12)
        at [_onLine] [as _onLine] (node:internal/readline/interface:417:12)
        at [_line] [as _line] (node:internal/readline/interface:888:18)
  }
}
```

But since NestJS only considers the caught error's stack trace, it does not include the root causes, making it hard to diagnose issues. The above example would only print something like the following:

```typescript
Error: An unexpected error occurred
    at REPL3:1:14
    at ContextifyScript.runInThisContext (node:vm:136:12)
    ... 7 lines matching cause stack trace ...
    at [_line] [as _line] (node:internal/readline/interface:888:18)
```

## What is the new behavior?

When an unexpected error occurs, NestJS now recursively logs error causes. This only focuses on error causes and does not display any custom property error objects may have.

The above example would generate the following stack trace:

```typescript
Error: An unexpected error occurred
    at REPL3:1:14
    at ContextifyScript.runInThisContext (node:vm:136:12)
Caused by Error: Something went wrong here
    at REPL2:1:13
    at ContextifyScript.runInThisContext (node:vm:136:12)
Caused by Error: The real cause of our problem
    at REPL1:1:13
    at ContextifyScript.runInThisContext (node:vm:136:12)
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This change makes sure that stack trace of errors without a cause are logged exactly the same way as before.
The only impact is that logged error stack traces may be longer. Deeply nested errors may cause logs to be less readable.

## Other information
None.