### PR TITLE
fix: Module id generatorAlgorithm can't be controlled in test #14455

### DIFF
--- a/packages/testing/test.ts
+++ b/packages/testing/test.ts
@@ -1,11 +1,19 @@
 import { ModuleMetadata } from '@nestjs/common/interfaces/modules/module-metadata.interface';
 import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { TestingModuleBuilder } from './testing-module.builder';
+import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
 
 export class Test {
   private static readonly metadataScanner = new MetadataScanner();
 
-  public static createTestingModule(metadata: ModuleMetadata) {
-    return new TestingModuleBuilder(this.metadataScanner, metadata);
+  public static createTestingModule(
+    metadata: ModuleMetadata,
+    contextOptions: NestApplicationContextOptions | undefined = undefined,
+  ) {
+    return new TestingModuleBuilder(
+      this.metadataScanner,
+      metadata,
+      contextOptions,
+    );
   }
 }

--- a/packages/testing/testing-module.builder.ts
+++ b/packages/testing/testing-module.builder.ts
@@ -28,7 +28,7 @@ import { TestingModule } from './testing-module';
  */
 export class TestingModuleBuilder {
   private readonly applicationConfig = new ApplicationConfig();
-  private readonly container = new NestContainer(this.applicationConfig);
+  private readonly container: NestContainer;
   private readonly overloadsMap = new Map();
   private readonly moduleOverloadsMap = new Map<
     ModuleDefinition,
@@ -41,7 +41,9 @@ export class TestingModuleBuilder {
   constructor(
     private readonly metadataScanner: MetadataScanner,
     metadata: ModuleMetadata,
+    contextOptions: NestApplicationContextOptions | undefined = undefined,
   ) {
+    this.container = new NestContainer(this.applicationConfig, contextOptions);
     this.module = this.createModule(metadata);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14455


## What is the new behavior?

Add the ability to control moduleIdGeneratorAlgorithm in TestingModuleBuilder

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information