### PR TITLE
fix(microservices): support custom strategy in async usefactory config

### DIFF
--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -78,22 +78,29 @@ export class NestMicroservice
   public createServer(config: CompleteMicroserviceOptions) {
     try {
       if ('useFactory' in config) {
-        this.microserviceConfig = this.resolveAsyncOptions(config);
+        const resolvedConfig = this.resolveAsyncOptions(config);
+        this.microserviceConfig = resolvedConfig;
+
+        // Inject custom strategy
+        if ('strategy' in resolvedConfig) {
+          this.serverInstance = resolvedConfig.strategy as Server;
+          return;
+        }
       } else {
         this.microserviceConfig = {
           transport: Transport.TCP,
           ...config,
         } as MicroserviceOptions;
+
+        if ('strategy' in config) {
+          this.serverInstance = config.strategy as Server;
+          return;
+        }
       }
 
-      if ('strategy' in config) {
-        this.serverInstance = config.strategy as Server;
-        return;
-      } else {
-        this.serverInstance = ServerFactory.create(
-          this.microserviceConfig,
-        ) as Server;
-      }
+      this.serverInstance = ServerFactory.create(
+        this.microserviceConfig,
+      ) as Server;
     } catch (e) {
       this.logger.error(e);
       throw e;

--- a/packages/microservices/test/nest-microservice.spec.ts
+++ b/packages/microservices/test/nest-microservice.spec.ts
@@ -1,0 +1,154 @@
+import { NestMicroservice } from '@nestjs/microservices/nest-microservice';
+import { Server, ServerTCP } from '@nestjs/microservices/server';
+import { GraphInspector } from '@nestjs/core/inspector/graph-inspector';
+import { ApplicationConfig } from '@nestjs/core/application-config';
+import { Transport } from '@nestjs/microservices/enums';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { AsyncMicroserviceOptions } from '@nestjs/microservices/interfaces';
+
+const createMockGraphInspector = (): GraphInspector =>
+  ({
+    insertOrphanedEnhancer: sinon.stub(),
+  }) as unknown as GraphInspector;
+
+const createMockAppConfig = (): ApplicationConfig =>
+  ({
+    useGlobalFilters: sinon.stub(),
+    useGlobalPipes: sinon.stub(),
+    useGlobalGuards: sinon.stub(),
+    useGlobalInterceptors: sinon.stub(),
+    setIoAdapter: sinon.stub(),
+  }) as unknown as ApplicationConfig;
+
+const mockContainer = {
+  getModuleCompiler: sinon.stub(),
+  getModules: () => new Map(),
+  get: () => null,
+  getHttpAdapterHost: () => undefined,
+} as any;
+
+describe('NestMicroservice', () => {
+  let mockGraphInspector: GraphInspector;
+  let mockAppConfig: ApplicationConfig;
+
+  beforeEach(() => {
+    mockGraphInspector = createMockGraphInspector();
+    mockAppConfig = createMockAppConfig();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should use ServerFactory if no strategy is provided', () => {
+    const instance = new NestMicroservice(
+      mockContainer,
+      { transport: Transport.TCP },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    expect((instance as any).serverInstance).to.be.instanceOf(ServerTCP);
+  });
+
+  it('should use provided strategy if present in config', () => {
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = sinon.stub();
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    expect((instance as any).serverInstance).to.equal(strategy);
+  });
+
+  it('should use strategy resolved from useFactory config', () => {
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = sinon.stub();
+    })();
+    const asyncConfig: AsyncMicroserviceOptions = {
+      useFactory: () => ({ strategy }),
+      inject: [],
+    };
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      asyncConfig,
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    expect((instance as any).serverInstance).to.equal(strategy);
+  });
+
+  it('should call listen() on server when listen() is called', async () => {
+    const listenSpy = sinon.spy((cb: () => void) => cb());
+    const strategy = new (class extends Server {
+      listen = listenSpy;
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = sinon.stub();
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    await instance.listen();
+    expect(listenSpy.calledOnce).to.be.true;
+  });
+
+  it('should delegate unwrap() to server', () => {
+    const unwrapStub = sinon.stub().returns('core');
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = unwrapStub;
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    expect(instance.unwrap()).to.equal('core');
+  });
+
+  it('should delegate on() to server', () => {
+    const onStub = sinon.stub();
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = onStub;
+      unwrap = sinon.stub();
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    const cb = () => {};
+    instance.on('test:event', cb);
+    expect(onStub.calledWith('test:event', cb)).to.be.true;
+  });
+});


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using dynamic microservice configuration with useFactory, any strategy field returned from the factory function is ignored.
This makes it impossible to provide a custom transport strategy dynamically.

Issue Number: [#15144](https://github.com/nestjs/nest/issues/15144)


## What is the new behavior?
NestMicroservice now properly checks for a strategy field after resolving AsyncMicroserviceOptions.useFactory().
Adds test cases to ensure both static and dynamic strategy injection paths work as expected.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No