### PR TITLE
perf: Switch deprecated parser querystring for fast-querystring

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -48,8 +48,8 @@ import {
   Response as LightMyRequestResponse,
 } from 'light-my-request';
 import { pathToRegexp } from 'path-to-regexp';
-// `querystring` is used internally in fastify for registering urlencoded body parser.
-import { parse as querystringParse } from 'querystring';
+// Fastify uses `fast-querystring` internally to quickly parse URL query strings.
+import { parse as querystringParse } from 'fast-querystring';
 import {
   FASTIFY_ROUTE_CONFIG_METADATA,
   FASTIFY_ROUTE_CONSTRAINTS_METADATA,

--- a/packages/platform-fastify/package.json
+++ b/packages/platform-fastify/package.json
@@ -21,6 +21,7 @@
     "@fastify/cors": "10.0.2",
     "@fastify/formbody": "8.0.2",
     "@fastify/middie": "9.0.3",
+    "fast-querystring": "1.1.2",
     "fastify": "5.2.1",
     "light-my-request": "6.6.0",
     "path-to-regexp": "8.2.0",


### PR DESCRIPTION
This should be considered. The performance gains are not negligible. Additionally, [find-my-way](https://github.com/delvedor/find-my-way/) and [Fastify](https://fastify.dev/) use it by default, so there's no reason to regress on this for the adapter.

The `querystring` is also absolutely deprecated with the last feature commit from 2018 (it seems). @kamilmysliwiec 
![image](https://github.com/user-attachments/assets/d3064a27-6f2c-48cd-826a-3cdfbe9fb490)

Related to https://github.com/nestjs/nest/pull/10248.