### PR TITLE
feat(core): expose listening stream from http adapter host

### DIFF
--- a/packages/core/helpers/http-adapter-host.ts
+++ b/packages/core/helpers/http-adapter-host.ts
@@ -1,3 +1,4 @@
+import { Observable, Subject } from 'rxjs';
 import { AbstractHttpAdapter } from '../adapters/http-adapter';
 
 /**
@@ -16,6 +17,8 @@ export class HttpAdapterHost<
   T extends AbstractHttpAdapter = AbstractHttpAdapter,
 > {
   private _httpAdapter?: T;
+  private _listen$ = new Subject<void>();
+  private isListening = false;
 
   /**
    * Accessor for the underlying `HttpAdapter`
@@ -34,5 +37,32 @@ export class HttpAdapterHost<
    */
   get httpAdapter(): T {
     return this._httpAdapter;
+  }
+
+  /**
+   * Observable that allows to subscribe to the `listen` event.
+   * This event is emitted when the HTTP application is listening for incoming requests.
+   */
+  get listen$(): Observable<void> {
+    return this._listen$.asObservable();
+  }
+
+  /**
+   * Sets the listening state of the application.
+   */
+  set listening(listening: boolean) {
+    this.isListening = listening;
+
+    if (listening) {
+      this._listen$.next();
+      this._listen$.complete();
+    }
+  }
+
+  /**
+   * Returns a boolean indicating whether the application is listening for incoming requests.
+   */
+  get listening(): boolean {
+    return this.isListening;
   }
 }

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -294,8 +294,12 @@ export class NestApplication
   public async listen(port: number | string, hostname: string): Promise<any>;
   public async listen(port: number | string, ...args: any[]): Promise<any> {
     this.assertNotInPreviewMode('listen');
-    !this.isInitialized && (await this.init());
 
+    if (!this.isInitialized) {
+      await this.init();
+    }
+
+    const httpAdapterHost = this.container.getHttpAdapterHostRef();
     return new Promise((resolve, reject) => {
       const errorHandler = (e: any) => {
         this.logger.error(e?.toString?.());
@@ -323,6 +327,8 @@ export class NestApplication
           if (address) {
             this.httpServer.removeListener('error', errorHandler);
             this.isListening = true;
+
+            httpAdapterHost.listening = true;
             resolve(this.httpServer);
           }
           if (isCallbackInOriginalArgs) {

--- a/packages/core/test/helpers/application-ref-host.spec.ts
+++ b/packages/core/test/helpers/application-ref-host.spec.ts
@@ -2,11 +2,27 @@ import { expect } from 'chai';
 import { HttpAdapterHost } from '../../helpers/http-adapter-host';
 
 describe('HttpAdapterHost', () => {
-  const applicationRefHost = new HttpAdapterHost();
+  let applicationRefHost: HttpAdapterHost;
+  beforeEach(() => {
+    applicationRefHost = new HttpAdapterHost();
+  });
+
   it('should wrap application reference', () => {
     const ref = {};
     applicationRefHost.httpAdapter = ref as any;
 
     expect(applicationRefHost.httpAdapter).to.be.eql(ref);
+  });
+
+  it('should emit listen event when listening is set to true', done => {
+    applicationRefHost.listen$.subscribe(() => {
+      expect(applicationRefHost.listening).to.be.true;
+      done();
+    });
+    applicationRefHost.listening = true;
+  });
+
+  it('listening should return false if the application isnt listening yet', () => {
+    expect(applicationRefHost.listening).to.be.false;
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13806


## What is the new behavior?

```ts
@Injectable()
export class AppService {
  constructor(httpAdapterHost: HttpAdapterHost) {
    // Can use it in the "onModuleInit" or "onApplicationBoostrap" hooks too
    // Supports multiple subscribers (uses RxJS Subject under the hood)
    httpAdapterHost.listen$.subscribe(() => console.log('HTTP server started'));
  }
}
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information