### PR TITLE
fix(common): enforce string type in validationpipe

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -206,6 +206,9 @@ export class ValidationPipe implements PipeTransform<any> {
     if (metatype === Number) {
       return +value;
     }
+    if (metatype === String) {
+      return String(value);
+    }
     return value;
   }
 


### PR DESCRIPTION
strictly parse the value to string to avoid nested objects being passed if the type is explicitly set to string

closes #14234

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The pipeline doesnt pass the value to string if an nested object is provided and the type is explicitly set to string.

Issue Number:  #14234


## What is the new behavior?
if the value of foo query set to string, it will parse it to string no matter the value.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information