### PR TITLE
fix(common): missing type def to support promises for class modules

### DIFF
--- a/packages/common/interfaces/modules/module-metadata.interface.ts
+++ b/packages/common/interfaces/modules/module-metadata.interface.ts
@@ -17,7 +17,11 @@ export interface ModuleMetadata {
    * required in this module.
    */
   imports?: Array<
-    Type<any> | DynamicModule | Promise<DynamicModule> | ForwardReference
+    | Type<any>
+    | DynamicModule
+    | Promise<DynamicModule>
+    | Promise<Type<any>>
+    | ForwardReference
   >;
   /**
    * Optional list of controllers defined in this module which have to be


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

if we have a promise resolving to a class-based nestjs module in the `imports` array, we will se a compilation error:

![image](https://github.com/user-attachments/assets/1313d33d-4849-453d-8071-4997888d11c8)



## What is the new behavior?

it seems that this is supported already but the type definition for that `imports` array is not correct. So I just fixed the type def.

![image](https://github.com/user-attachments/assets/4cc2e3d8-1f9a-450e-a584-1c85e73d2710)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

