### PR TITLE
fix(websockets): ensure non-shared servers call close method

### DIFF
--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -82,4 +82,12 @@ export class IoAdapter extends AbstractWsAdapter {
     }
     return { data: payload };
   }
+
+  public close(server: Server) {
+    if (this.forceCloseConnections && server.httpServer === this.httpServer) {
+      return;
+    }
+
+    return super.close(server);
+  }
 }

--- a/packages/websockets/adapters/ws-adapter.ts
+++ b/packages/websockets/adapters/ws-adapter.ts
@@ -23,6 +23,10 @@ export abstract class AbstractWsAdapter<
     this._forceCloseConnections = value;
   }
 
+  public get forceCloseConnections(): boolean {
+    return this._forceCloseConnections;
+  }
+
   constructor(appOrHttpServer?: INestApplicationContext | any) {
     if (appOrHttpServer && appOrHttpServer instanceof NestApplication) {
       this.httpServer = appOrHttpServer.getUnderlyingHttpServer();
@@ -40,9 +44,6 @@ export abstract class AbstractWsAdapter<
   }
 
   public async close(server: TServer) {
-    if (this._forceCloseConnections) {
-      return;
-    }
     const isCallable = server && isFunction(server.close);
     isCallable && (await new Promise(resolve => server.close(resolve)));
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When forceCloseConnections is enabled, non-shared HTTP servers are not being properly closed.


## What is the new behavior?
When forceCloseConnections is enabled, non-shared HTTP servers should be closed by WS.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information