### PR TITLE
fix: export cont REQUEST_METHOD_MAP from router-method-factory 

### DIFF
--- a/packages/core/helpers/router-method-factory.ts
+++ b/packages/core/helpers/router-method-factory.ts
@@ -1,7 +1,7 @@
 import { HttpServer } from '@nestjs/common';
 import { RequestMethod } from '@nestjs/common/enums/request-method.enum';
 
-const REQUEST_METHOD_MAP = {
+export const REQUEST_METHOD_MAP = {
   [RequestMethod.GET]: 'get',
   [RequestMethod.POST]: 'post',
   [RequestMethod.PUT]: 'put',


### PR DESCRIPTION
It is useful piece of code for create custom adapter

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
const REQUEST_METHOD_MAP  { *** }

Issue Number: N/A


## What is the new behavior?
export const REQUEST_METHOD_MAP  { *** }

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

For example people do that
[type HttpMethods =] = *** (https://github.com/seidelmartin/nest-koa-adapter/blob/d83478e55351be128762836a9cffff0e12b5c234/src/KoaAdapter.ts#L22)

but can use REQUEST_METHOD_MAP


I need for example something like:

```
m !== REQUEST_METHOD_MAP[RequestMethod.ALL]
          ? REQUEST_METHOD_MAP[m] as Method : undefined
```