### PR TITLE
fix(common): resolve file-type path explicitly

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -79,7 +79,12 @@ export class FileTypeValidator extends FileValidator<
     }
 
     try {
-      const fileTypePath = require.resolve('file-type');
+      let fileTypePath: string;
+      try {
+        fileTypePath = require.resolve('file-type');
+      } catch {
+        fileTypePath = 'file-type';
+      }
       const { fileTypeFromBuffer } =
         await loadEsm<typeof import('file-type')>(fileTypePath);
       const fileType = await fileTypeFromBuffer(file.buffer);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature

## What is the current behavior?
The `FileTypeValidator` uses `loadEsm('file-type')` which can resolve to an incorrect version of `file-type` in monorepos or when dependencies are hoisted, leading to validation failures with cryptic error messages.

Issue Number: #15270

## What is the new behavior?
The validator now explicitly resolves the path to the `file-type` dependency using `require.resolve('file-type')` before importing it. This ensures that the version of `file-type` declared in `@nestjs/common` is used.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No