### PR TITLE
feat(microservices): add event typings to the `@EventPattern` decorator

### DIFF
--- a/packages/microservices/decorators/event-pattern.decorator.ts
+++ b/packages/microservices/decorators/event-pattern.decorator.ts
@@ -13,12 +13,39 @@ import {
 import { Transport } from '../enums';
 import { PatternHandler } from '../enums/pattern-handler.enum';
 
+export type EventDataMethodDecorator<
+  TEventTypes extends Record<string, any>,
+  TKey extends keyof TEventTypes,
+> = (
+  target: object,
+  propertyKey: string | symbol,
+  descriptor: TypedPropertyDescriptor<
+    (data: TEventTypes[TKey], ...args: unknown[]) => any
+  >,
+) => void;
+
 /**
  * Subscribes to incoming events which fulfils chosen pattern.
  *
  * @publicApi
  */
 export const EventPattern: {
+  <TEventTypes extends Record<string, any>>(
+    topic: keyof TEventTypes,
+  ): EventDataMethodDecorator<TEventTypes, typeof topic>;
+  <TEventTypes extends Record<string, any>>(
+    topic: keyof TEventTypes,
+    transport: Transport | symbol,
+  ): EventDataMethodDecorator<TEventTypes, typeof topic>;
+  <TEventTypes extends Record<string, any>>(
+    topic: keyof TEventTypes,
+    extras: Record<string, any>,
+  ): EventDataMethodDecorator<TEventTypes, typeof topic>;
+  <TEventTypes extends Record<string, any>>(
+    topic: keyof TEventTypes,
+    transport: Transport | symbol,
+    extras: Record<string, any>,
+  ): EventDataMethodDecorator<TEventTypes, typeof topic>;
   <T = string>(metadata?: T): MethodDecorator;
   <T = string>(metadata?: T, transport?: Transport | symbol): MethodDecorator;
   <T = string>(metadata?: T, extras?: Record<string, any>): MethodDecorator;

--- a/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/event-pattern.decorator.spec.ts
@@ -85,6 +85,28 @@ describe('@EventPattern', () => {
       public static test() {}
     }
 
+    type TestComponent6EventTypes = {
+      'event-pattern-foo': { foo: string };
+      'event-pattern-bar': { bar: number };
+    };
+
+    // Static tests exclusively for type safety:
+    class TypeTestComponent {
+      @EventPattern<TestComponent6EventTypes>('event-pattern-foo')
+      testFoo(_event: { foo: string }, _additionalArg: string) {}
+
+      @EventPattern<TestComponent6EventTypes>('event-pattern-bar')
+      testBar(_event: { bar: number }) {}
+
+      // @ts-expect-error -- `foo` should be a string, not a number
+      @EventPattern<TestComponent6EventTypes>('event-pattern-foo')
+      testFooMismatch(_event: { foo: number }) {}
+
+      // @ts-expect-error -- `_event` should be `{ foo: string; }`, not a string
+      @EventPattern<TestComponent6EventTypes>('event-pattern-foo')
+      testFooMismatch2(_event: string) {}
+    }
+
     it(`should enhance method with ${PATTERN_METADATA} metadata`, () => {
       const [metadataArg] = Reflect.getMetadata(
         PATTERN_METADATA,


### PR DESCRIPTION
Adds overloads for `@EventPattern` to allow validation that decorated method signatures match event payload types based on a specified mapping type. Includes tests demonstrating correct usage and error cases with `// @ts-expect-error`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds overloads to the `@EventPattern` decorator that creates a static type constraint between the pattern and the decorated method's parameter type.

Example:
```typescript
type FooMessage = {
  foo: string;
};

type BarMessage = {
  bar: number;
};

type EventTypes = {
  'event-pattern-foo': FooMessage;
  'event-pattern-bar': BarMessage;
};

class FooBarTestComponent {
  // correct
  @EventPattern<EventTypes>('event-pattern-bar')
  testBar(event: BarMessage) {}

  // incorrect (foo is specified, but the parameter type is `string` instead of `FooMessage`
  @EventPattern<EventTypes>('event-pattern-foo')
  testFoo(event: string) {}
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- I'm unsure of what documentation should be added/where that lives.
- I'm unsure of whether or not `topic` is an appropriate name for these overloads instead of `metadata`.