### PR TITLE
test(core): add regression test for request scope bubbling

### DIFF
--- a/integration/injector/e2e/request-scope-bubbling.spec.ts
+++ b/integration/injector/e2e/request-scope-bubbling.spec.ts
@@ -1,0 +1,48 @@
+import { Injectable, Scope, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ContextIdFactory, REQUEST } from '@nestjs/core';
+import { expect } from 'chai';
+
+describe('Request Scope Bubbling', () => {
+  // 1. Define the "Poison" (Request Scoped Service)
+  @Injectable({ scope: Scope.REQUEST })
+  class ChildService {
+    // A random ID to verify uniqueness
+    public readonly id = Math.random();
+  }
+
+  // 2. Define the "Victim" (Singleton that depends on Request Scoped)
+  @Injectable()
+  class ParentService {
+    constructor(public readonly child: ChildService) {}
+  }
+
+  @Module({
+    providers: [ChildService, ParentService],
+  })
+  class TestModule {}
+
+  it('should downgrade a Singleton to Request-Scoped if it depends on a Request-Scoped provider', async () => {
+    // 3. Bootstrap the Module (using Test.createTestingModule instead of NestFactory)
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      imports: [TestModule],
+    }).compile();
+
+    // 4. Simulate Request 1
+    const contextId1 = ContextIdFactory.create();
+    const parent1 = await moduleRef.resolve(ParentService, contextId1);
+
+    // 5. Simulate Request 2
+    const contextId2 = ContextIdFactory.create();
+    const parent2 = await moduleRef.resolve(ParentService, contextId2);
+
+    // 6. Assertions (The "Moment of Truth")
+
+    // The Child IDs should be different (Proof of Request Scope)
+    expect(parent1.child.id).to.not.equal(parent2.child.id);
+
+    // The Parent instances should ALSO be different (Proof of Bubbling)
+    // If Parent was a true Singleton, these would be equal.
+    expect(parent1).to.not.equal(parent2);
+  });
+});


### PR DESCRIPTION
This adds an integration test to ensure that a Singleton service injected with a Request-Scoped dependency is correctly downgraded to Request-Scoped. This prevents future regressions in scope bubbling behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Test (Regression)

## What is the current behavior?
Currently, there is no explicit integration test in the codebase ensuring that a Singleton service injected with a Request-Scoped dependency is correctly downgraded to Request-Scoped (Scope Bubbling). While the mechanism works, the lack of a specific regression test leaves this architectural behavior vulnerable to accidental breakage in future updates.

Issue Number: N/A


## What is the new behavior?
Added a new integration test file (integration/injector/e2e/request-scope-bubbling.spec.ts) that:
1. Defines a Singleton Parent and a Request-Scoped Child.
2. Simulates two distinct requests.
3. Asserts that the Parent service instance is different for each request (confirming it was downgraded/bubbled correctly).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This test passes locally and validates the core Injector behavior regarding scope hierarchy.