### PR TITLE
feat(microservices): Allow custom exchangeType as string for plugin compatibility

### DIFF
--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -68,10 +68,3 @@ export interface AmqplibQueueOptions {
   maxPriority?: number;
   [key: string]: any;
 }
-
-type AmqpMainExchangeType = 'direct' | 'fanout' | 'topic' | 'headers';
-
-/**
- * @publicApi
- */
-export type AmqpExchangeType = AmqpMainExchangeType | (string & {});

--- a/packages/microservices/external/rmq-url.interface.ts
+++ b/packages/microservices/external/rmq-url.interface.ts
@@ -68,3 +68,10 @@ export interface AmqplibQueueOptions {
   maxPriority?: number;
   [key: string]: any;
 }
+
+type AmqpMainExchangeType = 'direct' | 'fanout' | 'topic' | 'headers';
+
+/**
+ * @publicApi
+ */
+export type AmqpExchangeType = AmqpMainExchangeType | (string & {});

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -283,10 +283,11 @@ export interface RmqOptions {
      */
     exchange?: string;
     /**
-     * Type of the exchange
+     * Type of the exchange.
+     * Accepts the AMQP standard types ('direct', 'fanout', 'topic', 'headers') or any custom exchange type name provided as a string literal.
      * @default 'topic'
      */
-    exchangeType?: string;
+    exchangeType?: 'direct' | 'fanout' | 'topic' | 'headers' | (string & {});
     /**
      * Additional routing key for the topic exchange.
      */

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -14,6 +14,7 @@ import { MqttClientOptions, QoS } from '../external/mqtt-options.interface';
 import { IORedisOptions } from '../external/redis.interface';
 import {
   AmqpConnectionManagerSocketOptions,
+  AmqpExchangeType,
   AmqplibQueueOptions,
   RmqUrl,
 } from '../external/rmq-url.interface';
@@ -286,7 +287,7 @@ export interface RmqOptions {
      * Type of the exchange
      * @default 'topic'
      */
-    exchangeType?: string;
+    exchangeType?: AmqpExchangeType;
     /**
      * Additional routing key for the topic exchange.
      */

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -286,7 +286,7 @@ export interface RmqOptions {
      * Type of the exchange
      * @default 'topic'
      */
-    exchangeType?: 'direct' | 'fanout' | 'topic' | 'headers';
+    exchangeType?: string;
     /**
      * Additional routing key for the topic exchange.
      */

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -14,7 +14,6 @@ import { MqttClientOptions, QoS } from '../external/mqtt-options.interface';
 import { IORedisOptions } from '../external/redis.interface';
 import {
   AmqpConnectionManagerSocketOptions,
-  AmqpExchangeType,
   AmqplibQueueOptions,
   RmqUrl,
 } from '../external/rmq-url.interface';
@@ -287,7 +286,7 @@ export interface RmqOptions {
      * Type of the exchange
      * @default 'topic'
      */
-    exchangeType?: AmqpExchangeType;
+    exchangeType?: string;
     /**
      * Additional routing key for the topic exchange.
      */

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -242,7 +242,7 @@ export interface RmqOptions {
      */
     socketOptions?: AmqpConnectionManagerSocketOptions;
     /**
-     * Iif true, the broker won’t expect an acknowledgement of messages delivered to this consumer; i.e., it will dequeue messages as soon as they’ve been sent down the wire.
+     * If true, the broker won’t expect an acknowledgement of messages delivered to this consumer; i.e., it will dequeue messages as soon as they’ve been sent down the wire.
      * @default false
      */
     noAck?: boolean;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, only the default exchange types can be used.

Issue Number: N/A


## What is the new behavior?

Make exchangeType configurable as a generic string instead of strict union, enabling support for plugins like [rabbitmq-delayed-message-exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) which use non-standard types (e.g., `x-delayed-message`, `x-local-random`).

| # | Exchange Type | Plugin | Key Features | Min. RabbitMQ |
|---|---------------|--------|--------------|---------------|
| 1 | **`x‑delayed-message`** | [rabbitmq_delayed_message_exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) | Schedules or retries messages via the `x-delay` header—removes the need for TTL‑DLX stacks | 3.6.0+ |
| 2 | **`x‑consistent-hash`** | [rabbitmq_consistent_hash_exchange](https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange) | Consistent‑hash key‑to‑queue load‑balancing with minimal key relocation when consumers scale | 3.7.0+ |
| 3 | **`x‑modulus-hash`** | [rabbitmq_sharding](https://github.com/rabbitmq/rabbitmq-sharding) | Simple `hash(key) mod N` sharding for linear throughput growth | 3.8.0+ |
| 4 | **`x‑random`** | [rabbitmq_random_exchange](https://github.com/rabbitmq/rabbitmq-random-exchange) | Picks one queue at random among those bound with the same routing key—lightweight load spread | 3.6.0+ |
| 5 | **`x‑local-random`** | [Local Random Exchange Docs](https://www.rabbitmq.com/docs/local-random-exchange) | Routes only to queues on the publisher’s node, then random‑selects—cuts network hops | 4.0.0+ |
| 6 | **`x‑lvc`** (Last Value Cache) | [rabbitmq_lvc_exchange](https://github.com/rabbitmq/rabbitmq-lvc-exchange) | Stores the **latest** message per routing key; new bindings receive that snapshot instantly | 3.6.0+ |
| 7 | **`x‑recent-history`** | [rabbitmq_recent_history_exchange](https://github.com/rabbitmq/rabbitmq-recent-history-exchange) | Keeps the last *N* (default 20) messages and replays them—ideal for chat or log viewers | 3.6.0+ |
| 8 | **`x‑rtopic`** (Reverse Topic) | [rabbitmq_rtopic_exchange](https://github.com/rabbitmq/rabbitmq-rtopic-exchange) | Lets publishers use wildcards (`*`, `#`) while bindings stay static—publisher‑driven multicast | 3.6.0+ |
| 9 | **`x‑management`** | [rabbitmq_management_exchange](https://github.com/rabbitmq/rabbitmq-management-exchange) | Invokes the Management HTTP API via pure AMQP frames—handy behind firewalls | 3.6.0+ |

![rabbitmqui-exchangeType](https://github.com/user-attachments/assets/692b2e82-92df-4a21-b378-feb523096f17)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information