### PR TITLE
test(sample): add unit and e2e tests for sample 24-serve-static

### DIFF
--- a/sample/24-serve-static/e2e/app/app.e2e-spec.ts
+++ b/sample/24-serve-static/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,29 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppController } from '../../src/app.controller';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  it('/api (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/api')
+      .expect(200)
+      .expect('Hello, world!');
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/sample/24-serve-static/e2e/jest-e2e.json
+++ b/sample/24-serve-static/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/24-serve-static/package.json
+++ b/sample/24-serve-static/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.13",
@@ -36,6 +36,7 @@
     "@nestjs/schematics": "11.0.9",
     "@nestjs/testing": "11.1.13",
     "@types/express": "5.0.6",
+    "@types/jest": "30.0.0",
     "@types/node": "24.10.13",
     "@types/supertest": "6.0.3",
     "jest": "30.2.0",
@@ -50,5 +51,22 @@
     "globals": "17.3.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.55.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
   }
 }

--- a/sample/24-serve-static/src/app.controller.spec.ts
+++ b/sample/24-serve-static/src/app.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppController } from './app.controller';
+
+describe('AppController', () => {
+  let appController: AppController;
+
+  beforeEach(async () => {
+    const app: TestingModule = await Test.createTestingModule({
+      controllers: [AppController],
+    }).compile();
+
+    appController = app.get<AppController>(AppController);
+  });
+
+  describe('getHello', () => {
+    it('should return "Hello, world!"', () => {
+      expect(appController.getHello()).toBe('Hello, world!');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds unit and e2e tests for sample 24-serve-static, addressing #1539.

The sample previously had no tests at all. I've added:

**Unit tests** (app.controller.spec.ts):
- Tests the getHello() method to ensure it returns the correct message

**E2e tests** (e2e/app/app.e2e-spec.ts):
- Tests the GET /api endpoint to verify it returns the expected response
- Sets the global prefix to 'api' to match the setup in main.ts

**Configuration**:
- Added jest configuration to package.json
- Added @types/jest to devDependencies
- Updated test:e2e script to use the jest e2e config
- Created jest-e2e.json following the same pattern as other samples

All tests pass successfully. Happy to make any adjustments if needed!