### PR TITLE
fix(microservices): fix grpc stream method return type

### DIFF
--- a/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
+++ b/packages/microservices/test/decorators/message-pattern.decorator.spec.ts
@@ -247,6 +247,18 @@ describe('@GrpcStreamMethod', () => {
       streaming: GrpcMethodStreamingType.RX_STREAMING,
     });
   });
+
+  it('should return Observable directly (not wrapped in Promise) when called method directly', () => {
+    class TestService {
+      @GrpcStreamMethod()
+      test(data$: any) {
+        return data$;
+      }
+    }
+    const service = new TestService();
+    const result = service.test({});
+    expect(result).to.not.have.property('then');
+  });
 });
 
 describe('@GrpcStreamCall', () => {


### PR DESCRIPTION
Ensure GrpcStreamMethod returns Observable directly instead of wrapping it in a Promise when called locally.

Closes #15953

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information