### PR TITLE
fix(express): Update express to address CVE-2025-15284

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.3",
     "cors": "2.8.5",
-    "express": "5.2.1",
+    "express": "5.2.2",
     "fast-json-stringify": "6.1.1",
     "fast-safe-stringify": "2.1.1",
     "file-type": "21.3.0",

--- a/packages/platform-express/package.json
+++ b/packages/platform-express/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "cors": "2.8.5",
-    "express": "5.2.1",
+    "express": "5.2.2",
     "multer": "2.0.2",
     "path-to-regexp": "8.3.0",
     "tslib": "2.8.1"


### PR DESCRIPTION
# Summary

A vulnerability in lib qs has been resolved, and Express has updated the version of lib used and will soon release an update incorporating this change.
> - https://github.com/expressjs/express/issues/6968.
> - https://github.com/expressjs/express/pull/6972.

The PR will remain in draft form until the new version is released. If the value differs from the version, it will also be changed along with the update of the lib qs version.

This ensures that Nest implements and makes available the latest and most secure version of Express as quickly as possible.
