### PR TITLE
fix(platform-express) make check for existing middlewares work with Express 5

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -471,9 +471,9 @@ export class ExpressAdapter extends AbstractHttpAdapter<
     const app = this.getInstance();
     return (
       !!app._router &&
-      !!app._router.stack &&
-      isFunction(app._router.stack.filter) &&
-      app._router.stack.some(
+      !!app.router.stack &&
+      isFunction(app.router.stack.filter) &&
+      app.router.stack.some(
         (layer: any) => layer && layer.handle && layer.handle.name === name,
       )
     );


### PR DESCRIPTION
Express 5 made the router public API again and renamed the field from app._router to app.router. This broke the detection mechanism whether a middleware named "jsonParser" or "urlencodedParser" is already re or not, because app._router no longer exists.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
    - the adjusted code seems totally untested. so not sure how to add a simple test. maybe I missed something?
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The express adapter overwrites existing middlewares called jsonParser and urlencodedParser with its on parsers.

This regression was caused by updating from Express 4 to 5. Express 5 exposes the router via app.router, while Express 4 exposed it via app._router.

Issue Number: N/A - I didn't create an issue yet - let me know if you need that

## What is the new behavior?

The express adapter respects existing middlewares called jsonParser and urlencodedParser and stops registering its own parser middleware.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information