### PR TITLE
chore: add issue types to issue templates forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,7 @@
 name: "\U0001F41B Bug Report"
 description: "If something isn't working as expected \U0001F914"
 labels: ["needs triage"]
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/Feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_request.yml
@@ -1,6 +1,7 @@
 name: "\U0001F680 Feature Request"
 description: "I have a suggestion \U0001F63B!"
 labels: ["type: enhancement :wolf:", "needs triage"]
+type: feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/Regression.yml
+++ b/.github/ISSUE_TEMPLATE/Regression.yml
@@ -1,6 +1,7 @@
 name: "\U0001F4A5 Regression"
 description: "Report an unexpected while upgrading your Nest application!"
 labels: ["type: bug :sob:", "needs triage"]
+type: bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/Suggestion_improve_performance.yml
+++ b/.github/ISSUE_TEMPLATE/Suggestion_improve_performance.yml
@@ -2,6 +2,7 @@ title: "perf: "
 name: "\U0001F525 Suggestion for Improving Performance"
 description: "I have a suggestion that might improve the performance of Nest \U00002728"
 labels: ["type: enhancement :wolf:", "needs triage"]
+type: task
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
how the issues will use the _type_ feature 
![image](https://github.com/user-attachments/assets/f3ba29bc-b2f8-4394-8493-c5b327405a64)

https://github.com/orgs/community/discussions/112806