### PR TITLE
fix(common): move file-type to optional peer dependency

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "file-type": "21.1.1",
     "iterare": "1.2.1",
     "load-esm": "1.0.3",
     "tslib": "2.8.1",
@@ -27,6 +26,7 @@
   "peerDependencies": {
     "class-transformer": ">=0.4.1",
     "class-validator": ">=0.13.2",
+    "file-type": "^21.0.0",
     "reflect-metadata": "^0.1.12 || ^0.2.0",
     "rxjs": "^7.1.0"
   },
@@ -35,6 +35,9 @@
       "optional": true
     },
     "class-transformer": {
+      "optional": true
+    },
+    "file-type": {
       "optional": true
     }
   }


### PR DESCRIPTION
## Summary

Move `file-type` from `dependencies` to `peerDependencies` to resolve npm hoisting issues.

## Problem

When another package (like `jimp`) depends on an older version of `file-type`, npm may hoist that older version to the root `node_modules`. The dynamic import in `FileTypeValidator` then loads the wrong version, causing validation failures with cryptic error messages like:

> Validation failed (current file type is application/octet-stream, expected type is application/octet-stream)

## Solution

**Moved** (not added) `file-type` from `dependencies` to `peerDependencies` as optional:
- Removes `file-type: "21.1.1"` from `dependencies`
- Adds `file-type: "^21.0.0"` to `peerDependencies`
- Marks it as `optional: true` in `peerDependenciesMeta`

This ensures npm warns users when an incompatible version would be hoisted, while not breaking projects that don't use `FileTypeValidator`.

## Test plan

- [x] All FileTypeValidator tests pass
- [x] No breaking changes for existing projects

## Related

- Supersedes #16008 (had unrelated changes and file-type in both deps and peerDeps)
- Supersedes #15364 (stale PR with conflicts)

Closes #15270