### PR TITLE
fix(fastify): uppercase http method names

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -289,35 +289,35 @@ export class FastifyAdapter<
   }
 
   public get(...args: any[]) {
-    return this.injectRouteOptions('get', ...args);
+    return this.injectRouteOptions('GET', ...args);
   }
 
   public post(...args: any[]) {
-    return this.injectRouteOptions('post', ...args);
+    return this.injectRouteOptions('POST', ...args);
   }
 
   public head(...args: any[]) {
-    return this.injectRouteOptions('head', ...args);
+    return this.injectRouteOptions('HEAD', ...args);
   }
 
   public delete(...args: any[]) {
-    return this.injectRouteOptions('delete', ...args);
+    return this.injectRouteOptions('DELETE', ...args);
   }
 
   public put(...args: any[]) {
-    return this.injectRouteOptions('put', ...args);
+    return this.injectRouteOptions('PUT', ...args);
   }
 
   public patch(...args: any[]) {
-    return this.injectRouteOptions('patch', ...args);
+    return this.injectRouteOptions('PATCH', ...args);
   }
 
   public options(...args: any[]) {
-    return this.injectRouteOptions('options', ...args);
+    return this.injectRouteOptions('OPTIONS', ...args);
   }
 
   public search(...args: any[]) {
-    return this.injectRouteOptions('search', ...args);
+    return this.injectRouteOptions('SEARCH', ...args);
   }
 
   public applyVersionFilter(


### PR DESCRIPTION
Fastify expects uppercase and won't auto-add the HEAD method otherwise

Closes #13016

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix


## What is the current behavior?

When a `GET` endpoint is registered with Fastify, Nest responds with 404 on a `HEAD` request

Issue Number: #14016 


## What is the new behavior?

Fastify correctly detects that the endpoint is a `GET` and auto-adds a `HEAD` handler too.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The Fastify logic is here and you can see it expects uppercase method names: 
https://github.com/fastify/fastify/blob/238d8a4f78b75c88e7b69b2d97fe27dd93fc520d/lib/route.js#L210