### PR TITLE
test(common): Add missing tests for StreamableFile

### DIFF
--- a/packages/common/test/file-stream/streamable-file.spec.ts
+++ b/packages/common/test/file-stream/streamable-file.spec.ts
@@ -19,6 +19,13 @@ describe('StreamableFile', () => {
       expect(streamableFile.getStream()).to.equal(stream);
     });
   });
+  describe('when input is neither Uint8Array nor has pipe method', () => {
+    it('should not set stream property', () => {
+      const invalidInput = { notPipe: true };
+      const streamableFile = new StreamableFile(invalidInput as any);
+      expect(streamableFile.getStream()).to.be.undefined;
+    });
+  });
   describe('when options is empty', () => {
     it('should return application/octet-stream for type and undefined for others', () => {
       const stream = new Readable();
@@ -153,6 +160,23 @@ describe('StreamableFile', () => {
       const stream = new Readable();
       const streamableFile = new StreamableFile(stream);
       expect(streamableFile.errorLogger).to.be.a('function');
+    });
+
+    describe('default error logger behavior', () => {
+      it('should call logger.error with the error', () => {
+        const stream = new Readable();
+        const streamableFile = new StreamableFile(stream);
+        const loggerErrorStub = sinon.stub(
+          (streamableFile as any).logger,
+          'error',
+        );
+        const error = new Error('test error');
+
+        streamableFile.errorLogger(error);
+
+        expect(loggerErrorStub.calledOnceWith(error)).to.be.true;
+        loggerErrorStub.restore();
+      });
     });
   });
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Test coverage improvement

## What is the current behavior?
The `StreamableFile` class in `packages/common/file-stream/` has 97.06% test coverage with two uncovered areas:
1. Default `logError` function body (`this.logger.error(err)`)
2. Edge case when constructor receives input that is neither `Uint8Array` nor has `pipe` method

Issue Number: N/A

## What is the new behavior?
Added 2 additional test cases:
1. **Default error logger behavior**: Verifies that `logger.error` is called with the error
2. **Invalid input edge case**: Verifies that `stream` property remains undefined when input lacks `pipe` method

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
- **Coverage improvement**: 97.06% → 100%
- **Tests added**: 2 new test cases (total: 17)
- All tests passing locally
- This is a follow-up to PR #16047 which initially added StreamableFile tests