### PR TITLE
fix(express): Update express to 4.22.1 to address CVE-2025-15284

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "class-transformer": "0.5.1",
         "class-validator": "0.14.1",
         "cors": "2.8.5",
-        "express": "4.21.2",
+        "express": "4.22.1",
         "fast-json-stringify": "6.0.0",
         "fast-safe-stringify": "2.1.1",
         "file-type": "20.4.1",
@@ -16736,39 +16736,39 @@
       "license": "Apache-2.0"
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.14.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
@@ -16779,15 +16779,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -16810,6 +16801,21 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/express/node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "cors": "2.8.5",
-    "express": "4.21.2",
+    "express": "4.22.1",
     "fast-json-stringify": "6.0.0",
     "fast-safe-stringify": "2.1.1",
     "file-type": "20.4.1",

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "body-parser": "1.20.3",
     "cors": "2.8.5",
-    "express": "4.21.2",
+    "express": "4.22.1",
     "multer": "2.0.2",
     "tslib": "2.8.1"
   },


### PR DESCRIPTION
## Summary

Bumps Express from 4.21.2 to 4.22.1 to address CVE-2025-15284 (qs arrayLimit bypass allowing DoS via memory exhaustion).

- Express 4.22.1 uses `qs ~6.14.0` which resolves to `qs@6.14.1` containing the fix
- https://github.com/advisories/GHSA-6rw7-vpxm-498p

## Changes

- `package.json`: express 4.21.2 → 4.22.1
- `packages/platform-express/package.json`: express 4.21.2 → 4.22.1
- `package-lock.json`: updated (qs now at 6.14.1)