### PR TITLE
fix(microservices): ensure all redis connections are closed

### DIFF
--- a/packages/microservices/server/server-redis.ts
+++ b/packages/microservices/server/server-redis.ts
@@ -104,10 +104,10 @@ export class ServerRedis extends Server<RedisEvents, RedisStatus> {
     });
   }
 
-  public close() {
+  public async close() {
     this.isManuallyClosed = true;
-    this.pubClient && this.pubClient.quit();
-    this.subClient && this.subClient.quit();
+    this.pubClient && (await this.pubClient.quit());
+    this.subClient && (await this.subClient.quit());
     this.pendingEventListeners = [];
   }
 

--- a/packages/microservices/test/server/server-redis.spec.ts
+++ b/packages/microservices/test/server/server-redis.spec.ts
@@ -59,11 +59,11 @@ describe('ServerRedis', () => {
       untypedServer.pubClient = pub;
       untypedServer.subClient = sub;
     });
-    it('should close pub & sub server', () => {
-      server.close();
+    it('should close pub & sub server', async () => {
+      await server.close();
 
-      expect(pub.quit.called).to.be.true;
-      expect(sub.quit.called).to.be.true;
+      expect(pub.quit.calledOnce).to.be.true;
+      expect(sub.quit.calledOnce).to.be.true;
     });
   });
   describe('handleConnection', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Redis connection were not properly closed for pub/sub client due to missing async/await

Issue Number: N/A


## What is the new behavior?
Added async/await when quit() is called for pub/sub client for server-redis so that all the connections are properly closed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information