### PR TITLE
fix(core): fix race condition in class dependency resolution from imported modules

### DIFF
--- a/integration/inspector/e2e/fixtures/post-init-graph.json
+++ b/integration/inspector/e2e/fixtures/post-init-graph.json
@@ -2263,6 +2263,22 @@
       },
       "id": "-1303681274"
     },
+    "-831049991": {
+      "source": "594986539",
+      "target": "-1721730431",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "InputModule",
+        "sourceClassName": "InputService",
+        "targetClassName": "CircularService",
+        "sourceClassToken": "InputService",
+        "targetClassToken": "CircularService",
+        "targetModuleName": "CircularModule",
+        "keyOrIndex": 0,
+        "injectionType": "constructor"
+      },
+      "id": "-831049991"
+    },
     "-886102564": {
       "source": "208171089",
       "target": "671882984",
@@ -2279,6 +2295,22 @@
         "internal": true
       },
       "id": "-886102564"
+    },
+    "-2146943494": {
+      "source": "-234035039",
+      "target": "928565345",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "RequestChainModule",
+        "sourceClassName": "RequestChainService",
+        "targetClassName": "HelperService",
+        "sourceClassToken": "RequestChainService",
+        "targetClassToken": "HelperService",
+        "targetModuleName": "HelperModule",
+        "keyOrIndex": 0,
+        "injectionType": "constructor"
+      },
+      "id": "-2146943494"
     },
     "-2003045613": {
       "source": "-377928898",
@@ -2311,38 +2343,6 @@
         "injectionType": "constructor"
       },
       "id": "-881420795"
-    },
-    "-831049991": {
-      "source": "594986539",
-      "target": "-1721730431",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "InputModule",
-        "sourceClassName": "InputService",
-        "targetClassName": "CircularService",
-        "sourceClassToken": "InputService",
-        "targetClassToken": "CircularService",
-        "targetModuleName": "CircularModule",
-        "keyOrIndex": 0,
-        "injectionType": "constructor"
-      },
-      "id": "-831049991"
-    },
-    "-2146943494": {
-      "source": "-234035039",
-      "target": "928565345",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "RequestChainModule",
-        "sourceClassName": "RequestChainService",
-        "targetClassName": "HelperService",
-        "sourceClassToken": "RequestChainService",
-        "targetClassToken": "HelperService",
-        "targetModuleName": "HelperModule",
-        "keyOrIndex": 0,
-        "injectionType": "constructor"
-      },
-      "id": "-2146943494"
     },
     "-1816180282": {
       "source": "-848516688",

--- a/integration/inspector/e2e/fixtures/pre-init-graph.json
+++ b/integration/inspector/e2e/fixtures/pre-init-graph.json
@@ -2181,22 +2181,6 @@
       },
       "id": "1976848738"
     },
-    "-2105726668": {
-      "source": "-1803759743",
-      "target": "1010833816",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "PropertiesModule",
-        "sourceClassName": "PropertiesService",
-        "targetClassName": "token",
-        "sourceClassToken": "PropertiesService",
-        "targetClassToken": "token",
-        "targetModuleName": "PropertiesModule",
-        "keyOrIndex": "token",
-        "injectionType": "property"
-      },
-      "id": "-2105726668"
-    },
     "-21463590": {
       "source": "-1378706112",
       "target": "1004276345",
@@ -2212,6 +2196,22 @@
         "injectionType": "constructor"
       },
       "id": "-21463590"
+    },
+    "-2105726668": {
+      "source": "-1803759743",
+      "target": "1010833816",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "PropertiesModule",
+        "sourceClassName": "PropertiesService",
+        "targetClassName": "token",
+        "sourceClassToken": "PropertiesService",
+        "targetClassToken": "token",
+        "targetModuleName": "PropertiesModule",
+        "keyOrIndex": "token",
+        "injectionType": "property"
+      },
+      "id": "-2105726668"
     },
     "-1657371464": {
       "source": "-1673986099",
@@ -2247,6 +2247,22 @@
       },
       "id": "-1303681274"
     },
+    "-831049991": {
+      "source": "594986539",
+      "target": "-1721730431",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "InputModule",
+        "sourceClassName": "InputService",
+        "targetClassName": "CircularService",
+        "sourceClassToken": "InputService",
+        "targetClassToken": "CircularService",
+        "targetModuleName": "CircularModule",
+        "keyOrIndex": 0,
+        "injectionType": "constructor"
+      },
+      "id": "-831049991"
+    },
     "-886102564": {
       "source": "208171089",
       "target": "671882984",
@@ -2263,6 +2279,22 @@
         "internal": true
       },
       "id": "-886102564"
+    },
+    "-2146943494": {
+      "source": "-234035039",
+      "target": "928565345",
+      "metadata": {
+        "type": "class-to-class",
+        "sourceModuleName": "RequestChainModule",
+        "sourceClassName": "RequestChainService",
+        "targetClassName": "HelperService",
+        "sourceClassToken": "RequestChainService",
+        "targetClassToken": "HelperService",
+        "targetModuleName": "HelperModule",
+        "keyOrIndex": 0,
+        "injectionType": "constructor"
+      },
+      "id": "-2146943494"
     },
     "-2003045613": {
       "source": "-377928898",
@@ -2295,38 +2327,6 @@
         "injectionType": "constructor"
       },
       "id": "-881420795"
-    },
-    "-831049991": {
-      "source": "594986539",
-      "target": "-1721730431",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "InputModule",
-        "sourceClassName": "InputService",
-        "targetClassName": "CircularService",
-        "sourceClassToken": "InputService",
-        "targetClassToken": "CircularService",
-        "targetModuleName": "CircularModule",
-        "keyOrIndex": 0,
-        "injectionType": "constructor"
-      },
-      "id": "-831049991"
-    },
-    "-2146943494": {
-      "source": "-234035039",
-      "target": "928565345",
-      "metadata": {
-        "type": "class-to-class",
-        "sourceModuleName": "RequestChainModule",
-        "sourceClassName": "RequestChainService",
-        "targetClassName": "HelperService",
-        "sourceClassToken": "RequestChainService",
-        "targetClassToken": "HelperService",
-        "targetModuleName": "HelperModule",
-        "keyOrIndex": 0,
-        "injectionType": "constructor"
-      },
-      "id": "-2146943494"
     },
     "-1816180282": {
       "source": "-848516688",

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -680,14 +680,11 @@ export class Injector {
         inquirerId,
       );
       if (!instanceHost.isResolved && !instanceWrapperRef.forwardRef) {
-        wrapper.settlementSignal?.insertRef(instanceWrapperRef.id);
-
-        await this.loadProvider(
-          instanceWrapperRef,
-          relatedModule,
-          contextId,
-          wrapper,
-        );
+        /*
+         * Provider will be loaded shortly in resolveComponentHost() once we pass the current
+         * Barrier. We cannot load it here because doing so could incorrectly evaluate the
+         * staticity of the dependency tree and lead to undefined / null injection.
+         */
         break;
       }
     }

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -447,63 +447,6 @@ describe('Injector', () => {
         ),
       ).to.eventually.be.eq(null);
     });
-
-    it('should call "loadProvider" when component is not resolved', async () => {
-      const moduleFixture = {
-        imports: new Map([
-          [
-            'key',
-            {
-              providers: {
-                has: () => true,
-                get: () =>
-                  new InstanceWrapper({
-                    isResolved: false,
-                  }),
-              },
-              exports: {
-                has: () => true,
-              },
-              imports: new Map(),
-            },
-          ],
-        ] as any),
-      };
-      await injector.lookupComponentInImports(
-        moduleFixture as any,
-        metatype as any,
-        new InstanceWrapper(),
-      );
-      expect(loadProvider.called).to.be.true;
-    });
-
-    it('should not call "loadProvider" when component is resolved', async () => {
-      const moduleFixture = {
-        relatedModules: new Map([
-          [
-            'key',
-            {
-              providers: {
-                has: () => true,
-                get: () => ({
-                  isResolved: true,
-                }),
-              },
-              exports: {
-                has: () => true,
-              },
-              relatedModules: new Map(),
-            },
-          ],
-        ] as any),
-      };
-      await injector.lookupComponentInImports(
-        moduleFixture as any,
-        metatype as any,
-        null!,
-      );
-      expect(loadProvider.called).to.be.false;
-    });
   });
 
   describe('resolveParamToken', () => {


### PR DESCRIPTION
Fix race condition in class dependency resolution, which could otherwise lead to undefined or null injection. This is a followup to #15405 that fixes another case of this bug that was not taken care of in the previous PR. In this case specifically, the staticity of the dependency tree could be checked before all dependencies are loaded and the param / property Barrier is passed, resulting in a potentially wrong evaluation of the `isTreeStatic` property of the `InstanceWrapper`.

Closes #4873

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
A specific setup of transient-scoped and request-scoped providers with many global modules leads to `null` or `undefined` injection due to incorrect evaluation of the staticity of the dependency tree with a specific setup of request-scoped and transient-scoped providers with many global modules.

Issue Number: #4873


## What is the new behavior?
The dependencies are injected correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I removed 2 test cases that test whether `loadProvider()` was called, because  `lookupComponentInImports()` no longer calls it. To catch future regressions, I extended an existing integration test introduced in my previous PR regarding this issue (#15405).

The fix lies in the removal of a `loadProvider()` call, which is safe, because it is called almost immediately (along with the appropriate settlement signal) after the method returns and the param / property Barrier is passed (via `resolveComponentHost()`).