### PR TITLE
fix: use express body-parser reexports

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -24,11 +24,6 @@ import {
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
 import { RouterMethodFactory } from '@nestjs/core/helpers/router-method-factory';
 import { LegacyRouteConverter } from '@nestjs/core/router/legacy-route-converter';
-import * as bodyparser from 'body-parser';
-import {
-  json as bodyParserJson,
-  urlencoded as bodyParserUrlencoded,
-} from 'body-parser';
 import * as cors from 'cors';
 import * as express from 'express';
 import type { Server } from 'http';
@@ -278,8 +273,8 @@ export class ExpressAdapter extends AbstractHttpAdapter<
     });
 
     const parserMiddleware = {
-      jsonParser: bodyParserJson(bodyParserJsonOptions),
-      urlencodedParser: bodyParserUrlencoded(bodyParserUrlencodedOptions),
+      jsonParser: express.json(bodyParserJsonOptions),
+      urlencodedParser: express.urlencoded(bodyParserUrlencodedOptions),
     };
     Object.keys(parserMiddleware)
       .filter(parser => !this.isMiddlewareApplied(parser))
@@ -294,7 +289,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
     options?: Omit<Options, 'verify'>,
   ): this {
     const parserOptions = getBodyParserOptions<Options>(rawBody, options);
-    const parser = bodyparser[type](parserOptions);
+    const parser = express[type](parserOptions);
 
     this.use(parser);
 

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -18,7 +18,6 @@
     "access": "public"
   },
   "dependencies": {
-    "body-parser": "1.20.3",
     "cors": "2.8.5",
     "express": "5.0.1",
     "multer": "1.4.5-lts.1",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`@nestjs/platform-express` depends on `express@5.0.1` and on `body-parser@1.20.3`. Express 5.0.1 itself depends on `body-parser@2.0.2` and reexports its middlewares. So 2 different versions of `body-parser` are installed and used.

## What is the new behavior?

`nestjs/platfrom-express` depends only on `express@5.0.1` and uses the body-parser reexports. They are not deprecated and will not be removed! See: https://github.com/expressjs/express/blob/master/lib/express.js#L77-L81

It was already proposed in #8645 a while ago.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

