### PR TITLE
feat(websockets): include exception cause to associate error with req

### DIFF
--- a/integration/websockets/e2e/error-gateway.spec.ts
+++ b/integration/websockets/e2e/error-gateway.spec.ts
@@ -11,20 +11,27 @@ describe('ErrorGateway', () => {
     const testingModule = await Test.createTestingModule({
       providers: [ErrorGateway],
     }).compile();
-    app = await testingModule.createNestApplication();
+
+    app = testingModule.createNestApplication();
     await app.listen(3000);
   });
 
   it(`should handle error`, async () => {
     const ws = io('http://localhost:8080');
-    ws.emit('push', {
-      test: 'test',
-    });
+    const pattern = 'push';
+    const data = { test: 'test' };
+
+    ws.emit(pattern, data);
+
     await new Promise<void>(resolve =>
       ws.on('exception', data => {
         expect(data).to.be.eql({
           status: 'error',
           message: 'test',
+          cause: {
+            pattern,
+            data,
+          },
         });
         resolve();
       }),

--- a/integration/websockets/e2e/error-gateway.spec.ts
+++ b/integration/websockets/e2e/error-gateway.spec.ts
@@ -24,8 +24,8 @@ describe('ErrorGateway', () => {
     ws.emit(pattern, data);
 
     await new Promise<void>(resolve =>
-      ws.on('exception', data => {
-        expect(data).to.be.eql({
+      ws.on('exception', error => {
+        expect(error).to.be.eql({
           status: 'error',
           message: 'test',
           cause: {

--- a/packages/websockets/exceptions/base-ws-exception-filter.ts
+++ b/packages/websockets/exceptions/base-ws-exception-filter.ts
@@ -8,7 +8,7 @@ import { isObject } from '@nestjs/common/utils/shared.utils';
 import { MESSAGES } from '@nestjs/core/constants';
 import { WsException } from '../errors/ws-exception';
 
-interface ErrorPayload {
+export interface ErrorPayload {
   /**
    * Error message identifier.
    */

--- a/packages/websockets/exceptions/base-ws-exception-filter.ts
+++ b/packages/websockets/exceptions/base-ws-exception-filter.ts
@@ -48,7 +48,7 @@ export class BaseWsExceptionFilter<TError = any>
   public catch(exception: TError, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();
     const pattern = host.switchToWs().getPattern();
-    const data = host.switchToWs().getPattern();
+    const data = host.switchToWs().getData();
     this.handleError(client, exception, {
       pattern,
       data,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Includes the `cause` attribute when emitting the `exception` message. This allows the error to be associated with the request that caused the exception.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information