### PR TITLE
fix: rabbitmq bindings and auto-generated queues

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -192,6 +192,15 @@ export class ClientRMQ extends ClientProxy {
     if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
+
+    if (this.options.exchange && this.options.routingKey) {
+      await channel.bindQueue(
+        this.queue,
+        this.options.exchange,
+        this.options.routingKey,
+      );
+    }
+
     await channel.prefetch(prefetchCount, isGlobalPrefetchCount);
     await this.consumeChannel(channel);
     resolve();

--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -33,7 +33,7 @@ export const PARAM_ARGS_METADATA = ROUTE_ARGS_METADATA;
 export const REQUEST_PATTERN_METADATA = 'microservices:request_pattern';
 export const REPLY_PATTERN_METADATA = 'microservices:reply_pattern';
 
-export const RQM_DEFAULT_QUEUE = 'default';
+export const RQM_DEFAULT_QUEUE = '';
 export const RQM_DEFAULT_PREFETCH_COUNT = 0;
 export const RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT = false;
 export const RQM_DEFAULT_QUEUE_OPTIONS = {};

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -209,6 +209,8 @@ export interface RmqOptions {
     isGlobalPrefetchCount?: boolean;
     queueOptions?: AmqplibQueueOptions;
     socketOptions?: AmqpConnectionManagerSocketOptions;
+    exchange?: string;
+    routingKey?: string;
     noAck?: boolean;
     consumerTag?: string;
     serializer?: Serializer;

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -153,6 +153,18 @@ export class ServerRMQ extends Server implements CustomTransportStrategy {
     if (!this.noAssert) {
       await channel.assertQueue(this.queue, this.queueOptions);
     }
+
+    if (this.options.exchange && this.options.routingKey) {
+      await channel.assertExchange(this.options.exchange, 'topic', {
+        durable: true,
+      });
+      await channel.bindQueue(
+        this.queue,
+        this.options.exchange,
+        this.options.routingKey,
+      );
+    }
+
     await channel.prefetch(this.prefetchCount, this.isGlobalPrefetchCount);
     channel.consume(
       this.queue,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when creating a new microservice with @nestjs/microservices for RMQ, using an empty string for the queue name creates a queue named default rather than a unique, exclusive queue. Additionally, binding a queue to an exchange specified by exchange and routingKey does not occur as expected.

Issue Number: #13931 


## What is the new behavior?

This PR modifies the default queue name behavior to use an auto-generated name when an empty string is provided. It also implements automatic binding of the queue to the specified exchange and routing key, aligning with standard RabbitMQ behavior.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR also includes updates to the microservices package documentation, detailing the new exchange and routingKey options and their behavior to ensure users have clear guidance on setting up RMQ queues and exchanges in alignment with RabbitMQ standards.

<img width="495" alt="스크린샷 2024-11-11 오전 3 08 25" src="https://github.com/user-attachments/assets/61a83ad3-39d9-4636-be3a-24618ba30dce">
<img width="608" alt="스크린샷 2024-11-11 오전 3 08 48" src="https://github.com/user-attachments/assets/5fd5a739-b2cc-4db7-923e-5bdf36db9cff">
<img width="639" alt="스크린샷 2024-11-11 오전 3 08 54" src="https://github.com/user-attachments/assets/d08fef3c-4bbd-40cb-82c2-6c9d0d5232f6">
