### PR TITLE
feat(core): Modify BaseExceptionFilter to print exception properties

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -12,6 +12,7 @@ import { isObject } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '../adapters';
 import { MESSAGES } from '../constants';
 import { HttpAdapterHost } from '../helpers/http-adapter-host';
+import { inspect } from 'util';
 
 export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
   private static readonly logger = new Logger('ExceptionsHandler');
@@ -71,7 +72,7 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
     if (this.isExceptionObject(exception)) {
       return BaseExceptionFilter.logger.error(
         exception.message,
-        exception.stack,
+        inspect(exception, false, null),
       );
     }
     return BaseExceptionFilter.logger.error(exception);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13550 #13870

## What is the new behavior?

First of all, I sincerely apologize for creating a new PR for the same issue. I couldn’t find the commit related to the previous approach of using the inspect utility function in #13870, so I created a PR.

In #13870, the `combineStackTrace` method was used to trace the `cause` of `Error`. However, it does not output other properties of the error object as intended by the code author.

While I agree that it's important to print the `cause` property of the `Error`, I also believe that other properties should be printed as well.

Below is an example of an error that occurred with the database using the pg library. It includes a code to identify the error and hints for debugging.

```
node_modules/pg-protocol/src/parser.ts:369
      name === 'notice' ? new NoticeMessage(length, messageValue) : new DatabaseError(messageValue, length, name)
                                                                    ^
error: terminating connection due to administrator command
    at Parser.parseErrorMessage (/Users/kpturner/fotech/panoptes-ui-prototype/node_modules/pg-protocol/src/parser.ts:369:69)
    at Parser.handlePacket (/Users/kpturner/fotech/panoptes-ui-prototype/node_modules/pg-protocol/src/parser.ts:188:21)
    at Parser.parse (/Users/kpturner/fotech/panoptes-ui-prototype/node_modules/pg-protocol/src/parser.ts:103:30)
    at Socket.<anonymous> (/Users/kpturner/fotech/panoptes-ui-prototype/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:390:28)
    at Socket.emit (node:domain:475:12)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at TCP.onStreamRead (node:internal/stream_base_commons:199:23) {
  length: 116,
  severity: 'FATAL',
  code: '57P01',
  detail: undefined,
  hint: undefined,
  position: undefined,
  internalPosition: undefined,
  internalQuery: undefined,
  where: undefined,
  schema: undefined,
  table: undefined,
  column: undefined,
  dataType: undefined,
  constraint: undefined,
  file: 'postgres.c',
  line: '2925',
  routine: 'ProcessInterrupts'
}
```

As shown in the example above, I believe it would be useful for debugging if other property values of the error object are printed.

I would like to ask for your opinion on this issue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

(I wasn’t sure whether to leave this in the issue section or the PR section, so I left it in the PR section to show the code changes. I apologize if it should have been in the issue section instead.)