### PR TITLE
fix(common): resolve extras in configurable module builder async methods

### DIFF
--- a/packages/common/module-utils/configurable-module.builder.ts
+++ b/packages/common/module-utils/configurable-module.builder.ts
@@ -4,6 +4,7 @@ import { Logger } from '../services/logger.service';
 import { randomStringGenerator } from '../utils/random-string-generator.util';
 import {
   ASYNC_METHOD_SUFFIX,
+  ASYNC_OPTIONS_METADATA_KEYS,
   CONFIGURABLE_MODULE_ID,
   DEFAULT_FACTORY_CLASS_METHOD_KEY,
   DEFAULT_METHOD_KEY,
@@ -254,7 +255,7 @@ export class ConfigurableModuleBuilder<
           },
           {
             ...self.extras,
-            ...options,
+            ...this.extractExtrasFromAsyncOptions(options, self.extras),
           },
         );
       }
@@ -277,8 +278,28 @@ export class ConfigurableModuleBuilder<
         return moduleOptions as ModuleOptions;
       }
 
+      private static extractExtrasFromAsyncOptions(
+        input: ConfigurableModuleAsyncOptions<ModuleOptions> &
+          ExtraModuleDefinitionOptions,
+        extras: ExtraModuleDefinitionOptions | undefined,
+      ): Partial<ExtraModuleDefinitionOptions> {
+        if (!extras) {
+          return {};
+        }
+        const extrasOptions = {};
+
+        Object.keys(input as object)
+          .filter(key => !ASYNC_OPTIONS_METADATA_KEYS.includes(key as any))
+          .forEach(key => {
+            extrasOptions[key] = input[key];
+          });
+
+        return extrasOptions;
+      }
+
       private static createAsyncProviders(
-        options: ConfigurableModuleAsyncOptions<ModuleOptions>,
+        options: ConfigurableModuleAsyncOptions<ModuleOptions> &
+          ExtraModuleDefinitionOptions,
       ): Provider[] {
         if (options.useExisting || options.useFactory) {
           if (options.inject && options.provideInjectionTokensFrom) {

--- a/packages/common/module-utils/constants.ts
+++ b/packages/common/module-utils/constants.ts
@@ -3,3 +3,16 @@ export const DEFAULT_FACTORY_CLASS_METHOD_KEY = 'create';
 
 export const ASYNC_METHOD_SUFFIX = 'Async';
 export const CONFIGURABLE_MODULE_ID = 'CONFIGURABLE_MODULE_ID';
+
+/**
+ * List of keys that are specific to ConfigurableModuleAsyncOptions
+ * and should be excluded when extracting user-defined extras.
+ */
+export const ASYNC_OPTIONS_METADATA_KEYS = [
+  'useFactory',
+  'useClass',
+  'useExisting',
+  'inject',
+  'imports',
+  'provideInjectionTokensFrom',
+] as const;

--- a/packages/common/test/module-utils/configurable-module.builder.spec.ts
+++ b/packages/common/test/module-utils/configurable-module.builder.spec.ts
@@ -24,6 +24,34 @@ describe('ConfigurableModuleBuilder', () => {
         global: true,
       });
     });
+
+    it('should preserve extras in registerAsync transformation', () => {
+      let capturedExtras: any;
+
+      const { ConfigurableModuleClass } = new ConfigurableModuleBuilder()
+        .setExtras(
+          { folder: 'default' },
+          (definition, extras: { folder: string }) => {
+            capturedExtras = extras;
+            return {
+              ...definition,
+              customProperty: `folder: ${extras.folder}`,
+            };
+          },
+        )
+        .build();
+
+      const asyncResult = ConfigurableModuleClass.registerAsync({
+        useFactory: () => ({}),
+        folder: 'forRootAsync',
+      });
+
+      expect(capturedExtras).to.deep.equal({ folder: 'forRootAsync' });
+      expect(asyncResult).to.have.property(
+        'customProperty',
+        'folder: forRootAsync',
+      );
+    });
   });
   describe('setClassMethodName', () => {
     it('should set static class method name and return typed builder', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using `ConfigurableModuleBuilder` with `.setExtras()` and calling `.registerAsync()`, the `transformModuleDefinition` function receives async-specific options mixed with user-defined extras, making it impossible to distinguish between the two.

The transformModuleDefinition receives all keys including useFactory, but only folder and isGlobal should be passed as extras.

Issue Number: #15661 

## What is the new behavior?
The registerAsync method now correctly filters out async-specific keys before passing extras to transformModuleDefinition.
Only user-defined extras are included.

- transformModuleDefinition now receives only user-defined extras
- Async-specific configuration remains in the correct scope
- No breaking changes to existing behavior

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No