### PR TITLE
fix(core): Handle wildcard routes with global prefix

### DIFF
--- a/packages/core/middleware/route-info-path-extractor.ts
+++ b/packages/core/middleware/route-info-path-extractor.ts
@@ -32,6 +32,10 @@ export class RouteInfoPathExtractor {
   public extractPathsFrom({ path, method, version }: RouteInfo): string[] {
     const versionPaths = this.extractVersionPathFrom(version);
 
+    if (this.prefixPath && path === '/*') {
+      path = '/*path';
+    }
+
     if (this.isAWildcard(path)) {
       const entries =
         versionPaths.length > 0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using a global prefix (via app.setGlobalPrefix()) in combination, NestJS throws an "Unsupported route path" warning. This is due to changes in the underlying path-to-regexp library, which now requires named parameters for wildcard routes.



## What is the new behavior?
With this change, the warning message no longer appears when using `app.setGlobalPrefix("/api")` in combination with wildcard routes. Users can now use global prefixes and wildcard routes together without seeing the "Unsupported route path" warning.

Example:
```typescript
app.setGlobalPrefix("/api");
```

This code now works as expected without any warnings.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information