### PR TITLE
fix(websockets): Prevent HTTP server early close in Socket.IO shutdown

### DIFF
--- a/integration/websockets/src/server.gateway.ts
+++ b/integration/websockets/src/server.gateway.ts
@@ -1,9 +1,10 @@
-import { UseInterceptors } from '@nestjs/common';
+import { OnApplicationShutdown, UseInterceptors } from '@nestjs/common';
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
+import * as Sinon from 'sinon';
 import { RequestInterceptor } from './request.interceptor';
 
 @WebSocketGateway()
-export class ServerGateway {
+export class ServerGateway implements OnApplicationShutdown {
   @SubscribeMessage('push')
   onPush(client, data) {
     return {
@@ -20,4 +21,6 @@ export class ServerGateway {
       data: { ...data, path: client.pattern },
     };
   }
+
+  onApplicationShutdown = Sinon.spy();
 }

--- a/packages/websockets/adapters/ws-adapter.ts
+++ b/packages/websockets/adapters/ws-adapter.ts
@@ -17,6 +17,7 @@ export abstract class AbstractWsAdapter<
 > implements WebSocketAdapter<TServer, TClient, TOptions>
 {
   protected readonly httpServer: any;
+  private _forceCloseConnections: boolean;
 
   constructor(appOrHttpServer?: INestApplicationContext | any) {
     if (appOrHttpServer && appOrHttpServer instanceof NestApplication) {
@@ -24,6 +25,10 @@ export abstract class AbstractWsAdapter<
     } else {
       this.httpServer = appOrHttpServer;
     }
+  }
+
+  public set forceCloseConnections(value: boolean) {
+    this._forceCloseConnections = value;
   }
 
   public bindClientConnect(server: TServer, callback: Function) {
@@ -35,6 +40,9 @@ export abstract class AbstractWsAdapter<
   }
 
   public async close(server: TServer) {
+    if (this._forceCloseConnections) {
+      return;
+    }
     const isCallable = server && isFunction(server.close);
     isCallable && (await new Promise(resolve => server.close(resolve)));
   }

--- a/packages/websockets/socket-module.ts
+++ b/packages/websockets/socket-module.ts
@@ -1,6 +1,7 @@
 import { NestApplicationOptions } from '@nestjs/common';
 import { InjectionToken } from '@nestjs/common/interfaces';
 import { Injectable } from '@nestjs/common/interfaces/injectable.interface';
+import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
 import { ApplicationConfig } from '@nestjs/core/application-config';
 import { GuardsConsumer } from '@nestjs/core/guards/guards-consumer';
 import { GuardsContextCreator } from '@nestjs/core/guards/guards-context-creator';
@@ -25,7 +26,8 @@ import { WebSocketsController } from './web-sockets-controller';
 
 export class SocketModule<
   THttpServer = any,
-  TAppOptions extends NestApplicationOptions = NestApplicationOptions,
+  TAppOptions extends
+    NestApplicationContextOptions = NestApplicationContextOptions,
 > {
   private readonly socketsContainer = new SocketsContainer();
   private applicationConfig: ApplicationConfig;
@@ -112,7 +114,8 @@ export class SocketModule<
   }
 
   private initializeAdapter() {
-    const forceCloseConnections = this.appOptions.forceCloseConnections;
+    const forceCloseConnections = (this.appOptions as NestApplicationOptions)
+      .forceCloseConnections;
     const adapter = this.applicationConfig.getIoAdapter();
     if (adapter) {
       (adapter as AbstractWsAdapter).forceCloseConnections =

--- a/packages/websockets/socket-module.ts
+++ b/packages/websockets/socket-module.ts
@@ -1,6 +1,6 @@
+import { NestApplicationOptions } from '@nestjs/common';
 import { InjectionToken } from '@nestjs/common/interfaces';
 import { Injectable } from '@nestjs/common/interfaces/injectable.interface';
-import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
 import { ApplicationConfig } from '@nestjs/core/application-config';
 import { GuardsConsumer } from '@nestjs/core/guards/guards-consumer';
 import { GuardsContextCreator } from '@nestjs/core/guards/guards-context-creator';
@@ -25,8 +25,7 @@ import { WebSocketsController } from './web-sockets-controller';
 
 export class SocketModule<
   THttpServer = any,
-  TAppOptions extends
-    NestApplicationContextOptions = NestApplicationContextOptions,
+  TAppOptions extends NestApplicationOptions = NestApplicationOptions,
 > {
   private readonly socketsContainer = new SocketsContainer();
   private applicationConfig: ApplicationConfig;
@@ -113,8 +112,11 @@ export class SocketModule<
   }
 
   private initializeAdapter() {
+    const forceCloseConnections = this.appOptions.forceCloseConnections;
     const adapter = this.applicationConfig.getIoAdapter();
     if (adapter) {
+      (adapter as AbstractWsAdapter).forceCloseConnections =
+        forceCloseConnections;
       this.isAdapterInitialized = true;
       return;
     }
@@ -124,6 +126,7 @@ export class SocketModule<
       () => require('@nestjs/platform-socket.io'),
     );
     const ioAdapter = new IoAdapter(this.httpServer);
+    ioAdapter.forceCloseConnections = forceCloseConnections;
     this.applicationConfig.setIoAdapter(ioAdapter);
 
     this.isAdapterInitialized = true;


### PR DESCRIPTION
fixes #13910

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13910 


## What is the new behavior?
When ws connections and other long-running connections are handled by the same HTTP server instance, the shutdown process will not be blocked, allowing for proper termination of all connection types.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information