### PR TITLE
feat(common): add UNPROCESSABLE_CONTENT for status 422

### DIFF
--- a/packages/common/enums/http-status.enum.ts
+++ b/packages/common/enums/http-status.enum.ts
@@ -43,7 +43,19 @@ export enum HttpStatus {
   EXPECTATION_FAILED = 417,
   I_AM_A_TEAPOT = 418,
   MISDIRECTED = 421,
+   /**
+   * Official RFC 9110 name for the 422 status code.
+   * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content
+   */
+  UNPROCESSABLE_CONTENT = 422,
+
+  /**
+   * @deprecated The name "Unprocessable Entity" is deprecated in favor of "Unprocessable Content" (RFC 9110).
+   * It will be removed in a future major version.
+   * @see https://www.rfc-editor.org/rfc/rfc9110.html#name-422-unprocessable-content
+   */
   UNPROCESSABLE_ENTITY = 422,
+  // ...
   LOCKED = 423,
   FAILED_DEPENDENCY = 424,
   PRECONDITION_REQUIRED = 428,


### PR DESCRIPTION
Adds the HttpStatus.UNPROCESSABLE_CONTENT enum in alignment with RFC 9110. The previous HttpStatus.UNPROCESSABLE_ENTITY is now marked as deprecated.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The framework currently only provides `HttpStatus.UNPROCESSABLE_ENTITY` for the 422 status code. This name is based on the obsolete RFC 4918.

Closes #15624 


## What is the new behavior?
This PR introduces `HttpStatus.UNPROCESSABLE_CONTENT` for the 422 status code, aligning the framework with the current RFC 9110 standard. The previous enum, `HttpStatus.UNPROCESSABLE_ENTITY`, has been marked as `@deprecated` to maintain backward compatibility while guiding users to the correct, modern standard.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No