### PR TITLE
refactor(microservices): fix wrong type for keepalive keys

### DIFF
--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -126,7 +126,7 @@ export class ClientGrpcProxy
       return {};
     }
     const keepaliveKeys: Record<
-      keyof GrpcOptions['options']['keepalive'],
+      keyof NonNullable<GrpcOptions['options']['keepalive']>,
       string
     > = {
       keepaliveTimeMs: 'grpc.keepalive_time_ms',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The type definition for the variable `keepaliveKeys` is incorrect.
Because `GrpcOptions['options']['keepalive']` can be undefined, an unintended type is being generated. (`Record<never, string>`)

## AS-IS
It is unintentionally allowing anu key values.
<img width="524" alt="스크린샷 2025-04-06 오후 11 58 56" src="https://github.com/user-attachments/assets/a4a3aa8b-1036-4bd6-a2a6-3c136538008e" />

## TO-BE

<img width="482" alt="스크린샷 2025-04-06 오후 11 59 08" src="https://github.com/user-attachments/assets/7156696c-711d-4fad-ab0e-f9297e5023c7" />

