### PR TITLE
chore(core): defer application shutdown until init finishes

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -54,6 +54,7 @@ export class NestApplicationContext<
   private shutdownCleanupRef?: (...args: unknown[]) => unknown;
   private _instanceLinksHost: InstanceLinksHost;
   private _moduleRefsForHooksByDistance?: Array<Module>;
+  private initializationPromise?: Promise<void>;
 
   protected get instanceLinksHost() {
     if (!this._instanceLinksHost) {
@@ -234,8 +235,8 @@ export class NestApplicationContext<
     if (this.isInitialized) {
       return this;
     }
-    await this.callInitHook();
-    await this.callBootstrapHook();
+    this.initializationPromise = this.internalInit();
+    await this.initializationPromise;
 
     this.isInitialized = true;
     return this;
@@ -246,6 +247,7 @@ export class NestApplicationContext<
    * @returns {Promise<void>}
    */
   public async close(signal?: string): Promise<void> {
+    await this.initializationPromise;
     await this.callDestroyHook();
     await this.callBeforeShutdownHook(signal);
     await this.dispose();
@@ -333,6 +335,7 @@ export class NestApplicationContext<
           return;
         }
         receivedSignal = true;
+        await this.initializationPromise;
         await this.callDestroyHook();
         await this.callBeforeShutdownHook(signal);
         await this.dispose();
@@ -429,6 +432,11 @@ export class NestApplicationContext<
       this.logger.error(error);
       throw new Error(error);
     }
+  }
+
+  private async internalInit() {
+    await this.callInitHook();
+    await this.callBootstrapHook();
   }
 
   private getModulesToTriggerHooksOn(): Module[] {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

Not fully sure if this is a bugfix or feature. I guess one could argue in both directions.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you use lifecycle methods during startup of the nestjs applications with async operations with calls e.g. to the database, message/job processing and you receive a SIGTERM signal it can happen that the connections required for the async operations are closed while executing those async operations. For us this happened now and then in our K8s cluster where the process can be terminated at any time. That can lead to unexpected errors.

Issue Number: N/A


## What is the new behavior?
When a shutdown is requested via the incoming termination signal, the application defers calling the shutdown hooks until the app is fully initialized.


## Does this PR introduce a breaking change?
- [] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information