### PR TITLE
fix(fastify-adapter): global prefix exclusion path handling w/middleware

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -627,10 +627,12 @@ export class FastifyAdapter<
       normalizedPath = normalizedPath === '/*path' ? '*path' : normalizedPath;
 
       // Normalize the path to support the prefix if it set in application
-      normalizedPath =
-        this._pathPrefix && !normalizedPath.startsWith(this._pathPrefix)
-          ? `${this._pathPrefix}${normalizedPath}*path`
-          : normalizedPath;
+      if (this._pathPrefix && !normalizedPath.startsWith(this._pathPrefix)) {
+        normalizedPath = `${this._pathPrefix}${normalizedPath}`;
+        if (normalizedPath.endsWith('/')) {
+          normalizedPath = `${normalizedPath}{*path}`;
+        }
+      }
 
       try {
         let { regexp: re } = pathToRegexp(normalizedPath);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Calling `setGlobalPrefix()` with an exclusion list that includes wildcards or parameters when middleware is present with fastify causes an error when trying to run the application.

Issue Number: https://github.com/nestjs/nest/issues/14894

## What is the new behavior?
Application starts, middleware is applied, prefix is applied and routes are correctly excluded.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I didn't make any specific doc updates as the docs are already correct for the expected behavior but if something else is needed just let me know. This was originally introduced by https://github.com/nestjs/nest/pull/13797 but I think this fix maintains the spirit and the desired outcome of that PR.