### PR TITLE
feat(errors): add InvalidTcpDataReceptionException for handling TCP receive errors​

### DIFF
--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -1,7 +1,7 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
-  constructor(name: string) {
+  constructor(err: string) {
     const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : 'The invalid received message from tcp server.';
     super(_errMsg);
   }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -1,8 +1,8 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
-  constructor(err: string) {
-    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : `The invalid received message from tcp server.`;
+  constructor(name: string) {
+    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : 'The invalid received message from tcp server.';
     super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -5,9 +5,12 @@ export class InvalidTcpDataReceptionException extends RuntimeException {
     const errMsgStr =
       typeof err === 'string'
         ? err
-        : err && typeof err === 'object' && 'message' in err && typeof (err as any).message === 'string'
-        ? (err as any).message
-        : String(err);
+        : err &&
+            typeof err === 'object' &&
+            'message' in err &&
+            typeof (err as any).message === 'string'
+          ? (err as any).message
+          : String(err);
     const _errMsg = errMsgStr.includes('Corrupted length value')
       ? `Corrupted length value of the received data supplied in a packet`
       : `The invalid received message from tcp server`;

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -1,8 +1,14 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
-  constructor(err: string) {
-    const _errMsg = err.includes('Corrupted length value')
+  constructor(err: string | Error) {
+    const errMsgStr =
+      typeof err === 'string'
+        ? err
+        : err && typeof err === 'object' && 'message' in err && typeof (err as any).message === 'string'
+        ? (err as any).message
+        : String(err);
+    const _errMsg = errMsgStr.includes('Corrupted length value')
       ? `Corrupted length value of the received data supplied in a packet`
       : `The invalid received message from tcp server`;
     super(_errMsg);

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -1,6 +1,6 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
-export class InvalidTcpMessageException extends RuntimeException {
+export class InvalidTcpDataReceptionException extends RuntimeException {
   constructor(err:string) {
     const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : `The invalid received message from tcp server.`
     super(_errMsg);

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -3,8 +3,8 @@ import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.excepti
 export class InvalidTcpDataReceptionException extends RuntimeException {
   constructor(err: string) {
     const _errMsg = err.includes('Corrupted length value') 
-      ? 'Corrupted length value of the received data supplied in a packet' 
-      : 'The invalid received message from tcp server';
+      ? `Corrupted length value of the received data supplied in a packet` 
+      : `The invalid received message from tcp server`;
     super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -2,8 +2,8 @@ import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.excepti
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
   constructor(err: string) {
-    const _errMsg = err.includes('Corrupted length value') 
-      ? `Corrupted length value of the received data supplied in a packet` 
+    const _errMsg = err.includes('Corrupted length value')
+      ? `Corrupted length value of the received data supplied in a packet`
       : `The invalid received message from tcp server`;
     super(_errMsg);
   }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -3,8 +3,8 @@ import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.excepti
 export class InvalidTcpDataReceptionException extends RuntimeException {
   constructor(err: string) {
     const _errMsg = err.includes('Corrupted length value') 
-      ? 'Corrupted length value of the received data supplied in a packet.' 
-      : 'The invalid received message from tcp server.';
+      ? 'Corrupted length value of the received data supplied in a packet' 
+      : 'The invalid received message from tcp server';
     super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -2,7 +2,9 @@ import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.excepti
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
   constructor(err: string) {
-    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : 'The invalid received message from tcp server.';
+    const _errMsg = err.includes('Corrupted length value') 
+      ? 'Corrupted length value of the received data supplied in a packet.' 
+      : 'The invalid received message from tcp server.';
     super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-data-reception.exception.ts
@@ -1,8 +1,8 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
 export class InvalidTcpDataReceptionException extends RuntimeException {
-  constructor(err:string) {
-    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : `The invalid received message from tcp server.`
+  constructor(err: string) {
+    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : `The invalid received message from tcp server.`;
     super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-message.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-message.exception.ts
@@ -1,7 +1,8 @@
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 
 export class InvalidTcpMessageException extends RuntimeException {
-  constructor() {
-    super(`The invalid data or message from tcp recv message.`);
+  constructor(err:string) {
+    const _errMsg = err.includes('Corrupted length value') ? 'Corrupted length value of the received data supplied in a packet.' : `The invalid received message from tcp server.`
+    super(_errMsg);
   }
 }

--- a/packages/microservices/errors/invalid-tcp-message.exception.ts
+++ b/packages/microservices/errors/invalid-tcp-message.exception.ts
@@ -1,0 +1,7 @@
+import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
+
+export class InvalidTcpMessageException extends RuntimeException {
+  constructor() {
+    super(`The invalid data or message from tcp recv message.`);
+  }
+}

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -84,7 +84,7 @@ export class ServerTCP extends Server<TcpEvents, TcpStatus> {
     );
     readSocket.on(TcpEventsMap.ERROR, err => {
       const invalidError = new InvalidTcpDataReceptionException(err);
-      this.handleError(invalidError as any)
+      this.handleError(invalidError as any);
     });
   }
 

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -82,7 +82,7 @@ export class ServerTCP extends Server<TcpEvents, TcpStatus> {
     readSocket.on('message', async (msg: ReadPacket & PacketId) =>
       this.handleMessage(readSocket, msg),
     );
-    readSocket.on(TcpEventsMap.ERROR, err=>{
+    readSocket.on(TcpEventsMap.ERROR, err => {
       const invalidError = new InvalidTcpDataReceptionException(err);
       this.handleError(invalidError)
     });

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -84,7 +84,7 @@ export class ServerTCP extends Server<TcpEvents, TcpStatus> {
     );
     readSocket.on(TcpEventsMap.ERROR, err => {
       const invalidError = new InvalidTcpDataReceptionException(err);
-      this.handleError(invalidError)
+      this.handleError(invalidError as any)
     });
   }
 

--- a/packages/microservices/server/server-tcp.ts
+++ b/packages/microservices/server/server-tcp.ts
@@ -14,6 +14,7 @@ import { TcpContext } from '../ctx-host/tcp.context';
 import { Transport } from '../enums';
 import { TcpEvents, TcpEventsMap, TcpStatus } from '../events/tcp.events';
 import { JsonSocket, TcpSocket } from '../helpers';
+import { InvalidTcpDataReceptionException } from '../errors/invalid-tcp-data-reception.exception';
 import {
   IncomingRequest,
   PacketId,
@@ -81,7 +82,10 @@ export class ServerTCP extends Server<TcpEvents, TcpStatus> {
     readSocket.on('message', async (msg: ReadPacket & PacketId) =>
       this.handleMessage(readSocket, msg),
     );
-    readSocket.on(TcpEventsMap.ERROR, this.handleError.bind(this));
+    readSocket.on(TcpEventsMap.ERROR, err=>{
+      const invalidError = new InvalidTcpDataReceptionException(err);
+      this.handleError(invalidError)
+    });
   }
 
   public async handleMessage(socket: TcpSocket, rawMessage: unknown) {


### PR DESCRIPTION
## Other information
Currently, when the NestJS ​​Server-TCP module​​ encounters ​​receive errors (recv errors)​​, the thrown error messages are overly verbose or include unnecessary low-level details (e.g., raw socket error stacks, unformatted binary data). This causes:
1. Developers to struggle to quickly identify the root cause;
2.Logs or monitoring systems to be cluttered with irrelevant information, reducing readability.
<img width="2310" height="1122" alt="image" src="https://github.com/user-attachments/assets/3ac7d362-d108-4eee-992e-24ea6ce0f19f" />


