### PR TITLE
fix(core): bring back `getHeader` and `appendHeader` methods from `AbstractHttpAdapter`

### DIFF
--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -158,7 +158,9 @@ export abstract class AbstractHttpAdapter<
   abstract setErrorHandler(handler: Function, prefix?: string);
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   abstract isHeadersSent(response: any);
+  abstract getHeader(response: any, name: string);
   abstract setHeader(response: any, name: string, value: string);
+  abstract appendHeader(response: any, name: string, value: string);
   abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
   abstract enableCors(options?: any, prefix?: string);
   abstract createMiddlewareFactory(

--- a/packages/core/test/utils/noop-adapter.spec.ts
+++ b/packages/core/test/utils/noop-adapter.spec.ts
@@ -21,9 +21,9 @@ export class NoopHttpAdapter extends AbstractHttpAdapter {
   setErrorHandler(handler: Function, prefix = '/'): any {}
   setNotFoundHandler(handler: Function, prefix = '/'): any {}
   isHeadersSent(response: any): any {}
-  getHeader?(response: any, name: string) {}
+  getHeader(response: any, name: string) {}
   setHeader(response: any, name: string, value: string): any {}
-  appendHeader?(response: any, name: string, value: string) {}
+  appendHeader(response: any, name: string, value: string) {}
   registerParserMiddleware(): any {}
   enableCors(options: any): any {}
   createMiddlewareFactory(requestMethod: RequestMethod): any {}

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -525,7 +525,7 @@ export class FastifyAdapter<
     return response.sent;
   }
 
-  public getHeader?(response: any, name: string) {
+  public getHeader(response: any, name: string) {
     return response.getHeader(name);
   }
 
@@ -533,7 +533,7 @@ export class FastifyAdapter<
     return response.header(name, value);
   }
 
-  public appendHeader?(response: any, name: string, value: string) {
+  public appendHeader(response: any, name: string, value: string) {
     response.header(name, value);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #15060


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information