### PR TITLE
fix(websockets): deliver exception errors to native ws clients

### DIFF
--- a/packages/websockets/exceptions/ws-exceptions-handler.ts
+++ b/packages/websockets/exceptions/ws-exceptions-handler.ts
@@ -14,7 +14,10 @@ export class WsExceptionsHandler extends BaseWsExceptionFilter {
 
   public handle(exception: Error | WsException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();
-    if (this.invokeCustomFilters(exception, host) || !client.emit) {
+    if (
+      this.invokeCustomFilters(exception, host) ||
+      (!client.emit && !client.send)
+    ) {
       return;
     }
     super.catch(exception, host);


### PR DESCRIPTION
BaseWsExceptionFilter used client.emit() to send exception payloads, which only works with socket.io. For native WebSocket clients (ws library), emit() is just EventEmitter.emit() and does not send data over the wire, causing exceptions to be silently swallowed.

Add sendExceptionToClient() and isNativeWebSocket() methods to BaseWsExceptionFilter to detect the client type and use client.send() for native WebSocket clients. Update WsExceptionsHandler guard to allow clients with send() through to the exception filter.

Closes #9056

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 When a `WsException` is thrown inside a gateway handler that uses `@nestjs/platform-ws` (raw `ws` library), the exception is silently swallowed — the client never receives any error. This happens because `BaseWsExceptionFilter` calls `client.emit('exception', payload)`, which is a socket.io-specific method. On raw `ws` WebSocket clients, `.emit()` is inherited from Node's `EventEmitter` and only dispatches events locally — it does not send anything over the wire. Additionally, the guard in `WsExceptionsHandler` (`!client.emit`) always passes for `ws` clients since they inherit `.emit` from `EventEmitter`, but the subsequent `client.emit()` call in the filter does nothing useful.

Issue Number: #9056


## What is the new behavior?
- `BaseWsExceptionFilter` now has a `sendExceptionToClient()` method that detects the client type and uses the appropriate transport:
- **Native ws clients** (detected via `send` + numeric `readyState` + no `nsp`): sends `JSON.stringify({ event, data: payload })` via `client.send()`, matching the format used by `WsAdapter.bindMessageHandlers` for normal
  responses
- **Socket.io clients**: uses `client.emit(event, payload)` (existing behavior, unchanged)
- `isNativeWebSocket()` helper method distinguishes raw ws clients from socket.io sockets
- `WsExceptionsHandler` guard updated from `!client.emit` to `!client.emit && !client.send` so raw ws clients reach the exception filter
- Both `sendExceptionToClient()` and `isNativeWebSocket()` are `protected`, allowing users who extend `BaseWsExceptionFilter` to override them for custom adapters


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
  Unit tests added for raw ws client error delivery, readyState guard, bare client bail-out, and `isNativeWebSocket` detection. E2e test added to verify `WsException` errors are received by raw ws clients when using `WsAdapter`.