### PR TITLE
fix(platform-express) respect custom parser middlewares in Express 5

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -470,7 +470,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
   private isMiddlewareApplied(name: string): boolean {
     const app = this.getInstance();
     return (
-      !!app._router &&
+      !!app.router &&
       !!app.router.stack &&
       isFunction(app.router.stack.filter) &&
       app.router.stack.some(

--- a/packages/platform-express/test/adapters/express-adapter.spec.ts
+++ b/packages/platform-express/test/adapters/express-adapter.spec.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 
 afterEach(() => sinon.restore());
 
-describe.only('ExpressAdapter', () => {
+describe('ExpressAdapter', () => {
   describe('registerParserMiddleware', () => {
     it('should register the express built-in parsers for json and urlencoded payloads', () => {
       const expressInstance = express();

--- a/packages/platform-express/test/adapters/express-adapter.spec.ts
+++ b/packages/platform-express/test/adapters/express-adapter.spec.ts
@@ -1,0 +1,46 @@
+import { ExpressAdapter } from '@nestjs/platform-express';
+import { expect } from 'chai';
+import * as express from 'express';
+import * as sinon from 'sinon';
+
+afterEach(() => sinon.restore());
+
+describe.only('ExpressAdapter', () => {
+  describe('registerParserMiddleware', () => {
+    it('should register the express built-in parsers for json and urlencoded payloads', () => {
+      const expressInstance = express();
+      const jsonParserInstance = express.json();
+      const urlencodedInstance = express.urlencoded();
+      const jsonParserSpy = sinon
+        .stub(express, 'json')
+        .returns(jsonParserInstance);
+      const urlencodedParserSpy = sinon
+        .stub(express, 'urlencoded')
+        .returns(urlencodedInstance);
+      const useSpy = sinon.spy(expressInstance, 'use');
+      const expressAdapter = new ExpressAdapter(expressInstance);
+
+      expressAdapter.registerParserMiddleware();
+
+      expect(useSpy.calledTwice).to.be.true;
+      expect(useSpy.calledWith(sinon.match.same(jsonParserInstance))).to.be
+        .true;
+      expect(useSpy.calledWith(sinon.match.same(urlencodedInstance))).to.be
+        .true;
+      expect(jsonParserSpy.calledOnceWith({})).to.be.true;
+      expect(urlencodedParserSpy.calledOnceWith({ extended: true })).to.be.true;
+    });
+
+    it('should not register default parsers if custom parsers have already been registered', () => {
+      const expressInstance = express();
+      expressInstance.use(function jsonParser() {});
+      expressInstance.use(function urlencodedParser() {});
+      const useSpy = sinon.spy(expressInstance, 'use');
+      const expressAdapter = new ExpressAdapter(expressInstance);
+
+      expressAdapter.registerParserMiddleware();
+
+      expect(useSpy.called).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Express 5 made the router public API again and renamed the field from app._router to app.router. This broke the detection mechanism whether a middleware named "jsonParser" or "urlencodedParser" is already registered or not.
Unfortunately, https://github.com/nestjs/nest/pull/14574 only fixed the issue partially. This commit now uses app.router everywhere.
To avoid future regressions a test was added to verify the expected behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The express adapter overwrites existing middlewares called jsonParser and urlencodedParser with its on parsers.

This regression was caused by updating from Express 4 to 5. Express 5 exposes the router via app.router, while Express 4 exposed it via app._router.

https://github.com/nestjs/nest/pull/14574 provided a partial fix, but one check was missed.

## What is the new behavior?

The express adapter respects existing middlewares called jsonParser and urlencodedParser.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information