### PR TITLE
Fix/enable case insensitive queries

### DIFF
--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -26,7 +26,6 @@ export interface NestExpressApplication<
    * @returns {HttpServer}
    */
   getHttpAdapter(): HttpServer<Express.Request, Express.Response, Express>;
-
   /**
    * Starts the application.
    *
@@ -41,7 +40,6 @@ export interface NestExpressApplication<
     hostname: string,
     callback?: () => void,
   ): Promise<TServer>;
-
   /**
    * A wrapper function around native `express.set()` method.
    *
@@ -51,7 +49,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   set(...args: any[]): this;
-
   /**
    * A wrapper function around native `express.engine()` method.
    * @example
@@ -60,7 +57,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   engine(...args: any[]): this;
-
   /**
    * A wrapper function around native `express.enable()` method.
    * @example
@@ -69,7 +65,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   enable(...args: any[]): this;
-
   /**
    * A wrapper function around native `express.disable()` method.
    *
@@ -79,7 +74,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   disable(...args: any[]): this;
-
   useStaticAssets(options: ServeStaticOptions): this;
   /**
    * Sets a base directory for public assets.
@@ -89,9 +83,7 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   useStaticAssets(path: string, options?: ServeStaticOptions): this;
-
   enableCors(options?: CorsOptions | CorsOptionsDelegate<any>): void;
-
   /**
    * Register Express body parsers on the fly. Will respect
    * the application's `rawBody` option.
@@ -109,7 +101,6 @@ export interface NestExpressApplication<
     parser: NestExpressBodyParserType,
     options?: Omit<Options, 'verify'>,
   ): this;
-
   /**
    * Sets one or multiple base directories for templates (views).
    *
@@ -119,7 +110,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   setBaseViewsDir(path: string | string[]): this;
-
   /**
    * Sets a view engine for templates (views).
    * @example
@@ -128,7 +118,6 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   setViewEngine(engine: string): this;
-
   /**
    * Sets app-level globals for view templates.
    *
@@ -140,4 +129,14 @@ export interface NestExpressApplication<
    * @returns {this}
    */
   setLocal(key: string, value: any): this;
+
+  /**
+   * Enables case-insensitive query parameter handling by normalizing query parameter keys to lowercase.
+   *
+   * @example
+   * app.enableCaseInsensitiveQueries();
+   *
+   * @returns {this}
+   */
+  enableCaseInsensitiveQueries(): this;
 }

--- a/packages/platform-express/test/adapters/express-adapter.spec.ts
+++ b/packages/platform-express/test/adapters/express-adapter.spec.ts
@@ -1,7 +1,29 @@
+import { Controller, Get, INestApplication, Query, Req } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
+import { NestExpressApplication } from '@nestjs/platform-express/interfaces/nest-express-application.interface';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
 import { expect } from 'chai';
 import * as express from 'express';
 import * as sinon from 'sinon';
+import { Request } from 'express';
+
+@Controller('test')
+export class AppController {
+  @Get()
+  getQuery(@Req() req: Request) {
+    const normalizedQuery = req.query;
+    const response = Object.entries(normalizedQuery)
+      .map(([key, value]) => {
+        const displayValue = Array.isArray(value)
+          ? value.join(', ')
+          : (value?.toString() ?? 'undefined');
+        return `${key}: ${displayValue}`;
+      })
+      .join(', ');
+    return response || 'No query parameters provided';
+  }
+}
 
 describe('ExpressAdapter', () => {
   afterEach(() => sinon.restore());
@@ -41,6 +63,52 @@ describe('ExpressAdapter', () => {
       expressAdapter.registerParserMiddleware();
 
       expect(useSpy.called).to.be.false;
+    });
+  });
+
+  describe('ExpressAdapter', () => {
+    let app: INestApplication & NestExpressApplication;
+
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        controllers: [AppController],
+      }).compile();
+      app = module.createNestApplication<NestExpressApplication>(
+        new ExpressAdapter(),
+        {},
+      );
+      app.enableCaseInsensitiveQueries();
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('normalizes all query parameters to lowercase', async () => {
+      await request(app.getHttpServer())
+        .get('/test?NAME=John&AGE=30&CiTy=NewYork&EMAIL=john@example.com')
+        .expect(
+          200,
+          'name: John, age: 30, city: NewYork, email: john@example.com',
+        );
+    });
+
+    it('handles empty queries', async () => {
+      await request(app.getHttpServer())
+        .get('/test')
+        .expect(200, 'No query parameters provided');
+    });
+
+    it('handles arrays and nested objects', async () => {
+      await request(app.getHttpServer())
+        .get(
+          '/test?NAMES=John,Jane&AGE=30&DETAILS[address]=123+St&DETAILS[city]=NY',
+        )
+        .expect(
+          200,
+          'names: John, Jane, age: 30, details[address]: 123 St, details[city]: NY',
+        );
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In NestJS v11, after the upgrade to Express 5.x, the req.query property became a read-only getter. This broke any middleware or logic that attempted to modify req.query to normalize query parameter keys (e.g., to make them case-insensitive). Currently, there is no built-in way to enable case-insensitive query handling in the @nestjs/platform-express package, and attempting to modify req.query directly results in a TypeError: Cannot set property query of #<IncomingMessage> which has only a getter

Issue Number: #15115


## What is the new behavior?
This PR introduces a new method enableCaseInsensitiveQueries to the ExpressAdapter class in the @nestjs/platform-express package. The method adds a middleware that normalizes all query parameter keys to lowercase, ensuring case-insensitive handling of query parameters. Key features of the new behavior include:
- Query parameter keys are normalized to lowercase (e.g., NAME=John becomes accessible as name).
- Supports nested objects and arrays in query parameters (e.g., DETAILS[address]=123+St becomes details[address]).
- The middleware uses Object.defineProperty to override the req.query getter, ensuring compatibility with Express 5.x’s read-only req.query.
- Comprehensive tests cover edge cases such as arrays, nested objects, and empty queries.
- The feature can be enabled by calling app.enableCaseInsensitiveQueries() after creating the Nest application.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
- **Documentation Proposal:** Below is a proposed documentation addition for maintainers to review and include:

### Case-Insensitive Query Parameters

Starting with NestJS v11, you can enable case-insensitive query parameter handling in applications using the `@nestjs/platform-express` package. This feature normalizes all query parameter keys to lowercase, allowing controllers to access parameters consistently regardless of the case used in the request URL.

To enable this feature, call the `enableCaseInsensitiveQueries` method on your application instance:

```typescript
import { NestFactory } from '@nestjs/core';
import { ExpressAdapter, NestExpressApplication } from '@nestjs/platform-express';
import { AppModule } from './app.module';

async function bootstrap() {
  const app = await NestFactory.create<NestExpressApplication>(
    AppModule,
    new ExpressAdapter(),
  );
  app.enableCaseInsensitiveQueries();
  await app.listen(3000);
}
bootstrap();
```
### Example

With case-insensitive queries enabled, a request to /test?NAME=John&AGE=30 will be processed as if the parameters were name=John and age=30. A controller can then access these parameters without worrying about the case:
```typescript
import { Controller, Get, Query, Req } from '@nestjs/common';
import { Request } from 'express';

@Controller('test')
export class AppController {
  @Get()
  getQuery(@Req() req: Request) {
    const normalizedQuery = req.query;
    const response = Object.entries(normalizedQuery)
      .map(([key, value]) => {
        const displayValue = Array.isArray(value)
          ? value.join(', ')
          : (value?.toString() ?? 'undefined');
        return `${key}: ${displayValue}`;
      })
      .join(', ');
    return response || 'No query parameters provided';
  }
}
```
This feature also supports nested objects and arrays in query parameters, ensuring consistent normalization across all keys.


- **Performance Consideration:** The Object.defineProperty approach is applied per request, which might have a minor performance overhead for applications with high query parameter usage. Future optimizations could include caching the normalized query object if needed.
- **Future Improvement:** The middleware currently relies on Object.defineProperty to override req.query. A more extensible approach might involve exposing a public API for custom query parameter transformations, which could be proposed in a follow-up PR if maintainers are interested.

This PR closes issue #15115 by addressing the Express 5.x compatibility issue and providing a new feature for case-insensitive query handling.