### PR TITLE
refactor(common): Prevent JavaScript being wrapped in `eval`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "fast-safe-stringify": "2.1.1",
         "file-type": "20.4.1",
         "iterare": "1.2.1",
+        "load-esm": "^1.0.2",
         "object-hash": "3.0.0",
         "path-to-regexp": "8.2.0",
         "reflect-metadata": "0.2.2",
@@ -26927,6 +26928,25 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/load-esm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
+      "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=13.2.0"
       }
     },
     "node_modules/load-json-file": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "fast-safe-stringify": "2.1.1",
     "file-type": "20.4.1",
     "iterare": "1.2.1",
+    "load-esm": "^1.0.2",
     "object-hash": "3.0.0",
     "path-to-regexp": "8.2.0",
     "reflect-metadata": "0.2.2",

--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -1,5 +1,6 @@
 import { FileValidator } from './file-validator.interface';
 import { IFile } from './interfaces';
+import { loadEsm } from 'load-esm';
 
 export type FileTypeValidatorOptions = {
   fileType: string | RegExp;
@@ -50,9 +51,8 @@ export class FileTypeValidator extends FileValidator<
     }
 
     try {
-      const { fileTypeFromBuffer } = (await eval(
-        'import ("file-type")',
-      )) as typeof import('file-type');
+      const { fileTypeFromBuffer } =
+        await loadEsm<typeof import('file-type')>('file-type');
 
       const fileType = await fileTypeFromBuffer(file.buffer);
 


### PR DESCRIPTION
Replace wrapping dynamic import of ESM module in `eval` with load-esm.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Wraps the dynamic import in an `eval` function, which is not the best workaround to avoid the TypeScript compiler breaks the  dynamic import.

More information: https://stackoverflow.com/a/79265806/28701779

## What is the new behavior?
Is uses [load-esm](https://github.com/Borewit/load-esm) instead, which is just like `eval` a simple trick to keep the dynamic import outside the scope of the TypeScript compiler, yet not by wrapping the entire ESM module in an `eval` method.

Not black and white science, wrapping code in `eval` this case the import and the entire ESM module, is not such a great idea:
- https://stackoverflow.com/a/198031/28701779


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Related to discussion https://github.com/nestjs/nest/issues/14970#issuecomment-2806486953