### PR TITLE
feat(common): add error format option to validation pipe

### DIFF
--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -23,6 +23,11 @@ import { isNil, isUndefined } from '../utils/shared.utils.js';
 /**
  * @publicApi
  */
+export type ValidationErrorFormat = 'list' | 'grouped';
+
+/**
+ * @publicApi
+ */
 export interface ValidationPipeOptions extends ValidatorOptions {
   transform?: boolean;
   disableErrorMessages?: boolean;
@@ -33,6 +38,18 @@ export interface ValidationPipeOptions extends ValidatorOptions {
   expectedType?: Type<any>;
   validatorPackage?: ValidatorPackage;
   transformerPackage?: TransformerPackage;
+  /**
+   * Specifies the format of validation error messages.
+   * - 'list': Returns an array of error message strings (default). The response message is `string[]`.
+   * - 'grouped': Returns an object with property paths as keys and arrays of unmodified error messages as values.
+   *   The response message is `Record<string, string[]>`. Custom messages defined in validation decorators
+   *   (e.g., `@IsNotEmpty({ message: 'Name is required' })`) are preserved without parent path prefixes.
+   *
+   * @remarks
+   * When using 'grouped', the `message` property in the error response changes from `string[]` to `Record<string, string[]>`.
+   * If you have exception filters or interceptors that assume `message` is always an array, they will need to be updated.
+   */
+  errorFormat?: ValidationErrorFormat;
 }
 
 let classValidator: any = {} as any;
@@ -59,6 +76,7 @@ export class ValidationPipe implements PipeTransform<any> {
   protected expectedType: Type<any> | undefined;
   protected exceptionFactory: (errors: ValidationError[]) => any;
   protected validateCustomDecorators: boolean;
+  protected errorFormat: ValidationErrorFormat;
 
   constructor(@Optional() options?: ValidationPipeOptions) {
     options = options || {};
@@ -69,6 +87,7 @@ export class ValidationPipe implements PipeTransform<any> {
       expectedType,
       transformOptions,
       validateCustomDecorators,
+      errorFormat,
       ...validatorOptions
     } = options;
 
@@ -81,6 +100,7 @@ export class ValidationPipe implements PipeTransform<any> {
     this.validateCustomDecorators = validateCustomDecorators || false;
     this.errorHttpStatusCode = errorHttpStatusCode || HttpStatus.BAD_REQUEST;
     this.expectedType = expectedType;
+    this.errorFormat = errorFormat || 'list';
     this.exceptionFactory =
       options.exceptionFactory || this.createExceptionFactory();
 
@@ -190,6 +210,12 @@ export class ValidationPipe implements PipeTransform<any> {
     return (validationErrors: ValidationError[] = []) => {
       if (this.isDetailedOutputDisabled) {
         return new HttpErrorByCode[this.errorHttpStatusCode]();
+      }
+      if (this.errorFormat === 'grouped') {
+        const errors = this.groupValidationErrors(validationErrors);
+        return new HttpErrorByCode[this.errorHttpStatusCode]({
+          message: errors,
+        });
       }
       const errors = this.flattenValidationErrors(validationErrors);
       return new HttpErrorByCode[this.errorHttpStatusCode](errors);
@@ -316,6 +342,25 @@ export class ValidationPipe implements PipeTransform<any> {
       .map(item => Object.values(item.constraints!))
       .flatten()
       .toArray();
+  }
+
+  protected groupValidationErrors(
+    validationErrors: ValidationError[],
+    parentPath?: string,
+  ): Record<string, string[]> {
+    const result: Record<string, string[]> = {};
+    for (const error of validationErrors) {
+      const path = parentPath
+        ? `${parentPath}.${error.property}`
+        : error.property;
+      if (error.constraints) {
+        result[path] = Object.values(error.constraints);
+      }
+      if (error.children && error.children.length) {
+        Object.assign(result, this.groupValidationErrors(error.children, path));
+      }
+    }
+    return result;
   }
 
   protected mapChildrenToValidationErrors(


### PR DESCRIPTION
## PR Checklist                                                                                                                                                      
Please check if your PR fulfills the following requirements:                                                                                                         
                                                                                                                                                                     
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md                                                          
- [x] Tests for the changes have been added (for bug fixes / features)                                                                                               
- [ ] Docs have been added / updated (for bug fixes / features)                                                                                                      
                                                                                                                                                                     
                                                                                                                                                                     
## PR Type                                                                                                                                                           
What kind of change does this PR introduce?                                                                                                                          
                                                                                                                                                                     
- [ ] Bugfix                                                                                                                                                         
- [x] Feature                                                                                                                                                        
- [ ] Code style update (formatting, local variables)                                                                                                                
- [ ] Refactoring (no functional changes, no api changes)                                                                                                            
- [ ] Build related changes                                                                                                                                          
- [ ] CI related changes                                                                                                                                             
- [ ] Other... Please describe:                                                                                                                                      
                                                                                                                                                                     
## What is the current behavior?                                                                                                                                     
                                                                                                                                                                     
When using `ValidationPipe` with nested object validation, custom error messages are prepended with the parent property path. For example, a custom message like     
`"name should not be empty"` becomes `"parent.name should not be empty"`, which modifies the user-defined message unexpectedly.                                      
                                                                                                                                                                     
Issue Number: #16268                                                                                                                                                 
                                                                                                                                                                     
                                                                                                                                                                     
## What is the new behavior?                                                                                                                                         
                                                                                                                                                                     
Add a new `errorFormat` option to `ValidationPipeOptions` with two modes:                                                                                            
                                                                                                                                                                     
- **`'list'`** (default): Current behavior - returns an array of error message strings with parent path prepended to messages. No breaking change.                   
- **`'grouped'`**: Returns a `Record<string, string[]>` where keys are dot-notation property paths and values are arrays of **unmodified** constraint messages.      
                                                                                                                                                                     
Example with `errorFormat: 'grouped'`:                                                                                                                               
                                                                                                                                                                     
```typescript                                                                                                                                                        
app.useGlobalPipes(new ValidationPipe({                                                                                                                              
  errorFormat: 'grouped',                                                                                                                                            
}));                                                                                                                                                                 
                                                                                                                                                                     
Response:                                                                                                                                                            
{                                                                                                                                                                    
  "message": {                                                                                                                                                       
    "parent.child": ["name should not be empty", "child must be a string"],                                                                                          
    "text": ["text must be a string"]                                                                                                                                
  }                                                                                                                                                                  
}
```                                                                                                                                                                    
                                                                                                                                                                     
This separates the property path from the message content, so custom messages are preserved as-is.                                                                   
                                                                                                                                                                     
## Does this PR introduce a breaking change?                                                                                                                            
                                                                                                                                                                     
- [ ] Yes                                                                                                                                                                
- [x] No                                                                                                                                                                 
                                                                                                                                                                     
## Other information                                                                                                                                                    
                                                                                                                                                                     
This approach is consistent with how other frameworks like Laravel and express-validator handle nested validation errors. The new groupValidationErrors method is    
added alongside the existing `flattenValidationErrors`, and the choice is made in `createExceptionFactory` based on the `errorFormat` option.