### PR TITLE
refactor(core): fix the typo 'controler' to 'controller'

### DIFF
--- a/packages/core/test/scanner.spec.ts
+++ b/packages/core/test/scanner.spec.ts
@@ -121,13 +121,13 @@ describe('DependenciesScanner', () => {
     class OverwrittenTestComponent {}
 
     @Controller('')
-    class OverwrittenControlerOne {}
+    class OverwrittenControllerOne {}
 
     @Controller('')
     class OverwrittenControllerTwo {}
 
     @Module({
-      controllers: [OverwrittenControlerOne],
+      controllers: [OverwrittenControllerOne],
       providers: [OverwrittenTestComponent],
     })
     class OverwrittenModuleOne {}
@@ -152,7 +152,7 @@ describe('DependenciesScanner', () => {
     class OverrideControllerTwo {}
 
     @Module({
-      controllers: [OverwrittenControlerOne],
+      controllers: [OverwrittenControllerOne],
       providers: [OverrideTestComponent],
     })
     class OverrideModuleOne {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a typo in `packages/core/test/scanner.spec.ts`
The class is named `OverwrittenControlerOne`

Issue Number: N/A


## What is the new behavior?
The typo has been fixed by renaming `OverwrittenControlerOne` to `OverwrittenControllerOne`


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information