### PR TITLE
fix(core): prevent stack overflow with snapshot enabled

### DIFF
--- a/packages/core/inspector/deterministic-uuid-registry.ts
+++ b/packages/core/inspector/deterministic-uuid-registry.ts
@@ -1,10 +1,11 @@
 export class DeterministicUuidRegistry {
   private static readonly registry = new Map<string, boolean>();
 
-  static get(str: string, inc = 0) {
-    const id = inc ? this.hashCode(`${str}_${inc}`) : this.hashCode(str);
-    if (this.registry.has(id)) {
-      return this.get(str, inc + 1);
+  static get(str: string) {
+    let id = this.hashCode(str);
+    let inc = 0;
+    while (this.registry.has(id)) {
+      id = this.hashCode(`${str}_${++inc}`);
     }
     this.registry.set(id, true);
     return id;


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With snapshot enabled it will use the deterministic UUID generator which in turn will keep track of a registry of currently in use UUIDs. They way it was doing the search for the next available UUID for the input key involved calling itself over and over until it found an available key, which could lead to a stack-overflow.

Issue Number: N/A

## What is the new behavior?

The most lazy fix I could think of to prevent the stack overflow during search for the next id was switching the self-recursion out with a while loop. It will not help with the ever-increasing registry size and slowness with snapshot enabled in the application until you grab the next snapshot, but it will prevent the stack overflow as the search won't go as deep as before.

Feel free to fix it another way if you're dissatisfied with this band-aid. Just wanted to highlight the issue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information