### PR TITLE
fix: logger print invalid context when no stack trace provided

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -574,7 +574,7 @@ export class ConsoleLogger implements LoggerService {
             stack: args[1] as string,
             context: this.context,
           }
-        : this.getContextAndMessagesToPrint(args);
+        : { ...this.getContextAndMessagesToPrint(args) };
     }
 
     const { messages, context } = this.getContextAndMessagesToPrint(args);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using the `ConsoleLogger.error` with two parameters, the logger will assumed that the second parameter is an Error or override of the context. 

If the second parameter not a `string` or an `Error`, it will use the second parameter as the context instead of using the default context of the Logger.

Ex:
```ts
function bootsrap() {
  const logger = new ConsoleLogger('MyCustomLogger');
  logger.error('Unexpected error', { requestId: '123456' });
}
```

Will log 
```sh
{ level: 'error', pid: 1, timestamp: 1770231457646, message: 'Unexpected error', context: { requestId: '123456' } }
```

## What is the new behavior?

When using the `ConsoleLogger.error` with two parameters, when the second parameter is not an Error, the logger will fallback to the default logger logic the detect the context from the provided arguments.

```ts
function bootsrap() {
  const logger = new ConsoleLogger('MyCustomLogger');
  logger.error('Unexpected error', { requestId: '123456' });
}
```

Will log

```sh
{ level: 'error', pid: 1, timestamp: 1770231457646, message: 'Unexpected error', context: 'MyCustomLogger' }
{ level: 'error', pid: 1, timestamp: 1770231457646, message: { requestId: '123456' }, context: 'MyCustomLogger' }
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information