### PR TITLE
fix(core): add missing catch handler for forward-ref provider resolution

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -553,9 +553,13 @@ export class Injector {
        * instantiated beforehand.
        */
       instanceHost.donePromise &&
-        void instanceHost.donePromise.then(() =>
-          this.loadProvider(instanceWrapper, moduleRef, contextId, inquirer),
-        );
+        void instanceHost.donePromise
+          .then(() =>
+            this.loadProvider(instanceWrapper, moduleRef, contextId, inquirer),
+          )
+          .catch(err => {
+            instanceWrapper.settlementSignal?.error(err);
+          });
     }
     if (instanceWrapper.async) {
       const host = instanceWrapper.getInstanceByContextId(


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?

### Why is this a problem?
1. No .catch() handler → The error becomes an unhandled promise rejection
2. No settlementSignal.error() called → Other providers waiting on donePromise never receive the error
3. Waiting providers hang forever or receive undefined instead of a proper error

When a `forwardRef` provider fails to load in a non-static context (REQUEST/TRANSIENT scope), the error is silently swallowed. This happens because the promise chain in `resolveComponentHost` uses fire-and-forget pattern without a `.catch()` handler, causing unhandled promise rejections.


## What is the new behavior?
Added a `.catch()` handler that propagates errors through `settlementSignal.error()`, matching the existing error handling pattern used elsewhere in the injector.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
- This fix follows the same error propagation pattern already used in `loadInstance` (lines 196-203).
- Added testcode