### PR TITLE
feat(common): add method parameter for sse decorator

### DIFF
--- a/packages/common/decorators/http/sse.decorator.ts
+++ b/packages/common/decorators/http/sse.decorator.ts
@@ -6,7 +6,7 @@ import { RequestMethod } from '../../enums/request-method.enum';
  *
  * @publicApi
  */
-export function Sse(path?: string): MethodDecorator {
+export function Sse(path?: string, method?: RequestMethod): MethodDecorator {
   return (
     target: object,
     key: string | symbol,
@@ -17,7 +17,7 @@ export function Sse(path?: string): MethodDecorator {
     Reflect.defineMetadata(PATH_METADATA, path, descriptor.value);
     Reflect.defineMetadata(
       METHOD_METADATA,
-      RequestMethod.GET,
+      method ?? RequestMethod.GET,
       descriptor.value,
     );
     Reflect.defineMetadata(SSE_METADATA, true, descriptor.value);

--- a/packages/common/test/decorators/sse.decorator.spec.ts
+++ b/packages/common/test/decorators/sse.decorator.spec.ts
@@ -8,6 +8,9 @@ describe('@Sse', () => {
   class Test {
     @Sse(prefix)
     public static test() {}
+
+    @Sse(prefix, RequestMethod.POST)
+    public static testPost() {}
   }
 
   it('should enhance method with expected http status code', () => {
@@ -18,6 +21,17 @@ describe('@Sse', () => {
     expect(method).to.be.eql(RequestMethod.GET);
 
     const metadata = Reflect.getMetadata(SSE_METADATA, Test.test);
+    expect(metadata).to.be.eql(true);
+  });
+
+  it('should enhance method with expected http status code for custom request method', () => {
+    const path = Reflect.getMetadata(PATH_METADATA, Test.testPost);
+    expect(path).to.be.eql('/prefix');
+
+    const method = Reflect.getMetadata(METHOD_METADATA, Test.testPost);
+    expect(method).to.be.eql(RequestMethod.POST);
+
+    const metadata = Reflect.getMetadata(SSE_METADATA, Test.testPost);
     expect(metadata).to.be.eql(true);
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the SSE decorator only supports the GET method, which limits scenarios where a request body is needed.  

Issue Number: N/A


## What is the new behavior?
Added a `method` parameter to the SSE decorator, allowing routes to use methods other than GET, enabling scenarios like sending a body with POST. This is supported by libs like`@microsoft/fetch-event-source` and `event-source-plus`.  


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information