### PR TITLE
fix(core): Order of module destroy should be the reverse of module init

### DIFF
--- a/integration/hooks/e2e/on-module-destroy.spec.ts
+++ b/integration/hooks/e2e/on-module-destroy.spec.ts
@@ -43,10 +43,7 @@ describe('OnModuleDestroy', () => {
   it('should sort modules by distance (topological sort) - DESC order', async () => {
     @Injectable()
     class BB implements OnModuleDestroy {
-      public field: string;
-      async onModuleDestroy() {
-        this.field = 'b-field';
-      }
+      onModuleDestroy = Sinon.spy();
     }
 
     @Module({
@@ -57,13 +54,10 @@ describe('OnModuleDestroy', () => {
 
     @Injectable()
     class AA implements OnModuleDestroy {
-      public field: string;
       constructor(private bb: BB) {}
-
-      async onModuleDestroy() {
-        this.field = this.bb.field + '_a-field';
-      }
+      onModuleDestroy = Sinon.spy();
     }
+
     @Module({
       imports: [B],
       providers: [AA],
@@ -78,7 +72,8 @@ describe('OnModuleDestroy', () => {
     await app.init();
     await app.close();
 
-    const instance = module.get(AA);
-    expect(instance.field).to.equal('b-field_a-field');
+    const aa = module.get(AA);
+    const bb = module.get(BB);
+    Sinon.assert.callOrder(aa.onModuleDestroy, bb.onModuleDestroy);
   });
 });

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -384,7 +384,10 @@ export class NestApplicationContext<
    * modules and its children.
    */
   protected async callDestroyHook(): Promise<void> {
-    const modulesSortedByDistance = this.getModulesToTriggerHooksOn();
+    const modulesSortedByDistance = [
+      ...this.getModulesToTriggerHooksOn(),
+    ].reverse();
+
     for (const module of modulesSortedByDistance) {
       await callModuleDestroyHook(module);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Suppose A depends on B, currently, A.onModuleDestroy is executed after B.onModuleDestroy. 

Issue Number: https://github.com/nestjs/nest/issues/14118


## What is the new behavior?

Suppose A depends on B, A.onModuleDestroy is executed before B.onModuleDestroy. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information