### PR TITLE
Fix shutdown hooks order

### DIFF
--- a/integration/hooks/e2e/on-app-shutdown.spec.ts
+++ b/integration/hooks/e2e/on-app-shutdown.spec.ts
@@ -23,10 +23,7 @@ describe('OnApplicationShutdown', () => {
   it('should sort modules by distance (topological sort) - DESC order', async () => {
     @Injectable()
     class BB implements OnApplicationShutdown {
-      public field: string;
-      async onApplicationShutdown() {
-        this.field = 'b-field';
-      }
+      onApplicationShutdown = Sinon.spy();
     }
 
     @Module({
@@ -37,12 +34,8 @@ describe('OnApplicationShutdown', () => {
 
     @Injectable()
     class AA implements OnApplicationShutdown {
-      public field: string;
       constructor(private bb: BB) {}
-
-      async onApplicationShutdown() {
-        this.field = this.bb.field + '_a-field';
-      }
+      onApplicationShutdown = Sinon.spy();
     }
     @Module({
       imports: [B],
@@ -58,7 +51,8 @@ describe('OnApplicationShutdown', () => {
     await app.init();
     await app.close();
 
-    const instance = module.get(AA);
-    expect(instance.field).to.equal('b-field_a-field');
+    const aa = module.get(AA);
+    const bb = module.get(BB);
+    Sinon.assert.callOrder(aa.onApplicationShutdown, bb.onApplicationShutdown);
   });
 });

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -439,7 +439,10 @@ export class NestApplicationContext<
    * modules and children.
    */
   protected async callShutdownHook(signal?: string): Promise<void> {
-    const modulesSortedByDistance = this.getModulesToTriggerHooksOn();
+    const modulesSortedByDistance = [
+      ...this.getModulesToTriggerHooksOn(),
+    ].reverse();
+
     for (const module of modulesSortedByDistance) {
       await callAppShutdownHook(module, signal);
     }
@@ -450,7 +453,10 @@ export class NestApplicationContext<
    * modules and children.
    */
   protected async callBeforeShutdownHook(signal?: string): Promise<void> {
-    const modulesSortedByDistance = this.getModulesToTriggerHooksOn();
+    const modulesSortedByDistance = [
+      ...this.getModulesToTriggerHooksOn(),
+    ].reverse();
+
     for (const module of modulesSortedByDistance) {
       await callBeforeAppShutdownHook(module, signal);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #14118

This issue was already closed. However the fix in #14111 only impacts the `onModuleDestroy` hook. Other shutdown hooks still have an incorrect behavior (i.e. are called in ascending distance order).

## What is the new behavior?

The `beforeApplicationShutdown` and `onApplicationShutdown` hooks are called in descending distance order.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is purposely extremely similar to #14111, but I'm open to suggestions if needed.
I've targeted `11.0.0` because this was also the case of the aforementioned PR.