### PR TITLE
feat(common): Set ConsoleLogger prefix via env

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -223,7 +223,7 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected formatPid(pid: number) {
-    return `[Nest] ${pid}  - `;
+    return `[${process.env.CONSOLE_LOGGER_PREFIX || 'Nest'}] ${pid}  - `;
   }
 
   protected formatContext(context: string): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #13913 #13841

## What is the new behavior?

In my previous PR, I overlooked the potential confusion caused by the `useLogger` method in the `INestApplication` interface.

I believe the issue at hand is to allow changing the prefix even when using the default `ConsoleLogger` provided by Nest.

Modifying INestApplication could lead to confusion with the useLogger method, so how about allowing the prefix to be changed via an environment variable instead?

This approach would enable changing the prefix through application runtime options without any code changes, making it the simplest solution to address the issue.

Do you foresee any potential issues with this approach, such as increasing code complexity or introducing other problems?

I would greatly appreciate your feedback.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
