### PR TITLE
fix(core): Make flattenRoutePath return a valid module

### DIFF
--- a/packages/core/router/utils/flatten-route-paths.util.ts
+++ b/packages/core/router/utils/flatten-route-paths.util.ts
@@ -14,7 +14,7 @@ export function flattenRoutePaths(routes: Routes) {
     if (item.children) {
       const childrenRef = item.children as Routes;
       childrenRef.forEach(child => {
-        if (!isString(child) && child.path) {
+        if (!isString(child) && isString(child.path)) {
           child.path = normalizePath(
             normalizePath(item.path) + normalizePath(child.path),
           );

--- a/packages/core/test/router/utils/flat-routes.spec.ts
+++ b/packages/core/test/router/utils/flat-routes.spec.ts
@@ -17,6 +17,12 @@ describe('flattenRoutePaths', () => {
     @Module({})
     class ChildModule4 {}
     @Module({})
+    class ChildModule5 {}
+    @Module({})
+    class ChildModule6 {}
+    @Module({})
+    class ChildParentPathModule {}
+    @Module({})
     class ParentChildModule {}
     @Module({})
     class ChildChildModule2 {}
@@ -70,6 +76,25 @@ describe('flattenRoutePaths', () => {
               ChildModule4,
             ],
           },
+          {
+            path: 'child3',
+            children: [
+              {
+                path: '',
+                module: ChildModule5,
+                children: [{ path: 'child', module: ChildParentPathModule }],
+              },
+            ],
+          },
+          {
+            path: 'child4',
+            children: [
+              {
+                path: '/',
+                module: ChildModule6,
+              },
+            ],
+          },
         ],
       },
       { path: '/v1', children: [AuthModule, CatsModule, DogsModule] },
@@ -91,6 +116,9 @@ describe('flattenRoutePaths', () => {
       },
       { path: '/parent/child2', module: ChildModule4 },
       { path: '/parent/child2/child', module: ChildModule3 },
+      { path: '/parent/child3', module: ChildModule5 },
+      { path: '/parent/child3/child', module: ChildParentPathModule },
+      { path: '/parent/child4', module: ChildModule6 },
       { path: '/v1', module: AuthModule },
       { path: '/v1', module: CatsModule },
       { path: '/v1', module: DogsModule },


### PR DESCRIPTION
flattenRoutePath method was returning an object instead of a module when path property was an empty string

closes #15332

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15332


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information