### PR TITLE
fix(common): Support fallbackToMimetype without buffer

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -69,7 +69,14 @@ export class FileTypeValidator extends FileValidator<
       );
     }
 
-    if (!isFileValid || !file.buffer) return false;
+    if (!isFileValid) return false;
+
+    if (!file.buffer) {
+      if (this.validationOptions.fallbackToMimetype) {
+        return !!file.mimetype.match(this.validationOptions.fileType);
+      }
+      return false;
+    }
 
     try {
       const { fileTypeFromBuffer } =

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -233,6 +233,32 @@ describe('FileTypeValidator', () => {
 
       expect(await fileTypeValidator.isValid(requestFile)).to.equal(false);
     });
+
+    it('should return true when no buffer is provided but fallbackToMimetype is enabled and mimetype matches', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'image/jpeg',
+        fallbackToMimetype: true,
+      });
+
+      const requestFile = {
+        mimetype: 'image/jpeg', // matches
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
+    });
+
+    it('should return false when no buffer is provided and fallbackToMimetype is enabled but mimetype does not match', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'image/jpeg',
+        fallbackToMimetype: true,
+      });
+
+      const requestFile = {
+        mimetype: 'image/png',
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(false);
+    });
   });
 
   describe('buildErrorMessage', () => {


### PR DESCRIPTION
Allow FileTypeValidator to validate files saved on disk where no buffer is available.
Use mimetype as a fallback when fallbackToMimetype=true and buffer is missing.
Preserves existing behavior when fallbackToMimetype is not enabled.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using Multer’s `diskStorage`, uploaded files do not include a `buffer`.
`FileTypeValidator` requires a buffer unless `skipMagicNumbersValidation` is enabled.
Even when `fallbackToMimetype=true`, validation fails because the `buffer` is missing.

This makes it impossible to validate disk-stored files using mimetype fallback.

Issue Number: N/A

## What is the new behavior?

- When `buffer` is missing:
  - If `fallbackToMimetype=true`, validation uses `mimetype` as a fallback.
  - If `fallbackToMimetype` is not enabled, behavior remains unchanged (validation fails).

This enables file validation for diskStorage without breaking existing logic.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This change is backward-compatible and only affects cases where
`fallbackToMimetype` is explicitly enabled. All existing behavior is preserved.
