### PR TITLE
feat(common): add force-console option to console logger

### DIFF
--- a/integration/hello-world/e2e/force-console.spec.ts
+++ b/integration/hello-world/e2e/force-console.spec.ts
@@ -1,0 +1,163 @@
+import { ConsoleLogger, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import * as sinon from 'sinon';
+import { expect } from 'chai';
+
+describe('ForceConsole Option', () => {
+  let app: INestApplication;
+
+  describe('When forceConsole is true', () => {
+    let consoleLogSpy: sinon.SinonSpy;
+    let consoleErrorSpy: sinon.SinonSpy;
+    let processStdoutSpy: sinon.SinonSpy;
+    let processStderrSpy: sinon.SinonSpy;
+
+    beforeEach(async () => {
+      // Spy on console and process methods
+      consoleLogSpy = sinon.spy(console, 'log');
+      consoleErrorSpy = sinon.spy(console, 'error');
+      processStdoutSpy = sinon.spy(process.stdout, 'write');
+      processStderrSpy = sinon.spy(process.stderr, 'write');
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication({
+        forceConsole: true,
+        logger: ['log', 'error'],
+      });
+
+      await app.init();
+    });
+
+    afterEach(async () => {
+      consoleLogSpy.restore();
+      consoleErrorSpy.restore();
+      processStdoutSpy.restore();
+      processStderrSpy.restore();
+      await app.close();
+    });
+
+    it('should use console.log instead of process.stdout.write', async () => {
+      const logger = new ConsoleLogger('TestContext', { forceConsole: true });
+      logger.log('Test log message');
+
+      // Should use console.log when forceConsole is true
+      expect(consoleLogSpy.called).to.be.true;
+      // Verify console.log was called with the message
+      const consoleLogCalls = consoleLogSpy
+        .getCalls()
+        .filter(call =>
+          call.args.some(arg => String(arg).includes('Test log message')),
+        );
+      expect(consoleLogCalls.length).to.be.greaterThan(0);
+    });
+
+    it('should use console.error instead of process.stderr.write', async () => {
+      const logger = new ConsoleLogger('TestContext', { forceConsole: true });
+      logger.error('Test error message');
+
+      // Should use console.error when forceConsole is true
+      expect(consoleErrorSpy.called).to.be.true;
+      // Verify console.error was called with the message
+      const consoleErrorCalls = consoleErrorSpy
+        .getCalls()
+        .filter(call =>
+          call.args.some(arg => String(arg).includes('Test error message')),
+        );
+      expect(consoleErrorCalls.length).to.be.greaterThan(0);
+    });
+
+    it('should handle GET request with forceConsole option enabled', () => {
+      return request(app.getHttpServer()).get('/hello').expect(200);
+    });
+  });
+
+  describe('When forceConsole is false (default)', () => {
+    let consoleLogSpy: sinon.SinonSpy;
+    let consoleErrorSpy: sinon.SinonSpy;
+    let processStdoutSpy: sinon.SinonSpy;
+    let processStderrSpy: sinon.SinonSpy;
+
+    beforeEach(async () => {
+      // Spy on console and process methods
+      consoleLogSpy = sinon.spy(console, 'log');
+      consoleErrorSpy = sinon.spy(console, 'error');
+      processStdoutSpy = sinon.spy(process.stdout, 'write');
+      processStderrSpy = sinon.spy(process.stderr, 'write');
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleRef.createNestApplication({
+        logger: ['log', 'error'],
+        // forceConsole is not set, defaults to false
+      });
+
+      await app.init();
+    });
+
+    afterEach(async () => {
+      consoleLogSpy.restore();
+      consoleErrorSpy.restore();
+      processStdoutSpy.restore();
+      processStderrSpy.restore();
+      await app.close();
+    });
+
+    it('should not directly call console.log when forceConsole is false', async () => {
+      const logger = new ConsoleLogger('TestContext');
+
+      // Reset spy to ensure clean state
+      consoleLogSpy.resetHistory();
+
+      logger.log('Test log message');
+
+      // When forceConsole is false, should not call console.log
+      expect(consoleLogSpy.called).to.be.false;
+    });
+
+    it('should not directly call console.error when forceConsole is false', async () => {
+      const logger = new ConsoleLogger('TestContext');
+
+      // Reset spy to ensure clean state
+      consoleErrorSpy.resetHistory();
+
+      logger.error('Test error message');
+
+      // When forceConsole is false, should not call console.error
+      expect(consoleErrorSpy.called).to.be.false;
+    });
+  });
+
+  describe('When forceConsole is set via NestFactory.create', () => {
+    it('should apply forceConsole to the default logger', async () => {
+      const consoleLogSpy = sinon.spy(console, 'log');
+      const processStdoutSpy = sinon.spy(process.stdout, 'write');
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      const testApp = moduleRef.createNestApplication({
+        forceConsole: true,
+      });
+
+      await testApp.init();
+
+      // The logger created by NestFactory should respect forceConsole option
+      const logger = new ConsoleLogger('AppContext', { forceConsole: true });
+      logger.log('Application started');
+
+      expect(consoleLogSpy.called).to.be.true;
+
+      consoleLogSpy.restore();
+      processStdoutSpy.restore();
+      await testApp.close();
+    });
+  });
+});

--- a/packages/common/interfaces/nest-application-context-options.interface.ts
+++ b/packages/common/interfaces/nest-application-context-options.interface.ts
@@ -67,4 +67,11 @@ export class NestApplicationContextOptions {
      */
     instanceDecorator: (instance: unknown) => unknown;
   };
+
+  /**
+   * If enabled, will force the use of console.log/console.error instead of process.stdout/stderr.write
+   * in the default ConsoleLogger. This is useful for test environments like Jest that can buffer console calls.
+   * @default false
+   */
+  forceConsole?: boolean;
 }

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -10,6 +10,7 @@ import {
 import { NestMicroserviceOptions } from '@nestjs/common/interfaces/microservices/nest-microservice-options.interface';
 import { NestApplicationContextOptions } from '@nestjs/common/interfaces/nest-application-context-options.interface';
 import { NestApplicationOptions } from '@nestjs/common/interfaces/nest-application-options.interface';
+import { ConsoleLogger } from '@nestjs/common/services/console-logger.service';
 import { Logger } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { isFunction, isNil } from '@nestjs/common/utils/shared.utils';
@@ -299,9 +300,14 @@ export class NestFactoryStatic {
     if (!options) {
       return;
     }
-    const { logger, bufferLogs, autoFlushLogs } = options;
+    const { logger, bufferLogs, autoFlushLogs, forceConsole } = options;
     if ((logger as boolean) !== true && !isNil(logger)) {
       Logger.overrideLogger(logger);
+    } else if (forceConsole) {
+      // If no custom logger is provided but forceConsole is true,
+      // create a ConsoleLogger with forceConsole option
+      const consoleLogger = new ConsoleLogger({ forceConsole: true });
+      Logger.overrideLogger(consoleLogger);
     }
     if (bufferLogs) {
       Logger.attachBuffer();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, ConsoleLogger always uses process.stdout.write() and process.stderr.write() for output.
This causes issues in test environments like Jest, which can buffer console.* calls but not direct stream writes. making it difficult to capture or suppress log output during tests.

Issue Number: #15483 


## What is the new behavior?
Added a new forceConsole option to ConsoleLoggerOptions that, when set to true, forces the logger to use console.log() and console.error() instead of process.stdout.write() and process.stderr.write().

This allows test frameworks like Jest to properly buffer and capture log output, making tests cleaner and enabling log assertion testing.

Example usage:
```ts
const logger = new ConsoleLogger({ forceConsole: true });
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information