### PR TITLE
fix(common): Allow fallback to mimetype on magic number mismatch

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -135,7 +135,9 @@ export class FileTypeValidator extends FileValidator<
 
       if (fileType) {
         // Match detected mime type against allowed type
-        return !!fileType.mime.match(this.validationOptions.fileType);
+        if (fileType.mime.match(this.validationOptions.fileType)) {
+          return true;
+        }
       }
 
       /**

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -259,6 +259,24 @@ describe('FileTypeValidator', () => {
 
       expect(await fileTypeValidator.isValid(requestFile)).to.equal(false);
     });
+
+    it('should return true when magic number mismatches but fallbackToMimetype is enabled and mimetype matches', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'text/csv',
+        fallbackToMimetype: true,
+      });
+
+      const jpegBuffer = Buffer.from([
+        0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
+      ]);
+
+      const requestFile = {
+        mimetype: 'text/csv',
+        buffer: jpegBuffer,
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
+    });
   });
 
   describe('buildErrorMessage', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, FileTypeValidator immediately fails validation if magic number detection returns a MIME type that mismatches the expected type, even if `fallbackToMimetype: true` is enabled.

Issue Number: #16110


## What is the new behavior?

When magic number detection fails (including mismatches), the validator now correctly proceeds to check the `fallbackToMimetype` option. If enabled, it validates against the file's mimetype string, allowing valid files to pass even if their magic numbers were misidentified.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information