### PR TITLE
feat(core): Get optional parameter metadata with getOwnMetadata

### DIFF
--- a/integration/injector/e2e/inherited-optional-dependency.ts
+++ b/integration/injector/e2e/inherited-optional-dependency.ts
@@ -1,0 +1,64 @@
+import { Injectable, mixin, Module, Optional } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { expect } from 'chai';
+import { UnknownDependenciesException } from '@nestjs/core/errors/exceptions/unknown-dependencies.exception';
+
+chai.use(chaiAsPromised);
+
+describe('Inherited optional dependency', () => {
+  const Foo = () => {
+    class FooMixin {
+      constructor(@Optional() option: any) {}
+    }
+    return mixin(FooMixin);
+  };
+
+  @Injectable()
+  class NeededService {
+    exec() {
+      return 'exec';
+    }
+  }
+
+  @Module({
+    providers: [NeededService],
+    exports: [NeededService],
+  })
+  class SomeModule {}
+
+  @Injectable()
+  class FooService extends Foo() {
+    constructor(private readonly neededService: NeededService) {
+      super();
+    }
+
+    doSomething() {
+      return this.neededService.exec();
+    }
+  }
+
+  @Module({
+    imports: [],
+    providers: [FooService],
+    exports: [FooService],
+  })
+  class FooModule {}
+
+  /**
+   * You can see details on this issue here: https://github.com/nestjs/nest/issues/2581
+   */
+  it('should remove optional dependency metadata inherited from base class', async () => {
+    const module = Test.createTestingModule({
+      imports: [SomeModule, FooModule],
+    });
+
+    await expect(
+      module.compile(),
+    ).to.eventually.be.rejected.and.be.an.instanceOf(
+      UnknownDependenciesException,
+    );
+  });
+});

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -395,7 +395,7 @@ export class Injector {
   }
 
   public reflectOptionalParams<T>(type: Type<T>): any[] {
-    return Reflect.getMetadata(OPTIONAL_DEPS_METADATA, type) || [];
+    return Reflect.getOwnMetadata(OPTIONAL_DEPS_METADATA, type) || [];
   }
 
   public reflectSelfParams<T>(type: Type<T>): any[] {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves #2581 

Currently, Nest does not throw an error even when a child class has incomplete dependencies due to an optional parameter declared in a parent class.

To demonstrate the reason for this behavior, here is a simplified reproduction:

```ts
function OnClassDecorator(): ClassDecorator {
  return (target) => {};
}

function OnParameterDecorator(): ParameterDecorator {
  return (target, key, index) => {
    const args = Reflect.getMetadata("onparameter", target) ?? [];
    Reflect.defineMetadata("onparameter", [...args, index], target);
  };
}

type Type<T = any> = new (...args: any[]) => T;

function mixin(mixinClass: Type<any>) {
  Object.defineProperty(mixinClass, "name", {
    value: "something",
  });
  OnClassDecorator()(mixinClass);
  return mixinClass;
}

const barMixin = () => {
  class Bar {
    constructor(@OnParameterDecorator() private readonly foo?: Foo) {}
  }
  return mixin(Bar);
};

class NeededClass {}

@OnClassDecorator()
class Baz extends barMixin() {
  constructor(private readonly neededClass: NeededClass) {
    super();
  }
}

console.log(Reflect.getMetadata("design:paramtypes", Baz)); // ✅ [ [class NeededClass] ]
console.log(Reflect.getMetadata("onparameter", Baz)); // ❌ [ 0 ]
```

Just like in the issue report, a mixin was created and applied to a class.
Here, `@OnClassDecorator` serves the role of @Injectable, and `@OnParameterDecorator` simulates @Optional.

In the `Baz` class, `design:paramtypes` gets overridden by its own constructor and is correctly set as `[ [class NeededClass] ]`.
However, the `onparameter` metadata remains from the parent class, since it was extended using `[...args, index]` and not overridden.

Let’s look into what actually happens, based on the reproduction:

https://github.com/nestjs/nest/blob/eab3910d0d60afe466829aa6ea89270c6682b6b0/packages/core/injector/injector.ts#L387-L399

The `Injector` retrieves both `paramtypes` and `optional` metadata.
In this case, the constructor parameters reflect the new `JwtAuthGuard`, so `paramtypes` would contain `[ [class JwtAuthGuard] ]`.
However, due to the @Optional decorator declared in the parent class (e.g., `AuthGuard`), [0] ends up in the optional metadata.

> `@Optional` stores the index of the parameter in the metadata.

https://github.com/nestjs/nest/blob/eab3910d0d60afe466829aa6ea89270c6682b6b0/packages/core/injector/injector.ts#L325-L331

As a result, the first parameter of `JwtAuthGuard` is mistakenly treated as optional.
This causes Nest to silently ignore the missing dependency—even though it’s not imported by the module—because it assumes the parameter is optional.

Ultimately, this does not appear to be an issue exclusive to the use of mixins.

## What is the new behavior?

Changed from `getMetadata` to `getOwnMetadata` when retrieving optional parameters in a simpler way.

Now, the optional status of a parameter is determined solely by its own @Optional, without mistakenly inheriting the @Optional from its parent.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information