### PR TITLE
test(common): add tests for validation pipe on 'custom' types

### DIFF
--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -478,6 +478,56 @@ describe('ValidationPipe', () => {
     });
   });
 
+  describe('option: "validateCustomDecorators" when metadata.type is not `body`', () => {
+    describe('when is set to `true`', () => {
+      it('should transform and validate', async () => {
+        const target = new ValidationPipe({
+          validateCustomDecorators: true,
+        });
+
+        const metadata: ArgumentMetadata = {
+          type: 'custom',
+          metatype: TestModel,
+          data: '',
+        };
+
+        const testObj = { prop1: 'value1', prop2: 'value2' };
+        expect(await target.transform(testObj, metadata)).to.not.be.undefined;
+      });
+    });
+    describe('when is set to `false`', () => {
+      it('should throw an error', async () => {
+        const target = new ValidationPipe({
+          validateCustomDecorators: false,
+        });
+
+        const metadata: ArgumentMetadata = {
+          type: 'custom',
+          metatype: TestModel,
+          data: '',
+        };
+
+        const objNotFollowingTestModel = { prop1: undefined, prop2: 'value2' };
+        expect(await target.transform(objNotFollowingTestModel, metadata)).to
+          .not.be.undefined;
+      });
+    });
+    describe('when is not supplied', () => {
+      it('should transform and validate', async () => {
+        const target = new ValidationPipe({});
+
+        const metadata: ArgumentMetadata = {
+          type: 'custom',
+          metatype: TestModel,
+          data: '',
+        };
+
+        const testObj = { prop1: 'value1', prop2: 'value2' };
+        expect(await target.transform(testObj, metadata)).to.not.be.undefined;
+      });
+    });
+  });
+
   describe('option: "errorHttpStatusCode"', () => {
     describe('when validation fails', () => {
       beforeEach(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

no tests regarding `validateCustomDecorators` option of `ValidationPipe`

## What is the new behavior?

more unit tests to cover all values for `validateCustomDecorators` option of `ValidationPipe`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

