### PR TITLE
feat(core): add declarative route rewrites support

### DIFF
--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -27,3 +27,4 @@ export * from './scope-options.interface';
 export * from './type.interface';
 export * from './version-options.interface';
 export * from './websockets/web-socket-adapter.interface';
+export * from './route-rewrite-options.interface';

--- a/packages/common/interfaces/nest-application-options.interface.ts
+++ b/packages/common/interfaces/nest-application-options.interface.ts
@@ -4,6 +4,7 @@ import {
 } from './external/cors-options.interface';
 import { HttpsOptions } from './external/https-options.interface';
 import { NestApplicationContextOptions } from './nest-application-context-options.interface';
+import { RouteRewriteOptions } from './route-rewrite-options.interface';
 
 /**
  * @publicApi
@@ -30,4 +31,8 @@ export interface NestApplicationOptions extends NestApplicationContextOptions {
    * keep-alive connections in the HTTP adapter.
    */
   forceCloseConnections?: boolean;
+  /**
+   * Route rewrite configurations. Allows routing requests from old paths to new paths.
+   */
+  routeRewrites?: RouteRewriteOptions[];
 }

--- a/packages/common/interfaces/route-rewrite-options.interface.ts
+++ b/packages/common/interfaces/route-rewrite-options.interface.ts
@@ -1,0 +1,31 @@
+import { RequestMethod } from '../enums/request-method.enum';
+
+/**
+ * Route rewrite configuration options.
+ * Allows routing requests from old paths to new paths.
+ *
+ * @publicApi
+ */
+export interface RouteRewriteOptions {
+  /**
+   * The original path to rewrite from.
+   */
+  from: string;
+
+  /**
+   * The destination path to rewrite to.
+   */
+  to: string;
+
+  /**
+   * HTTP methods to apply the rewrite rule to.
+   * If not specified, applies to all methods.
+   */
+  methods?: RequestMethod | RequestMethod[];
+
+  /**
+   * HTTP status code for the redirect response.
+   * @default 301 (Moved Permanently)
+   */
+  statusCode?: number;
+}

--- a/packages/core/application-config.ts
+++ b/packages/core/application-config.ts
@@ -6,7 +6,10 @@ import {
   VersioningOptions,
   WebSocketAdapter,
 } from '@nestjs/common';
-import { GlobalPrefixOptions } from '@nestjs/common/interfaces';
+import {
+  GlobalPrefixOptions,
+  RouteRewriteOptions,
+} from '@nestjs/common/interfaces';
 import { InstanceWrapper } from './injector/instance-wrapper';
 import { ExcludeRouteMetadata } from './router/interfaces/exclude-route-metadata.interface';
 
@@ -24,6 +27,7 @@ export class ApplicationConfig {
   private readonly globalRequestInterceptors: InstanceWrapper<NestInterceptor>[] =
     [];
   private readonly globalRequestGuards: InstanceWrapper<CanActivate>[] = [];
+  private routeRewrites: RouteRewriteOptions[] = [];
 
   constructor(private ioAdapter: WebSocketAdapter | null = null) {}
 
@@ -146,5 +150,13 @@ export class ApplicationConfig {
 
   public getVersioning(): VersioningOptions | undefined {
     return this.versioningOptions;
+  }
+
+  public setRouteRewrites(routeRewrites: RouteRewriteOptions[]): void {
+    this.routeRewrites = routeRewrites;
+  }
+
+  public getRouteRewrites(): RouteRewriteOptions[] {
+    return this.routeRewrites;
   }
 }

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -91,6 +91,10 @@ export class NestFactoryStatic {
     this.setAbortOnError(serverOrOptions, options);
     this.registerLoggerConfiguration(appOptions);
 
+    if (appOptions?.routeRewrites) {
+      applicationConfig.setRouteRewrites(appOptions.routeRewrites);
+    }
+
     await this.initialize(
       moduleCls,
       container,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Issue Number: #15619

## What is the new behavior?
This PR introduces a declarative route rewrite system that allows applications to configure route rewrites at the application level using the routeRewrites option in NestApplicationOptions.

Key Features:
- Declarative Configuration: Configure route rewrites through application options
- HTTP Method Support: Specify which HTTP methods to apply rewrites to (or all methods by default)
- Custom Status Codes: Configure redirect status codes (defaults to 301 Moved Permanently)
- Global Prefix Integration: Automatically handles global prefix in route paths
- Performance Optimized: Route rewrites are registered during application startup, not per-request

```typescript
const app = await NestFactory.create(AppModule, {
  routeRewrites: [
    // Redirect all methods from old path to new path
    { from: '/old-api', to: '/new-api' },

    // Method-specific rewrite with custom status code
    {
      from: '/legacy-users',
      to: '/users',
      methods: RequestMethod.GET,
      statusCode: 302
    },

    // Multiple methods
    {
      from: '/old-posts',
      to: '/posts',
      methods: [RequestMethod.GET, RequestMethod.POST]
    }
  ]
});
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
Added `private readonly config: ApplicationConfig` parameter to enable access to route rewrite configurations