### PR TITLE
fix: middleware sort issues

### DIFF
--- a/integration/hello-world/e2e/middleware-execute-order.spec.ts
+++ b/integration/hello-world/e2e/middleware-execute-order.spec.ts
@@ -22,7 +22,17 @@ class GlobalModule {
   }
 }
 
-@Module({ imports: [GlobalModule] })
+@Global()
+@Module({})
+class GlobalModule2 {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply((req, res, next) => res.send(RETURN_VALUE_GLOBAL + '2'))
+      .forRoutes('ping');
+  }
+}
+
+@Module({ imports: [GlobalModule, GlobalModule2] })
 class ModuleX {
   configure(consumer: MiddlewareConsumer) {
     consumer

--- a/packages/core/middleware/middleware-module.ts
+++ b/packages/core/middleware/middleware-module.ts
@@ -150,13 +150,17 @@ export class MiddlewareModule<
       ([moduleA], [moduleB]) => {
         const moduleARef = this.container.getModuleByKey(moduleA)!;
         const moduleBRef = this.container.getModuleByKey(moduleB)!;
-        if (moduleARef.distance === Number.MAX_VALUE) {
+        const isModuleAGlobal = moduleARef.distance === Number.MAX_VALUE;
+        const isModuleBGlobal = moduleBRef.distance === Number.MAX_VALUE;
+        if (isModuleAGlobal && isModuleBGlobal) {
+          return 0;
+        }
+        if (isModuleAGlobal) {
           return -1;
         }
-        if (moduleBRef.distance === Number.MAX_VALUE) {
+        if (isModuleBGlobal) {
           return 1;
         }
-
         return moduleARef.distance - moduleBRef.distance;
       },
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Global middleware is not executed in import order, because sort is not stable

Issue Number: N/A


## What is the new behavior?

Preserve order of global middleware definitions.  
Sort docs state a list of rules that the sort function must adhere to. Current impl violates it and as such the order is not stable. Violation happens when 2 modules are both global but he return value is not 0. so if comparing a,b it retuns a is "bigger" and if comparing b,a it returns b is "bigger".

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This bug was introduced in https://github.com/nestjs/nest/commit/44490dcad084c856e52987a38b3553a4c112e266