### PR TITLE
fix(microservices): Revisit RMQ pattern matching with wildcards

### DIFF
--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -21,6 +21,9 @@ export const RQM_DEFAULT_QUEUE_OPTIONS = {};
 export const RQM_DEFAULT_NOACK = true;
 export const RQM_DEFAULT_PERSISTENT = false;
 export const RQM_DEFAULT_NO_ASSERT = false;
+export const RMQ_SEPARATOR = '.';
+export const RMQ_WILDCARD_SINGLE = '*';
+export const RMQ_WILDCARD_ALL = '#';
 
 export const ECONNREFUSED = 'ECONNREFUSED';
 export const CONN_ERR = 'CONN_ERR';

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -8,6 +8,9 @@ import {
   CONNECTION_FAILED_MESSAGE,
   DISCONNECTED_RMQ_MESSAGE,
   NO_MESSAGE_HANDLER,
+  RMQ_SEPARATOR,
+  RMQ_WILDCARD_ALL,
+  RMQ_WILDCARD_SINGLE,
   RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT,
   RQM_DEFAULT_NOACK,
   RQM_DEFAULT_NO_ASSERT,
@@ -63,7 +66,7 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
   protected readonly queue: string;
   protected readonly noAck: boolean;
   protected readonly queueOptions: any;
-  protected readonly wildcardHandlers = new Map<RegExp, MessageHandler>();
+  protected readonly wildcardHandlers = new Map<string, MessageHandler>();
   protected pendingEventListeners: Array<{
     event: keyof RmqEvents;
     callback: RmqEvents[keyof RmqEvents];
@@ -365,8 +368,8 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     if (this.wildcardHandlers.size === 0) {
       return null;
     }
-    for (const [regex, handler] of this.wildcardHandlers) {
-      if (regex.test(pattern)) {
+    for (const [wildcardPattern, handler] of this.wildcardHandlers) {
+      if (this.matchRmqPattern(wildcardPattern, pattern)) {
         return handler;
       }
     }
@@ -392,20 +395,43 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     const handlers = this.getHandlers();
 
     handlers.forEach((handler, pattern) => {
-      const regex = this.convertRoutingKeyToRegex(pattern);
-      if (regex) {
-        this.wildcardHandlers.set(regex, handler);
+      if (pattern.includes('#') || pattern.includes('*')) {
+        this.wildcardHandlers.set(pattern, handler);
       }
     });
   }
 
-  private convertRoutingKeyToRegex(routingKey: string): RegExp | undefined {
-    if (!routingKey.includes('#') && !routingKey.includes('*')) {
-      return;
+  private matchRmqPattern(pattern: string, routingKey: string): boolean {
+    if (!routingKey) {
+      return pattern === RMQ_WILDCARD_ALL;
     }
-    let regexPattern = routingKey.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
-    regexPattern = regexPattern.replace(/\*/g, '[^.]+');
-    regexPattern = regexPattern.replace(/#/g, '.*');
-    return new RegExp(`^${regexPattern}$`);
+
+    const patternSegments = pattern.split(RMQ_SEPARATOR);
+    const routingKeySegments = routingKey.split(RMQ_SEPARATOR);
+
+    const patternSegmentsLength = patternSegments.length;
+    const routingKeySegmentsLength = routingKeySegments.length;
+    const lastIndex = patternSegmentsLength - 1;
+
+    for (const [i, currentPattern] of patternSegments.entries()) {
+      const currentRoutingKey = routingKeySegments[i];
+
+      if (!currentRoutingKey && !currentPattern) {
+        continue;
+      }
+      if (!currentRoutingKey && currentPattern !== RMQ_WILDCARD_ALL) {
+        return false;
+      }
+      if (currentPattern === RMQ_WILDCARD_ALL) {
+        return i === lastIndex;
+      }
+      if (
+        currentPattern !== RMQ_WILDCARD_SINGLE &&
+        currentPattern !== currentRoutingKey
+      ) {
+        return false;
+      }
+    }
+    return patternSegmentsLength === routingKeySegmentsLength;
   }
 }

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -395,7 +395,10 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     const handlers = this.getHandlers();
 
     handlers.forEach((handler, pattern) => {
-      if (pattern.includes('#') || pattern.includes('*')) {
+      if (
+        pattern.includes(RMQ_WILDCARD_ALL) ||
+        pattern.includes(RMQ_WILDCARD_SINGLE)
+      ) {
         this.wildcardHandlers.set(pattern, handler);
       }
     });

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -311,9 +311,7 @@ describe('ServerRMQ', () => {
     let matchRmqPattern: (pattern: string, routingKey: string) => boolean;
 
     beforeEach(() => {
-      matchRmqPattern = (untypedServer as any).matchRmqPattern.bind(
-        untypedServer,
-      );
+      matchRmqPattern = untypedServer.matchRmqPattern.bind(untypedServer);
     });
 
     describe('exact matches', () => {

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -306,4 +306,130 @@ describe('ServerRMQ', () => {
       expect(nack.calledWith(message, false, false)).not.to.be.true;
     });
   });
+
+  describe('matchRmqPattern', () => {
+    let matchRmqPattern: (pattern: string, routingKey: string) => boolean;
+
+    beforeEach(() => {
+      matchRmqPattern = (untypedServer as any).matchRmqPattern.bind(
+        untypedServer,
+      );
+    });
+
+    describe('exact matches', () => {
+      it('should match identical patterns', () => {
+        expect(matchRmqPattern('user.created', 'user.created')).to.be.true;
+        expect(matchRmqPattern('order.updated', 'order.updated')).to.be.true;
+      });
+
+      it('should not match different patterns', () => {
+        expect(matchRmqPattern('user.created', 'user.updated')).to.be.false;
+        expect(matchRmqPattern('order.created', 'user.created')).to.be.false;
+      });
+
+      it('should handle patterns with $ character (original issue)', () => {
+        expect(
+          matchRmqPattern('$internal.plugin.status', '$internal.plugin.status'),
+        ).to.be.true;
+        expect(
+          matchRmqPattern(
+            '$internal.plugin.0.status',
+            '$internal.plugin.0.status',
+          ),
+        ).to.be.true;
+        expect(matchRmqPattern('user.$special.event', 'user.$special.event')).to
+          .be.true;
+      });
+    });
+
+    describe('single wildcard (*)', () => {
+      it('should match single segments', () => {
+        expect(matchRmqPattern('user.*', 'user.created')).to.be.true;
+        expect(matchRmqPattern('user.*', 'user.updated')).to.be.true;
+        expect(matchRmqPattern('*.created', 'user.created')).to.be.true;
+        expect(matchRmqPattern('*.created', 'order.created')).to.be.true;
+      });
+
+      it('should not match when segment counts differ', () => {
+        expect(matchRmqPattern('user.*', 'user.profile.created')).to.be.false;
+        expect(matchRmqPattern('*.created', 'user.profile.created')).to.be
+          .false;
+      });
+
+      it('should handle patterns with $ and *', () => {
+        expect(
+          matchRmqPattern(
+            '$internal.plugin.*.status',
+            '$internal.plugin.0.status',
+          ),
+        ).to.be.true;
+        expect(
+          matchRmqPattern(
+            '$internal.plugin.*.status',
+            '$internal.plugin.1.status',
+          ),
+        ).to.be.true;
+        expect(matchRmqPattern('$internal.*.status', '$internal.plugin.status'))
+          .to.be.true;
+      });
+
+      it('should handle multiple * wildcards', () => {
+        expect(matchRmqPattern('*.*.created', 'user.profile.created')).to.be
+          .true;
+        expect(matchRmqPattern('*.*.created', 'order.item.created')).to.be.true;
+        expect(matchRmqPattern('*.*.created', 'user.created')).to.be.false;
+      });
+    });
+
+    describe('catch all wildcard (#)', () => {
+      it('should match when # is at the end', () => {
+        expect(matchRmqPattern('user.#', 'user.created')).to.be.true;
+        expect(matchRmqPattern('user.#', 'user.profile.created')).to.be.true;
+        expect(matchRmqPattern('user.#', 'user.profile.details.updated')).to.be
+          .true;
+      });
+
+      it('should handle patterns with $ and #', () => {
+        expect(matchRmqPattern('$internal.#', '$internal.plugin.status')).to.be
+          .true;
+        expect(matchRmqPattern('$internal.#', '$internal.plugin.0.status')).to
+          .be.true;
+        expect(
+          matchRmqPattern('$internal.plugin.#', '$internal.plugin.0.status'),
+        ).to.be.true;
+      });
+
+      it('should handle # at the beginning', () => {
+        expect(matchRmqPattern('#', 'user.created')).to.be.true;
+        expect(matchRmqPattern('#', 'user.profile.created')).to.be.true;
+        expect(matchRmqPattern('#', 'created')).to.be.true;
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty routing key', () => {
+        expect(matchRmqPattern('user.created', '')).to.be.false;
+        expect(matchRmqPattern('*', '')).to.be.false;
+        expect(matchRmqPattern('#', '')).to.be.true;
+      });
+
+      it('should handle single segments', () => {
+        expect(matchRmqPattern('user', 'user')).to.be.true;
+        expect(matchRmqPattern('*', 'user')).to.be.true;
+        expect(matchRmqPattern('#', 'user')).to.be.true;
+      });
+
+      it('should handle complex $ patterns that previously failed', () => {
+        expect(
+          matchRmqPattern(
+            '$exchange.*.routing.#',
+            '$exchange.topic.routing.key.test',
+          ),
+        ).to.be.true;
+        expect(matchRmqPattern('$sys.#', '$sys.broker.clients')).to.be.true;
+        expect(matchRmqPattern('$SYS.#', '$SYS.broker.load.messages.received'))
+          .to.be.true;
+      });
+    });
+  });
 });


### PR DESCRIPTION
close #15304

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 15304


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Before starting I asked myself, what would be the best approach?
  
  Option 1: Keep Current Regex but Make it Safer

  Tradeoffs:
  - ✅ Minimal change, maintains current performance, backward compatible
  - ❌ Still vulnerable to other typical regex issues, complex escaping logic, harder to maintain

  Option 2: Use Map and Nested For Loop same as SeerverMQTT

  Based on MQTT approach (matchMqttPattern in server-mqtt.ts:180-210):
  - Split patterns and topics by separator
  - Loop through segments comparing each one
  - Handle wildcards with simple string comparison

  Tradeoffs:
  - ✅ No regex vulnerabilities, easier to understand, similar to existing MQTT code
  - ✅ More predictable performance (O(n) where n = segments)
  - ❌ Different implementation from current regex approach
  - ❌ Might be less efficient when there are many handlers and topic segments

  Option 3: Use Trie to store patterns and handlers (such as https://github.com/davedoesdev/qlobber)

  Based on qlobber library:
  - Stores patterns in a trie data structure
  - Highly optimized for topic matching
  - Based on the same algorithm used for [RabbitMQ exchange routing](https://github.com/rabbitmq/rabbitmq-server/blob/60be7d8046291b505fa47b18ed7f4fa94bc74a3a/deps/rabbit/src/rabbit_db_topic_exchange.erl#L131)

  Tradeoffs:
  - ✅ Best performance for many patterns (O(log n) lookup)
  - ✅ Handles complex wildcard scenarios elegantly
  - ✅ Would work for ServerMQTT too
  - ❌ Adds external dependency
  - ❌ Larger implementation change

I went with option 2: it seems more reasonable.