### PR TITLE
chore(sample): ignore all package lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 packages/*/package-lock.json
-sample/*/package-lock.json
+sample/**/package-lock.json
 
 # dependencies
 node_modules/


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Some samples have sub folders and old .gitignore rule didn't take their package-lock.json files into consideration.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When I run npm run build:samples on my machine. I have a bunch of package-lock.json files' changes afterwards.

Issue Number: N/A


## What is the new behavior?

These package-lock.json files are ignored by version control.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information