### PR TITLE
feat(common): add method options to @sse decorator

### DIFF
--- a/packages/common/decorators/http/sse.decorator.ts
+++ b/packages/common/decorators/http/sse.decorator.ts
@@ -6,7 +6,12 @@ import { RequestMethod } from '../../enums/request-method.enum';
  *
  * @publicApi
  */
-export function Sse(path?: string): MethodDecorator {
+export function Sse(
+  path?: string,
+  options: { [METHOD_METADATA]?: RequestMethod } = {
+    [METHOD_METADATA]: RequestMethod.GET,
+  },
+): MethodDecorator {
   return (
     target: object,
     key: string | symbol,
@@ -17,7 +22,7 @@ export function Sse(path?: string): MethodDecorator {
     Reflect.defineMetadata(PATH_METADATA, path, descriptor.value);
     Reflect.defineMetadata(
       METHOD_METADATA,
-      RequestMethod.GET,
+      options[METHOD_METADATA],
       descriptor.value,
     );
     Reflect.defineMetadata(SSE_METADATA, true, descriptor.value);

--- a/packages/common/test/decorators/sse.decorator.spec.ts
+++ b/packages/common/test/decorators/sse.decorator.spec.ts
@@ -8,6 +8,9 @@ describe('@Sse', () => {
   class Test {
     @Sse(prefix)
     public static test() {}
+
+    @Sse(prefix, { method: RequestMethod.POST })
+    public static testUsingOptions() {}
   }
 
   it('should enhance method with expected http status code', () => {
@@ -18,6 +21,16 @@ describe('@Sse', () => {
     expect(method).to.be.eql(RequestMethod.GET);
 
     const metadata = Reflect.getMetadata(SSE_METADATA, Test.test);
+    expect(metadata).to.be.eql(true);
+  });
+  it('should enhance method with expected http status code and method from options', () => {
+    const path = Reflect.getMetadata(PATH_METADATA, Test.testUsingOptions);
+    expect(path).to.be.eql('/prefix');
+
+    const method = Reflect.getMetadata(METHOD_METADATA, Test.testUsingOptions);
+    expect(method).to.be.eql(RequestMethod.POST);
+
+    const metadata = Reflect.getMetadata(SSE_METADATA, Test.testUsingOptions);
     expect(metadata).to.be.eql(true);
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the `@Sse` decorator is hardcoded to use the `GET` method, which limits certain use cases where an `EventSource` polyfill on the client side uses a different `HTTP` method.

Issue Number: N/A


## What is the new behavior?
The new behavior allows specifying which `HTTP` method the endpoint supports, while still defaulting to `GET` if none is provided

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is my first time contributing to a repository, so please excuse any beginner mistakes I may have made.