### PR TITLE
fix(microservices): do not re-create client connection once get client by service name

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -66,7 +66,7 @@ export class ClientGrpcProxy
   }
 
   public getService<T extends object>(name: string): T {
-    const grpcClient = this.createClientByServiceName(name);
+    const grpcClient = this.getClientByServiceName(name);
     const clientRef = this.getClient(name);
     if (!clientRef) {
       throw new InvalidGrpcServiceException(name);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
### Memory leak potential with Grpc

I saw the method `getService` from `client-grpc.ts` always re-create `client` that could lead to memory potentially. Also I saw method `getClientByServiceName` has been implemented by not being used by anywhere. 

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
My backend got issue when calling `getService` multiple times and I observed that memory has been increased constantly (I know that we should call `getService` only once when NestModule has been inited but there is exception for my codebase). 

I've tested by calling thousand of grpc calls (that will call `getService` method) and here is the memory profiling.
<img width="924" alt="image" src="https://github.com/user-attachments/assets/10e7a54b-e8d9-4b45-b0b4-dc812f11b357" />

Issue Number: N/A


## What is the new behavior?
After changing `createClientByServiceName` by `getClientByServiceName`, the memory issue has been solved, no more memory increasing occur. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information