### PR TITLE
Decouple Node.js-specific primitives from public KafkaJS type definitions

### DIFF
--- a/packages/microservices/external/kafka.interface.ts
+++ b/packages/microservices/external/kafka.interface.ts
@@ -57,9 +57,16 @@ type Mechanism = {
   authenticationProvider: (args: AuthenticationProviderArgs) => Authenticator;
 };
 
+export interface TlsOptions {
+  ca?: string | Uint8Array;
+  cert?: string | Uint8Array;
+  key?: string | Uint8Array;
+  rejectUnauthorized?: boolean;
+}
+
 export interface KafkaConfig {
   brokers: string[] | BrokersFunction;
-  ssl?: tls.ConnectionOptions | boolean;
+  ssl?: boolean | TlsOptions;
   sasl?: SASLOptions | Mechanism;
   clientId?: string;
   connectionTimeout?: number;
@@ -79,8 +86,14 @@ export interface ISocketFactoryArgs {
   ssl: tls.ConnectionOptions;
   onConnect: () => void;
 }
+export interface KafkaSocket {
+  write(data: Uint8Array): void;
+  end(): void;
+  destroy(): void;
+  on(event: string, listener: (...args: any[]) => void): void;
+}
 
-export type ISocketFactory = (args: ISocketFactoryArgs) => net.Socket;
+export type ISocketFactory = (args: ISocketFactoryArgs) => KafkaSocket;
 
 export interface OauthbearerProviderResponse {
   value: string;
@@ -118,9 +131,12 @@ export interface ProducerConfig {
   maxInFlightRequests?: number;
 }
 
+export type BinaryData = Uint8Array;
+
+
 export interface Message {
-  key?: Buffer | string | null;
-  value: Buffer | string | null;
+  key?: BinaryData | string | null;
+  value: BinaryData | string | null;
   partition?: number;
   headers?: IHeaders;
   timestamp?: string;


### PR DESCRIPTION
This change reduces tight coupling to Node.js by abstracting Node-specific primitives such as Buffer, net.Socket, and tls.ConnectionOptions from the public type surface.

The goal is to improve portability, testability, and long-term maintainability of the type definitions while preserving full compatibility with existing Node.js usage.

No runtime behavior is changed. This refactor only affects type declarations and introduces lightweight, runtime-agnostic abstractions where appropriate.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information