### PR TITLE
fix(microservices): ensure all the amqp connections are closed properly

### DIFF
--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -100,9 +100,9 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     }
   }
 
-  public close(): void {
-    this.channel && this.channel.close();
-    this.server && this.server.close();
+  public async close(): Promise<void> {
+    this.channel && (await this.channel.close());
+    this.server && (await this.server.close());
     this.pendingEventListeners = [];
   }
 
@@ -135,7 +135,7 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     this.pendingEventListeners = [];
 
     const connectFailedEvent = 'connectFailed';
-    this.server!.once(connectFailedEvent, (error: Record<string, unknown>) => {
+    this.server!.once(connectFailedEvent, async (error: Record<string, unknown>) => {
       this._status$.next(RmqStatus.DISCONNECTED);
 
       this.logger.error(CONNECTION_FAILED_MESSAGE);
@@ -150,7 +150,7 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
         return;
       }
       if (++this.connectionAttempts === maxConnectionAttempts) {
-        this.close();
+        await this.close();
         callback?.(error.err ?? new Error(CONNECTION_FAILED_MESSAGE));
       }
     });

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -135,25 +135,28 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     this.pendingEventListeners = [];
 
     const connectFailedEvent = 'connectFailed';
-    this.server!.once(connectFailedEvent, async (error: Record<string, unknown>) => {
-      this._status$.next(RmqStatus.DISCONNECTED);
+    this.server!.once(
+      connectFailedEvent,
+      async (error: Record<string, unknown>) => {
+        this._status$.next(RmqStatus.DISCONNECTED);
 
-      this.logger.error(CONNECTION_FAILED_MESSAGE);
-      if (error?.err) {
-        this.logger.error(error.err);
-      }
-      const isReconnecting = !!this.channel;
-      if (
-        maxConnectionAttempts === INFINITE_CONNECTION_ATTEMPTS ||
-        isReconnecting
-      ) {
-        return;
-      }
-      if (++this.connectionAttempts === maxConnectionAttempts) {
-        await this.close();
-        callback?.(error.err ?? new Error(CONNECTION_FAILED_MESSAGE));
-      }
-    });
+        this.logger.error(CONNECTION_FAILED_MESSAGE);
+        if (error?.err) {
+          this.logger.error(error.err);
+        }
+        const isReconnecting = !!this.channel;
+        if (
+          maxConnectionAttempts === INFINITE_CONNECTION_ATTEMPTS ||
+          isReconnecting
+        ) {
+          return;
+        }
+        if (++this.connectionAttempts === maxConnectionAttempts) {
+          await this.close();
+          callback?.(error.err ?? new Error(CONNECTION_FAILED_MESSAGE));
+        }
+      },
+    );
   }
 
   public createClient<T = any>(): T {

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -78,13 +78,13 @@ describe('ServerRMQ', () => {
       untypedServer.server = rmqServer;
       untypedServer.channel = rmqChannel;
     });
-    it('should close server', () => {
-      server.close();
-      expect(rmqServer.close.called).to.be.true;
+    it('should close server', async () => {
+      await server.close();
+      expect(rmqServer.close.calledOnce).to.be.true;
     });
-    it('should close channel', () => {
-      server.close();
-      expect(rmqChannel.close.called).to.be.true;
+    it('should close channel', async () => {
+      await server.close();
+      expect(rmqChannel.close.calledOnce).to.be.true;
     });
   });
 

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -80,11 +80,11 @@ describe('ServerRMQ', () => {
     });
     it('should close server', async () => {
       await server.close();
-      expect(rmqServer.close.calledOnce).to.be.true;
+      expect(rmqServer.close.called).to.be.true;
     });
     it('should close channel', async () => {
       await server.close();
-      expect(rmqChannel.close.calledOnce).to.be.true;
+      expect(rmqChannel.close.called).to.be.true;
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
AMQP close connection method is asynchronous, in the current behaviour, connection were not properly closed for channel/server due to missing `async/await`.

Issue Number: N/A


## What is the new behavior?
Added `async/await` when `close()` is called for channel/server in `server-rmq` so that all the connections are properly closed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information