### PR TITLE
fix(microservices): include discarded rmq client options

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -135,9 +135,7 @@ export class ClientRMQ extends ClientProxy {
 
   public createClient(): AmqpConnectionManager {
     const socketOptions = this.getOptionsProp(this.options, 'socketOptions');
-    return rmqPackage.connect(this.urls, {
-      connectionOptions: socketOptions?.connectionOptions,
-    });
+    return rmqPackage.connect(this.urls, socketOptions);
   }
 
   public mergeDisconnectEvent<T = any>(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Configuration properties were being discarded upon rmqClient creation.
All other properties, beside 'connectionOptions', from the this.options.socketOptions object ( of type AmqpConnectionManagerSocketOptions ) were being discarded on the creation of the AmqpConnectionManager client
See:
https://github.com/nestjs/nest/blob/master/packages/microservices/external/rmq-url.interface.ts#L47 https://github.com/jwalton/node-amqp-connection-manager/blob/v4.1.14/src/AmqpConnectionManager.ts#L46

Issue Number: https://github.com/nestjs/nest/issues/5788#issuecomment-2373361313

## What is the new behavior?

The other properties from the socketOptions key will now be included ( if present ) when the rmqClient is created


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information