### PR TITLE
fix(core): Improve middleware route exclusion for dynamic endpoints

### DIFF
--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -11,9 +11,10 @@ import {
 } from '@nestjs/common/interfaces/middleware';
 import { stripEndSlash } from '@nestjs/common/utils/shared.utils';
 import { iterate } from 'iterare';
+import { isRouteIncluded } from '../router/utils';
 import { RouteInfoPathExtractor } from './route-info-path-extractor';
 import { RoutesMapper } from './routes-mapper';
-import { filterMiddleware } from './utils';
+import { filterMiddleware, mapToExcludeRoute } from './utils';
 
 export class MiddlewareBuilder implements MiddlewareConsumer {
   private readonly middlewareCollection = new Set<MiddlewareConfiguration>();
@@ -84,9 +85,19 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
 
       const flattedRoutes = this.getRoutesFlatList(routes);
       const forRoutes = this.removeOverlappedRoutes(flattedRoutes);
+
+      const includedRoutes = flattedRoutes.filter(route =>
+        isRouteIncluded(
+          mapToExcludeRoute(this.excludedRoutes),
+          route.path,
+          route.method,
+        ),
+      );
+
       const configuration = {
         middleware: filterMiddleware(
           this.middleware,
+          includedRoutes,
           this.excludedRoutes,
           this.builder.getHttpAdapter(),
         ),

--- a/packages/core/router/interfaces/exclude-route-metadata.interface.ts
+++ b/packages/core/router/interfaces/exclude-route-metadata.interface.ts
@@ -16,3 +16,5 @@ export interface ExcludeRouteMetadata {
    */
   requestMethod: RequestMethod;
 }
+
+export type RouteMetadata = ExcludeRouteMetadata;

--- a/packages/core/router/utils/exclude-route.util.ts
+++ b/packages/core/router/utils/exclude-route.util.ts
@@ -21,3 +21,19 @@ export function isRouteExcluded(
     return false;
   });
 }
+
+export function isRouteIncluded(
+  excludedRoutes: ExcludeRouteMetadata[],
+  path: string,
+  requestMethod?: RequestMethod,
+) {
+  return excludedRoutes.some(route => {
+    if (
+      isRequestMethodAll(route.requestMethod) ||
+      route.requestMethod === requestMethod
+    ) {
+      return route.pathRegex.exec(addLeadingSlash(path)) && route.path !== path;
+    }
+    return false;
+  });
+}

--- a/packages/core/test/middleware/utils.spec.ts
+++ b/packages/core/test/middleware/utils.spec.ts
@@ -1,6 +1,7 @@
 import { RequestMethod, Type } from '@nestjs/common';
 import { addLeadingSlash } from '@nestjs/common/utils/shared.utils';
 import { expect } from 'chai';
+import * as pathToRegexp from 'path-to-regexp';
 import * as sinon from 'sinon';
 import {
   assignToken,
@@ -11,7 +12,6 @@ import {
   mapToExcludeRoute,
 } from '../../middleware/utils';
 import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
-import * as pathToRegexp from 'path-to-regexp';
 
 describe('middleware utils', () => {
   const noopAdapter = new NoopHttpAdapter({});
@@ -46,14 +46,16 @@ describe('middleware utils', () => {
       middleware = [Test, fnMiddleware, undefined, null];
     });
     it('should return filtered middleware', () => {
-      expect(filterMiddleware(middleware, [], noopAdapter)).to.have.length(2);
+      expect(filterMiddleware(middleware, [], [], noopAdapter)).to.have.length(
+        2,
+      );
     });
   });
   describe('mapToClass', () => {
     describe('when middleware is a class', () => {
       describe('when there is no excluded routes', () => {
         it('should return an identity', () => {
-          const type = mapToClass(Test, [], noopAdapter);
+          const type = mapToClass(Test, [], [], noopAdapter);
           expect(type).to.eql(Test);
         });
       });
@@ -61,6 +63,7 @@ describe('middleware utils', () => {
         it('should return a host class', () => {
           const type = mapToClass(
             Test,
+            [],
             mapToExcludeRoute([{ path: '*', method: RequestMethod.ALL }]),
             noopAdapter,
           );
@@ -71,16 +74,21 @@ describe('middleware utils', () => {
     });
     describe('when middleware is a function', () => {
       it('should return a metatype', () => {
-        const metatype = mapToClass(fnMiddleware, [], noopAdapter);
+        const metatype = mapToClass(fnMiddleware, [], [], noopAdapter);
         expect(metatype).to.not.eql(fnMiddleware);
       });
       it('should define a `use` method', () => {
-        const metatype = mapToClass(fnMiddleware, [], noopAdapter) as Type<any>;
+        const metatype = mapToClass(
+          fnMiddleware,
+          [],
+          [],
+          noopAdapter,
+        ) as Type<any>;
         expect(new metatype().use).to.exist;
       });
       it('should encapsulate a function', () => {
         const spy = sinon.spy();
-        const metatype = mapToClass(spy, [], noopAdapter) as Type<any>;
+        const metatype = mapToClass(spy, [], [], noopAdapter) as Type<any>;
         new metatype().use();
         expect(spy.called).to.be.true;
       });
@@ -113,7 +121,7 @@ describe('middleware utils', () => {
     });
   });
 
-  describe('isRouteExcluded', () => {
+  describe('isMiddlewareRouteExcluded', () => {
     let adapter: NoopHttpAdapter;
 
     beforeEach(() => {
@@ -121,6 +129,7 @@ describe('middleware utils', () => {
       sinon.stub(adapter, 'getRequestMethod').callsFake(() => 'GET');
       sinon.stub(adapter, 'getRequestUrl').callsFake(() => '/cats/3');
     });
+
     describe('when route is excluded', () => {
       const path = '/cats/(.*)';
       const excludedRoutes = mapToExcludeRoute([
@@ -130,13 +139,242 @@ describe('middleware utils', () => {
         },
       ]);
       it('should return true', () => {
-        expect(isMiddlewareRouteExcluded({}, excludedRoutes, adapter)).to.be
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
           .true;
       });
     });
+
     describe('when route is not excluded', () => {
       it('should return false', () => {
-        expect(isMiddlewareRouteExcluded({}, [], adapter)).to.be.false;
+        expect(isMiddlewareRouteExcluded({}, [], [], adapter)).to.be.false;
+      });
+    });
+
+    describe('when using regex pattern exclusion', () => {
+      beforeEach(() => {
+        (adapter.getRequestUrl as sinon.SinonStub).callsFake(() => '/cats/123');
+      });
+
+      it('should exclude numeric ids', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id(\\d+)', method: RequestMethod.GET },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .true;
+      });
+
+      it('should not exclude non-numeric ids', () => {
+        (adapter.getRequestUrl as sinon.SinonStub).callsFake(() => '/cats/abc');
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id(\\d+)', method: RequestMethod.GET },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .false;
+      });
+    });
+
+    describe('when using different HTTP methods', () => {
+      const path = '/cats/(.*)';
+
+      it('should exclude when methods match', () => {
+        (adapter.getRequestMethod as sinon.SinonStub).callsFake(() => 'POST');
+        const excludedRoutes = mapToExcludeRoute([
+          { path, method: RequestMethod.POST },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .true;
+      });
+
+      it('should not exclude when methods differ', () => {
+        (adapter.getRequestMethod as sinon.SinonStub).callsFake(() => 'POST');
+        const excludedRoutes = mapToExcludeRoute([
+          { path, method: RequestMethod.GET },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .false;
+      });
+
+      it('should exclude when method is ALL', () => {
+        (adapter.getRequestMethod as sinon.SinonStub).callsFake(() => 'DELETE');
+        const excludedRoutes = mapToExcludeRoute([
+          { path, method: RequestMethod.ALL },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .true;
+      });
+    });
+
+    describe('when using query parameters', () => {
+      it('should exclude matching base path regardless of query params', () => {
+        (adapter.getRequestUrl as sinon.SinonStub).callsFake(
+          () => '/cats/3?page=1&limit=10',
+        );
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id', method: RequestMethod.GET },
+        ]);
+        expect(isMiddlewareRouteExcluded({}, [], excludedRoutes, adapter)).to.be
+          .true;
+      });
+    });
+
+    describe('when using included routes', () => {
+      describe('with static routes', () => {
+        beforeEach(() => {
+          (adapter.getRequestUrl as sinon.SinonStub).callsFake(() => '/cats');
+        });
+
+        it('should not exclude when path matches included static route', () => {
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.false;
+        });
+
+        it('should exclude when path does not match included static route', () => {
+          (adapter.getRequestUrl as sinon.SinonStub).callsFake(() => '/dogs');
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/dogs', method: RequestMethod.GET },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.true;
+        });
+
+        it('should handle multiple static routes', () => {
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET },
+            { path: '/dogs', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.false;
+        });
+      });
+
+      describe('with mixed static and dynamic routes', () => {
+        it('should prioritize static route inclusion over dynamic exclusion', () => {
+          (adapter.getRequestUrl as sinon.SinonStub).callsFake(() => '/cats');
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats', method: RequestMethod.GET }, // static route
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/:any', method: RequestMethod.GET }, // dynamic route
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.false;
+        });
+
+        it('should handle static sub-paths', () => {
+          (adapter.getRequestUrl as sinon.SinonStub).callsFake(
+            () => '/cats/details',
+          );
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats/details', method: RequestMethod.GET }, // static sub-path
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats/:action', method: RequestMethod.GET }, // dynamic route
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.false;
+        });
+      });
+
+      describe('with dynamic routes', () => {
+        beforeEach(() => {
+          (adapter.getRequestUrl as sinon.SinonStub).callsFake(
+            () => '/cats/123',
+          );
+        });
+
+        it('should not exclude when path is in included routes', () => {
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats/:id', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats/:id', method: RequestMethod.GET },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.false;
+        });
+
+        it('should exclude when path matches excluded but not included', () => {
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/dogs/:id', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats/:id', method: RequestMethod.GET },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.true;
+        });
+
+        it('should handle method-specific inclusions', () => {
+          (adapter.getRequestMethod as sinon.SinonStub).callsFake(() => 'POST');
+          const includedRoutes = mapToExcludeRoute([
+            { path: '/cats/:id', method: RequestMethod.GET },
+          ]);
+          const excludedRoutes = mapToExcludeRoute([
+            { path: '/cats/:id', method: RequestMethod.POST },
+          ]);
+          expect(
+            isMiddlewareRouteExcluded(
+              {},
+              includedRoutes,
+              excludedRoutes,
+              adapter,
+            ),
+          ).to.be.true;
+        });
       });
     });
   });

--- a/packages/core/test/router/utils/exclude-route.util.spec.ts
+++ b/packages/core/test/router/utils/exclude-route.util.spec.ts
@@ -1,0 +1,168 @@
+import { RequestMethod } from '@nestjs/common';
+import { expect } from 'chai';
+import { mapToExcludeRoute } from '../../../middleware/utils';
+import {
+  isRequestMethodAll,
+  isRouteExcluded,
+  isRouteIncluded,
+} from '../../../router/utils/exclude-route.util';
+
+describe('exclude-route.util', () => {
+  describe('isRequestMethodAll', () => {
+    it('should return true for RequestMethod.ALL', () => {
+      expect(isRequestMethodAll(RequestMethod.ALL)).to.be.true;
+    });
+
+    it('should return true for -1', () => {
+      expect(isRequestMethodAll(RequestMethod.ALL)).to.be.true;
+    });
+
+    it('should return false for other methods', () => {
+      expect(isRequestMethodAll(RequestMethod.GET)).to.be.false;
+      expect(isRequestMethodAll(RequestMethod.POST)).to.be.false;
+      expect(isRequestMethodAll(RequestMethod.DELETE)).to.be.false;
+    });
+  });
+
+  describe('isRouteExcluded', () => {
+    describe('with static routes', () => {
+      it('should match exact paths', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats', RequestMethod.GET)).to
+          .be.true;
+      });
+
+      it('should not match different paths', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/dogs', RequestMethod.GET)).to
+          .be.false;
+      });
+
+      it('should respect HTTP method', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats', RequestMethod.POST)).to
+          .be.false;
+      });
+
+      it('should match any method when using RequestMethod.ALL', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.ALL },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats', RequestMethod.GET)).to
+          .be.true;
+        expect(isRouteExcluded(excludedRoutes, '/cats', RequestMethod.POST)).to
+          .be.true;
+      });
+    });
+
+    describe('with dynamic routes', () => {
+      it('should match parameterized paths', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(isRouteExcluded(excludedRoutes, '/cats/abc', RequestMethod.GET))
+          .to.be.true;
+      });
+
+      it('should match regex patterns', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id(\\d+)', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(isRouteExcluded(excludedRoutes, '/cats/abc', RequestMethod.GET))
+          .to.be.false;
+      });
+
+      it('should match wildcard patterns', () => {
+        const excludedRoutes = mapToExcludeRoute([
+          { path: '/cats/(.*)', method: RequestMethod.GET },
+        ]);
+        expect(isRouteExcluded(excludedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(
+          isRouteExcluded(excludedRoutes, '/cats/details', RequestMethod.GET),
+        ).to.be.true;
+      });
+    });
+  });
+
+  describe('isRouteIncluded', () => {
+    describe('with static routes', () => {
+      it('should not match exact paths', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats', RequestMethod.GET)).to
+          .be.false;
+      });
+
+      it('should not match different paths', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/dogs', RequestMethod.GET)).to
+          .be.false;
+      });
+    });
+
+    describe('with dynamic routes', () => {
+      it('should match parameterized paths', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(isRouteIncluded(includedRoutes, '/cats/abc', RequestMethod.GET))
+          .to.be.true;
+      });
+
+      it('should match regex patterns', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id(\\d+)', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(isRouteIncluded(includedRoutes, '/cats/abc', RequestMethod.GET))
+          .to.be.false;
+      });
+
+      it('should match wildcard patterns', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats/(.*)', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(
+          isRouteIncluded(includedRoutes, '/cats/details', RequestMethod.GET),
+        ).to.be.true;
+      });
+
+      it('should respect HTTP method', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id', method: RequestMethod.GET },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.POST))
+          .to.be.false;
+      });
+
+      it('should match any method when using RequestMethod.ALL', () => {
+        const includedRoutes = mapToExcludeRoute([
+          { path: '/cats/:id', method: RequestMethod.ALL },
+        ]);
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.GET))
+          .to.be.true;
+        expect(isRouteIncluded(includedRoutes, '/cats/123', RequestMethod.POST))
+          .to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
fixes #13593

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13593 


## What is the new behavior?
The middleware route exclusion now correctly handles the coexistence of static and dynamic routes:
- Static routes (e.g., /all) are not affected by dynamic route exclusions
- Dynamic routes (e.g., /:id) can be excluded without impacting other routes
- Middleware correctly runs for non-excluded routes while skipping excluded ones

For example, when excluding /:id route:
- Middleware runs for /all endpoint 
- Middleware skips /:id endpoint 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information