### PR TITLE
feat(fastify): add decorator for custom schema

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -53,6 +53,7 @@ import { parse as querystringParse } from 'fast-querystring';
 import {
   FASTIFY_ROUTE_CONFIG_METADATA,
   FASTIFY_ROUTE_CONSTRAINTS_METADATA,
+  FASTIFY_ROUTE_SCHEMA_METADATA,
 } from '../constants';
 import { NestFastifyBodyParserOptions } from '../interfaces';
 import {
@@ -752,9 +753,14 @@ export class FastifyAdapter<
       handlerRef,
     );
 
+    const routeSchema = Reflect.getMetadata(
+      FASTIFY_ROUTE_SCHEMA_METADATA,
+      handlerRef,
+    );
+
     const hasConfig = !isUndefined(routeConfig);
     const hasConstraints = !isUndefined(routeConstraints);
-
+    const hasSchema = !isUndefined(routeSchema);
     const routeToInject: RouteOptions<TServer, TRawRequest, TRawResponse> &
       RouteShorthandOptions = {
       method: routerMethodKey,
@@ -766,7 +772,7 @@ export class FastifyAdapter<
       this.instance.addHttpMethod(routerMethodKey, { hasBody: true });
     }
 
-    if (isVersioned || hasConstraints || hasConfig) {
+    if (isVersioned || hasConstraints || hasConfig || hasSchema) {
       const isPathAndRouteTuple = args.length === 2;
       if (isPathAndRouteTuple) {
         const constraints = {
@@ -782,6 +788,9 @@ export class FastifyAdapter<
             config: {
               ...routeConfig,
             },
+          }),
+          ...(hasSchema && {
+            schema: routeSchema,
           }),
         };
 

--- a/packages/platform-fastify/constants.ts
+++ b/packages/platform-fastify/constants.ts
@@ -1,3 +1,4 @@
 export const FASTIFY_ROUTE_CONFIG_METADATA = '__fastify_route_config__';
 export const FASTIFY_ROUTE_CONSTRAINTS_METADATA =
   '__fastify_route_constraints__';
+export const FASTIFY_ROUTE_SCHEMA_METADATA = '__fastify_route_schema__';

--- a/packages/platform-fastify/decorators/index.ts
+++ b/packages/platform-fastify/decorators/index.ts
@@ -1,2 +1,3 @@
 export * from './route-config.decorator';
 export * from './route-constraints.decorator';
+export * from './route-schema.decorator';

--- a/packages/platform-fastify/decorators/route-schema.decorator.ts
+++ b/packages/platform-fastify/decorators/route-schema.decorator.ts
@@ -1,0 +1,15 @@
+import { SetMetadata } from '@nestjs/common';
+import { FASTIFY_ROUTE_SCHEMA_METADATA } from '../constants';
+import { FastifySchema } from 'fastify';
+
+/**
+ * @publicApi
+ * Allows setting the schema for the route. Schema is an object that can contain the following properties:
+ * - body: JsonSchema
+ * - querystring or query: JsonSchema
+ * - params: JsonSchema
+ * - response: Record<HttpStatusCode, JsonSchema>
+ * @param schema See {@link https://fastify.dev/docs/latest/Reference/Routes/#routes-options}
+ */
+export const RouteSchema = (schema: FastifySchema) =>
+  SetMetadata(FASTIFY_ROUTE_SCHEMA_METADATA, schema);

--- a/packages/platform-fastify/test/decorators/router-schema.decorator.spec.ts
+++ b/packages/platform-fastify/test/decorators/router-schema.decorator.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import { FASTIFY_ROUTE_SCHEMA_METADATA } from '../../constants';
+import { RouteSchema } from '../../decorators/route-schema.decorator';
+
+describe('@RouteSchema', () => {
+  const routeSchema = { body: 'testValue' };
+  class Test {
+    config;
+    @RouteSchema(routeSchema)
+    public static test() {}
+  }
+
+  it('should enhance method with expected fastify route schema', () => {
+    const path = Reflect.getMetadata(FASTIFY_ROUTE_SCHEMA_METADATA, Test.test);
+    expect(path).to.be.eql(routeSchema);
+  });
+});


### PR DESCRIPTION
Add an ability to attach json schema to request with a RequestSchema decorator

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, there is no easy way of using fastify's [schema property](https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/) and adding a response schema can have positive impact on performance [source](https://fastify.dev/docs/latest/Reference/Validation-and-Serialization/#serialization)

Issue Number: N/A


## What is the new behavior?

This PR adds a new decorator `RequestSchema` that takes a schema object and sets it as `schema` property on fastify route [doc](https://fastify.dev/docs/latest/Reference/Routes/#routes-options)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
