### PR TITLE
fix(core): revisit dependencies w/ possibly higher distance

### DIFF
--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -389,12 +389,12 @@ export class DependenciesScanner {
     // Skip "InternalCoreModule" from calculating distance
     modulesGenerator.next();
 
-    const modulesStack = [];
-    const calculateDistance = (moduleRef: Module, distance = 1) => {
-      if (!moduleRef || modulesStack.includes(moduleRef)) {
+    const calculateDistance = (moduleRef: Module, distance = 1, modulesStack = []) => {
+      const localModulesStack = [...modulesStack];
+      if (!moduleRef || localModulesStack.includes(moduleRef)) {
         return;
       }
-      modulesStack.push(moduleRef);
+      localModulesStack.push(moduleRef);
 
       const moduleImports = moduleRef.imports;
       moduleImports.forEach(importedModuleRef => {
@@ -402,7 +402,7 @@ export class DependenciesScanner {
           if (distance > importedModuleRef.distance) {
             importedModuleRef.distance = distance;
           }
-          calculateDistance(importedModuleRef, distance + 1);
+          calculateDistance(importedModuleRef, distance + 1, localModulesStack);
         }
       });
     };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14096 


## What is the new behavior?
The module distance is reevaluated when the module is not within the modules visited in the current depth search. This should be enough to avoid endless loops on cyclic dependency graphs. However, modules that have dependency paths of different length are now evaluated to the higher distance.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information