### PR TITLE
refactor(common): fix the typo 'sring' to 'string'

### DIFF
--- a/packages/common/services/utils/filter-log-levels.util.ts
+++ b/packages/common/services/utils/filter-log-levels.util.ts
@@ -5,23 +5,23 @@ import { isLogLevel } from './is-log-level.util';
  * @publicApi
  */
 export function filterLogLevels(parseableString = ''): LogLevel[] {
-  const sanitizedSring = parseableString.replaceAll(' ', '').toLowerCase();
+  const sanitizedString = parseableString.replaceAll(' ', '').toLowerCase();
 
-  if (sanitizedSring[0] === '>') {
-    const orEqual = sanitizedSring[1] === '=';
+  if (sanitizedString[0] === '>') {
+    const orEqual = sanitizedString[1] === '=';
 
     const logLevelIndex = (LOG_LEVELS as string[]).indexOf(
-      sanitizedSring.substring(orEqual ? 2 : 1),
+      sanitizedString.substring(orEqual ? 2 : 1),
     );
 
     if (logLevelIndex === -1) {
-      throw new Error(`parse error (unknown log level): ${sanitizedSring}`);
+      throw new Error(`parse error (unknown log level): ${sanitizedString}`);
     }
 
     return LOG_LEVELS.slice(orEqual ? logLevelIndex : logLevelIndex + 1);
-  } else if (sanitizedSring.includes(',')) {
-    return sanitizedSring.split(',').filter(isLogLevel);
+  } else if (sanitizedString.includes(',')) {
+    return sanitizedString.split(',').filter(isLogLevel);
   }
 
-  return isLogLevel(sanitizedSring) ? [sanitizedSring] : LOG_LEVELS;
+  return isLogLevel(sanitizedString) ? [sanitizedString] : LOG_LEVELS;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a typo in `packages/common/services/utils/filter-log-levels.util.ts`:  
The variable is named `sanitizedSring`.

Issue Number: N/A


## What is the new behavior?
The typo has been fixed by renaming `sanitizedSring` to `sanitizedString`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information