### PR TITLE
feat(common): add method overload for sse decorator

### DIFF
--- a/packages/common/decorators/http/sse.decorator.ts
+++ b/packages/common/decorators/http/sse.decorator.ts
@@ -1,16 +1,30 @@
 import { METHOD_METADATA, PATH_METADATA, SSE_METADATA } from '../../constants';
 import { RequestMethod } from '../../enums/request-method.enum';
+import { SseOptions } from '../../interfaces/http/sse-options.interface';
 
 /**
  * Declares this route as a Server-Sent-Events endpoint
  *
+ * @param path Route path (defaults to '/')
+ * @param method HTTP method or options (defaults to GET)
+ *
  * @publicApi
+ *
+ * @example
+ * ```typescript
+ * @Sse('events')
+ * events(): Observable<MessageEvent> { ... }
+ *
+ * @Sse('chat', RequestMethod.POST)
+ * chat(): Observable<MessageEvent> { ... }
+ * ```
  */
+export function Sse(path: string, method: RequestMethod): MethodDecorator;
+export function Sse(path: string, options: SseOptions): MethodDecorator;
+export function Sse(path?: string): MethodDecorator;
 export function Sse(
   path?: string,
-  options: { [METHOD_METADATA]?: RequestMethod } = {
-    [METHOD_METADATA]: RequestMethod.GET,
-  },
+  methodOrOptions?: RequestMethod | SseOptions,
 ): MethodDecorator {
   return (
     target: object,
@@ -19,12 +33,16 @@ export function Sse(
   ) => {
     path = path && path.length ? path : '/';
 
+    let method: RequestMethod = RequestMethod.GET;
+
+    if (typeof methodOrOptions === 'number') {
+      method = methodOrOptions;
+    } else if (methodOrOptions && 'method' in methodOrOptions) {
+      method = methodOrOptions.method ?? RequestMethod.GET;
+    }
+
     Reflect.defineMetadata(PATH_METADATA, path, descriptor.value);
-    Reflect.defineMetadata(
-      METHOD_METADATA,
-      options[METHOD_METADATA],
-      descriptor.value,
-    );
+    Reflect.defineMetadata(METHOD_METADATA, method, descriptor.value);
     Reflect.defineMetadata(SSE_METADATA, true, descriptor.value);
     return descriptor;
   };

--- a/packages/common/interfaces/http/index.ts
+++ b/packages/common/interfaces/http/index.ts
@@ -3,3 +3,4 @@ export * from './http-redirect-response.interface';
 export * from './http-server.interface';
 export * from './message-event.interface';
 export * from './raw-body-request.interface';
+export * from './sse-options.interface';

--- a/packages/common/interfaces/http/sse-options.interface.ts
+++ b/packages/common/interfaces/http/sse-options.interface.ts
@@ -1,0 +1,14 @@
+import { RequestMethod } from '../../enums/request-method.enum';
+
+/**
+ * Configuration options for @Sse() decorator
+ *
+ * @publicApi
+ */
+export interface SseOptions {
+  /**
+   * HTTP method for the SSE endpoint.
+   * @default RequestMethod.GET
+   */
+  method?: RequestMethod;
+}

--- a/packages/common/test/decorators/sse.decorator.spec.ts
+++ b/packages/common/test/decorators/sse.decorator.spec.ts
@@ -11,6 +11,15 @@ describe('@Sse', () => {
 
     @Sse(prefix, { method: RequestMethod.POST })
     public static testUsingOptions() {}
+
+    @Sse(prefix, RequestMethod.POST)
+    public static testUsingDirectMethod() {}
+
+    @Sse(prefix, RequestMethod.PUT)
+    public static testUsingPutMethod() {}
+
+    @Sse(prefix, RequestMethod.PATCH)
+    public static testUsingPatchMethod() {}
   }
 
   it('should enhance method with expected http status code', () => {
@@ -32,5 +41,35 @@ describe('@Sse', () => {
 
     const metadata = Reflect.getMetadata(SSE_METADATA, Test.testUsingOptions);
     expect(metadata).to.be.eql(true);
+  });
+  it('should accept method as direct parameter (new API)', () => {
+    const path = Reflect.getMetadata(PATH_METADATA, Test.testUsingDirectMethod);
+    expect(path).to.be.eql('/prefix');
+
+    const method = Reflect.getMetadata(
+      METHOD_METADATA,
+      Test.testUsingDirectMethod,
+    );
+    expect(method).to.be.eql(RequestMethod.POST);
+
+    const metadata = Reflect.getMetadata(
+      SSE_METADATA,
+      Test.testUsingDirectMethod,
+    );
+    expect(metadata).to.be.eql(true);
+  });
+  it('should support PUT method via direct parameter', () => {
+    const method = Reflect.getMetadata(
+      METHOD_METADATA,
+      Test.testUsingPutMethod,
+    );
+    expect(method).to.be.eql(RequestMethod.PUT);
+  });
+  it('should support PATCH method via direct parameter', () => {
+    const method = Reflect.getMetadata(
+      METHOD_METADATA,
+      Test.testUsingPatchMethod,
+    );
+    expect(method).to.be.eql(RequestMethod.PATCH);
   });
 });

--- a/sample/01-cats-app/src/core/interceptors/transform.interceptor.ts
+++ b/sample/01-cats-app/src/core/interceptors/transform.interceptor.ts
@@ -12,9 +12,10 @@ export interface Response<T> {
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
-{
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
   intercept(
     context: ExecutionContext,
     next: CallHandler<T>,

--- a/sample/10-fastify/src/core/interceptors/transform.interceptor.ts
+++ b/sample/10-fastify/src/core/interceptors/transform.interceptor.ts
@@ -12,9 +12,10 @@ export interface Response<T> {
 }
 
 @Injectable()
-export class TransformInterceptor<T>
-  implements NestInterceptor<T, Response<T>>
-{
+export class TransformInterceptor<T> implements NestInterceptor<
+  T,
+  Response<T>
+> {
   intercept(
     context: ExecutionContext,
     next: CallHandler<T>,

--- a/sample/26-queues/e2e/audio/audio.e2e-spec.ts
+++ b/sample/26-queues/e2e/audio/audio.e2e-spec.ts
@@ -21,9 +21,7 @@ describe('AudioController (e2e)', () => {
 
   describe('/audio/transcode (POST)', () => {
     it('should queue a transcoding job and return success', () => {
-      return request(app.getHttpServer())
-        .post('/audio/transcode')
-        .expect(201);
+      return request(app.getHttpServer()).post('/audio/transcode').expect(201);
     });
 
     it('should handle multiple concurrent requests', async () => {
@@ -35,9 +33,7 @@ describe('AudioController (e2e)', () => {
     });
 
     it('should reject GET requests', () => {
-      return request(app.getHttpServer())
-        .get('/audio/transcode')
-        .expect(404);
+      return request(app.getHttpServer()).get('/audio/transcode').expect(404);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
`@Sse()` defaults to GET and supports custom methods only via an options object.
This is not obvious/discoverable, and users may attempt `@Post()` + `@Sse()` which conflicts on HTTP method metadata.

Issue Number: #16340


## What is the new behavior?
`@Sse()` supports an additional overload to pass `RequestMethod` directly, while keeping the existing options-object API fully supported.

~~~ts
@Sse('/stream', { method: RequestMethod.POST }) // existing (still works)
@Sse('/chat', RequestMethod.POST)               // new (more ergonomic)
~~~

Also adds `SseOptions` for type-safe options and updates JSDoc + unit tests to cover the new overload.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- Backward compatible: existing `@Sse(path)` and `@Sse(path, { method })` behavior unchanged.
- Added/updated unit tests for decorator metadata and overload behavior.
~~~
Files:
- packages/common/interfaces/http/sse-options.interface.ts (new)
- packages/common/interfaces/http/index.ts
- packages/common/decorators/http/sse.decorator.ts
- packages/common/test/decorators/sse.decorator.spec.ts
~~~