### PR TITLE
feat(sample): add hmr with esm example

### DIFF
--- a/sample/36-hmr-esm/.gitignore
+++ b/sample/36-hmr-esm/.gitignore
@@ -1,0 +1,18 @@
+# dependencies
+/node_modules
+
+# IDE
+/.idea
+/.awcache
+/.vscode
+
+# misc
+npm-debug.log
+
+# tests
+/test
+/coverage
+/.nyc_output
+
+# dist
+/dist

--- a/sample/36-hmr-esm/e2e/cats/cats.e2e-spec.ts
+++ b/sample/36-hmr-esm/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,34 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { CatsModule } from '../../src/cats/cats.module';
+import { CatsService } from '../../src/cats/cats.service';
+import { CoreModule } from '../../src/core/core.module';
+
+describe('Cats', () => {
+  const catsService = { findAll: () => ['test'] };
+
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CatsModule, CoreModule],
+    })
+      .overrideProvider(CatsService)
+      .useValue(catsService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  it(`/GET cats`, () => {
+    return request(app.getHttpServer()).get('/cats').expect(200).expect({
+      data: catsService.findAll(),
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/sample/36-hmr-esm/e2e/jest-e2e.json
+++ b/sample/36-hmr-esm/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/36-hmr-esm/eslint.config.mjs
+++ b/sample/36-hmr-esm/eslint.config.mjs
@@ -1,0 +1,42 @@
+// @ts-check
+import eslint from '@eslint/js';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  {
+    ignores: ['eslint.config.mjs'],
+  },
+  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
+  eslintPluginPrettierRecommended,
+  {
+    languageOptions: {
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+      ecmaVersion: 5,
+      sourceType: 'module',
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/no-unsafe-return': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-call': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/require-await': 'warn',
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+);

--- a/sample/36-hmr-esm/jest.json
+++ b/sample/36-hmr-esm/jest.json
@@ -1,0 +1,14 @@
+{
+  "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/src/.*\\.(test|spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/36-hmr-esm/package.json
+++ b/sample/36-hmr-esm/package.json
@@ -1,0 +1,77 @@
+{
+  "name": "nest-typescript-starter",
+  "version": "1.0.0",
+  "description": "Nest TypeScript starter repository",
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "nest build",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "start:debug": "nest start --debug --watch",
+    "start:dev:hmr": "nest build --webpack --webpackPath webpack-hmr.config.cjs --watch",
+    "start:prod": "node dist/main",
+    "lint": "eslint '{src,apps,libs,test}/**/*.ts' --fix",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
+  },
+  "dependencies": {
+    "@nestjs/common": "11.1.9",
+    "@nestjs/core": "11.1.9",
+    "@nestjs/platform-express": "11.1.9",
+    "class-transformer": "0.5.1",
+    "class-validator": "0.14.3",
+    "reflect-metadata": "0.2.2",
+    "rimraf": "6.1.2",
+    "rxjs": "7.8.2"
+  },
+  "devDependencies": {
+    "run-script-webpack-plugin": "0.2.0",
+    "webpack": "5.97.1",
+    "webpack-node-externals": "3.0.0",
+    "@eslint/eslintrc": "3.3.3",
+    "@eslint/js": "9.39.2",
+    "@nestjs/cli": "11.0.14",
+    "@nestjs/schematics": "11.0.9",
+    "@nestjs/testing": "11.1.9",
+    "@types/express": "5.0.6",
+    "@types/jest": "30.0.0",
+    "@types/node": "24.10.3",
+    "@types/supertest": "6.0.3",
+    "@types/webpack-env": "1.18.5",
+    "jest": "30.2.0",
+    "prettier": "3.7.4",
+    "supertest": "7.1.4",
+    "ts-jest": "29.4.6",
+    "ts-loader": "9.5.4",
+    "ts-node": "10.9.2",
+    "tsconfig-paths": "4.2.0",
+    "eslint": "9.39.2",
+    "eslint-plugin-prettier": "5.5.4",
+    "globals": "16.5.0",
+    "typescript": "5.9.3",
+    "typescript-eslint": "8.49.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
+  }
+}

--- a/sample/36-hmr-esm/src/app.module.ts
+++ b/sample/36-hmr-esm/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CatsModule } from './cats/cats.module';
+import { CoreModule } from './core/core.module';
+
+@Module({
+  imports: [CoreModule, CatsModule],
+})
+export class AppModule {}

--- a/sample/36-hmr-esm/src/cats/cats.controller.spec.ts
+++ b/sample/36-hmr-esm/src/cats/cats.controller.spec.ts
@@ -1,0 +1,54 @@
+import { Test } from '@nestjs/testing';
+import { CatsController } from './cats.controller';
+import { CatsService } from './cats.service';
+import { Cat } from './interfaces/cat.interface';
+
+describe('CatsController', () => {
+  let catsController: CatsController;
+  let catsService: CatsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [CatsController],
+      providers: [CatsService],
+    }).compile();
+
+    catsService = moduleRef.get<CatsService>(CatsService);
+    catsController = moduleRef.get<CatsController>(CatsController);
+  });
+
+  describe('findAll', () => {
+    it('should return an array of cats', async () => {
+      const cats: Cat[] = [
+        {
+          age: 2,
+          breed: 'Bombay',
+          name: 'Pixel',
+        },
+      ];
+      // @ts-ignore
+      catsService.cats = cats;
+
+      expect(await catsController.findAll()).toBe(cats);
+    });
+  });
+
+  describe('create', () => {
+    it('should add a new cat', async () => {
+      const cat: Cat = {
+        age: 2,
+        breed: 'Bombay',
+        name: 'Pixel',
+      };
+      const expectedCatArray = [cat];
+
+      // @ts-ignore
+      expect(catsService.cats).toStrictEqual([]);
+
+      await catsController.create(cat);
+
+      // @ts-ignore
+      expect(catsService.cats).toStrictEqual(expectedCatArray);
+    });
+  });
+});

--- a/sample/36-hmr-esm/src/cats/cats.controller.ts
+++ b/sample/36-hmr-esm/src/cats/cats.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { ParseIntPipe } from '../common/pipes/parse-int.pipe';
+import { CatsService } from './cats.service';
+import { CreateCatDto } from './dto/create-cat.dto';
+import { Cat } from './interfaces/cat.interface';
+
+@UseGuards(RolesGuard)
+@Controller('cats')
+export class CatsController {
+  constructor(private readonly catsService: CatsService) {}
+
+  @Post()
+  @Roles(['admin'])
+  async create(@Body() createCatDto: CreateCatDto) {
+    this.catsService.create(createCatDto);
+  }
+
+  @Get()
+  async findAll(): Promise<Cat[]> {
+    return this.catsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(
+    @Param('id', new ParseIntPipe())
+    id: number,
+  ) {
+    // Retrieve a Cat instance by ID
+    console.log(id);
+  }
+}

--- a/sample/36-hmr-esm/src/cats/cats.module.ts
+++ b/sample/36-hmr-esm/src/cats/cats.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CatsController } from './cats.controller';
+import { CatsService } from './cats.service';
+
+@Module({
+  controllers: [CatsController],
+  providers: [CatsService],
+})
+export class CatsModule {}

--- a/sample/36-hmr-esm/src/cats/cats.service.spec.ts
+++ b/sample/36-hmr-esm/src/cats/cats.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test } from '@nestjs/testing';
+import { CatsService } from './cats.service';
+import { Cat } from './interfaces/cat.interface';
+
+describe('CatsService', () => {
+  let catsService: CatsService;
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [CatsService],
+    }).compile();
+
+    catsService = moduleRef.get<CatsService>(CatsService);
+  });
+
+  describe('findAll', () => {
+    it('should return an array of cats', async () => {
+      const result = [
+        {
+          name: 'Frajola',
+          age: 2,
+          breed: 'Stray',
+        },
+      ];
+      //@ts-ignore
+      catsService.cats = result;
+
+      await expect(catsService.findAll()).resolves.toBe(result);
+    });
+  });
+
+  describe('create', () => {
+    it('should add a new cat', async () => {
+      const cat: Cat = {
+        name: 'Frajola',
+        age: 2,
+        breed: 'Stray',
+      };
+      const expectedCatArray = [cat];
+      //@ts-ignore
+      expect(catsService.cats).toStrictEqual([]);
+
+      catsService.create(cat);
+      //@ts-ignore
+      expect(catsService.cats).toStrictEqual(expectedCatArray);
+    });
+  });
+});

--- a/sample/36-hmr-esm/src/cats/cats.service.ts
+++ b/sample/36-hmr-esm/src/cats/cats.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { Cat } from './interfaces/cat.interface';
+
+@Injectable()
+export class CatsService {
+  private readonly cats: Cat[] = [];
+
+  create(cat: Cat) {
+    this.cats.push(cat);
+  }
+
+  findAll(): Promise<Cat[]> {
+    return Promise.resolve(this.cats);
+  }
+}

--- a/sample/36-hmr-esm/src/cats/dto/create-cat.dto.ts
+++ b/sample/36-hmr-esm/src/cats/dto/create-cat.dto.ts
@@ -1,0 +1,12 @@
+import { IsInt, IsString } from 'class-validator';
+
+export class CreateCatDto {
+  @IsString()
+  readonly name: string;
+
+  @IsInt()
+  readonly age: number;
+
+  @IsString()
+  readonly breed: string;
+}

--- a/sample/36-hmr-esm/src/cats/interfaces/cat.interface.ts
+++ b/sample/36-hmr-esm/src/cats/interfaces/cat.interface.ts
@@ -1,0 +1,5 @@
+export interface Cat {
+  name: string;
+  age: number;
+  breed: string;
+}

--- a/sample/36-hmr-esm/src/common/decorators/roles.decorator.ts
+++ b/sample/36-hmr-esm/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,3 @@
+import { Reflector } from '@nestjs/core';
+
+export const Roles = Reflector.createDecorator<string[]>();

--- a/sample/36-hmr-esm/src/common/filters/http-exception.filter.ts
+++ b/sample/36-hmr-esm/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,22 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter<HttpException> {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+    const statusCode = exception.getStatus();
+
+    response.status(statusCode).json({
+      statusCode,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+    });
+  }
+}

--- a/sample/36-hmr-esm/src/common/guards/roles.guard.ts
+++ b/sample/36-hmr-esm/src/common/guards/roles.guard.ts
@@ -1,0 +1,21 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Roles } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const roles = this.reflector.get(Roles, context.getHandler());
+    if (!roles) {
+      return true;
+    }
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const hasRole = () =>
+      user.roles.some(role => !!roles.find(item => item === role));
+
+    return user && user.roles && hasRole();
+  }
+}

--- a/sample/36-hmr-esm/src/common/interceptors/exception.interceptor.ts
+++ b/sample/36-hmr-esm/src/common/interceptors/exception.interceptor.ts
@@ -1,0 +1,25 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+@Injectable()
+export class ErrorsInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next
+      .handle()
+      .pipe(
+        catchError(err =>
+          throwError(
+            () => new HttpException('New message', HttpStatus.BAD_GATEWAY),
+          ),
+        ),
+      );
+  }
+}

--- a/sample/36-hmr-esm/src/common/interceptors/timeout.interceptor.ts
+++ b/sample/36-hmr-esm/src/common/interceptors/timeout.interceptor.ts
@@ -1,0 +1,15 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+@Injectable()
+export class TimeoutInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle().pipe(timeout(5000));
+  }
+}

--- a/sample/36-hmr-esm/src/common/middleware/logger.middleware.ts
+++ b/sample/36-hmr-esm/src/common/middleware/logger.middleware.ts
@@ -1,0 +1,9 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+@Injectable()
+export class LoggerMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    console.log(`Request...`);
+    next();
+  }
+}

--- a/sample/36-hmr-esm/src/common/pipes/parse-int.pipe.ts
+++ b/sample/36-hmr-esm/src/common/pipes/parse-int.pipe.ts
@@ -1,0 +1,17 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+
+@Injectable()
+export class ParseIntPipe implements PipeTransform<string> {
+  async transform(value: string, metadata: ArgumentMetadata) {
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      throw new BadRequestException('Validation failed');
+    }
+    return val;
+  }
+}

--- a/sample/36-hmr-esm/src/common/pipes/validation.pipe.ts
+++ b/sample/36-hmr-esm/src/common/pipes/validation.pipe.ts
@@ -1,0 +1,30 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+  Type,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+@Injectable()
+export class ValidationPipe implements PipeTransform<any> {
+  async transform(value: any, metadata: ArgumentMetadata) {
+    const { metatype } = metadata;
+    if (!metatype || !this.toValidate(metatype)) {
+      return value;
+    }
+    const object = plainToInstance(metatype, value);
+    const errors = await validate(object);
+    if (errors.length > 0) {
+      throw new BadRequestException('Validation failed');
+    }
+    return value;
+  }
+
+  private toValidate(metatype: Type<any>): boolean {
+    const types = [String, Boolean, Number, Array, Object];
+    return !types.find(type => metatype === type);
+  }
+}

--- a/sample/36-hmr-esm/src/core/core.module.ts
+++ b/sample/36-hmr-esm/src/core/core.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { LoggingInterceptor } from './interceptors/logging.interceptor';
+import { TransformInterceptor } from './interceptors/transform.interceptor';
+
+@Module({
+  providers: [
+    { provide: APP_INTERCEPTOR, useClass: TransformInterceptor },
+    { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
+  ],
+})
+export class CoreModule {}

--- a/sample/36-hmr-esm/src/core/interceptors/logging.interceptor.ts
+++ b/sample/36-hmr-esm/src/core/interceptors/logging.interceptor.ts
@@ -1,0 +1,20 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    console.log('Before...');
+
+    const now = Date.now();
+    return next
+      .handle()
+      .pipe(tap(() => console.log(`After... ${Date.now() - now}ms`)));
+  }
+}

--- a/sample/36-hmr-esm/src/core/interceptors/transform.interceptor.ts
+++ b/sample/36-hmr-esm/src/core/interceptors/transform.interceptor.ts
@@ -1,0 +1,25 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+export interface Response<T> {
+  data: T;
+}
+
+@Injectable()
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<T>,
+  ): Observable<Response<T>> {
+    return next.handle().pipe(map(data => ({ data })));
+  }
+}

--- a/sample/36-hmr-esm/src/main.ts
+++ b/sample/36-hmr-esm/src/main.ts
@@ -1,0 +1,19 @@
+import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+declare const module: any;
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
+
+  await app.listen(process.env.PORT ?? 3000);
+  console.log(`Application is running on: ${await app.getUrl()}`);
+
+  if (module.hot) {
+    module.hot.accept();
+    module.hot.dispose(() => app.close());
+  }
+}
+bootstrap();

--- a/sample/36-hmr-esm/tsconfig.build.json
+++ b/sample/36-hmr-esm/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/sample/36-hmr-esm/tsconfig.json
+++ b/sample/36-hmr-esm/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/sample/36-hmr-esm/webpack-hmr.config.cjs
+++ b/sample/36-hmr-esm/webpack-hmr.config.cjs
@@ -1,0 +1,25 @@
+const nodeExternals = require('webpack-node-externals');
+const { RunScriptWebpackPlugin } = require('run-script-webpack-plugin');
+
+module.exports = function (options, webpack) {
+    return {
+        ...options,
+        entry: ['webpack/hot/poll?100', options.entry],
+        externals: [
+            nodeExternals({
+                allowlist: ['webpack/hot/poll?100'],
+            }),
+        ],
+        output: {
+            filename: 'main.cjs',
+        },
+        plugins: [
+            ...options.plugins,
+            new webpack.HotModuleReplacementPlugin(),
+            new webpack.WatchIgnorePlugin({
+                paths: [/\.js$/, /\.d\.ts$/],
+            }),
+            new RunScriptWebpackPlugin({ name: 'main.cjs', autoRestart: false }),
+        ],
+    };
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Other (Sample)

## What is the current behavior?
Currently, there is no example showing how to configure Hot Module Replacement (HMR) in a project using ESM (`"type": "module"`). When users attempt to standard HMR recipe, they encounter `require is not defined in ES module scope` because the CLI uses `require` to load the webpack configuration.

Issue Number: #14331

## What is the new behavior?
This PR adds `sample/36-hmr-esm`, which demonstrates the correct configuration for HMR with ESM:
1.  Using `"type": "module"` in `package.json`.
2.  Renaming the configuration file to `webpack-hmr.config.cjs` to allow `require` via CommonJS.
3.  Configuring `output.filename: 'main.cjs'` in webpack to ensure correct runtime execution.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No