### PR TITLE
feat(microservices): allow access to mqttClient

### DIFF
--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -94,6 +94,13 @@ export class ClientMqtt extends ClientProxy {
     return mqttPackage.connect(this.url, this.options as MqttOptions);
   }
 
+  public async getMqttClient(): Promise<MqttClient> {
+    if (!this.mqttClient) {
+      await this.connect();
+    }
+    return this.mqttClient;
+  }
+
   public handleError(client: MqttClient) {
     client.addListener(
       ERROR_EVENT,

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -10,6 +10,12 @@ describe('ClientMqtt', () => {
   const test = 'test';
   let client: ClientMqtt = new ClientMqtt({});
 
+  describe('getMqttClient', () => {
+    it(`should return "mqttClient"`, async () => {
+      const mqttClient = await client.getMqttClient();
+      expect(mqttClient).to.exist.and.to.equal(client['mqttClient']);
+    });
+  });
   describe('getRequestPattern', () => {
     it(`should leave pattern as it is`, () => {
       expect(client.getRequestPattern(test)).to.equal(test);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I want to remove the retained message in the MQTT broker, but the mqtt client proxy is unable to send null message with retain flag (which is the way to remove a retained message), so we need to expose the original `mqttClient` instance from mqttjs to do some customized operations.

Issue Number: N/A


## What is the new behavior?
```typescript
@Injectable()
export class MqttService {
  constructor(@Inject("MQTT_SERVICE") private readonly mqttClientProxy: ClientMqtt) {}

  async someAciton() {
    // get the original mqtt client from mqtt.js
    const mqttClient = await this.mqttClientProxy.getMqttClient();
    // we can now use this original client to do some customized operations
    // ...
  }

}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information