### PR TITLE
test(sample): add unit tests for sample 18-context

### DIFF
--- a/sample/18-context/package.json
+++ b/sample/18-context/package.json
@@ -30,6 +30,8 @@
     "@eslint/js": "9.39.2",
     "@nestjs/cli": "11.0.16",
     "@nestjs/schematics": "11.0.9",
+    "@nestjs/testing": "11.1.13",
+    "@types/jest": "30.0.0",
     "@types/node": "24.10.13",
     "@types/supertest": "6.0.3",
     "jest": "30.2.0",
@@ -44,5 +46,22 @@
     "globals": "17.3.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.55.0"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "ts"
+    ],
+    "rootDir": "src",
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node"
   }
 }

--- a/sample/18-context/src/app.module.spec.ts
+++ b/sample/18-context/src/app.module.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from './app.module';
+import { AppService } from './app.service';
+
+describe('AppModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  });
+
+  it('should compile the module', () => {
+    expect(module).toBeDefined();
+  });
+
+  it('should provide AppService', () => {
+    const appService = module.get<AppService>(AppService);
+    expect(appService).toBeDefined();
+    expect(appService).toBeInstanceOf(AppService);
+  });
+
+  it('should provide MyDynamicProvider with value "foobar"', () => {
+    const provider = module.get('MyDynamicProvider');
+    expect(provider).toBe('foobar');
+  });
+
+  it('should allow AppService to work correctly', () => {
+    const appService = module.get<AppService>(AppService);
+    expect(appService.getHello()).toBe('Hello world!');
+  });
+});

--- a/sample/18-context/src/app.service.spec.ts
+++ b/sample/18-context/src/app.service.spec.ts
@@ -1,0 +1,22 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+
+describe('AppService', () => {
+  let service: AppService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AppService],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return "Hello world!"', () => {
+    expect(service.getHello()).toBe('Hello world!');
+  });
+});

--- a/sample/18-context/src/my-dynamic.module.spec.ts
+++ b/sample/18-context/src/my-dynamic.module.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MyDynamicModule } from './my-dynamic.module';
+
+describe('MyDynamicModule', () => {
+  it('should create a dynamic module with the correct provider', () => {
+    const dynamicModule = MyDynamicModule.register('test-value');
+
+    expect(dynamicModule.module).toBe(MyDynamicModule);
+    expect(dynamicModule.providers).toBeDefined();
+    expect(dynamicModule.providers?.length).toBe(1);
+    expect(dynamicModule.providers?.[0]).toEqual({
+      provide: 'MyDynamicProvider',
+      useValue: 'test-value',
+    });
+    expect(dynamicModule.exports).toEqual(['MyDynamicProvider']);
+  });
+
+  it('should make the provider value accessible', async () => {
+    const testValue = { foo: 'bar', baz: 42 };
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [MyDynamicModule.register(testValue)],
+    }).compile();
+
+    const provider = module.get('MyDynamicProvider');
+    expect(provider).toEqual(testValue);
+  });
+
+  it('should accept different value types', async () => {
+    const stringModule = await Test.createTestingModule({
+      imports: [MyDynamicModule.register('string-value')],
+    }).compile();
+    expect(stringModule.get('MyDynamicProvider')).toBe('string-value');
+
+    const numberModule = await Test.createTestingModule({
+      imports: [MyDynamicModule.register(123)],
+    }).compile();
+    expect(numberModule.get('MyDynamicProvider')).toBe(123);
+
+    const objectModule = await Test.createTestingModule({
+      imports: [MyDynamicModule.register({ key: 'value' })],
+    }).compile();
+    expect(objectModule.get('MyDynamicProvider')).toEqual({ key: 'value' });
+  });
+});


### PR DESCRIPTION
Hey! 👋

I noticed sample 18-context was missing tests (related to #1539), so I added some unit tests to cover the basic functionality.

**What's covered:**
- AppService.getHello() returns the expected greeting
- MyDynamicModule.register() creates a dynamic module with the correct provider
- The provider value is accessible through DI
- AppModule compiles correctly and all providers work together

Since this is a standalone application context sample (no HTTP server), I only added unit tests—no e2e tests needed here.

All tests passing locally ✅

Let me know if you'd like me to adjust anything!