### PR TITLE
fix(core): Calculate module distance after bindGlobalScope

### DIFF
--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -92,10 +92,10 @@ export class DependenciesScanner {
       overrides: options?.overrides,
     });
     await this.scanModulesForDependencies();
-    this.calculateModulesDistance();
-
     this.addScopedEnhancersMetadata();
     this.container.bindGlobalScope();
+
+    this.calculateModulesDistance();
   }
 
   public async scanForModules({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The global module’s `onModuleInit` is **not** called before its dependent’s `onModuleInit`. This happens because, during the distance calculation, the global module is not yet included in the dependent’s `imports`. It only appears in the `imports` after `bindGlobalScope`, so the distance should be calculated at that point.

Issue Number: https://github.com/nestjs/nest/issues/14117

## What is the new behavior?

The global module’s `onModuleInit` is called before its dependent’s `onModuleInit`.

The test mentioned above passes.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information