### PR TITLE
feat(microservices): return all clients from kafka unwrap

### DIFF
--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -245,7 +245,7 @@ export class ServerKafka extends Server<never, KafkaStatus> {
         'Not initialized. Please call the "listen"/"startAllMicroservices" method before accessing the server.',
       );
     }
-    return this.client as T;
+    return [this.client, this.consumer, this.producer] as T;
   }
 
   public on<


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [#11616](https://github.com/nestjs/nest/issues/11616)

While the new major release ships an ability to unwrap underlying server instance, it's still not possible to manipulate on existing consumer and producer instances which are created in `start` method. As an example provided in the issue, we still can't subscribe heartbeat event on consumer created by NestJS

## What is the new behavior?

Following the example in Redis server, we can return all created instances, but not just client instance. In this case everyone can get an access to consumer and producers

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`unwrap` method is not type-safe and fully depend on developer who define expected type. If someone is already start using `unwrap` method we might get into the trouble of unexpected result and developer must change their expected type manually

```typescript
const client = microservice.unwrap<Kafka>(); // old
const [client] = microservice.unwrap<[Kafka]>() // new
```

## Other information