### PR TITLE
feat(common): Add fallbackToMimetype support in FileTypeValidator

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -11,6 +11,12 @@ export type FileTypeValidatorOptions = {
    * @default false
    */
   skipMagicNumbersValidation?: boolean;
+
+  /**
+   * If `true`, and magic number check fails, fallback to mimetype comparison.
+   * @default false
+   */
+  fallbackToMimetype?: boolean;
 };
 
 /**
@@ -27,10 +33,26 @@ export class FileTypeValidator extends FileValidator<
   IFile
 > {
   buildErrorMessage(file?: IFile): string {
+    const expected = this.validationOptions.fileType;
+
     if (file?.mimetype) {
-      return `Validation failed (current file type is ${file.mimetype}, expected type is ${this.validationOptions.fileType})`;
+      const baseMessage = `Validation failed (current file type is ${file.mimetype}, expected type is ${expected})`;
+
+      /**
+       * If fallbackToMimetype is enabled, this means the validator failed to detect the file type
+       * via magic number inspection (e.g. due to an unknown or too short buffer),
+       * and instead used the mimetype string provided by the client as a fallback.
+       *
+       * This message clarifies that fallback logic was used, in case users rely on file signatures.
+       */
+      if (this.validationOptions.fallbackToMimetype) {
+        return `${baseMessage} - magic number detection failed, used mimetype fallback`;
+      }
+
+      return baseMessage;
     }
-    return `Validation failed (expected type is ${this.validationOptions.fileType})`;
+
+    return `Validation failed (expected type is ${expected})`;
   }
 
   async isValid(file?: IFile): Promise<boolean> {
@@ -40,25 +62,34 @@ export class FileTypeValidator extends FileValidator<
 
     const isFileValid = !!file && 'mimetype' in file;
 
+    // Skip magic number validation if set
     if (this.validationOptions.skipMagicNumbersValidation) {
       return (
         isFileValid && !!file.mimetype.match(this.validationOptions.fileType)
       );
     }
 
-    if (!isFileValid || !file.buffer) {
-      return false;
-    }
+    if (!isFileValid || !file.buffer) return false;
 
     try {
       const { fileTypeFromBuffer } =
         await loadEsm<typeof import('file-type')>('file-type');
-
       const fileType = await fileTypeFromBuffer(file.buffer);
 
-      return (
-        !!fileType && !!fileType.mime.match(this.validationOptions.fileType)
-      );
+      if (fileType) {
+        // Match detected mime type against allowed type
+        return !!fileType.mime.match(this.validationOptions.fileType);
+      }
+
+      /**
+       * Fallback logic: If file-type cannot detect magic number (e.g. file too small),
+       * Optionally fall back to mimetype string for compatibility.
+       * This is useful for plain text, CSVs, or files without recognizable signatures.
+       */
+      if (this.validationOptions.fallbackToMimetype) {
+        return !!file.mimetype.match(this.validationOptions.fileType);
+      }
+      return false;
     } catch {
       return false;
     }


### PR DESCRIPTION
Introduce `fallbackToMimetype` option to allow fallback to mimetype validation when magic number detection fails (e.g., for small or undetectable buffers like text or CSV files).

Also enhanced `buildErrorMessage()` to reflect precise validation failure reasons depending on buffer presence and mimetype state.

Added unit tests to cover fallback logic and error message variants.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, `FileTypeValidator` only relies on magic number detection.  
When the file buffer is too short or lacks a detectable signature, validation fails even if the mimetype is correctly set.

Issue Number: #14977 
- Allows developers to enable fallback to mimetype validation using `fallbackToMimetype: true`
- Better error messaging when fallback is triggered or buffer is missing
- Adds relevant unit tests for fallback behavior and error formatting

## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

- A separate PR will be submitted to backport this feature to `10.4.17`, as this issue was originally reported in v10.
- See discussion: https://github.com/nestjs/nest/issues/14977

## Other information