### PR TITLE
fix(core): make `isHttpError` check stricter

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -83,8 +83,6 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
    * @param err error object
    */
   public isHttpError(err: any): err is { statusCode: number; message: string } {
-    console.log({ err, errName: err.constructor.name });
-
     if (!err || typeof err !== 'object') {
       return false;
     }

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -79,14 +79,25 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
   }
 
   /**
-   * Checks if the thrown error comes from the "http-errors" library.
+   * Checks if the thrown error is a FastifyError or comes from the "http-errors" library.
    * @param err error object
    */
   public isHttpError(err: any): err is { statusCode: number; message: string } {
+    console.log({ err, errName: err.constructor.name });
+
     if (!err || typeof err !== 'object') {
       return false;
     }
 
+    if (
+      err.constructor.name === 'FastifyError' &&
+      typeof err.code === 'string' &&
+      typeof err.statusCode === 'number'
+    ) {
+      return true;
+    }
+
+    // "http-errors" error signature
     return (
       typeof err.expose === 'boolean' &&
       typeof err.statusCode === 'number' &&

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -83,6 +83,15 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
    * @param err error object
    */
   public isHttpError(err: any): err is { statusCode: number; message: string } {
-    return err?.statusCode && err?.message;
+    if (!err || typeof err !== 'object') {
+      return false;
+    }
+
+    return (
+      typeof err.expose === 'boolean' &&
+      typeof err.statusCode === 'number' &&
+      err.status === err.statusCode &&
+      err instanceof Error
+    );
   }
 }

--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -79,7 +79,7 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
   }
 
   /**
-   * Checks if the thrown error comes from the "http-errors" library.
+   * Checks if the thrown error is a FastifyError or comes from the "http-errors" library.
    * @param err error object
    */
   public isHttpError(err: any): err is { statusCode: number; message: string } {
@@ -87,6 +87,15 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
       return false;
     }
 
+    if (
+      err.constructor.name === 'FastifyError' &&
+      typeof err.code === 'string' &&
+      typeof err.statusCode === 'number'
+    ) {
+      return true;
+    }
+
+    // "http-errors" error signature
     return (
       typeof err.expose === 'boolean' &&
       typeof err.statusCode === 'number' &&

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -3,6 +3,7 @@ import { isNil, isObject } from '@nestjs/common/utils/shared.utils';
 import { expect } from 'chai';
 import * as createHttpError from 'http-errors';
 import * as sinon from 'sinon';
+import fastifyErrors from '@fastify/error';
 import { AbstractHttpAdapter } from '../../adapters';
 import { InvalidExceptionFilterException } from '../../errors/exceptions/invalid-exception-filter.exception';
 import { ExceptionsHandler } from '../../exceptions/exceptions-handler';
@@ -54,6 +55,23 @@ describe('ExceptionsHandler', () => {
         jsonStub.calledWith({
           statusCode: 500,
           message: 'Internal server error',
+        }),
+      ).to.be.true;
+    });
+    it('should treat fastify errors as http errors', () => {
+      const fastifyError = fastifyErrors.createError(
+        'FST_ERR_CTP_EMPTY_JSON_BODY',
+        "Body cannot be empty when content-type is set to 'application/json'",
+        400,
+      )();
+      handler.next(fastifyError, new ExecutionContextHost([0, response]));
+
+      expect(statusStub.calledWith(400)).to.be.true;
+      expect(
+        jsonStub.calledWith({
+          statusCode: 400,
+          message:
+            "Body cannot be empty when content-type is set to 'application/json'",
         }),
       ).to.be.true;
     });

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -53,6 +53,21 @@ describe('ExceptionsHandler', () => {
         message: 'Internal server error',
       });
     });
+    it('should not treat errors from external API calls as errors from "http-errors" library', () => {
+      const apiCallError = Object.assign(
+        new Error('Some external API call failed'),
+        { status: 400 },
+      );
+      handler.next(apiCallError, new ExecutionContextHost([0, response]));
+
+      expect(statusStub.calledWith(500)).to.be.true;
+      expect(
+        jsonStub.calledWith({
+          statusCode: 500,
+          message: 'Internal server error',
+        }),
+      ).to.be.true;
+    });
     describe('when exception is instantiated by "http-errors" library', () => {
       it('should send expected response status code and message', () => {
         const error = new createHttpError.NotFound('User does not exist');

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -1,11 +1,14 @@
 import { HttpException } from '@nestjs/common';
-import { isNil, isObject } from '@nestjs/common/utils/shared.utils.js';
-import createHttpError from 'http-errors';
-import { AbstractHttpAdapter } from '../../adapters/index.js';
-import { InvalidExceptionFilterException } from '../../errors/exceptions/invalid-exception-filter.exception.js';
-import { ExceptionsHandler } from '../../exceptions/exceptions-handler.js';
-import { ExecutionContextHost } from '../../helpers/execution-context-host.js';
-import { NoopHttpAdapter } from '../utils/noop-adapter.js';
+import { isNil, isObject } from '@nestjs/common/utils/shared.utils';
+import { expect } from 'chai';
+import * as createHttpError from 'http-errors';
+import * as sinon from 'sinon';
+import fastifyErrors from '@fastify/error';
+import { AbstractHttpAdapter } from '../../adapters';
+import { InvalidExceptionFilterException } from '../../errors/exceptions/invalid-exception-filter.exception';
+import { ExceptionsHandler } from '../../exceptions/exceptions-handler';
+import { ExecutionContextHost } from '../../helpers/execution-context-host';
+import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
 
 describe('ExceptionsHandler', () => {
   let adapter: AbstractHttpAdapter;
@@ -52,6 +55,23 @@ describe('ExceptionsHandler', () => {
         statusCode: 500,
         message: 'Internal server error',
       });
+    });
+    it('should treat fastify errors as http errors', () => {
+      const fastifyError = fastifyErrors.createError(
+        'FST_ERR_CTP_EMPTY_JSON_BODY',
+        "Body cannot be empty when content-type is set to 'application/json'",
+        400,
+      )();
+      handler.next(fastifyError, new ExecutionContextHost([0, response]));
+
+      expect(statusStub.calledWith(400)).to.be.true;
+      expect(
+        jsonStub.calledWith({
+          statusCode: 400,
+          message:
+            "Body cannot be empty when content-type is set to 'application/json'",
+        }),
+      ).to.be.true;
     });
     it('should not treat errors from external API calls as errors from "http-errors" library', () => {
       const apiCallError = Object.assign(

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -1,14 +1,12 @@
 import { HttpException } from '@nestjs/common';
-import { isNil, isObject } from '@nestjs/common/utils/shared.utils';
-import { expect } from 'chai';
-import * as createHttpError from 'http-errors';
-import * as sinon from 'sinon';
+import { isNil, isObject } from '@nestjs/common/utils/shared.utils.js';
+import createHttpError from 'http-errors';
+import { AbstractHttpAdapter } from '../../adapters/index.js';
+import { InvalidExceptionFilterException } from '../../errors/exceptions/invalid-exception-filter.exception.js';
+import { ExceptionsHandler } from '../../exceptions/exceptions-handler.js';
+import { ExecutionContextHost } from '../../helpers/execution-context-host.js';
+import { NoopHttpAdapter } from '../utils/noop-adapter.js';
 import fastifyErrors from '@fastify/error';
-import { AbstractHttpAdapter } from '../../adapters';
-import { InvalidExceptionFilterException } from '../../errors/exceptions/invalid-exception-filter.exception';
-import { ExceptionsHandler } from '../../exceptions/exceptions-handler';
-import { ExecutionContextHost } from '../../helpers/execution-context-host';
-import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
 
 describe('ExceptionsHandler', () => {
   let adapter: AbstractHttpAdapter;
@@ -64,14 +62,12 @@ describe('ExceptionsHandler', () => {
       )();
       handler.next(fastifyError, new ExecutionContextHost([0, response]));
 
-      expect(statusStub.calledWith(400)).to.be.true;
-      expect(
-        jsonStub.calledWith({
-          statusCode: 400,
-          message:
-            "Body cannot be empty when content-type is set to 'application/json'",
-        }),
-      ).to.be.true;
+      expect(statusStub).toHaveBeenCalledWith(400);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 400,
+        message:
+          "Body cannot be empty when content-type is set to 'application/json'",
+      });
     });
     it('should not treat errors from external API calls as errors from "http-errors" library', () => {
       const apiCallError = Object.assign(
@@ -80,13 +76,11 @@ describe('ExceptionsHandler', () => {
       );
       handler.next(apiCallError, new ExecutionContextHost([0, response]));
 
-      expect(statusStub.calledWith(500)).to.be.true;
-      expect(
-        jsonStub.calledWith({
-          statusCode: 500,
-          message: 'Internal server error',
-        }),
-      ).to.be.true;
+      expect(statusStub).toHaveBeenCalledWith(500);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
     });
     it('should treat fastify errors as http errors', () => {
       const fastifyError = fastifyErrors.createError(
@@ -96,14 +90,12 @@ describe('ExceptionsHandler', () => {
       )();
       handler.next(fastifyError, new ExecutionContextHost([0, response]));
 
-      expect(statusStub.calledWith(400)).to.be.true;
-      expect(
-        jsonStub.calledWith({
-          statusCode: 400,
-          message:
-            "Body cannot be empty when content-type is set to 'application/json'",
-        }),
-      ).to.be.true;
+      expect(statusStub).toHaveBeenCalledWith(400);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 400,
+        message:
+          "Body cannot be empty when content-type is set to 'application/json'",
+      });
     });
     it('should not treat errors from external API calls as errors from "http-errors" library', () => {
       const apiCallError = Object.assign(
@@ -112,13 +104,11 @@ describe('ExceptionsHandler', () => {
       );
       handler.next(apiCallError, new ExecutionContextHost([0, response]));
 
-      expect(statusStub.calledWith(500)).to.be.true;
-      expect(
-        jsonStub.calledWith({
-          statusCode: 500,
-          message: 'Internal server error',
-        }),
-      ).to.be.true;
+      expect(statusStub).toHaveBeenCalledWith(500);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
     });
     describe('when exception is instantiated by "http-errors" library', () => {
       it('should send expected response status code and message', () => {

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -57,6 +57,21 @@ describe('ExceptionsHandler', () => {
         }),
       ).to.be.true;
     });
+    it('should not treat errors from external API calls as errors from "http-errors" library', () => {
+      const apiCallError = Object.assign(
+        new Error('Some external API call failed'),
+        { status: 400 },
+      );
+      handler.next(apiCallError, new ExecutionContextHost([0, response]));
+
+      expect(statusStub.calledWith(500)).to.be.true;
+      expect(
+        jsonStub.calledWith({
+          statusCode: 500,
+          message: 'Internal server error',
+        }),
+      ).to.be.true;
+    });
     describe('when exception is instantiated by "http-errors" library', () => {
       it('should send expected response status code and message', () => {
         const error = new createHttpError.NotFound('User does not exist');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/nest/issues/14738


## What is the new behavior?

The new logic is stricter and almost the same as the one in `http-errors` library.

Additional check for `expose` property for example should remove a lot of false positives like `ResponseError` from ElasticSearch SDK.

## Does this PR introduce a breaking change?

Not sure
