### PR TITLE
fix(microservice): prevent error logs during redis client shutdown

### DIFF
--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -54,10 +54,10 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
   }
 
   public async close() {
+    this.isManuallyClosed = true;
     this.pubClient && (await this.pubClient.quit());
     this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
-    this.isManuallyClosed = true;
     this.pendingEventListeners = [];
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When calling `close()` on `ClientRedis`, the `isManuallyClosed` flag is set **after** awaiting the `quit()` calls on the Redis clients. If Redis emits the `'end'` event during or after `quit()`, event handlers may see `isManuallyClosed` as `false` and incorrectly log errors or attempt reconnection logic. This creates a race condition and can result in misleading error logs during a normal shutdown.


## What is the new behavior?

The `isManuallyClosed` flag is now set to `true` **before** calling `quit()` on the Redis clients. This ensures that any event handlers triggered during shutdown will see the correct state and will not log errors or attempt reconnection when the shutdown is intentional.

Additional tests have been added to verify this behavior and prevent regressions.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information