### PR TITLE
feat(common): add error messages for file validators

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -20,7 +20,10 @@ export class FileTypeValidator extends FileValidator<
   FileTypeValidatorOptions,
   IFile
 > {
-  buildErrorMessage(): string {
+  buildErrorMessage(file?: IFile): string {
+    if (file?.mimetype) {
+      return `Validation failed (current file type is ${file.mimetype}, expected type is ${this.validationOptions.fileType})`;
+    }
     return `Validation failed (expected type is ${this.validationOptions.fileType})`;
   }
 

--- a/packages/common/pipes/file/max-file-size.validator.ts
+++ b/packages/common/pipes/file/max-file-size.validator.ts
@@ -17,7 +17,7 @@ export class MaxFileSizeValidator extends FileValidator<
   MaxFileSizeValidatorOptions,
   IFile
 > {
-  buildErrorMessage(): string {
+  buildErrorMessage(file?: IFile): string {
     if ('message' in this.validationOptions) {
       if (typeof this.validationOptions.message === 'function') {
         return this.validationOptions.message(this.validationOptions.maxSize);
@@ -26,6 +26,9 @@ export class MaxFileSizeValidator extends FileValidator<
       return this.validationOptions.message!;
     }
 
+    if (file?.size) {
+      return `Validation failed (current file size is ${file.size}, expected size is less than ${this.validationOptions.maxSize})`;
+    }
     return `Validation failed (expected size is less than ${this.validationOptions.maxSize})`;
   }
 

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -93,5 +93,19 @@ describe('FileTypeValidator', () => {
         `Validation failed (expected type is ${fileType})`,
       );
     });
+
+    it('should include the file type in the error message when a file is provided', () => {
+      const currentFileType = 'image/png';
+      const fileType = 'image/jpeg';
+      const fileTypeValidator = new FileTypeValidator({
+        fileType,
+      });
+
+      const file = { mimetype: currentFileType } as any;
+
+      expect(fileTypeValidator.buildErrorMessage(file)).to.equal(
+        `Validation failed (current file type is ${currentFileType}, expected type is ${fileType})`,
+      );
+    });
   });
 });

--- a/packages/common/test/pipes/file/max-file-size.validator.spec.ts
+++ b/packages/common/test/pipes/file/max-file-size.validator.spec.ts
@@ -60,5 +60,18 @@ describe('MaxFileSizeValidator', () => {
         `Validation failed (expected size is less than ${oneKb})`,
       );
     });
+
+    it('should include the file size in the error message when a file is provided', () => {
+      const currentFileSize = oneKb + 1;
+      const maxFileSizeValidator = new MaxFileSizeValidator({
+        maxSize: oneKb,
+      });
+
+      const file = { size: currentFileSize } as any;
+
+      expect(maxFileSizeValidator.buildErrorMessage(file)).to.equal(
+        `Validation failed (current file size is ${currentFileSize}, expected size is less than ${oneKb})`,
+      );
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, the file validation system (e.g., MaxFileSizeValidator and FileTypeValidator) provides error messages that are not context-aware.

Specifically:

MaxFileSizeValidator uses a default error message that does not include the current file size if available.
FileTypeValidator uses a default error message without referencing the current file's MIME type.
This limits the usefulness of the error messages for developers, as they lack specific context regarding what caused the validation failure.


Issue Number: #14070 


## What is the new behavior?

This PR enhances the error message generation for file validators:

example code:
```
@Post('upload-image')
@UseInterceptors(FileInterceptor('file'))
uploadFile(
  @UploadedFile(
    new ParseFilePipe({
      validators: [
        new MaxFileSizeValidator({ maxSize: 1024 }),
        new FileTypeValidator({ fileType: '.(png|jpeg|jpg)' }),
      ],
    }),
  )
  file: Express.Multer.File,
) {
  console.log(file);
}
```

MaxFileSizeValidator:
Error messages now dynamically include the current file size if provided, improving the clarity of validation failures.
Example:
![image](https://github.com/user-attachments/assets/b20a0df2-510c-41c0-8c32-95cae8f6e5a6)


FileTypeValidator:
Error messages now include the current file's MIME type, allowing developers to understand which type was detected during validation.
Example:
![image](https://github.com/user-attachments/assets/0a3f96e5-0f66-4eb1-b3d7-a40db70d79e8)



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No