### PR TITLE
fix(core): prevent duplicate providers

### DIFF
--- a/packages/core/test/injector/duplicate-providers.spec.ts
+++ b/packages/core/test/injector/duplicate-providers.spec.ts
@@ -1,0 +1,95 @@
+/// <reference types="mocha" />
+/// <reference types="chai" />
+/// <reference types="sinon" />
+
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import { Module as ModuleDecorator } from '../../../common/decorators/modules/module.decorator';
+import { RuntimeException } from '../../errors/exceptions/runtime.exception';
+
+// Test providers
+class TestProvider1 {}
+class TestProvider2 {}
+
+describe('Duplicate providers detection', () => {
+  describe('when registering the same class provider twice', () => {
+    it('should throw a RuntimeException', async () => {
+      @ModuleDecorator({
+        providers: [TestProvider1, TestProvider1],
+      })
+      class TestModule {}
+
+      try {
+        await Test.createTestingModule({
+          imports: [TestModule],
+        }).compile();
+
+        // If we reach here, no error was thrown
+        expect.fail('Expected error for duplicate providers was not thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(RuntimeException);
+        expect(error.message).to.include('Duplicate provider found');
+        expect(error.message).to.include('TestProvider1');
+      }
+    });
+  });
+
+  describe('when registering the same token in custom providers', () => {
+    it('should throw a RuntimeException', async () => {
+      @ModuleDecorator({
+        providers: [
+          {
+            provide: 'TOKEN',
+            useValue: 'value1',
+          },
+          {
+            provide: 'TOKEN',
+            useValue: 'value2',
+          },
+        ],
+      })
+      class TestModule {}
+
+      try {
+        await Test.createTestingModule({
+          imports: [TestModule],
+        }).compile();
+
+        // If we reach here, no error was thrown
+        expect.fail('Expected error for duplicate providers was not thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(RuntimeException);
+        expect(error.message).to.include('Duplicate provider found');
+        expect(error.message).to.include('TOKEN');
+      }
+    });
+  });
+
+  describe('when registering a class provider and custom provider with the same token', () => {
+    it('should throw a RuntimeException', async () => {
+      @ModuleDecorator({
+        providers: [
+          TestProvider1,
+          {
+            provide: TestProvider1,
+            useClass: TestProvider2,
+          },
+        ],
+      })
+      class TestModule {}
+
+      try {
+        await Test.createTestingModule({
+          imports: [TestModule],
+        }).compile();
+
+        // If we reach here, no error was thrown
+        expect.fail('Expected error for duplicate providers was not thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(RuntimeException);
+        expect(error.message).to.include('Duplicate provider found');
+        expect(error.message).to.include('TestProvider1');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, when multiple identical providers are registered in the same NestJS module, the system does not throw any error. Instead, it silently ignores duplicate providers with the exception of transient and request-scoped providers. This can lead to unexpected behavior where developers might assume all their providers are being registered, but some are being silently overwritten.
For example, if a `DatabaseConnectionProvider` is accidentally included twice in a module's providers array, or registered both directly and through a re-exported module, the application would silently create redundant database connections. In high-load systems, this could quickly lead to exhausted connection pools or even database server overload.


## What is the new behavior?
With the implemented changes:
1. When a duplicate provider is detected in a module (same token being registered more than once), the system will now throw a RuntimeException with a clear error message.
2. The error message explicitly states which module contains the duplicate provider and which provider is duplicated: Duplicate provider found in module ${this._metatype.name}. Provider "${providerName}" was already registered.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information