### PR TITLE
chore(fastify): upgrade `@fastify/middie` to address security vulnerability

### DIFF
--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@fastify/cors": "9.0.1",
     "@fastify/formbody": "7.4.0",
-    "@fastify/middie": "8.3.1",
+    "@fastify/middie": "8.3.3",
     "fastify": "4.28.1",
     "light-my-request": "6.0.0",
     "path-to-regexp": "3.3.0",


### PR DESCRIPTION
see https://github.com/fastify/middie/releases/tag/v8.3.3