### PR TITLE
feat(common): add parse string pipe for primitive string parameters

### DIFF
--- a/packages/common/pipes/index.ts
+++ b/packages/common/pipes/index.ts
@@ -8,3 +8,4 @@ export * from './parse-float.pipe';
 export * from './parse-int.pipe';
 export * from './parse-uuid.pipe';
 export * from './validation.pipe';
+export * from './parse-string.pipe';

--- a/packages/common/pipes/parse-string.pipe.ts
+++ b/packages/common/pipes/parse-string.pipe.ts
@@ -1,0 +1,85 @@
+import { Injectable, Optional } from '../decorators/core';
+import { ArgumentMetadata, HttpStatus } from '../index';
+import { PipeTransform } from '../interfaces/features/pipe-transform.interface';
+import {
+  ErrorHttpStatusCode,
+  HttpErrorByCode,
+} from '../utils/http-error-by-code.util';
+import { isNil } from '../utils/shared.utils';
+
+/**
+ * @publicApi
+ */
+export interface ParseStringPipeOptions {
+  /**
+   * If true, the pipe will return null or undefined if the value is not provided
+   * @default false
+   */
+  optional?: boolean;
+
+  /**
+   * The HTTP status code to be used in the response when the validation fails.
+   */
+  errorHttpStatusCode?: ErrorHttpStatusCode;
+
+  /**
+   * A factory function that returns an exception object to be thrown
+   * if validation fails.
+   * @param error Error message
+   * @returns The exception object
+   */
+  exceptionFactory?: (error: string) => any;
+}
+
+/**
+ * Defines the built-in ParseString Pipe
+ *
+ * @see [Built-in Pipes](https://docs.nestjs.com/pipes#built-in-pipes)
+ *
+ * @publicApi
+ */
+@Injectable()
+export class ParseStringPipe implements PipeTransform<string> {
+  protected exceptionFactory: (error: string) => any;
+
+  constructor(@Optional() protected readonly options?: ParseStringPipeOptions) {
+    options = options || {};
+    const { exceptionFactory, errorHttpStatusCode = HttpStatus.BAD_REQUEST } =
+      options;
+
+    this.exceptionFactory =
+      exceptionFactory ||
+      (error => new HttpErrorByCode[errorHttpStatusCode](error));
+  }
+
+  /**
+   * Method that accesses and performs optional transformation on argument for
+   * in-flight requests.
+   *
+   * @param value currently processed route argument
+   * @param metadata contains metadata about the currently processed route argument
+   */
+  async transform(value: string, metadata: ArgumentMetadata): Promise<string> {
+    if (isNil(value) && this.options?.optional) {
+      return value;
+    }
+
+    if (!this.isString(value)) {
+      throw this.exceptionFactory('Validation failed (string is expected)');
+    }
+
+    const trimmed = value.trim();
+
+    if (trimmed.length === 0) {
+      throw this.exceptionFactory(
+        'Validation failed (non-empty string is expected)',
+      );
+    }
+
+    return trimmed;
+  }
+
+  protected isString(value: unknown): value is string {
+    return typeof value === 'string';
+  }
+}

--- a/packages/common/test/pipes/parse-string.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-string.pipe.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { HttpException } from '../../exceptions';
+import { ArgumentMetadata } from '../../interfaces';
+import { ParseStringPipe } from '../../pipes/parse-string.pipe';
+
+class CustomTestError extends HttpException {
+  constructor() {
+    super('This is a TestException', 418);
+  }
+}
+
+describe('ParseStringPipe', () => {
+  let target: ParseStringPipe;
+  const metadata = {} as ArgumentMetadata;
+
+  beforeEach(() => {
+    target = new ParseStringPipe({
+      exceptionFactory: () => new CustomTestError(),
+    });
+  });
+
+  describe('transform', () => {
+    describe('when validation passes', () => {
+      it('should return trimmed string', async () => {
+        const value = '  nestjs ';
+        expect(await target.transform(value, metadata)).to.equal('nestjs');
+      });
+
+      it('should not throw an error if the value is undefined/null and optional is true', async () => {
+        const optionalTarget = new ParseStringPipe({ optional: true });
+        const value = await optionalTarget.transform(undefined!, metadata);
+        expect(value).to.equal(undefined);
+      });
+    });
+
+    describe('when validation fails', () => {
+      it('should throw an error if value is not a string', async () => {
+        return expect(
+          target.transform(123 as any, metadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+
+      it('should throw an error if string is empty after trimming', async () => {
+        return expect(target.transform('   ', metadata)).to.be.rejectedWith(
+          CustomTestError,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

NestJS currently provides built-in pipes for parsing primitive parameters such as `ParseIntPipe` and `ParseEnumPipe`.  
However, there is no built-in pipe for validating **non-empty string parameters**, which requires manual trimming and empty-checking in application code.

## What is the new behavior?

Added `ParseStringPipe`, a built-in pipe for validating string-based route or query parameters:

```ts
@Get()
find(
  @Query('search', ParseStringPipe) search: string,
) {
  return this.service.find(search);
}
```

## Does this PR introduce a breaking change? 
- [ ] Yes 
- [x] No