### PR TITLE
fix(core): isolate nested transient providers in static context

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -968,10 +968,11 @@ export class Injector {
   }
 
   /**
-   * For nested TRANSIENT dependencies (TRANSIENT -> TRANSIENT) in non-static contexts,
-   * returns parentInquirer to ensure each parent TRANSIENT gets its own instance.
-   * This is necessary because in REQUEST/DURABLE scopes, the same TRANSIENT wrapper
-   * can be used by multiple parents, causing nested TRANSIENTs to be shared incorrectly.
+   * For nested TRANSIENT dependencies (TRANSIENT -> TRANSIENT),
+   * returns parentInquirer to ensure each parent gets its own instance of nested TRANSIENTs.
+   * This applies to both STATIC and non-static (REQUEST/DURABLE) contexts.
+   * Without this, the same TRANSIENT wrapper can be used by multiple parents,
+   * causing nested TRANSIENTs to be shared incorrectly.
    * For non-TRANSIENT -> TRANSIENT, returns inquirer (current wrapper being created).
    */
   private getEffectiveInquirer(
@@ -980,10 +981,7 @@ export class Injector {
     parentInquirer: InstanceWrapper | undefined,
     contextId: ContextId,
   ): InstanceWrapper | undefined {
-    return dependency?.isTransient &&
-      inquirer?.isTransient &&
-      parentInquirer &&
-      contextId !== STATIC_CONTEXT
+    return dependency?.isTransient && inquirer?.isTransient && parentInquirer
       ? parentInquirer
       : inquirer;
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When multiple DEFAULT scoped providers inject the same TRANSIENT → TRANSIENT chain, the nested TRANSIENT instances are incorrectly shared
- DefaultParent1 → TransientService[1] → NestedTransient[1]
- DefaultParent2 → TransientService[2] → NestedTransient[1]  ← Shared!

This is because `getEffectiveInquirer()` has a `contextId !== STATIC_CONTEXT` condition that excludes STATIC context from nested TRANSIENT isolation logic.

Issue Number: #16257


## What is the new behavior?
Each DEFAULT scoped parent now receives its own isolated nested TRANSIENT chain
- DefaultParent1 → TransientService[1] → NestedTransient[1]
- DefaultParent2 → TransientService[2] → NestedTransient[2]  ← Isolated!


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information
cc. @Legiew