### PR TITLE
feat: supporting fine async storage control

### DIFF
--- a/packages/core/guards/guards-consumer.ts
+++ b/packages/core/guards/guards-consumer.ts
@@ -20,6 +20,12 @@ export class GuardsConsumer {
 
     for (const guard of guards) {
       const result = guard.canActivate(context);
+      if (typeof result === 'boolean') {
+        if (!result) {
+          return false;
+        }
+        continue;
+      }
       if (await this.pickResult(result)) {
         continue;
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If we have multiple sync guards being executed and the second one initializes a AsyncLocalStorage, The storage gets lost due to Nodejs promise handling.

Issue Number: N/A


## What is the new behavior?
In the same situation, the storage is accessible along the request, which is useful if you want to have contextual operation with some granular control "guard wide"

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This need appeared after I created two libs:
* [winston-context-logger](https://www.npmjs.com/package/winston-context-logger), which offers a logger integrated with an async local storage that is common for me to initialize at guards in projects using NestJS (this lib is not well documented yet)
* https://www.npmjs.com/package/newrelic-nestjs-instrumentation, which uses a similar strategy to initialize a New Relic transaction when none exists. This is useful to auto-instrument things not supported yet when using NestJS, like HTTP/2 and queue consumers. It's important for the module to be the first one to be imported in a project.


When I use these libs separately, everything works out, but when I try to use them together, the context I create for winston-context-logger is not present during the request. This is due to how Node.js deals with consecutive awaits inside a loop, and this problem is avoided by not awaiting when canActivate returns a boolean, and everything works out as expected