### PR TITLE
test(microservices): verify kafka run options forwarding

### DIFF
--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -339,6 +339,11 @@ export interface KafkaOptions {
     postfixId?: string;
     client?: KafkaConfig;
     consumer?: ConsumerConfig;
+    /**
+     * Options passed to KafkaJS consumer.run().
+     * Note: `partitionsConsumedConcurrently` (KafkaJS parameter) controls
+     * concurrent processing at the partition level (not topic level).
+     */
     run?: Omit<ConsumerRunConfig, 'eachBatch' | 'eachMessage'>;
     subscribe?: Omit<ConsumerSubscribeTopics, 'topics'>;
     producer?: ProducerConfig;

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -256,6 +256,39 @@ describe('ServerKafka', () => {
       expect(run.called).to.be.true;
       expect(connect.called).to.be.true;
     });
+    it('should pass run options with partitionsConsumedConcurrently to consumer.run()', async () => {
+      untypedServer.logger = new NoopLogger();
+      untypedServer.options.run = {
+        partitionsConsumedConcurrently: 5,
+      };
+      await server.listen(callback);
+      await server.bindEvents(untypedServer.consumer);
+
+      expect(run.called).to.be.true;
+      expect(run.firstCall.args[0]).to.include({
+        partitionsConsumedConcurrently: 5,
+      });
+      expect(run.firstCall.args[0]).to.have.property('eachMessage');
+    });
+    it('should pass multiple run options to consumer.run()', async () => {
+      untypedServer.logger = new NoopLogger();
+      untypedServer.options.run = {
+        partitionsConsumedConcurrently: 3,
+        autoCommit: false,
+        autoCommitInterval: 5000,
+      };
+      await server.listen(callback);
+      await server.bindEvents(untypedServer.consumer);
+
+      expect(run.called).to.be.true;
+      const callArg = run.firstCall.args[0];
+      expect(callArg).to.include({
+        partitionsConsumedConcurrently: 3,
+        autoCommit: false,
+        autoCommitInterval: 5000,
+      });
+      expect(callArg).to.have.property('eachMessage');
+    });
   });
 
   describe('getMessageHandler', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Tests + inline JSDoc clarification (no runtime behavior change)

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14590

`ServerKafka` forwards `options.run` to KafkaJS `consumer.run()`, but there is no explicit test coverage proving that `options.run.*` is passed through without being dropped/filtered. Also, `partitionsConsumedConcurrently` is easy to misunderstand as topic-level concurrency although it is partition-level in KafkaJS.

## What is the new behavior?
Adds test coverage to verify `options.run.*` is passed to KafkaJS `consumer.run()` and includes `eachMessage` handler, plus adds a short JSDoc note clarifying that `partitionsConsumedConcurrently` controls partition-level concurrency (KafkaJS parameter), not topic-level.

### Summary
- Add 2 test cases in `packages/microservices/test/server/server-kafka.spec.ts` to verify:
  - `partitionsConsumedConcurrently` is forwarded to `consumer.run()`
  - other `options.run` fields (e.g. `autoCommit`, `autoCommitInterval`) are forwarded as well
- Add a minimal JSDoc note for `KafkaOptions.run` in `packages/microservices/interfaces/microservice-configuration.interface.ts`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

### Test Plan
~~~bash
npm test
npm run lint
npm run build
~~~

### Notes
- No runtime behavior changes; this PR is test coverage + inline contract clarification only.
- Related to #14590 (partition-level concurrency via KafkaJS `partitionsConsumedConcurrently`).