### PR TITLE
fix(microservices): use replySubject insteadof drain buffer for grpc …

### DIFF
--- a/packages/microservices/decorators/message-pattern.decorator.ts
+++ b/packages/microservices/decorators/message-pattern.decorator.ts
@@ -150,29 +150,13 @@ export function GrpcStreamMethod(
 
     const originalMethod = descriptor.value;
 
-    // Override original method to call the "drainBuffer" method on the first parameter
-    // This is required to avoid premature message emission
-    descriptor.value = async function (
-      this: any,
-      observable: any,
-      ...args: any[]
-    ) {
-      const result = await Promise.resolve(
-        originalMethod.apply(this, [observable, ...args]),
-      );
-
-      // Drain buffer if "drainBuffer" method is available
-      if (observable && observable.drainBuffer) {
-        observable.drainBuffer();
-      }
-      return result;
-    };
-
     // Copy all metadata from the original method to the new one
     const metadataKeys = Reflect.getMetadataKeys(originalMethod);
+
     metadataKeys.forEach(metadataKey => {
       const metadataValue = Reflect.getMetadata(metadataKey, originalMethod);
-      Reflect.defineMetadata(metadataKey, metadataValue, descriptor.value);
+
+      Reflect.defineMetadata(metadataKey, metadataValue, originalMethod);
     });
   };
 }


### PR DESCRIPTION
…stream call

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Previous implementation of drain buffer caused the controller to hang because complete method did not used for rxjs Subject, and it makes no sense too use Subject at all, just ReplySubject is fully enough

Issue Number: N/A


## What is the new behavior?
Every grpc stream chunk will be recorded inside rxjs ReplaySubject and repeats again full sequence for every new subscriber

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information