### PR TITLE
fix(grpc-loader): add new options by generic props loader

### DIFF
--- a/packages/microservices/interfaces/client-metadata.interface.ts
+++ b/packages/microservices/interfaces/client-metadata.interface.ts
@@ -14,7 +14,7 @@ import {
 import { Serializer } from './serializer.interface';
 import { ConnectionOptions } from 'tls';
 
-export type ClientOptions<ClientProviderOverrideOptions> =
+export type ClientOptions<ClientProviderOverrideOptions = {}> =
   | RedisOptions
   | NatsOptions
   | MqttOptions

--- a/packages/microservices/interfaces/client-metadata.interface.ts
+++ b/packages/microservices/interfaces/client-metadata.interface.ts
@@ -14,7 +14,7 @@ import {
 import { Serializer } from './serializer.interface';
 import { ConnectionOptions } from 'tls';
 
-export type ClientOptions<ClientProviderCustomOptions = {}> =
+export type ClientOptions<ClientProviderCustomOptions = any> =
   | RedisOptions
   | NatsOptions
   | MqttOptions

--- a/packages/microservices/interfaces/client-metadata.interface.ts
+++ b/packages/microservices/interfaces/client-metadata.interface.ts
@@ -14,11 +14,11 @@ import {
 import { Serializer } from './serializer.interface';
 import { ConnectionOptions } from 'tls';
 
-export type ClientOptions<ClientProviderOverrideOptions = {}> =
+export type ClientOptions<ClientProviderCustomOptions = {}> =
   | RedisOptions
   | NatsOptions
   | MqttOptions
-  | GrpcOptions<ClientProviderOverrideOptions>
+  | GrpcOptions<ClientProviderCustomOptions>
   | KafkaOptions
   | TcpClientOptions
   | RmqOptions;

--- a/packages/microservices/interfaces/client-metadata.interface.ts
+++ b/packages/microservices/interfaces/client-metadata.interface.ts
@@ -14,11 +14,11 @@ import {
 import { Serializer } from './serializer.interface';
 import { ConnectionOptions } from 'tls';
 
-export type ClientOptions =
+export type ClientOptions<ClientProviderOverrideOptions> =
   | RedisOptions
   | NatsOptions
   | MqttOptions
-  | GrpcOptions
+  | GrpcOptions<ClientProviderOverrideOptions>
   | KafkaOptions
   | TcpClientOptions
   | RmqOptions;

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -57,7 +57,7 @@ interface DefaultLoaderOptions {
 /**
  * @publicApi
  */
-export interface GrpcOptions<GrpcLoaderOption = {}> {
+export interface GrpcOptions<GrpcLoaderOptions = {}> {
   transport?: Transport.GRPC;
   options: {
     url?: string;
@@ -81,7 +81,7 @@ export interface GrpcOptions<GrpcLoaderOption = {}> {
     packageDefinition?: any;
     gracefulShutdown?: boolean;
     onLoadPackageDefinition?: (pkg: any, server: any) => void;
-    loader?: GrpcLoaderOption | DefaultLoaderOptions;
+    loader?: GrpcLoaderOptions | DefaultLoaderOptions;
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -22,8 +22,8 @@ import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
 
-export type MicroserviceOptions =
-  | GrpcOptions
+export type MicroserviceOptions<GrpcLoaderOption> =
+  | GrpcOptions<GrpcLoaderOption>
   | TcpOptions
   | RedisOptions
   | NatsOptions
@@ -43,7 +43,7 @@ export interface CustomStrategy {
 /**
  * @publicApi
  */
-export interface GrpcOptions {
+export interface GrpcOptions<GrpcLoaderOption> {
   transport?: Transport.GRPC;
   options: {
     url?: string;
@@ -67,19 +67,21 @@ export interface GrpcOptions {
     packageDefinition?: any;
     gracefulShutdown?: boolean;
     onLoadPackageDefinition?: (pkg: any, server: any) => void;
-    loader?: {
-      keepCase?: boolean;
-      alternateCommentMode?: boolean;
-      longs?: Function;
-      enums?: Function;
-      bytes?: Function;
-      defaults?: boolean;
-      arrays?: boolean;
-      objects?: boolean;
-      oneofs?: boolean;
-      json?: boolean;
-      includeDirs?: string[];
-    };
+    loader?:
+      | GrpcLoaderOption
+      | {
+          keepCase?: boolean;
+          alternateCommentMode?: boolean;
+          longs?: Function;
+          enums?: Function;
+          bytes?: Function;
+          defaults?: boolean;
+          arrays?: boolean;
+          objects?: boolean;
+          oneofs?: boolean;
+          json?: boolean;
+          includeDirs?: string[];
+        };
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -22,7 +22,7 @@ import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
 
-export type MicroserviceOptions<GrpcLoaderOption = {}> =
+export type MicroserviceOptions<GrpcLoaderOption = any> =
   | GrpcOptions<GrpcLoaderOption>
   | TcpOptions
   | RedisOptions

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -57,7 +57,7 @@ interface DefaultLoaderOptions {
 /**
  * @publicApi
  */
-export interface GrpcOptions<GrpcLoaderOptions = any> {
+export interface GrpcOptions<GrpcLoaderOptions = DefaultLoaderOptions> {
   transport?: Transport.GRPC;
   options: {
     url?: string;
@@ -81,7 +81,7 @@ export interface GrpcOptions<GrpcLoaderOptions = any> {
     packageDefinition?: any;
     gracefulShutdown?: boolean;
     onLoadPackageDefinition?: (pkg: any, server: any) => void;
-    loader?: GrpcLoaderOptions | DefaultLoaderOptions;
+    loader?: GrpcLoaderOptions;
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -22,7 +22,7 @@ import { CustomTransportStrategy } from './custom-transport-strategy.interface';
 import { Deserializer } from './deserializer.interface';
 import { Serializer } from './serializer.interface';
 
-export type MicroserviceOptions<GrpcLoaderOption> =
+export type MicroserviceOptions<GrpcLoaderOption = {}> =
   | GrpcOptions<GrpcLoaderOption>
   | TcpOptions
   | RedisOptions
@@ -40,10 +40,24 @@ export interface CustomStrategy {
   options?: {};
 }
 
+interface DefaultLoaderOptions {
+  keepCase?: boolean;
+  alternateCommentMode?: boolean;
+  longs?: Function;
+  enums?: Function;
+  bytes?: Function;
+  defaults?: boolean;
+  arrays?: boolean;
+  objects?: boolean;
+  oneofs?: boolean;
+  json?: boolean;
+  includeDirs?: string[];
+}
+
 /**
  * @publicApi
  */
-export interface GrpcOptions<GrpcLoaderOption> {
+export interface GrpcOptions<GrpcLoaderOption = {}> {
   transport?: Transport.GRPC;
   options: {
     url?: string;
@@ -67,21 +81,7 @@ export interface GrpcOptions<GrpcLoaderOption> {
     packageDefinition?: any;
     gracefulShutdown?: boolean;
     onLoadPackageDefinition?: (pkg: any, server: any) => void;
-    loader?:
-      | GrpcLoaderOption
-      | {
-          keepCase?: boolean;
-          alternateCommentMode?: boolean;
-          longs?: Function;
-          enums?: Function;
-          bytes?: Function;
-          defaults?: boolean;
-          arrays?: boolean;
-          objects?: boolean;
-          oneofs?: boolean;
-          json?: boolean;
-          includeDirs?: string[];
-        };
+    loader?: GrpcLoaderOption | DefaultLoaderOptions;
   };
 }
 

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -57,7 +57,7 @@ interface DefaultLoaderOptions {
 /**
  * @publicApi
  */
-export interface GrpcOptions<GrpcLoaderOptions = {}> {
+export interface GrpcOptions<GrpcLoaderOptions = any> {
   transport?: Transport.GRPC;
   options: {
     url?: string;

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -15,8 +15,8 @@ import {
 
 @Module({})
 export class ClientsModule {
-  static register<ClientProviderOverrideOptions>(
-    options: ClientsModuleOptions<ClientProviderOverrideOptions>,
+  static register<ClientProviderCustomOptions>(
+    options: ClientsModuleOptions<ClientProviderCustomOptions>,
   ): DynamicModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
     const clients = (clientsOptions || []).map(item => {

--- a/packages/microservices/module/clients.module.ts
+++ b/packages/microservices/module/clients.module.ts
@@ -15,7 +15,9 @@ import {
 
 @Module({})
 export class ClientsModule {
-  static register(options: ClientsModuleOptions): DynamicModule {
+  static register<ClientProviderOverrideOptions>(
+    options: ClientsModuleOptions<ClientProviderOverrideOptions>,
+  ): DynamicModule {
     const clientsOptions = !Array.isArray(options) ? options.clients : options;
     const clients = (clientsOptions || []).map(item => {
       return {
@@ -23,6 +25,7 @@ export class ClientsModule {
         useValue: this.assignOnAppShutdownHook(ClientProxyFactory.create(item)),
       };
     });
+
     return {
       module: ClientsModule,
       global: !Array.isArray(options) && options.isGlobal,

--- a/packages/microservices/module/interfaces/clients-module.interface.ts
+++ b/packages/microservices/module/interfaces/clients-module.interface.ts
@@ -1,19 +1,19 @@
 import { ClientOptions, CustomClientOptions } from '../../interfaces';
 import { Type, Provider, ModuleMetadata } from '@nestjs/common/interfaces';
 
-export type ClientProvider<ClientProviderOverrideOptions = {}> =
-  | ClientOptions<ClientProviderOverrideOptions>
+export type ClientProvider<ClientProviderCustomOptions = {}> =
+  | ClientOptions<ClientProviderCustomOptions>
   | CustomClientOptions;
 
-export type ClientProviderOptions<ClientProviderOverrideOptions> =
-  ClientProvider<ClientProviderOverrideOptions> & {
+export type ClientProviderOptions<ClientProviderCustomOptions> =
+  ClientProvider<ClientProviderCustomOptions> & {
     name: string | symbol;
   };
 
-export type ClientsModuleOptions<ClientProviderOverrideOptions = {}> =
-  | Array<ClientProviderOptions<ClientProviderOverrideOptions>>
+export type ClientsModuleOptions<ClientProviderCustomOptions = {}> =
+  | Array<ClientProviderOptions<ClientProviderCustomOptions>>
   | {
-      clients: Array<ClientProviderOptions<ClientProviderOverrideOptions>>;
+      clients: Array<ClientProviderOptions<ClientProviderCustomOptions>>;
       isGlobal?: boolean;
     };
 

--- a/packages/microservices/module/interfaces/clients-module.interface.ts
+++ b/packages/microservices/module/interfaces/clients-module.interface.ts
@@ -1,7 +1,7 @@
 import { ClientOptions, CustomClientOptions } from '../../interfaces';
 import { Type, Provider, ModuleMetadata } from '@nestjs/common/interfaces';
 
-export type ClientProvider<ClientProviderCustomOptions = {}> =
+export type ClientProvider<ClientProviderCustomOptions = any> =
   | ClientOptions<ClientProviderCustomOptions>
   | CustomClientOptions;
 
@@ -10,7 +10,7 @@ export type ClientProviderOptions<ClientProviderCustomOptions> =
     name: string | symbol;
   };
 
-export type ClientsModuleOptions<ClientProviderCustomOptions = {}> =
+export type ClientsModuleOptions<ClientProviderCustomOptions = any> =
   | Array<ClientProviderOptions<ClientProviderCustomOptions>>
   | {
       clients: Array<ClientProviderOptions<ClientProviderCustomOptions>>;

--- a/packages/microservices/module/interfaces/clients-module.interface.ts
+++ b/packages/microservices/module/interfaces/clients-module.interface.ts
@@ -1,16 +1,19 @@
 import { ClientOptions, CustomClientOptions } from '../../interfaces';
 import { Type, Provider, ModuleMetadata } from '@nestjs/common/interfaces';
 
-export type ClientProvider = ClientOptions | CustomClientOptions;
+export type ClientProvider<ClientProviderOverrideOptions = {}> =
+  | ClientOptions<ClientProviderOverrideOptions>
+  | CustomClientOptions;
 
-export type ClientProviderOptions = ClientProvider & {
-  name: string | symbol;
-};
+export type ClientProviderOptions<ClientProviderOverrideOptions> =
+  ClientProvider<ClientProviderOverrideOptions> & {
+    name: string | symbol;
+  };
 
-export type ClientsModuleOptions =
-  | Array<ClientProviderOptions>
+export type ClientsModuleOptions<ClientProviderOverrideOptions = {}> =
+  | Array<ClientProviderOptions<ClientProviderOverrideOptions>>
   | {
-      clients: Array<ClientProviderOptions>;
+      clients: Array<ClientProviderOptions<ClientProviderOverrideOptions>>;
       isGlobal?: boolean;
     };
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
The current grpc loader options for custom options has type any.

Issue Number: #13930 


## What is the new behavior?
This PR allows to pass generic type to the grpc loader options, and then, the custom options provided starts having type safety.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->