### PR TITLE
feat(common): add pipes for multiple files validation

### DIFF
--- a/packages/common/pipes/file/group-files.pipe.ts
+++ b/packages/common/pipes/file/group-files.pipe.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '../../decorators/core';
+import { PipeTransform } from '../../interfaces/features/pipe-transform.interface';
+
+interface FileField {
+  fieldname: string;
+}
+
+/**
+ * Defines the built-in GroupFiles Pipe. This pipe can be used to group incoming files
+ * by `fieldname`, before validation. It should only be used with `AnyFilesInterceptor()`
+ * and the `@UploadedFiles()` decorator.
+ *
+ * @see [Built-in Pipes](https://docs.nestjs.com/pipes#built-in-pipes)
+ *
+ * @publicApi
+ */
+@Injectable()
+export class GroupFilesPipe implements PipeTransform<any> {
+  transform(value: any) {
+    if (!Array.isArray(value)) {
+      return value;
+    }
+
+    const result: Record<string, FileField[]> = {};
+
+    for (const file of value) {
+      if (!('fieldname' in file) || typeof file.fieldname !== 'string') {
+        return value;
+      }
+
+      let group = result[file.fieldname];
+
+      if (!group) {
+        group = [];
+        result[file.fieldname] = group;
+      }
+      group.push(file);
+    }
+
+    return result;
+  }
+}

--- a/packages/common/pipes/file/index.ts
+++ b/packages/common/pipes/file/index.ts
@@ -4,3 +4,6 @@ export * from './max-file-size.validator';
 export * from './parse-file-options.interface';
 export * from './parse-file.pipe';
 export * from './parse-file-pipe.builder';
+export * from './parse-file-fields-options.interface';
+export * from './parse-file-fields.pipe';
+export * from './group-files.pipe';

--- a/packages/common/pipes/file/parse-file-fields-options.interface.ts
+++ b/packages/common/pipes/file/parse-file-fields-options.interface.ts
@@ -1,0 +1,6 @@
+import { ParseFileOptions } from './parse-file-options.interface';
+
+export interface ParseFileFieldsOptions {
+  commonOptions?: ParseFileOptions;
+  fields: Array<{ name: string; options?: ParseFileOptions }>;
+}

--- a/packages/common/pipes/file/parse-file-fields.pipe.ts
+++ b/packages/common/pipes/file/parse-file-fields.pipe.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '../../decorators/core';
+import { PipeTransform } from '../../interfaces/features/pipe-transform.interface';
+import { FileValidator } from './file-validator.interface';
+import { ParseFilePipe } from './parse-file.pipe';
+import { IFile } from './interfaces';
+import { ParseFileFieldsOptions } from './parse-file-fields-options.interface';
+import { ParseFileOptions } from './parse-file-options.interface';
+
+type FileFields = Record<string, IFile[]>;
+
+/**
+ * Defines the built-in ParseFileFields Pipe that can be used to validate multiple files.
+ * It should only be used with the `@UploadedFiles()` decorator, `FileFieldsInterceptor`,
+ * and `AnyFilesInterceptor` interceptors. When files are extracted with the
+ * `AnyFilesInterceptor`, this pipe should be associated with the GroupFiles Pipe.
+ *
+ * @see [Built-in Pipes](https://docs.nestjs.com/pipes#built-in-pipes)
+ *
+ * @publicApi
+ */
+@Injectable()
+export class ParseFileFieldsPipe
+  implements PipeTransform<FileFields, Promise<FileFields>>
+{
+  private pipesMap = new Map<string, ParseFilePipe>();
+
+  constructor(private readonly options: ParseFileFieldsOptions) {}
+
+  async transform(value: FileFields): Promise<FileFields> {
+    const { fields, commonOptions } = this.options;
+    const promises: Promise<any>[] = [];
+
+    for (const { name, options } of fields) {
+      let pipe = this.pipesMap.get(name);
+
+      if (!pipe) {
+        const mergedOptions = options
+          ? this.mergeWithCommonOptions(options)
+          : commonOptions;
+
+        pipe = new ParseFilePipe(mergedOptions);
+        this.pipesMap.set(name, pipe);
+      }
+
+      promises.push(pipe.transform(value[name]));
+    }
+
+    const values = await Promise.all(promises);
+    const output: FileFields = {};
+
+    for (let i = 0; i < fields.length; ++i) {
+      output[fields[i].name] = values[i];
+    }
+
+    return output;
+  }
+
+  public mergeWithCommonOptions(options: ParseFileOptions): ParseFileOptions {
+    const {
+      fileIsRequired,
+      validators,
+      errorHttpStatusCode,
+      exceptionFactory,
+    } = options;
+    const { commonOptions } = this.options;
+    const commonValidators: FileValidator[] = commonOptions?.validators ?? [];
+
+    return {
+      fileIsRequired: fileIsRequired ?? commonOptions?.fileIsRequired ?? true,
+      errorHttpStatusCode:
+        errorHttpStatusCode ?? commonOptions?.errorHttpStatusCode,
+      validators: commonValidators.concat(validators ?? []),
+      exceptionFactory: exceptionFactory ?? commonOptions?.exceptionFactory,
+    };
+  }
+}

--- a/packages/common/test/pipes/file/group-files.pipe.spec.ts
+++ b/packages/common/test/pipes/file/group-files.pipe.spec.ts
@@ -1,0 +1,54 @@
+import { GroupFilesPipe } from '../../../pipes';
+import { expect } from 'chai';
+
+describe('GroupFilesPipe', () => {
+  let pipe: GroupFilesPipe;
+
+  beforeEach(() => {
+    pipe = new GroupFilesPipe();
+  });
+
+  describe('transform', () => {
+    it('should return an empty object the input is an empty array', () => {
+      expect(pipe.transform([])).to.deep.equal({});
+    });
+
+    it('should return input value when it is not an array', () => {
+      const inputObj = { foo: 'bar' };
+
+      expect(pipe.transform(inputObj)).to.deep.equal(inputObj);
+      expect(pipe.transform('a random string')).to.equal('a random string');
+      expect(pipe.transform(null)).to.equal(null);
+      expect(pipe.transform(undefined)).to.equal(undefined);
+    });
+
+    it('should return input value when one file misses the "fieldname" prop', () => {
+      const input = [
+        { fieldname: 'foo', mimetype: 'image/png' },
+        { fieldname: 'bar', mimetype: 'application/pdf' },
+        { mimetype: 'video/mp4' },
+      ];
+
+      expect(pipe.transform(input)).to.deep.equal(input);
+    });
+
+    it('should group files by fieldname', () => {
+      const input = [
+        { fieldname: 'foo', mimetype: 'image/png' },
+        { fieldname: 'bar', mimetype: 'application/pdf' },
+        { fieldname: 'baz', mimetype: 'video/mp4' },
+        { fieldname: 'foo', mimetype: 'image/jpeg' },
+      ];
+      const result = {
+        foo: [
+          { fieldname: 'foo', mimetype: 'image/png' },
+          { fieldname: 'foo', mimetype: 'image/jpeg' },
+        ],
+        bar: [{ fieldname: 'bar', mimetype: 'application/pdf' }],
+        baz: [{ fieldname: 'baz', mimetype: 'video/mp4' }],
+      };
+
+      expect(pipe.transform(input)).to.deep.equal(result);
+    });
+  });
+});

--- a/packages/common/test/pipes/file/parse-file-fields.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file-fields.pipe.spec.ts
@@ -1,0 +1,210 @@
+import { expect, use } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+
+import { BadRequestException } from '../../../exceptions';
+import { FileValidator, ParseFileFieldsPipe } from '../../../pipes';
+
+use(chaiAsPromised);
+
+class AlwaysValidValidator extends FileValidator {
+  isValid(): boolean {
+    return true;
+  }
+
+  buildErrorMessage(): string {
+    return '';
+  }
+}
+
+const customErrorMessage = 'Custom error message';
+
+class AlwaysInvalidValidator extends FileValidator {
+  isValid(): boolean {
+    return false;
+  }
+
+  buildErrorMessage(): string {
+    return customErrorMessage;
+  }
+}
+
+describe('ParseFileFieldsPipe', () => {
+  const images = [
+    { fieldname: 'images', mimetype: 'image/png', size: 64 },
+    { fieldname: 'images', mimetype: 'image/jpeg', size: 128 },
+  ];
+
+  const documents = [
+    { fieldname: 'documents', mimetype: 'application/pdf', size: 256 },
+  ];
+
+  const extras = [{ fieldname: 'extras', mimetype: 'image/webp', size: 512 }];
+
+  const allFiles = { images, documents, extras };
+
+  describe('transform', () => {
+    it('only ouputs files specified in the options', async () => {
+      const pipe = new ParseFileFieldsPipe({
+        fields: [{ name: 'documents' }, { name: 'images' }],
+      });
+      const result = await pipe.transform(allFiles);
+
+      expect(Object.keys(result)).to.deep.equal(['documents', 'images']);
+    });
+
+    it('should throw when required file is not present', () => {
+      const pipe = new ParseFileFieldsPipe({
+        fields: [{ name: 'images' }, { name: 'documents' }, { name: 'extras' }],
+      });
+
+      return expect(pipe.transform({ images, documents })).to.be.rejectedWith(
+        BadRequestException,
+        'File is required',
+      );
+    });
+
+    it('should throw when a file does not pass validation', () => {
+      const pipe = new ParseFileFieldsPipe({
+        fields: [
+          {
+            name: 'extras',
+            options: {
+              validators: [new AlwaysValidValidator({})],
+            },
+          },
+          {
+            name: 'documents',
+            options: {
+              validators: [new AlwaysInvalidValidator({})],
+            },
+          },
+        ],
+      });
+
+      expect(pipe.transform({ documents, extras })).to.be.rejectedWith(
+        customErrorMessage,
+      );
+    });
+  });
+
+  describe('mergeWithCommonOptions', () => {
+    describe('commonOptions', () => {
+      it('returns common options when there no field specific options', () => {
+        const commonOptions = {
+          fileIsRequired: false,
+          validators: [new AlwaysValidValidator({})],
+          errorHttpStatusCode: 400,
+        };
+        const pipe = new ParseFileFieldsPipe({
+          commonOptions,
+          fields: [],
+        });
+
+        expect(pipe.mergeWithCommonOptions({})).to.deep.equal({
+          ...commonOptions,
+          exceptionFactory: undefined,
+        });
+      });
+
+      it('returns a default options object when there is no options', () => {
+        const pipe = new ParseFileFieldsPipe({
+          fields: [],
+        });
+
+        expect(pipe.mergeWithCommonOptions({})).to.deep.equal({
+          fileIsRequired: true,
+          errorHttpStatusCode: undefined,
+          validators: [],
+          exceptionFactory: undefined,
+        });
+      });
+    });
+
+    describe('fileIsRequired', () => {
+      it('is by default true', () => {
+        const pipe = new ParseFileFieldsPipe({
+          fields: [],
+        });
+        const mergedOptions = pipe.mergeWithCommonOptions({});
+
+        expect(mergedOptions.fileIsRequired).to.be.true;
+      });
+
+      it('gives priority to field specific value', () => {
+        const pipe = new ParseFileFieldsPipe({
+          commonOptions: { fileIsRequired: true },
+          fields: [],
+        });
+        const mergedOptions = pipe.mergeWithCommonOptions({
+          fileIsRequired: false,
+        });
+
+        expect(mergedOptions.fileIsRequired).to.be.false;
+      });
+    });
+
+    describe('validators', () => {
+      it('commonValidators are listed first', () => {
+        const alwaysValid = new AlwaysValidValidator({});
+        const alwaysInvalid = new AlwaysInvalidValidator({});
+        const pipe = new ParseFileFieldsPipe({
+          commonOptions: {
+            validators: [alwaysValid],
+          },
+          fields: [],
+        });
+        const { validators } = pipe.mergeWithCommonOptions({
+          validators: [alwaysInvalid],
+        });
+
+        expect(validators!.length).to.equal(2);
+        expect(validators![0]).to.equal(alwaysValid);
+      });
+
+      it('validators are correctly merged', () => {
+        const alwaysValid = new AlwaysValidValidator({});
+        const alwaysInvalid = new AlwaysInvalidValidator({});
+        const pipe = new ParseFileFieldsPipe({
+          commonOptions: {
+            validators: [alwaysInvalid],
+          },
+          fields: [],
+        });
+        const { validators } = pipe.mergeWithCommonOptions({
+          validators: [alwaysValid],
+        });
+
+        expect(validators).to.deep.equal([alwaysInvalid, alwaysValid]);
+      });
+    });
+
+    describe('errorHttpStatusCode and exceptionFactory', () => {
+      it('defaults to "undefined"', () => {
+        const pipe = new ParseFileFieldsPipe({
+          fields: [],
+        });
+        const mergedOptions = pipe.mergeWithCommonOptions({});
+
+        expect(mergedOptions.errorHttpStatusCode).to.equal(undefined);
+        expect(mergedOptions.exceptionFactory).to.equal(undefined);
+      });
+
+      it('field specific options have priority', () => {
+        const customExceptionFactory = message => new Error(message);
+        const pipe = new ParseFileFieldsPipe({
+          commonOptions: {
+            errorHttpStatusCode: 400,
+          },
+          fields: [],
+        });
+        const mergedOptions = pipe.mergeWithCommonOptions({
+          errorHttpStatusCode: 422,
+          exceptionFactory: customExceptionFactory,
+        });
+
+        expect(mergedOptions.errorHttpStatusCode).to.equal(422);
+        expect(mergedOptions.exceptionFactory).to.equal(customExceptionFactory);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When dealing with file uploads, NestJS offers the `ParseFilePipe` to help validate files uploaded under the same name. But when several files are uploaded with different names, there is not built-in pipe available and the validation is usually done in the controller method or service.

```typescript
@Post('upload')
@UseInterceptors(
  FileFieldsInterceptor([
    { name: 'avatar', maxCount: 1 },
    { name: 'background', maxCount: 1 },
  ])
)
uploadFile(
  @UploadedFiles()
  files: { avatar?: Express.Multer.File[], background?: Express.Multer.File[] }
) {
  const { avatar, background } = files;
  // Files are validated here...
}
```

Issue Number: N/A

## What is the new behavior?

This PR adds two new pipes, `ParseFileFieldsPipe` and `GroupFilesPipe` that can be used to validate multiple files together in association with the `UploadedFiles` decorator and file interceptors.

Here are some examples:

```typescript
@Controller('uploads')
export class UploadsController {
  @Post()
  @UseInterceptors(
    FileFieldsInterceptor([
      { name: 'avatar', maxCount: 1 },
      { name: 'documents', maxCount: 2 },
    ]),
  )
  upload(
    @UploadedFiles(
      new ParseFileFieldsPipe({
        fields: [
          {
            name: 'documents',
            options: {
              fileIsRequired: false,
              validators: [
                new FileTypeValidator({ fileType: 'application/pdf' }),
              ],
            },
          },
          {
            name: 'avatar',
            options: {
              validators: [
                new FileTypeValidator({ fileType: /.(jpeg|png)$/ }),
              ],
            },
          },
        ],
      })
    )
    files,
  ) {
    console.log('Received:', files);

    return 'Hi!';
  }
}
```

The `ParseFileFieldsPipe` constructor accepts an `options` object with a `fields` prop that defines for each uploaded file, the validation options that will passed to the `ParseFilePipe` object that will be used for validation.

It is also possible to validate files extracted with `AnyFilesInterceptor()` by using `GroupFilesPipe` and `ParseFileFieldsPipe` together:

```typescript
@Post()
  @UseInterceptors(
    AnyFilesInterceptor(),
  )
  upload(
    @UploadedFiles(
      new GroupFilesPipe(),
      new ParseFileFieldsPipe({
        fields: [
          {
            name: 'documents',
            options: {
              validators: [
                new FileTypeValidator({ fileType: /.(zip|png)$/ }),
              ],
            }
          },
          {
            name: 'avatar'
            options: {
              validators: [
                new FileTypeValidator({ fileType: /.(jpeg|png)$/ }),
              ],
            },
          },
        ],
      })
    )
    files,
  ) {
    console.log('Received:', files);

    return 'Hi!';
  }
}
```

The `GroupFilesPipe` is used to group uploaded files by `fieldname`, like the `FileFieldsInterceptor` does.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If the PR is accepted, the NestJS doc about file uploads will be updated to integrate the new features.