### PR TITLE
build(sample): replace cli-color with smaller and faster ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
   },
   "dependencies": {
     "@nuxtjs/opencollective": "0.3.2",
+    "ansis": "3.3.2",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
-    "cli-color": "2.0.4",
     "cors": "2.8.5",
     "express": "4.21.1",
     "fast-json-stringify": "6.0.0",

--- a/tools/gulp/tasks/samples.ts
+++ b/tools/gulp/tasks/samples.ts
@@ -1,5 +1,5 @@
 import * as childProcess from 'child_process';
-import * as clc from 'cli-color';
+import { blue, magenta } from 'ansis';
 import * as log from 'fancy-log';
 import { task } from 'gulp';
 import { resolve } from 'path';
@@ -43,7 +43,7 @@ async function executeNPMScriptInDirectory(
   appendScript?: string,
 ) {
   const dirName = dir.replace(resolve(__dirname, '../../../'), '');
-  log.info(`Running ${clc.blue(script)} in ${clc.magenta(dirName)}`);
+  log.info(`Running ${blue(script)} in ${magenta(dirName)}`);
   try {
     const result = await exec(
       `${script} --prefix ${dir} ${appendScript ? '-- ' + appendScript : ''}`,
@@ -52,7 +52,7 @@ async function executeNPMScriptInDirectory(
     //   cwd: join(process.cwd(), dir),
     // });
 
-    log.info(`Finished running ${clc.blue(script)} in ${clc.magenta(dirName)}`);
+    log.info(`Finished running ${blue(script)} in ${magenta(dirName)}`);
     if (result.stderr) {
       log.error(result.stderr);
     }
@@ -60,7 +60,7 @@ async function executeNPMScriptInDirectory(
       log.error(result.stdout);
     }
   } catch (err) {
-    log.error(`Failed running ${clc.blue(script)} in ${clc.magenta(dirName)}`);
+    log.error(`Failed running ${blue(script)} in ${magenta(dirName)}`);
     if (err.stderr) {
       log.error(err.stderr);
     }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added. => **Manual test**: color output in CLI using `npm run build:samples`
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

no changes

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR replaces the [cli-color](https://github.com/medikoo/cli-color) package with smaller, faster, TypeScript-friendly [ansis](https://github.com/webdiscus/ansis).

### Benefits of `ansis`

- Installed package size is smaller: ansis `11 KB` (no dependencies) vs cli-color `754 KB` (5 dependencies)
  see [Compare the size of most popular packages](https://github.com/webdiscus/ansis#compare-size)
- 20x faster than `cli-color`, see [Benchmarks](https://github.com/webdiscus/ansis#benchmark)
- Supports `Bun` and `Deno` runtimes
- [Fallback](https://github.com/webdiscus/ansis#fallback) to supported color space: TrueColor → 256 colors → 16 colors → no colors
- Supports [environment variables](https://github.com/webdiscus/ansis#cli-vars) `NO_COLOR` `FORCE_COLOR` and flags `--no-color` `--color`
- Supports [named import](https://github.com/webdiscus/ansis#named-import):  `import { red, green, bold, ansi256, hex } from 'ansis'`
- Zero dependencies
- TypeScript-friendly
- 100% test coverage

### Packages that already use `ansis`

  - [oclif/core](https://github.com/oclif/core/blob/prerelease/beta/package.json) - used in your `devDependencies` -> `artillery`
  - [sequelize/core](https://github.com/sequelize/sequelize/blob/main/packages/core/package.json)
  - [facebook/stylex](https://github.com/facebook/stylex/blob/main/packages/cli/package.json)
  - [salesforcecli/cli](https://github.com/salesforcecli/cli/blob/main/package.json)
  - [grafana/faro-javascript-bundler-plugins](https://github.com/grafana/faro-javascript-bundler-plugins/blob/main/packages/faro-bundlers-shared/package.json)
  - and [thousands others](https://github.com/webdiscus/ansis/network/dependents)

## Test

This PR does not require unit/integration tests.

But you can do the `manual test`:

```
git clone https://github.com/webdiscus/nestjs.git
cd nestjs
git checkout cli-color-to-ansis
yarn

npm run build:samples
```
In console output will be displayed color text:

![image](https://github.com/user-attachments/assets/2568f9e0-175e-4c08-b34a-a4b8361ddfc5)
