### PR TITLE
fix(sample): make sample 34 test resilient to external package changes

### DIFF
--- a/sample/34-using-esm-packages/test/app.e2e-spec.ts
+++ b/sample/34-using-esm-packages/test/app.e2e-spec.ts
@@ -19,11 +19,10 @@ describe('AppController (e2e)', () => {
     return request(app.getHttpServer())
       .get('/')
       .expect(200)
-      .expect(
-        JSON.stringify({
-          jsonString:
-            '{"json":{"big":"10"},"meta":{"values":{"big":["bigint"]}}}',
-        }),
-      );
+      .expect((res) => {
+        const result = JSON.parse(res.body.jsonString);
+        expect(result.json.big).toBe('10');
+        expect(result.meta.values.big).toEqual(['bigint']);
+      });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Sample 34 E2E test fails with `superjson` 2.2.3 due to exact JSON string matching
```
expected '{"jsonString":"{"json":{"big":"10"},"meta":{"values":{"big":["bigint"]}}}"}'
got      '{"jsonString":"{"json":{"big":"10"},"meta":{"values":{"big":["bigint"]},"v":1}}"}'
```
Sample 34's purpose is to demonstrate **ESM package import**, not to validate `superjson`'s serialization format.

superjson 2.2.3 was published to npm on Oct 22, 2025 (06:20 UTC), and CI tests started failing immediately after. The package added a "v": 1 field to the meta object for backward compatibility


### Root Cause
- Test uses exact JSON string comparison
- `superjson` 2.2.3 added internal version field for backward compatibility ([PR #311](https://github.com/flightcontrolhq/superjson/pull/311))
- Test breaks on external package's internal format changes


Issue Number: #15834


## What is the new behavior?
Changed test from exact JSON string matching to object comparison

```typescript
// Before
.expect(
  JSON.stringify({
    jsonString: '{"json":{"big":"10"},"meta":{"values":{"big":["bigint"]}}}',
  }),
);

// After
.expect((res) => {
  const result = JSON.parse(res.body.jsonString);
  expect(result.json.big).toBe('10');
  expect(result.meta.values.big).toEqual(['bigint']);
});
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
### Related
- superjson issue: https://github.com/flightcontrolhq/superjson/issues/310
- superjson PR: https://github.com/flightcontrolhq/superjson/pull/311

### Alternatives considered
1. Object comparison (implemented) - most robust
2. Pin superjson to 2.2.2 - prevents testing with latest packages
3. Update expected output to include "v": 1 - still fragile to future changes