### PR TITLE
fix: add set function to nest-application.interface.ts

### DIFF
--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -163,4 +163,12 @@ export interface INestApplication<
    * @returns {Promise<void>}
    */
   close(): Promise<void>;
+
+  /**
+   * Sets compatibility flags on the application
+   *
+   * @params {string} The flag to set
+   * @params {string} The value of the flag
+   */
+  set(flag, value): void;
 }


### PR DESCRIPTION
Add the missing definition for the `app.set` function to the nest application interface. This fixes an issue where if you follow the migration guide for query parsing in nestJS v11 you will end up with a TypeScript compiler error for the undefined `.set` property. See https://docs.nestjs.com/migration-guide#query-parameters-parsing

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Following the migrations docs and using `app.set` will produce a TS compiler error.

Issue Number: N/A


## What is the new behavior?

The `app.set` function is correctly defined and no compiler error will be produced.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information