### PR TITLE
fix(microservices): ensure all redis and amqp client closes properly

### DIFF
--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -53,9 +53,9 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
     return `${pattern}.reply`;
   }
 
-  public close() {
-    this.pubClient && this.pubClient.quit();
-    this.subClient && this.subClient.quit();
+  public async close() {
+    this.pubClient && (await this.pubClient.quit());
+    this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
     this.isManuallyClosed = true;
     this.pendingEventListeners = [];

--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -96,9 +96,9 @@ export class ClientRMQ extends ClientProxy<RmqEvents, RmqStatus> {
     this.initializeDeserializer(options);
   }
 
-  public close(): void {
-    this.channel && this.channel.close();
-    this.client && this.client.close();
+  public async close(): Promise<void> {
+    this.channel && (await this.channel.close());
+    this.client && (await this.client.close());
     this.channel = null;
     this.client = null;
     this.pendingEventListeners = [];

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -195,22 +195,22 @@ describe('ClientRedis', () => {
       untypedClient.pubClient = pub;
       untypedClient.subClient = sub;
     });
-    it('should close "pub" when it is not null', () => {
-      client.close();
+    it('should close "pub" when it is not null', async () => {
+      await client.close();
       expect(pubClose.called).to.be.true;
     });
-    it('should not close "pub" when it is null', () => {
+    it('should not close "pub" when it is null', async () => {
       untypedClient.pubClient = null;
-      client.close();
+      await client.close();
       expect(pubClose.called).to.be.false;
     });
-    it('should close "sub" when it is not null', () => {
-      client.close();
+    it('should close "sub" when it is not null', async () => {
+      await client.close();
       expect(subClose.called).to.be.true;
     });
-    it('should not close "sub" when it is null', () => {
+    it('should not close "sub" when it is null', async () => {
       untypedClient.subClient = null;
-      client.close();
+      await client.close();
       expect(subClose.called).to.be.false;
     });
   });

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -368,13 +368,13 @@ describe('ClientRMQ', function () {
       untypedClient.client = { close: clientCloseSpy };
     });
 
-    it('should close channel when it is not null', () => {
-      client.close();
+    it('should close channel when it is not null', async () => {
+      await client.close();
       expect(channelCloseSpy.called).to.be.true;
     });
 
-    it('should close client when it is not null', () => {
-      client.close();
+    it('should close client when it is not null', async () => {
+      await client.close();
       expect(clientCloseSpy.called).to.be.true;
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Redis and AMQP close connection method is asynchronous, in the current behaviour, connection were not properly closed for pub/sub or channel/client for clients due to missing `async/await`.

Issue Number: N/A


## What is the new behavior?
Added `async/await` when `close()` is called for pub/sub or channel/client in `client-redis` and `client-rmq` respectively, so that all the connections are properly closed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information