### PR TITLE
feat(common): add generic for argument metadata

### DIFF
--- a/packages/common/interfaces/features/pipe-transform.interface.ts
+++ b/packages/common/interfaces/features/pipe-transform.interface.ts
@@ -19,7 +19,7 @@ export interface ArgumentMetadata<Metatype = any> {
    * Underlying base type (e.g., `String`) of the parameter, based on the type
    * definition in the route handler.
    */
-  readonly metatype?: Type<MetaType> | undefined;
+  readonly metatype?: Type<Metatype> | undefined;
   /**
    * String passed as an argument to the decorator.
    * Example: `@Body('userId')` would yield `userId`


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

When using the `ArgumentMetadata` type in a transform pipe, we can't type `metadata?.metatype` which always ends up with a `as XXX` because the type is fixed to `Type<any>`

## What is the new behavior?

**Optional** generic can be passed to `ArgumentMetadata<MyClass>` so that we can do:

```ts
if (metadata?.metatype) {
  const metatype = new metadata.metatype()
}
```

and get type safety both in the constructor _and_ instance type

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No