### PR TITLE
test(sample): add unit tests for sample 27-scheduling

### DIFF
--- a/sample/27-scheduling/src/app.module.spec.ts
+++ b/sample/27-scheduling/src/app.module.spec.ts
@@ -1,0 +1,23 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule } from './app.module';
+import { TasksService } from './tasks/tasks.service';
+
+describe('AppModule', () => {
+  let module: TestingModule;
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  });
+
+  it('should compile the module', () => {
+    expect(module).toBeDefined();
+  });
+
+  it('should provide TasksService', () => {
+    const tasksService = module.get<TasksService>(TasksService);
+    expect(tasksService).toBeDefined();
+    expect(tasksService).toBeInstanceOf(TasksService);
+  });
+});

--- a/sample/27-scheduling/src/tasks/tasks.service.spec.ts
+++ b/sample/27-scheduling/src/tasks/tasks.service.spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TasksService } from './tasks.service';
+import { Logger } from '@nestjs/common';
+
+describe('TasksService', () => {
+  let service: TasksService;
+  let loggerSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TasksService],
+    }).compile();
+
+    service = module.get<TasksService>(TasksService);
+    loggerSpy = jest.spyOn(Logger.prototype, 'debug').mockImplementation();
+  });
+
+  afterEach(() => {
+    loggerSpy.mockRestore();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('handleCron', () => {
+    it('should call logger.debug with cron message', () => {
+      service.handleCron();
+      expect(loggerSpy).toHaveBeenCalledWith('Called when the second is 45');
+    });
+  });
+
+  describe('handleInterval', () => {
+    it('should call logger.debug with interval message', () => {
+      service.handleInterval();
+      expect(loggerSpy).toHaveBeenCalledWith('Called every 10 seconds');
+    });
+  });
+
+  describe('handleTimeout', () => {
+    it('should call logger.debug with timeout message', () => {
+      service.handleTimeout();
+      expect(loggerSpy).toHaveBeenCalledWith('Called once after 5 seconds');
+    });
+  });
+});


### PR DESCRIPTION
Hey! 👋

I noticed in #1539 that sample 27-scheduling didn't have any tests yet, so I added some unit tests for it.

Added tests for:
- TasksService (testing the @Cron, @Interval, and @Timeout decorated methods)
- AppModule (verifying it compiles and provides TasksService)

Since this sample doesn't have any HTTP controllers, I kept it to unit tests only — no e2e needed.

All tests are passing locally. Let me know if you'd like any changes!