### PR TITLE
fix(core): fix race condition in class dependency resolution

### DIFF
--- a/integration/injector/e2e/many-global-modules.spec.ts
+++ b/integration/injector/e2e/many-global-modules.spec.ts
@@ -1,0 +1,130 @@
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Global, Inject, Injectable, Module, Scope } from '@nestjs/common';
+
+@Global()
+@Module({})
+export class GlobalModule1 {}
+
+@Global()
+@Module({})
+export class GlobalModule2 {}
+
+@Global()
+@Module({})
+export class GlobalModule3 {}
+
+@Global()
+@Module({})
+export class GlobalModule4 {}
+
+@Global()
+@Module({})
+export class GlobalModule5 {}
+
+@Global()
+@Module({})
+export class GlobalModule6 {}
+
+@Global()
+@Module({})
+export class GlobalModule7 {}
+
+@Global()
+@Module({})
+export class GlobalModule8 {}
+
+@Global()
+@Module({})
+export class GlobalModule9 {}
+
+@Global()
+@Module({})
+export class GlobalModule10 {}
+
+@Injectable()
+class TransientProvider {}
+
+@Injectable()
+class RequestProvider {}
+
+@Injectable()
+export class Dependant {
+  constructor(
+    private readonly transientProvider: TransientProvider,
+
+    @Inject(RequestProvider)
+    private readonly requestProvider: RequestProvider,
+  ) {}
+
+  public checkDependencies() {
+    expect(this.transientProvider).to.be.instanceOf(TransientProvider);
+    expect(this.requestProvider).to.be.instanceOf(RequestProvider);
+  }
+}
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: TransientProvider,
+      scope: Scope.TRANSIENT,
+      useClass: TransientProvider,
+    },
+    {
+      provide: Dependant,
+      scope: Scope.DEFAULT,
+      useClass: Dependant,
+    },
+  ],
+})
+export class GlobalModuleWithTransientProviderAndDependant {}
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: RequestProvider,
+      scope: Scope.REQUEST,
+      useFactory: () => {
+        return new RequestProvider();
+      },
+    },
+  ],
+  exports: [RequestProvider],
+})
+export class GlobalModuleWithRequestProvider {}
+
+@Module({
+  imports: [
+    GlobalModule1,
+    GlobalModule2,
+    GlobalModule3,
+    GlobalModule4,
+    GlobalModule5,
+    GlobalModule6,
+    GlobalModule7,
+    GlobalModule8,
+    GlobalModule9,
+    GlobalModule10,
+    GlobalModuleWithTransientProviderAndDependant,
+    GlobalModuleWithRequestProvider,
+  ],
+})
+export class AppModule {}
+
+describe('Many global modules', () => {
+  it('should inject request-scoped useFactory provider and transient-scoped useClass provider from different modules', async () => {
+    const moduleBuilder = Test.createTestingModule({
+      imports: [AppModule],
+    });
+    const moduleRef = await moduleBuilder.compile();
+
+    const dependant = await moduleRef.resolve(Dependant);
+    const checkDependenciesSpy = sinon.spy(dependant, 'checkDependencies');
+    dependant.checkDependencies();
+
+    expect(checkDependenciesSpy.called).to.be.true;
+  });
+});

--- a/integration/inspector/e2e/fixtures/post-init-graph.json
+++ b/integration/inspector/e2e/fixtures/post-init-graph.json
@@ -2197,22 +2197,6 @@
       },
       "id": "1976848738"
     },
-    "-2105726668": {
-      "source": "-1803759743",
-      "target": "1010833816",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "PropertiesModule",
-        "sourceClassName": "PropertiesService",
-        "targetClassName": "token",
-        "sourceClassToken": "PropertiesService",
-        "targetClassToken": "token",
-        "targetModuleName": "PropertiesModule",
-        "keyOrIndex": "token",
-        "injectionType": "property"
-      },
-      "id": "-2105726668"
-    },
     "-21463590": {
       "source": "-1378706112",
       "target": "1004276345",
@@ -2228,6 +2212,22 @@
         "injectionType": "constructor"
       },
       "id": "-21463590"
+    },
+    "-2105726668": {
+      "source": "-1803759743",
+      "target": "1010833816",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "PropertiesModule",
+        "sourceClassName": "PropertiesService",
+        "targetClassName": "token",
+        "sourceClassToken": "PropertiesService",
+        "targetClassToken": "token",
+        "targetModuleName": "PropertiesModule",
+        "keyOrIndex": "token",
+        "injectionType": "property"
+      },
+      "id": "-2105726668"
     },
     "-1657371464": {
       "source": "-1673986099",

--- a/packages/core/helpers/barrier.ts
+++ b/packages/core/helpers/barrier.ts
@@ -1,0 +1,51 @@
+/**
+ * A simple barrier to synchronize flow of multiple async operations.
+ */
+export class Barrier {
+  private currentCount: number;
+  private targetCount: number;
+  private promise: Promise<void>;
+  private resolve: () => void;
+
+  constructor(targetCount: number) {
+    this.currentCount = 0;
+    this.targetCount = targetCount;
+
+    this.promise = new Promise<void>(resolve => {
+      this.resolve = resolve;
+    });
+  }
+
+  /**
+   * Signal that a participant has reached the barrier.
+   *
+   * The barrier will be resolved once `targetCount` participants have reached it.
+   */
+  public signal(): void {
+    this.currentCount += 1;
+    if (this.currentCount === this.targetCount) {
+      this.resolve();
+    }
+  }
+
+  /**
+   * Wait for the barrier to be resolved.
+   *
+   * @returns A promise that resolves when the barrier is resolved.
+   */
+  public async wait(): Promise<void> {
+    return this.promise;
+  }
+
+  /**
+   * Signal that a participant has reached the barrier and wait for the barrier to be resolved.
+   *
+   * The barrier will be resolved once `targetCount` participants have reached it.
+   *
+   * @returns A promise that resolves when the barrier is resolved.
+   */
+  public async signalAndWait(): Promise<void> {
+    this.signal();
+    return this.wait();
+  }
+}

--- a/packages/core/test/helpers/barrier.spec.ts
+++ b/packages/core/test/helpers/barrier.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import { Barrier } from '../../../core/helpers/barrier';
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { setTimeout } from 'timers/promises';
+chai.use(chaiAsPromised);
+
+describe('Barrier', () => {
+  const targetCount = 3;
+  let barrier: Barrier;
+  let barrierResolveSpy: sinon.SinonSpy;
+
+  beforeEach(() => {
+    barrier = new Barrier(targetCount);
+    barrierResolveSpy = sinon.spy(<any>barrier, 'resolve');
+  });
+
+  afterEach(() => {
+    // resolve any promises that may still be waiting in the background
+    (<any>barrier).resolve();
+  });
+
+  describe('signal', () => {
+    it('should resolve the barrier when target count is reached', async () => {
+      for (let i = 0; i < targetCount; i++) {
+        barrier.signal();
+      }
+
+      expect(barrierResolveSpy.called).to.be.true;
+    });
+
+    it('should not resolve the barrier when target count is not reached', async () => {
+      for (let i = 0; i < targetCount - 1; i++) {
+        barrier.signal();
+      }
+
+      expect(barrierResolveSpy.called).to.be.false;
+      expect((<any>barrier).currentCount).to.be.equal(targetCount - 1);
+    });
+  });
+
+  describe('wait', () => {
+    it('should resolve when target count is reached', async () => {
+      const waitPromise = barrier.wait();
+
+      for (let i = 0; i < targetCount; i++) {
+        barrier.signal();
+      }
+
+      expect(waitPromise).to.be.fulfilled;
+    });
+
+    it('should not resolve when target count is not reached', async () => {
+      const waitPromise = barrier.wait();
+
+      for (let i = 0; i < targetCount - 1; i++) {
+        barrier.signal();
+      }
+
+      expect(waitPromise).not.to.be.fulfilled;
+    });
+  });
+
+  describe('signalAndWait', () => {
+    it('should resolve when target count is reached', async () => {
+      const promise = Promise.all(
+        Array.from({ length: targetCount }, () => barrier.signalAndWait()),
+      );
+
+      // wait for the promise to be resolved
+      await promise;
+
+      expect(promise).to.be.fulfilled;
+      expect(barrierResolveSpy.called).to.be.true;
+    });
+
+    it('should not resolve when target count is not reached', async () => {
+      const promise = Promise.all(
+        Array.from({ length: targetCount - 1 }, () => barrier.signalAndWait()),
+      );
+
+      /*
+       * Give the promise some time to work. We cannot await the promise because the test case would
+       * get stuck.
+       */
+      await setTimeout(5);
+
+      expect(promise).not.to.be.fulfilled;
+      expect(barrierResolveSpy.called).to.be.false;
+    });
+  });
+});

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -545,7 +545,7 @@ describe('Injector', () => {
     });
   });
 
-  describe('resolveComponentInstance', () => {
+  describe('resolveComponentHost', () => {
     let module: any;
     beforeEach(() => {
       module = {
@@ -560,16 +560,8 @@ describe('Injector', () => {
         const loadStub = sinon
           .stub(injector, 'loadProvider')
           .callsFake(() => null!);
-        sinon
-          .stub(injector, 'lookupComponent')
-          .returns(Promise.resolve(wrapper));
 
-        await injector.resolveComponentInstance(
-          module,
-          '',
-          { index: 0, dependencies: [] },
-          wrapper,
-        );
+        await injector.resolveComponentHost(module, wrapper);
         expect(loadStub.called).to.be.true;
       });
       it('should not call loadProvider (isResolved)', async () => {
@@ -578,16 +570,7 @@ describe('Injector', () => {
           .stub(injector, 'loadProvider')
           .callsFake(() => null!);
 
-        sinon
-          .stub(injector, 'lookupComponent')
-          .returns(Promise.resolve(wrapper));
-
-        await injector.resolveComponentInstance(
-          module,
-          '',
-          { index: 0, dependencies: [] },
-          wrapper,
-        );
+        await injector.resolveComponentHost(module, wrapper);
         expect(loadStub.called).to.be.false;
       });
       it('should not call loadProvider (forwardRef)', async () => {
@@ -599,16 +582,7 @@ describe('Injector', () => {
           .stub(injector, 'loadProvider')
           .callsFake(() => null!);
 
-        sinon
-          .stub(injector, 'lookupComponent')
-          .returns(Promise.resolve(wrapper));
-
-        await injector.resolveComponentInstance(
-          module,
-          '',
-          { index: 0, dependencies: [] },
-          wrapper,
-        );
+        await injector.resolveComponentHost(module, wrapper);
         expect(loadStub.called).to.be.false;
       });
     });
@@ -624,16 +598,8 @@ describe('Injector', () => {
           async: true,
           instance,
         });
-        sinon
-          .stub(injector, 'lookupComponent')
-          .returns(Promise.resolve(wrapper));
 
-        const result = await injector.resolveComponentInstance(
-          module,
-          '',
-          { index: 0, dependencies: [] },
-          wrapper,
-        );
+        const result = await injector.resolveComponentHost(module, wrapper);
         expect(result.instance).to.be.true;
       });
     });

--- a/packages/core/test/pipes/pipes-consumer.spec.ts
+++ b/packages/core/test/pipes/pipes-consumer.spec.ts
@@ -15,7 +15,7 @@ describe('PipesConsumer', () => {
     beforeEach(() => {
       value = 0;
       data = null;
-      (metatype = {}), (type = RouteParamtypes.QUERY);
+      ((metatype = {}), (type = RouteParamtypes.QUERY));
       stringifiedType = 'query';
       transforms = [
         createPipe(sinon.stub().callsFake(val => val + 1)),

--- a/packages/testing/testing-injector.ts
+++ b/packages/testing/testing-injector.ts
@@ -23,7 +23,7 @@ export class TestingInjector extends Injector {
     this.container = container;
   }
 
-  public async resolveComponentInstance<T>(
+  public async resolveComponentWrapper<T>(
     moduleRef: Module,
     name: any,
     dependencyContext: InjectorDependencyContext,
@@ -33,7 +33,7 @@ export class TestingInjector extends Injector {
     keyOrIndex?: string | number,
   ): Promise<InstanceWrapper> {
     try {
-      const existingProviderWrapper = await super.resolveComponentInstance(
+      const existingProviderWrapper = await super.resolveComponentWrapper(
         moduleRef,
         name,
         dependencyContext,
@@ -44,39 +44,72 @@ export class TestingInjector extends Injector {
       );
       return existingProviderWrapper;
     } catch (err) {
-      if (this.mocker) {
-        const mockedInstance = this.mocker(name);
-        if (!mockedInstance) {
-          throw err;
-        }
-        const newWrapper = new InstanceWrapper({
-          name,
-          isAlias: false,
-          scope: wrapper.scope,
-          instance: mockedInstance,
-          isResolved: true,
-          host: moduleRef,
-          metatype: wrapper.metatype,
-        });
-        const internalCoreModule = this.container.getInternalCoreModuleRef();
-        if (!internalCoreModule) {
-          throw new Error(
-            'Expected to have internal core module reference at this point.',
-          );
-        }
-
-        internalCoreModule.addCustomProvider(
-          {
-            provide: name,
-            useValue: mockedInstance,
-          },
-          internalCoreModule.providers,
-        );
-        internalCoreModule.addExportedProviderOrModule(name);
-        return newWrapper;
-      } else {
-        throw err;
-      }
+      return this.mockWrapper(err, moduleRef, name, wrapper);
     }
+  }
+
+  public async resolveComponentHost<T>(
+    moduleRef: Module,
+    instanceWrapper: InstanceWrapper<T>,
+    contextId = STATIC_CONTEXT,
+    inquirer?: InstanceWrapper,
+  ): Promise<InstanceWrapper> {
+    try {
+      const existingProviderWrapper = await super.resolveComponentHost(
+        moduleRef,
+        instanceWrapper,
+        contextId,
+        inquirer,
+      );
+      return existingProviderWrapper;
+    } catch (err) {
+      return this.mockWrapper(
+        err,
+        moduleRef,
+        instanceWrapper.name,
+        instanceWrapper,
+      );
+    }
+  }
+
+  private async mockWrapper<T>(
+    err: Error,
+    moduleRef: Module,
+    name: any,
+    wrapper: InstanceWrapper<T>,
+  ): Promise<InstanceWrapper> {
+    if (!this.mocker) {
+      throw err;
+    }
+
+    const mockedInstance = this.mocker(name);
+    if (!mockedInstance) {
+      throw err;
+    }
+    const newWrapper = new InstanceWrapper({
+      name,
+      isAlias: false,
+      scope: wrapper.scope,
+      instance: mockedInstance,
+      isResolved: true,
+      host: moduleRef,
+      metatype: wrapper.metatype,
+    });
+    const internalCoreModule = this.container.getInternalCoreModuleRef();
+    if (!internalCoreModule) {
+      throw new Error(
+        'Expected to have internal core module reference at this point.',
+      );
+    }
+
+    internalCoreModule.addCustomProvider(
+      {
+        provide: name,
+        useValue: mockedInstance,
+      },
+      internalCoreModule.providers,
+    );
+    internalCoreModule.addExportedProviderOrModule(name);
+    return newWrapper;
   }
 }


### PR DESCRIPTION
Fix race condition in class dependency resolution, which could otherwise lead to undefined or null injection. Split the resolution process in 2 parts with barrier synchronization in between to ensure all dependencies are present in dependant's instance wrapper and the staticity of its dependency tree is evaluated correctly.

Closes #4873

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When working with many global modules, a specific combination of providers leads to `null` or `undefined` injection.

Issue Number: #4873

## What is the new behavior?
The dependencies are injected correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
There was a race condition in `Injector.resolveConstructorParams()` so I introduced a barrier to synchronize the dependency resolution process. This included some refactoring of the `Injector` class. For more details, see my investigation in #4873.

Unit tests for `Injector` only tested the former `resolveComponentInstance()` method, which consisted of `lookupComponent()` and `resolveComponentHost()`. Since `lookupComponent()` was always mocked, I decided to just rewrite the suite to test `resolveComponentHost()` and use the mocked instance wrapper directly without modifying the core of the test cases.

The change in `packages/core/test/pipes/pipes-consumer.spec.ts` is a result of `npm run format`.