### PR TITLE
feat(common): modify Logger to allow setting a prefix

### DIFF
--- a/packages/common/interfaces/nest-application-context-options.interface.ts
+++ b/packages/common/interfaces/nest-application-context-options.interface.ts
@@ -10,6 +10,11 @@ export class NestApplicationContextOptions {
   logger?: LoggerService | LogLevel[] | false;
 
   /**
+   * Logger prefix.
+   */
+  loggerPrefix?: string;
+
+  /**
    * Whether to abort the process on Error. By default, the process is exited.
    * Pass `false` to override the default behavior. If `false` is passed, Nest will not exit
    * the application and instead will rethrow the exception.

--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -79,6 +79,13 @@ export interface INestApplication<TServer = any>
   setGlobalPrefix(prefix: string, options?: GlobalPrefixOptions): this;
 
   /**
+   * Registers a prefix for logger
+   *
+   * @param {string} prefix The prefix for logger
+   */
+  setLoggerPrefix(prefix: string): this;
+
+  /**
    * Register Ws Adapter which will be used inside Gateways.
    * Use when you want to override default `socket.io` library.
    *

--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -20,6 +20,8 @@ export interface ConsoleLoggerOptions {
   timestamp?: boolean;
 }
 
+const DEFAULT_PREFIX = 'Nest';
+
 const DEFAULT_LOG_LEVELS: LogLevel[] = [
   'log',
   'error',
@@ -42,6 +44,7 @@ const dateTimeFormatter = new Intl.DateTimeFormat(undefined, {
 export class ConsoleLogger implements LoggerService {
   private static lastTimestampAt?: number;
   private originalContext?: string;
+  private static prefix: string = DEFAULT_PREFIX;
 
   constructor();
   constructor(context: string);
@@ -175,6 +178,14 @@ export class ConsoleLogger implements LoggerService {
   }
 
   /**
+   * Set logger prefix
+   * @param setPrefix prefix
+   */
+  setPrefix(prefix: string): void {
+    ConsoleLogger.prefix = prefix;
+  }
+
+  /**
    * Set logger context
    * @param context context
    */
@@ -223,7 +234,7 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected formatPid(pid: number) {
-    return `[Nest] ${pid}  - `;
+    return `[${ConsoleLogger.prefix}] ${pid}  - `;
   }
 
   protected formatContext(context: string): string {

--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -179,7 +179,7 @@ export class ConsoleLogger implements LoggerService {
 
   /**
    * Set logger prefix
-   * @param setPrefix prefix
+   * @param prefix prefix
    */
   setPrefix(prefix: string): void {
     ConsoleLogger.prefix = prefix;

--- a/packages/common/services/logger.service.ts
+++ b/packages/common/services/logger.service.ts
@@ -47,6 +47,12 @@ export interface LoggerService {
    * @param levels log levels
    */
   setLogLevels?(levels: LogLevel[]): any;
+
+  /**
+   * Set prefix
+   * @param prefix prefix
+   */
+  setPrefix?(prefix: string): void;
 }
 
 interface LogBufferRecord {
@@ -120,6 +126,10 @@ export class Logger implements LoggerService {
       }
     }
     return Logger.staticInstanceRef;
+  }
+
+  setPrefix(prefix: string): void {
+    this.localInstance?.setPrefix?.(prefix);
   }
 
   /**

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -382,6 +382,11 @@ export class NestApplication
     return this;
   }
 
+  public setLoggerPrefix(prefix: string): this {
+    this.logger.setPrefix(prefix);
+    return this;
+  }
+
   public useWebSocketAdapter(adapter: WebSocketAdapter): this {
     this.config.setIoAdapter(adapter);
     return this;

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -287,9 +287,12 @@ export class NestFactoryStatic {
     if (!options) {
       return;
     }
-    const { logger, bufferLogs, autoFlushLogs } = options;
+    const { logger, bufferLogs, autoFlushLogs, loggerPrefix } = options;
     if ((logger as boolean) !== true && !isNil(logger)) {
       Logger.overrideLogger(logger);
+    }
+    if (loggerPrefix) {
+      this.logger.setPrefix(loggerPrefix);
     }
     if (bufferLogs) {
       Logger.attachBuffer();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13841 

## What is the new behavior?

Hello,

I became interested in this issue, so I made some methods.

As suggested in the issue (`app.setLoggerPrefix('my-app-name')`), I created a setLoggerPrefix method.

```typescript
async function bootstrap() {
  const app = await NestFactory.create(AppModule);

  app.setLoggerPrefix('app-name');

  await app.listen(3000);
}
```

I expected it to be used in this way.

However, I noticed that logging also occurs when `NestFactory.create` is called. The prefix set with `app.setLoggerPrefix` does not apply to these log messages because `NestFactory.create` is called before `app.setLoggerPrefix`.

To address this, I added a `loggerPrefix` field to `NestApplicationContextOptions`, and now you can use it like this:

```typescript
async function bootstrap() {
  const app = await NestFactory.create(AppModule, { loggerPrefix: 'app-name' });

  await app.listen(3000);
}
```

What are your thoughts on this approach? I'd appreciate your feedback.

![image](https://github.com/user-attachments/assets/9072e440-738e-4fd9-b5b0-ed02cdb04844)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information