### PR TITLE
fix(fastify): Migrate fastify top-level options to routerOptions

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -250,10 +250,13 @@ export class FastifyAdapter<
       instanceOrOptions && (instanceOrOptions as TInstance).server
         ? instanceOrOptions
         : fastify({
-            constraints: {
-              version: this.versionConstraint as any,
-            },
             ...(instanceOrOptions as FastifyServerOptions),
+            routerOptions: {
+              ...(instanceOrOptions as FastifyServerOptions)?.routerOptions,
+              constraints: {
+                version: this.versionConstraint as any,
+              },
+            },
           });
 
     this.setInstance(instance);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Fastify separated router-level configuration (`find-my-way` options) from the root instance configuration to improve modularity and plugin isolation. As of Fastify v6, options such as `constraints`, `caseSensitive`, `ignoreTrailingSlash`, and [others](https://github.com/fastify/fastify/blob/1564559c355b4aa1f00f7371f71f896ebe94f862/lib/route.js#L57) are **validated and stored exclusively under `routerOptions`**.

Nest’s FastifyAdapter currently registers the version constraint directly under the root Fastify instance options, which triggers the following warning:

```
(node:18960) [FSTDEP022] FastifyWarning: The router options for constraints property access is deprecated. Please use "options.routerOptions" instead for accessing router options. The router options will be removed in `fastify@6`.
```


Issue Number: https://github.com/nestjs/nest/issues/15825


## What is the new behavior?
updates FastifyAdapter to comply with Fastify v6 conventions by moving version constraint registration into `routerOptions.constraints`.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
## Other information

* **Related Fastify Issues and PRs**

  * [[fastify/fastify#3809](https://github.com/fastify/fastify/issues/3809)](https://github.com/fastify/fastify/issues/3809) — *Move router options to own key*
  * [[fastify/fastify#5985](https://github.com/fastify/fastify/pull/5985)](https://github.com/fastify/fastify/pull/5985) — *Implements the change for Fastify v6*


Only the `constraints` option, which Nest uses internally for versioning, is now managed by the `FastifyAdapter`, while other routing options such as `ignoreTrailingSlash` and `caseSensitive `were never controlled by Nest directly and therefore must be moved manually under `routerOptions` in the user’s adapter configuration.

 ```typescript
  const adapter = new FastifyAdapter({
    trustProxy: true,
    routerOptions: {
      ignoreTrailingSlash: true,
      caseSensitive: false,
      // ...etc
    },
  });
 ```