### PR TITLE
fix(microservices): report correct buffer length in exception

### DIFF
--- a/packages/microservices/helpers/json-socket.ts
+++ b/packages/microservices/helpers/json-socket.ts
@@ -24,8 +24,9 @@ export class JsonSocket extends TcpSocket {
     this.buffer += data;
 
     if (this.buffer.length > MAX_BUFFER_SIZE) {
+      const bufferLength = this.buffer.length;
       this.buffer = '';
-      throw new MaxPacketLengthExceededException(this.buffer.length);
+      throw new MaxPacketLengthExceededException(bufferLength);
     }
 
     if (this.contentLength === null) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

MaxPacketLengthExceededException always reports length of 0

Issue Number: https://github.com/nestjs/nest/issues/15472

## What is the new behavior?

MaxPacketLengthExceededException correctly reports the actual buffer length.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information