### PR TITLE
chore: shallow cloning `wrk` repository on benchmark setup

### DIFF
--- a/.circleci/install-wrk.sh
+++ b/.circleci/install-wrk.sh
@@ -6,7 +6,7 @@ cd "$(dirname "$0")"
 
 cd /tmp/
 sudo apt-get install build-essential libssl-dev git -y
-git clone https://github.com/wg/wrk.git wrk
+git clone --depth=1 https://github.com/wg/wrk.git wrk
 cd wrk
 sudo make
 # move the executable to somewhere in your PATH, ex:


### PR DESCRIPTION
just to make this script a bit faster and less footprint in the `wrk` directory.