### PR TITLE
fix(microservices): avoid registering transport-less MessagePattern handlers on transport-based servers

### DIFF
--- a/packages/microservices/listeners-controller.ts
+++ b/packages/microservices/listeners-controller.ts
@@ -76,7 +76,6 @@ export class ListenersController {
     patternHandlers
       .filter(
         ({ transport }) =>
-          isUndefined(transport) ||
           isUndefined(serverInstance.transportId) ||
           transport === serverInstance.transportId,
       )


### PR DESCRIPTION
Removed check for undefined transport in patternHandlers filter

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using multiple microservice transports (e.g., Redis + RabbitMQ), a @MessagePattern() decorator without explicit transport is currently registered on every microservice during connectMicroservice.

This happens because:

@MessagePattern() stores metadata with transport = undefined

In listeners-controller.ts, inside registerPatternHandlers(), there is no filtering on the actual transport

As a result, all handlers without an explicit transport end up being associated with the current microservice, even if they do not belong to it


## What is the new behavior?
@MessagePattern() without a transport should not be implicitly bound to any specific transport-based server (Redis, RMQ, etc.).

Only handlers whose transport matches the server's transportId should be registered for that microservice.

In other words, a "transport-less" handler should not be automatically attached to a Redis or RabbitMQ microservice just because it exists.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

It shouldn't be a breaking change as nobody expect such behavior.