### PR TITLE
fix(common): add follow-back exception

### DIFF
--- a/packages/common/exceptions/bad-gateway.exception.ts
+++ b/packages/common/exceptions/bad-gateway.exception.ts
@@ -43,7 +43,7 @@ export class BadGatewayException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Bad Gateway',
         HttpStatus.BAD_GATEWAY,
       ),
       HttpStatus.BAD_GATEWAY,

--- a/packages/common/exceptions/bad-request.exception.ts
+++ b/packages/common/exceptions/bad-request.exception.ts
@@ -43,7 +43,7 @@ export class BadRequestException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Bad Request',
         HttpStatus.BAD_REQUEST,
       ),
       HttpStatus.BAD_REQUEST,

--- a/packages/common/exceptions/conflict.exception.ts
+++ b/packages/common/exceptions/conflict.exception.ts
@@ -43,7 +43,7 @@ export class ConflictException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Conflict',
         HttpStatus.CONFLICT,
       ),
       HttpStatus.CONFLICT,

--- a/packages/common/exceptions/forbidden.exception.ts
+++ b/packages/common/exceptions/forbidden.exception.ts
@@ -43,7 +43,7 @@ export class ForbiddenException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Forbidden',
         HttpStatus.FORBIDDEN,
       ),
       HttpStatus.FORBIDDEN,

--- a/packages/common/exceptions/gateway-timeout.exception.ts
+++ b/packages/common/exceptions/gateway-timeout.exception.ts
@@ -43,7 +43,7 @@ export class GatewayTimeoutException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Gateway Timeout',
         HttpStatus.GATEWAY_TIMEOUT,
       ),
       HttpStatus.GATEWAY_TIMEOUT,

--- a/packages/common/exceptions/http-version-not-supported.exception.ts
+++ b/packages/common/exceptions/http-version-not-supported.exception.ts
@@ -45,7 +45,7 @@ export class HttpVersionNotSupportedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'HTTP Version Not Supported',
         HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
       ),
       HttpStatus.HTTP_VERSION_NOT_SUPPORTED,

--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -46,7 +46,7 @@ export class ImATeapotException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || `I'm a teapot`,
         HttpStatus.I_AM_A_TEAPOT,
       ),
       HttpStatus.I_AM_A_TEAPOT,

--- a/packages/common/exceptions/internal-server-error.exception.ts
+++ b/packages/common/exceptions/internal-server-error.exception.ts
@@ -45,7 +45,7 @@ export class InternalServerErrorException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Internal Server Error',
         HttpStatus.INTERNAL_SERVER_ERROR,
       ),
       HttpStatus.INTERNAL_SERVER_ERROR,

--- a/packages/common/exceptions/method-not-allowed.exception.ts
+++ b/packages/common/exceptions/method-not-allowed.exception.ts
@@ -43,7 +43,7 @@ export class MethodNotAllowedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Method Not Allowed',
         HttpStatus.METHOD_NOT_ALLOWED,
       ),
       HttpStatus.METHOD_NOT_ALLOWED,

--- a/packages/common/exceptions/misdirected.exception.ts
+++ b/packages/common/exceptions/misdirected.exception.ts
@@ -43,7 +43,7 @@ export class MisdirectedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Misdirected',
         HttpStatus.MISDIRECTED,
       ),
       HttpStatus.MISDIRECTED,

--- a/packages/common/exceptions/not-acceptable.exception.ts
+++ b/packages/common/exceptions/not-acceptable.exception.ts
@@ -43,7 +43,7 @@ export class NotAcceptableException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Not Acceptable',
         HttpStatus.NOT_ACCEPTABLE,
       ),
       HttpStatus.NOT_ACCEPTABLE,

--- a/packages/common/exceptions/not-found.exception.ts
+++ b/packages/common/exceptions/not-found.exception.ts
@@ -43,7 +43,7 @@ export class NotFoundException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Not Found',
         HttpStatus.NOT_FOUND,
       ),
       HttpStatus.NOT_FOUND,

--- a/packages/common/exceptions/not-implemented.exception.ts
+++ b/packages/common/exceptions/not-implemented.exception.ts
@@ -43,7 +43,7 @@ export class NotImplementedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Not Implemented',
         HttpStatus.NOT_IMPLEMENTED,
       ),
       HttpStatus.NOT_IMPLEMENTED,

--- a/packages/common/exceptions/payload-too-large.exception.ts
+++ b/packages/common/exceptions/payload-too-large.exception.ts
@@ -43,7 +43,7 @@ export class PayloadTooLargeException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Payload Too Large',
         HttpStatus.PAYLOAD_TOO_LARGE,
       ),
       HttpStatus.PAYLOAD_TOO_LARGE,

--- a/packages/common/exceptions/precondition-failed.exception.ts
+++ b/packages/common/exceptions/precondition-failed.exception.ts
@@ -43,7 +43,7 @@ export class PreconditionFailedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Precondition Failed',
         HttpStatus.PRECONDITION_FAILED,
       ),
       HttpStatus.PRECONDITION_FAILED,

--- a/packages/common/exceptions/request-timeout.exception.ts
+++ b/packages/common/exceptions/request-timeout.exception.ts
@@ -43,7 +43,7 @@ export class RequestTimeoutException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Request Timeout',
         HttpStatus.REQUEST_TIMEOUT,
       ),
       HttpStatus.REQUEST_TIMEOUT,

--- a/packages/common/exceptions/service-unavailable.exception.ts
+++ b/packages/common/exceptions/service-unavailable.exception.ts
@@ -43,7 +43,7 @@ export class ServiceUnavailableException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Service Unavailable',
         HttpStatus.SERVICE_UNAVAILABLE,
       ),
       HttpStatus.SERVICE_UNAVAILABLE,

--- a/packages/common/exceptions/unauthorized.exception.ts
+++ b/packages/common/exceptions/unauthorized.exception.ts
@@ -43,7 +43,7 @@ export class UnauthorizedException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Unauthorized',
         HttpStatus.UNAUTHORIZED,
       ),
       HttpStatus.UNAUTHORIZED,

--- a/packages/common/exceptions/unprocessable-entity.exception.ts
+++ b/packages/common/exceptions/unprocessable-entity.exception.ts
@@ -45,7 +45,7 @@ export class UnprocessableEntityException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Unprocessable Entity',
         HttpStatus.UNPROCESSABLE_ENTITY,
       ),
       HttpStatus.UNPROCESSABLE_ENTITY,

--- a/packages/common/exceptions/unsupported-media-type.exception.ts
+++ b/packages/common/exceptions/unsupported-media-type.exception.ts
@@ -45,7 +45,7 @@ export class UnsupportedMediaTypeException extends HttpException {
     super(
       HttpException.createBody(
         objectOrError,
-        description!,
+        description || 'Unsupported Media Type',
         HttpStatus.UNSUPPORTED_MEDIA_TYPE,
       ),
       HttpStatus.UNSUPPORTED_MEDIA_TYPE,


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current constructors under `common/exceptions` pass the extracted `description` directly to `HttpException.createBody`. If no description is specified as an option, there is no default fallback, so an undefined error message may be generated in the response body.

Issue Number: N/A


## What is the new behavior?
A fallback value (e.g., `|| “Bad Gateway”`) has been added to the `description` argument of the constructors under `common/exceptions`. This ensures that a default error message is always provided, similar to other exception classes, even if no specific description is passed as an option.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No