### PR TITLE
fix(common): preserve default description for teapot exception

### DIFF
--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -40,13 +40,13 @@ export class ImATeapotException extends HttpException {
     objectOrError?: any,
     descriptionOrOptions: string | HttpExceptionOptions = `I'm a teapot`,
   ) {
-    const { description, httpExceptionOptions } =
+    const { description = "I'm a teapot", httpExceptionOptions } =
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description,
         HttpStatus.I_AM_A_TEAPOT,
       ),
       HttpStatus.I_AM_A_TEAPOT,


### PR DESCRIPTION
apply default description ("I'm a teapot") when HttpExceptionOptions are provided without an explicit description. previously, passing only an options object such as { cause } resulted in description being undefined because extractDescriptionAndOptionsFrom() does not apply any fallback. this change restores consistent behavior with other built-in HTTP exceptions, which all preserve their default descriptions when options are provided without a description.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #15961


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information