### PR TITLE
fix(websockets): send WsException errors to native WebSocket clients

### DIFF
--- a/integration/websockets/e2e/ws-error-gateway.spec.ts
+++ b/integration/websockets/e2e/ws-error-gateway.spec.ts
@@ -1,9 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { Test } from '@nestjs/testing';
-import { expect } from 'chai';
-import * as WebSocket from 'ws';
-import { WsErrorGateway } from '../src/ws-error.gateway';
+import WebSocket from 'ws';
+import { WsErrorGateway } from '../src/ws-error.gateway.js';
 
 async function createNestApp(...gateways: any[]): Promise<INestApplication> {
   const testingModule = await Test.createTestingModule({
@@ -36,7 +35,7 @@ describe('WebSocketGateway (WsAdapter) - Error Handling', () => {
     await new Promise<void>(resolve =>
       ws.on('message', data => {
         const response = JSON.parse(data.toString());
-        expect(response).to.deep.equal({
+        expect(response).toEqual({
           event: 'exception',
           data: {
             status: 'error',

--- a/integration/websockets/e2e/ws-error-gateway.spec.ts
+++ b/integration/websockets/e2e/ws-error-gateway.spec.ts
@@ -1,0 +1,61 @@
+import { INestApplication } from '@nestjs/common';
+import { WsAdapter } from '@nestjs/platform-ws';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as WebSocket from 'ws';
+import { WsErrorGateway } from '../src/ws-error.gateway';
+
+async function createNestApp(...gateways: any[]): Promise<INestApplication> {
+  const testingModule = await Test.createTestingModule({
+    providers: gateways,
+  }).compile();
+  const app = testingModule.createNestApplication();
+  app.useWebSocketAdapter(new WsAdapter(app) as any);
+  return app;
+}
+
+describe('WebSocketGateway (WsAdapter) - Error Handling', () => {
+  let ws: WebSocket, app: INestApplication;
+
+  it('should send WsException error to client via native WebSocket', async () => {
+    app = await createNestApp(WsErrorGateway);
+    await app.listen(3000);
+
+    ws = new WebSocket('ws://localhost:8085');
+    await new Promise(resolve => ws.on('open', resolve));
+
+    ws.send(
+      JSON.stringify({
+        event: 'push',
+        data: {
+          test: 'test',
+        },
+      }),
+    );
+
+    await new Promise<void>(resolve =>
+      ws.on('message', data => {
+        const response = JSON.parse(data.toString());
+        expect(response).to.deep.equal({
+          event: 'exception',
+          data: {
+            status: 'error',
+            message: 'test',
+            cause: {
+              pattern: 'push',
+              data: {
+                test: 'test',
+              },
+            },
+          },
+        });
+        ws.close();
+        resolve();
+      }),
+    );
+  });
+
+  afterEach(async function () {
+    await app.close();
+  });
+});

--- a/integration/websockets/src/ws-error.gateway.ts
+++ b/integration/websockets/src/ws-error.gateway.ts
@@ -1,0 +1,14 @@
+import {
+  SubscribeMessage,
+  WebSocketGateway,
+  WsException,
+} from '@nestjs/websockets';
+import { throwError } from 'rxjs';
+
+@WebSocketGateway(8085)
+export class WsErrorGateway {
+  @SubscribeMessage('push')
+  onPush() {
+    return throwError(() => new WsException('test'));
+  }
+}

--- a/packages/websockets/exceptions/ws-exceptions-handler.ts
+++ b/packages/websockets/exceptions/ws-exceptions-handler.ts
@@ -16,7 +16,7 @@ export class WsExceptionsHandler extends BaseWsExceptionFilter {
 
   public handle(exception: Error | WsException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();
-    if (this.invokeCustomFilters(exception, host) || !client.emit) {
+    if (this.invokeCustomFilters(exception, host) || !client) {
       return;
     }
     super.catch(exception, host);

--- a/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
@@ -99,13 +99,13 @@ describe('WsExceptionsHandler', () => {
     });
 
     describe('when client uses "send" instead of "emit" (native WebSocket)', () => {
-      let sendStub: sinon.SinonStub;
-      let wsClient: { send: sinon.SinonStub; readyState: number };
+      let sendStub: ReturnType<typeof vi.fn>;
+      let wsClient: { send: ReturnType<typeof vi.fn>; readyState: number };
       let wsExecutionContextHost: ExecutionContextHost;
 
       beforeEach(() => {
         handler = new WsExceptionsHandler();
-        sendStub = sinon.stub();
+        sendStub = vi.fn();
         wsClient = { send: sendStub, readyState: 1 };
         wsExecutionContextHost = new ExecutionContextHost([
           wsClient,
@@ -116,9 +116,9 @@ describe('WsExceptionsHandler', () => {
 
       it('should send JSON-stringified error via "send" when exception is unknown', () => {
         handler.handle(new Error(), wsExecutionContextHost);
-        expect(sendStub.calledOnce).to.be.true;
-        const sent = JSON.parse(sendStub.getCall(0).args[0]);
-        expect(sent).to.deep.equal({
+        expect(sendStub).toHaveBeenCalledTimes(1);
+        const sent = JSON.parse(sendStub.mock.calls[0][0]);
+        expect(sent).toEqual({
           event: 'exception',
           data: {
             status: 'error',
@@ -134,9 +134,9 @@ describe('WsExceptionsHandler', () => {
       it('should send JSON-stringified error via "send" for WsException with object', () => {
         const message = { custom: 'Unauthorized' };
         handler.handle(new WsException(message), wsExecutionContextHost);
-        expect(sendStub.calledOnce).to.be.true;
-        const sent = JSON.parse(sendStub.getCall(0).args[0]);
-        expect(sent).to.deep.equal({
+        expect(sendStub).toHaveBeenCalledTimes(1);
+        const sent = JSON.parse(sendStub.mock.calls[0][0]);
+        expect(sent).toEqual({
           event: 'exception',
           data: message,
         });
@@ -145,9 +145,9 @@ describe('WsExceptionsHandler', () => {
       it('should send JSON-stringified error via "send" for WsException with string', () => {
         const message = 'Unauthorized';
         handler.handle(new WsException(message), wsExecutionContextHost);
-        expect(sendStub.calledOnce).to.be.true;
-        const sent = JSON.parse(sendStub.getCall(0).args[0]);
-        expect(sent).to.deep.equal({
+        expect(sendStub).toHaveBeenCalledTimes(1);
+        const sent = JSON.parse(sendStub.mock.calls[0][0]);
+        expect(sent).toEqual({
           event: 'exception',
           data: {
             message,
@@ -168,9 +168,9 @@ describe('WsExceptionsHandler', () => {
         it('should send error without cause via "send"', () => {
           const message = 'Unauthorized';
           handler.handle(new WsException(message), wsExecutionContextHost);
-          expect(sendStub.calledOnce).to.be.true;
-          const sent = JSON.parse(sendStub.getCall(0).args[0]);
-          expect(sent).to.deep.equal({
+          expect(sendStub).toHaveBeenCalledTimes(1);
+          const sent = JSON.parse(sendStub.mock.calls[0][0]);
+          expect(sent).toEqual({
             event: 'exception',
             data: {
               message,

--- a/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
@@ -100,13 +100,13 @@ describe('WsExceptionsHandler', () => {
 
     describe('when client uses "send" instead of "emit" (native WebSocket)', () => {
       let sendStub: sinon.SinonStub;
-      let wsClient: { send: sinon.SinonStub };
+      let wsClient: { send: sinon.SinonStub; readyState: number };
       let wsExecutionContextHost: ExecutionContextHost;
 
       beforeEach(() => {
         handler = new WsExceptionsHandler();
         sendStub = sinon.stub();
-        wsClient = { send: sendStub };
+        wsClient = { send: sendStub, readyState: 1 };
         wsExecutionContextHost = new ExecutionContextHost([
           wsClient,
           data,

--- a/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
@@ -50,7 +50,6 @@ describe('WsExceptionsHandler', () => {
           const message = 'Unauthorized';
 
           handler.handle(new WsException(message), executionContextHost);
-          console.log(emitStub.mock.calls[0]);
           expect(emitStub).toHaveBeenCalledWith('exception', {
             message,
             status: 'error',


### PR DESCRIPTION
## Summary

`BaseWsExceptionFilter` called `client.emit('exception', payload)` to send errors, but native WebSocket clients (via `@nestjs/platform-ws`) don't have an `emit` method — only Socket.IO clients do. This meant that when using `WsAdapter`, any `WsException` thrown in a `@SubscribeMessage` handler was silently swallowed and never reached the client.

On top of that, `WsExceptionsHandler.handle()` had a `!client.emit` guard that short-circuited the entire exception handling pipeline for non-Socket.IO clients.

## Changes

- Added a protected `emitMessage()` method to `BaseWsExceptionFilter` that checks whether the client has `emit` (Socket.IO) or `send` (native WS) and dispatches accordingly
- For native WS clients, errors are sent as `JSON.stringify({ event: 'exception', data: payload })`, consistent with the `{ event, data }` message format the WS adapter already uses
- Changed the `!client.emit` guard in `WsExceptionsHandler` to `!client`, so exceptions are properly handled regardless of adapter type
- Updated type constraints from `{ emit: Function }` to `{ emit?: Function; send?: Function }` to accept both client types

## Test plan

- Added unit tests for native WS client error handling (unknown errors, WsException with object, WsException with string, includeCause=false)
- Added e2e integration test (`ws-error-gateway.spec.ts`) that spins up a `WsAdapter`-based gateway, sends a message that triggers a `WsException`, and asserts the error response is received by the client
- Existing Socket.IO tests remain unchanged and should continue to pass

Closes #9056