### PR TITLE
test: add unit and e2e tests for sample 08-webpack

### DIFF
--- a/sample/08-webpack/.gitignore
+++ b/sample/08-webpack/.gitignore
@@ -13,7 +13,7 @@ npm-debug.log
 /quick-start
 
 # tests
-/test
+/test/coverage
 /coverage
 /.nyc_output
 

--- a/sample/08-webpack/jest.config.js
+++ b/sample/08-webpack/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  rootDir: 'src',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest',
+  },
+  collectCoverageFrom: ['**/*.(t|j)s'],
+  coverageDirectory: '../coverage',
+  testEnvironment: 'node',
+};

--- a/sample/08-webpack/package.json
+++ b/sample/08-webpack/package.json
@@ -8,8 +8,8 @@
     "build:dev": "nest build --watch --webpack --webpackPath webpack-hmr.config.js",
     "start": "node dist/main",
     "lint": "eslint '{src,apps,libs,test}/**/*.ts' --fix",
-    "test": "echo 'No tests implemented yet.'",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test": "jest",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.9",
@@ -24,16 +24,22 @@
     "@eslint/js": "9.39.1",
     "@nestjs/cli": "11.0.14",
     "@nestjs/schematics": "11.0.9",
-    "@types/node": "24.10.3",
+    "@nestjs/testing": "^11.1.9",
+    "@types/jest": "^30.0.0",
+    "@types/node": "^24.10.3",
+    "@types/supertest": "^6.0.3",
     "eslint": "9.39.1",
     "eslint-plugin-prettier": "5.5.4",
     "globals": "16.5.0",
+    "jest": "^30.2.0",
     "start-server-webpack-plugin": "2.2.5",
+    "supertest": "^7.1.4",
+    "ts-jest": "^29.4.6",
     "ts-loader": "9.5.4",
     "ts-node": "10.9.2",
+    "typescript-eslint": "8.49.0",
     "webpack": "5.103.0",
     "webpack-cli": "6.0.1",
-    "webpack-node-externals": "3.0.0",
-    "typescript-eslint": "8.49.0"
+    "webpack-node-externals": "3.0.0"
   }
 }

--- a/sample/08-webpack/src/app.controller.spec.ts
+++ b/sample/08-webpack/src/app.controller.spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+describe('AppController', () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+      providers: [AppService],
+    }).compile();
+
+    appController = module.get<AppController>(AppController);
+  });
+
+  it('should be defined', () => {
+    expect(appController).toBeDefined();
+  });
+
+  it('should return "Hello World!"', () => {
+    expect(appController.getHello()).toBe('Hello world!');
+  });
+});

--- a/sample/08-webpack/src/app.service.spec.ts
+++ b/sample/08-webpack/src/app.service.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppService],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return "Hello World!"', () => {
+    expect(service.getHello()).toBe('Hello world!');
+  });
+});

--- a/sample/08-webpack/test/app.e2e-spec.ts
+++ b/sample/08-webpack/test/app.e2e-spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from './../src/app.module';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('/ (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello world!');
+  });
+});

--- a/sample/08-webpack/test/jest-e2e.json
+++ b/sample/08-webpack/test/jest-e2e.json
@@ -1,0 +1,9 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": ".",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  }
+}


### PR DESCRIPTION
## Description
Adds comprehensive test coverage for the `08-webpack` sample application.

## Changes
- Add Jest configuration for unit and e2e tests
- Add unit tests for `AppController` and `AppService`  
- Add e2e test for GET / endpoint
- Update `.gitignore` to allow test folder while ignoring coverage
- Install required testing dependencies (jest, supertest, @types/jest, @types/supertest)

## Test Results
All tests passing:
- Unit tests: 4 passed (AppController: 2, AppService: 2)
- E2e tests: 1 passed

Closes #14508
