### PR TITLE
feat: allow multiple module paths in router module

### DIFF
--- a/integration/hello-world/e2e/router-module.spec.ts
+++ b/integration/hello-world/e2e/router-module.spec.ts
@@ -48,7 +48,10 @@ describe('RouterModule', () => {
     },
   ];
   const routes2: Routes = [
-    { path: 'v1', children: [AuthModule, PaymentsModule, NoSlashModule] },
+    {
+      path: ['v1', 'v2'],
+      children: [AuthModule, PaymentsModule, NoSlashModule],
+    },
   ];
 
   @Module({
@@ -90,6 +93,12 @@ describe('RouterModule', () => {
   it('should hit the "NoSlashController"', async () => {
     return request(app.getHttpServer())
       .get('/v1/no-slash-controller')
+      .expect(200, 'NoSlashController');
+  });
+
+  it('should hit the "NoSlashController on v2"', async () => {
+    return request(app.getHttpServer())
+      .get('/v2/no-slash-controller')
       .expect(200, 'NoSlashController');
   });
 

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -30,6 +30,13 @@ export const addLeadingSlash = (path?: string): string =>
       : path
     : '';
 
+export const normalizePaths = (paths: string | string[]): string[] => {
+  if (Array.isArray(paths)) {
+    return paths.map(path => normalizePath(path));
+  }
+  return [normalizePath(paths)];
+};
+
 export const normalizePath = (path?: string): string =>
   path
     ? path.startsWith('/')

--- a/packages/core/middleware/routes-mapper.ts
+++ b/packages/core/middleware/routes-mapper.ts
@@ -91,25 +91,31 @@ export class RoutesMapper {
 
     const toRouteInfo = (item: RouteDefinition, prefix: string) =>
       item.path?.flatMap(p => {
-        let endpointPath = modulePath ?? '';
-        endpointPath += this.normalizeGlobalPath(prefix) + addLeadingSlash(p);
+        const endpointPaths = modulePath ?? [''];
 
-        const routeInfo: RouteInfo = {
-          path: endpointPath,
-          method: item.requestMethod,
-        };
-        const version = item.version ?? controllerVersion;
-        if (version && versioningConfig) {
-          if (typeof version !== 'string' && Array.isArray(version)) {
-            return version.map(v => ({
-              ...routeInfo,
-              version: toUndefinedIfNeural(v),
-            }));
+        return endpointPaths.flatMap(endpointPath => {
+          const fullPath =
+            endpointPath +
+            this.normalizeGlobalPath(prefix) +
+            addLeadingSlash(p);
+
+          const routeInfo: RouteInfo = {
+            path: fullPath,
+            method: item.requestMethod,
+          };
+          const version = item.version ?? controllerVersion;
+          if (version && versioningConfig) {
+            if (typeof version !== 'string' && Array.isArray(version)) {
+              return version.map(v => ({
+                ...routeInfo,
+                version: toUndefinedIfNeural(v),
+              }));
+            }
+            routeInfo.version = toUndefinedIfNeural(version);
           }
-          routeInfo.version = toUndefinedIfNeural(version);
-        }
 
-        return routeInfo;
+          return routeInfo;
+        });
       });
 
     return ([] as string[])
@@ -158,7 +164,7 @@ export class RoutesMapper {
 
   private getModulePath(
     metatype: Type<unknown> | undefined,
-  ): string | undefined {
+  ): string[] | undefined {
     if (!metatype) {
       return;
     }

--- a/packages/core/router/interfaces/route-path-metadata.interface.ts
+++ b/packages/core/router/interfaces/route-path-metadata.interface.ts
@@ -18,9 +18,9 @@ export interface RoutePathMetadata {
   globalPrefix?: string;
 
   /**
-   * Module-level path registered through the "RouterModule".
+   * Module-level path or paths registered through the "RouterModule".
    */
-  modulePath?: string;
+  modulePath?: string | string[];
 
   /**
    * Controller-level version (e.g., @Controller({ version: '1.0' }) = "1.0").

--- a/packages/core/router/interfaces/routes.interface.ts
+++ b/packages/core/router/interfaces/routes.interface.ts
@@ -1,7 +1,7 @@
 import { Type } from '@nestjs/common';
 
 export interface RouteTree {
-  path: string;
+  path: string | string[];
   module?: Type<any>;
   children?: (RouteTree | Type<any>)[];
 }

--- a/packages/core/router/router-module.ts
+++ b/packages/core/router/router-module.ts
@@ -1,6 +1,6 @@
 import { DynamicModule, Inject, Module, Type } from '@nestjs/common';
 import { MODULE_PATH } from '@nestjs/common/constants';
-import { normalizePath } from '@nestjs/common/utils/shared.utils';
+import { normalizePaths } from '@nestjs/common/utils/shared.utils';
 import { Module as ModuleClass } from '../injector/module';
 import { ModulesContainer } from '../injector/modules-container';
 import { Routes, RouteTree } from './interfaces';
@@ -58,15 +58,15 @@ export class RouterModule {
   private initialize() {
     const flattenedRoutes = flattenRoutePaths(this.routes);
     flattenedRoutes.forEach(route => {
-      const modulePath = normalizePath(route.path);
-      this.registerModulePathMetadata(route.module, modulePath);
+      const modulePaths = normalizePaths(route.path);
+      this.registerModulePathMetadata(route.module, modulePaths);
       this.updateTargetModulesCache(route.module);
     });
   }
 
   private registerModulePathMetadata(
     moduleCtor: Type<unknown>,
-    modulePath: string,
+    modulePath: string | string[],
   ) {
     Reflect.defineMetadata(
       MODULE_PATH + this.modulesContainer.applicationId,

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -89,7 +89,7 @@ export class RoutesResolver implements Resolver {
     routes: Map<string | symbol | Function, InstanceWrapper<Controller>>,
     moduleName: string,
     globalPrefix: string,
-    modulePath: string,
+    modulePath: string | string[],
     applicationRef: HttpServer,
   ) {
     routes.forEach(instanceWrapper => {
@@ -207,7 +207,9 @@ export class RoutesResolver implements Resolver {
     );
   }
 
-  private getModulePathMetadata(metatype: Type<unknown>): string | undefined {
+  private getModulePathMetadata(
+    metatype: Type<unknown>,
+  ): string | string[] | undefined {
     const modulesContainer = this.container.getModules();
     const modulePath = Reflect.getMetadata(
       MODULE_PATH + modulesContainer.applicationId,

--- a/packages/core/router/utils/flatten-route-paths.util.ts
+++ b/packages/core/router/utils/flatten-route-paths.util.ts
@@ -5,7 +5,7 @@ import { Routes } from '../interfaces/routes.interface';
 export function flattenRoutePaths(routes: Routes) {
   const result: Array<{
     module: Type;
-    path: string;
+    path: string | string[];
   }> = [];
   routes.forEach(item => {
     if (item.module && item.path) {
@@ -14,10 +14,30 @@ export function flattenRoutePaths(routes: Routes) {
     if (item.children) {
       const childrenRef = item.children as Routes;
       childrenRef.forEach(child => {
-        if (!isString(child) && isString(child.path)) {
-          child.path = normalizePath(
-            normalizePath(item.path) + normalizePath(child.path),
-          );
+        if (
+          !isString(child) &&
+          (isString(child.path) || Array.isArray(child.path))
+        ) {
+          const normalizedChildPaths: string[] = [];
+          const parentPaths = Array.isArray(item.path)
+            ? item.path
+            : [item.path];
+          for (const parentPath of parentPaths) {
+            const childPaths = Array.isArray(child.path)
+              ? child.path
+              : [child.path];
+            for (const childPath of childPaths) {
+              normalizedChildPaths.push(
+                normalizePath(
+                  normalizePath(parentPath) + normalizePath(childPath),
+                ),
+              );
+            }
+          }
+          child.path =
+            normalizedChildPaths.length === 1
+              ? normalizedChildPaths[0]
+              : normalizedChildPaths;
         } else {
           result.push({ path: item.path, module: child as any as Type });
         }

--- a/packages/core/test/router/utils/flat-routes.spec.ts
+++ b/packages/core/test/router/utils/flat-routes.spec.ts
@@ -21,6 +21,12 @@ describe('flattenRoutePaths', () => {
     @Module({})
     class ChildModule6 {}
     @Module({})
+    class ChildModule7 {}
+    @Module({})
+    class ChildModule8 {}
+    @Module({})
+    class ChildModule9 {}
+    @Module({})
     class ChildParentPathModule {}
     @Module({})
     class ParentChildModule {}
@@ -95,6 +101,23 @@ describe('flattenRoutePaths', () => {
               },
             ],
           },
+          {
+            path: ['/child5', '/child6', '/child7'],
+            children: [
+              {
+                path: '',
+                module: ChildModule7,
+              },
+              {
+                path: '/child8',
+                module: ChildModule8,
+              },
+              {
+                path: ['/child9', '/child10'],
+                module: ChildModule9,
+              },
+            ],
+          },
         ],
       },
       { path: '/v1', children: [AuthModule, CatsModule, DogsModule] },
@@ -119,6 +142,29 @@ describe('flattenRoutePaths', () => {
       { path: '/parent/child3', module: ChildModule5 },
       { path: '/parent/child3/child', module: ChildParentPathModule },
       { path: '/parent/child4', module: ChildModule6 },
+      {
+        path: ['/parent/child5', '/parent/child6', '/parent/child7'],
+        module: ChildModule7,
+      },
+      {
+        path: [
+          '/parent/child5/child8',
+          '/parent/child6/child8',
+          '/parent/child7/child8',
+        ],
+        module: ChildModule8,
+      },
+      {
+        path: [
+          '/parent/child5/child9',
+          '/parent/child5/child10',
+          '/parent/child6/child9',
+          '/parent/child6/child10',
+          '/parent/child7/child9',
+          '/parent/child7/child10',
+        ],
+        module: ChildModule9,
+      },
       { path: '/v1', module: AuthModule },
       { path: '/v1', module: CatsModule },
       { path: '/v1', module: DogsModule },
@@ -127,6 +173,8 @@ describe('flattenRoutePaths', () => {
       { path: '/v3', module: AuthModule3 },
       { path: '/v3', module: CatsModule3 },
     ];
-    expect(flattenRoutePaths(routes)).to.be.eql(expectedRoutes);
+    const result = flattenRoutePaths(routes);
+    console.log(result);
+    expect(result).to.be.eql(expectedRoutes);
   });
 });

--- a/sample/01-cats-app/src/core/interceptors/transform.interceptor.ts
+++ b/sample/01-cats-app/src/core/interceptors/transform.interceptor.ts
@@ -12,9 +12,10 @@ export interface Response<T> {
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
-{
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
   intercept(
     context: ExecutionContext,
     next: CallHandler<T>,

--- a/sample/10-fastify/src/core/interceptors/transform.interceptor.ts
+++ b/sample/10-fastify/src/core/interceptors/transform.interceptor.ts
@@ -12,9 +12,10 @@ export interface Response<T> {
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
-{
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
   intercept(
     context: ExecutionContext,
     next: CallHandler<T>,


### PR DESCRIPTION
The Router module allows defining multiple paths for a module. This enhancement updates the route resolution logic to accommodate multiple paths, ensuring that all specified paths are correctly registered and logged.

Controllers allow the definition of multiple basePaths like this:
@Controller(['equipment/:assetId', 'assets/:assetId'])

I want to bring the same functionality to the RouteModule such that we can nest controllers like this:
RouterModule.register([ { path: ['equipment/:assetId', 'assets/:assetId'], module: AssetModule, } ]),

Closes #16052

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information