### PR TITLE
fix(microservices): fix kafka serilization of class instances

### DIFF
--- a/packages/microservices/serializers/kafka-request.serializer.ts
+++ b/packages/microservices/serializers/kafka-request.serializer.ts
@@ -43,7 +43,9 @@ export class KafkaRequestSerializer
       !isNil(value) && !isString(value) && !Buffer.isBuffer(value);
 
     if (isObjectOrArray) {
-      return isPlainObject(value) || Array.isArray(value)
+      return isPlainObject(value) ||
+        Array.isArray(value) ||
+        value.toString == Object.prototype.toString // Prevent default [object Object] behavior
         ? JSON.stringify(value)
         : value.toString();
     } else if (isUndefined(value)) {

--- a/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
+++ b/packages/microservices/test/serializers/kafka-request.serializer.spec.ts
@@ -75,6 +75,22 @@ describe('KafkaRequestSerializer', () => {
       });
     });
 
+    it('complex object with inherited .toString()', async () => {
+      class ComplexParent {
+        private readonly name = 'complexParent';
+        public toString(): string {
+          return this.name;
+        }
+      }
+
+      class ComplexChild extends ComplexParent {}
+
+      expect(await instance.serialize(new ComplexChild())).to.deep.eq({
+        headers: {},
+        value: 'complexParent',
+      });
+    });
+
     it('complex object without .toString()', async () => {
       class ComplexWithOutToString {
         private readonly name = 'complex';
@@ -83,7 +99,7 @@ describe('KafkaRequestSerializer', () => {
       expect(await instance.serialize(new ComplexWithOutToString())).to.deep.eq(
         {
           headers: {},
-          value: '[object Object]',
+          value: '{"name":"complex"}',
         },
       );
     });


### PR DESCRIPTION
Fix serilization of class instances that doesn't have own toString() implementation and therefore inherit the standard behavior of [object Object]. Add test for inherited classes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Class instances when send (or returned with request-response pattern) over kafka are serialized using toString() which leads to [object Object] when they have no own implementation of toString(). 

Issue Number: #15491


## What is the new behavior?
Instances of classes are only serialized when they have an own toString() implementation or inherit one. Basically when it doesn't have standard toString() [object Object] behavior. Otherwise they are serialized by JSON.stringify() like the plain objects.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information