### PR TITLE
feat(fastify): adding opts to the listen method interface and deprecating variadic JSDocs warnings

### DIFF
--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -99,7 +99,7 @@ export interface NestFastifyApplication<
     callback?: (err: Error | null, address: string) => void,
   ): Promise<TServer>;
   listen(
-    opts: FastifyListenOptions,
+    opts?: FastifyListenOptions,
   ): Promise<TServer>;
   listen(
     callback?: (err: Error | null, address: string) => void,

--- a/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
+++ b/packages/platform-fastify/interfaces/nest-fastify-application.interface.ts
@@ -2,6 +2,7 @@ import { INestApplication, HttpServer } from '@nestjs/common';
 import {
   FastifyBodyParser,
   FastifyInstance,
+  FastifyListenOptions,
   FastifyPluginAsync,
   FastifyPluginCallback,
   FastifyPluginOptions,
@@ -94,18 +95,40 @@ export interface NestFastifyApplication<
    * @returns A Promise that, when resolved, is a reference to the underlying HttpServer.
    */
   listen(
-    port: number | string,
-    callback?: (err: Error, address: string) => void,
+    opts: FastifyListenOptions,
+    callback?: (err: Error | null, address: string) => void,
   ): Promise<TServer>;
+  listen(
+    opts: FastifyListenOptions,
+  ): Promise<TServer>;
+  listen(
+    callback?: (err: Error | null, address: string) => void,
+  ): Promise<TServer>;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
+  listen(
+    port: number | string,
+    callback?: (err: Error | null, address: string) => void,
+  ): Promise<TServer>;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(
     port: number | string,
     address: string,
-    callback?: (err: Error, address: string) => void,
+    callback?: (err: Error | null, address: string) => void,
   ): Promise<TServer>;
+  /**
+   * @deprecated Variadic listen method is deprecated. Please use `.listen(optionsObject, callback)` instead. The variadic signature will be removed in `fastify@5`
+   * @see https://github.com/fastify/fastify/pull/3712
+   */
   listen(
     port: number | string,
     address: string,
     backlog: number,
-    callback?: (err: Error, address: string) => void,
+    callback?: (err: Error | null, address: string) => void,
   ): Promise<TServer>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
related to [https://github.com/fastify/fastify/pull/3712](https://github.com/fastify/fastify/pull/3712), [https://github.com/fastify/fastify/issues/3652](https://github.com/fastify/fastify/issues/3652) [https://github.com/fastify/fastify/pull/3751](https://github.com/fastify/fastify/pull/3751)

adding the missing instance.listen() interface to allow the use of opts: FastifyListenOptions argument instead of variadic arguments only, accordingly with the current version of fastify.

variadic is already deprecated in fastify v4 TS interfaces, being runtime warned in v5 and should be removed in v6.

this change **_is not removing any previous behavior_**.

## What is the new behavior?

allows the use of listen option object:

```typescript
await app.listen({
  host: 'localhost',
  port: 8080,
  listenTextResolver: (address) => `web server listening at ${address}`,
});
```

```typescript
interface FastifyListenOptions {
  /**
   * Default to `0` (picks the first available open port).
   */
  port?: number;
  /**
   * Default to `localhost`.
   */
  host?: string;
  /**
   * Will be ignored if `port` is specified.
   * @see [Identifying paths for IPC connections](https://nodejs.org/api/net.html#identifying-paths-for-ipc-connections).
   */
  path?: string;
  /**
   * Specify the maximum length of the queue of pending connections.
   * The actual length will be determined by the OS through sysctl settings such as `tcp_max_syn_backlog` and `somaxconn` on Linux.
   * Default to `511`.
   */
  backlog?: number;
  /**
   * Default to `false`.
   */
  exclusive?: boolean;
  /**
   * For IPC servers makes the pipe readable for all users.
   * Default to `false`.
   */
  readableAll?: boolean;
  /**
   * For IPC servers makes the pipe writable for all users.
   * Default to `false`.
   */
  writableAll?: boolean;
  /**
   * For TCP servers, setting `ipv6Only` to `true` will disable dual-stack support, i.e., binding to host `::` won't make `0.0.0.0` be bound.
   * Default to `false`.
   */
  ipv6Only?: boolean;
  /**
   * An AbortSignal that may be used to close a listening server.
   * @since This option is available only in Node.js v15.6.0 and greater
   */
  signal?: AbortSignal;

  /**
   * Function that resolves text to log after server has been successfully started
   * @param address
   */
  listenTextResolver?: (address: string) => string;
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information