### PR TITLE
fix(common) add graphql to context type

### DIFF
--- a/packages/common/interfaces/features/arguments-host.interface.ts
+++ b/packages/common/interfaces/features/arguments-host.interface.ts
@@ -1,4 +1,4 @@
-export type ContextType = 'http' | 'ws' | 'rpc';
+export type ContextType = 'http' | 'ws' | 'rpc' | 'graphql';
 
 /**
  * Methods to obtain request and response objects.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) - Type change
- [ ] Docs have been added / updated (for bug fixes / features) - Type change


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Type change for graphql

## What is the current behavior?
* My company uses nest a lot with graphql and i noticed the graphql is missing from this const forcing me to use any or cast type even though `graphql` is a valid type here. This is helpful when you have differnt types of endpoints like api and graphql.

Issue Number: N/A


## What is the new behavior?
* Properly type graphql to the context type

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Sample code
```
import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
import { GqlExecutionContext } from "@nestjs/graphql";
import { Request } from "express";
import { logger } from "src/observability/logger";
import { Auth0Service } from "./auth0-service";
import { JwtService } from "./jwt-service";

@Injectable()
export class AuthGuard implements CanActivate {
	constructor(
		private readonly jwtService: JwtService,
		private readonly auth0Service: Auth0Service,
	) {}

	async canActivate(context: ExecutionContext): Promise<boolean> {
		let request: Request;
		if (context.getType() === "http") {
			request = context.switchToHttp().getRequest();
		} else {
			logger.info(`GraphQL context`, { type: context.getType() }); // <- info: GraphQL context {"timestamp":"2025-12-10 08:14:38","type":"graphql"}
			const gqlContext = GqlExecutionContext.create(context);
			request = gqlContext.getContext().req;
		}
		const token = request.headers?.authorization?.split(" ")[1];
		if (!token) {
			return false;
		}
		const payload = await this.jwtService.validateRequest(request);
		if (!payload) {
			return false;
		}
		const user = await this.auth0Service.getUserByIdentity(
			payload.sub as string,
		);
		if (!user) {
			return false;
		}
		logger.info(`Authenticated user`, { user });
		(request as Request & { user: unknown }).user = user;
		return true;
	}
}
```