### PR TITLE
chore(sample): remove `@types/dotenv` useless dev dep

### DIFF
--- a/sample/25-dynamic-modules/package.json
+++ b/sample/25-dynamic-modules/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@eslint/eslintrc": "3.2.0",
     "@eslint/js": "9.18.0",
-    "@types/dotenv": "8.2.3",
     "@nestjs/cli": "11.0.0",
     "@nestjs/schematics": "11.0.0",
     "@nestjs/testing": "11.0.3",

--- a/sample/26-queues/package.json
+++ b/sample/26-queues/package.json
@@ -36,7 +36,6 @@
     "@nestjs/schematics": "11.0.0",
     "@nestjs/testing": "11.0.3",
     "@types/bull": "4.10.4",
-    "@types/dotenv": "8.2.3",
     "@types/express": "5.0.0",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.7",

--- a/sample/27-scheduling/package.json
+++ b/sample/27-scheduling/package.json
@@ -35,7 +35,6 @@
     "@nestjs/schematics": "11.0.0",
     "@nestjs/testing": "11.0.3",
     "@types/bull": "4.10.4",
-    "@types/dotenv": "8.2.3",
     "@types/express": "5.0.0",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.7",

--- a/sample/28-sse/package.json
+++ b/sample/28-sse/package.json
@@ -32,7 +32,6 @@
     "@nestjs/cli": "11.0.0",
     "@nestjs/schematics": "11.0.0",
     "@nestjs/testing": "11.0.3",
-    "@types/dotenv": "8.2.3",
     "@types/express": "5.0.0",
     "@types/jest": "29.5.14",
     "@types/node": "22.10.7",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/78fca8e6-3e4c-4f81-ae11-e97cdace4f7f)

as we are using the latest version of `dotenv`, we don't need the `@types/dotenv` anymore