### PR TITLE
fix(common): Fix skipping maxArrayLength and maxStringLength option

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -522,10 +522,10 @@ export class ConsoleLogger implements LoggerService {
       breakLength,
     };
 
-    if (this.options.maxArrayLength) {
+    if (typeof this.options.maxArrayLength !== 'undefined') {
       inspectOptions.maxArrayLength = this.options.maxArrayLength;
     }
-    if (this.options.maxStringLength) {
+    if (typeof this.options.maxStringLength !== 'undefined') {
       inspectOptions.maxStringLength = this.options.maxStringLength;
     }
 

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -897,6 +897,36 @@ describe('Logger', () => {
       processStdoutWriteSpy.restore();
     });
 
+    it('should respect maxStringLength when set to 0', () => {
+      const consoleLogger = new ConsoleLogger({
+        colors: false,
+        compact: false,
+        maxStringLength: 0,
+      });
+
+      consoleLogger.log({ name: 'abcdef' });
+
+      expect(processStdoutWriteSpy.calledOnce).to.be.true;
+      expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+        "''... 6 more characters",
+      );
+    });
+
+    it('should respect maxArrayLength when set to 0', () => {
+      const consoleLogger = new ConsoleLogger({
+        colors: false,
+        compact: false,
+        maxArrayLength: 0,
+      });
+
+      consoleLogger.log({ items: ['a', 'b', 'c'] });
+
+      expect(processStdoutWriteSpy.calledOnce).to.be.true;
+      expect(processStdoutWriteSpy.firstCall.firstArg).to.include(
+        '... 3 more items',
+      );
+    });
+
     it('should support custom formatter', () => {
       class CustomConsoleLogger extends ConsoleLogger {
         protected formatMessage(


### PR DESCRIPTION
Fixes #16229

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16229


## What is the new behavior?

Now setting maxArrayLength and maxStringLength to 0 works as described in docs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information