### PR TITLE
test(sample-11): add unit and e2e tests for swagger

### DIFF
--- a/sample/11-swagger/src/cats/cats.controller.spec.ts
+++ b/sample/11-swagger/src/cats/cats.controller.spec.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateCatDto } from './dto/create-cat.dto';
+import { Cat } from './entities/cat.entity';
+import { CatsController } from './cats.controller';
+import { CatsService } from './cats.service';
+
+describe('CatsController', () => {
+  let controller: CatsController;
+  let service: CatsService;
+
+  const cat: Cat = { name: 'Kitty', age: 2, breed: 'Maine Coon' };
+  const createCatDto: CreateCatDto = {
+    name: 'Kitty',
+    age: 2,
+    breed: 'Maine Coon',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CatsController],
+      providers: [
+        {
+          provide: CatsService,
+          useValue: {
+            create: vi.fn().mockReturnValue(cat),
+            findOne: vi.fn().mockReturnValue(cat),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CatsController>(CatsController);
+    service = module.get<CatsService>(CatsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should call service.create and return the created cat', async () => {
+      const result = await controller.create(createCatDto);
+      expect(service.create).toHaveBeenCalledWith(createCatDto);
+      expect(result).toEqual(cat);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should call service.findOne with parsed id and return the cat', () => {
+      const result = controller.findOne('0');
+      expect(service.findOne).toHaveBeenCalledWith(0);
+      expect(result).toEqual(cat);
+    });
+  });
+});

--- a/sample/11-swagger/src/cats/cats.service.spec.ts
+++ b/sample/11-swagger/src/cats/cats.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CreateCatDto } from './dto/create-cat.dto';
+import { CatsService } from './cats.service';
+
+describe('CatsService', () => {
+  let service: CatsService;
+
+  const createCatDto: CreateCatDto = {
+    name: 'Kitty',
+    age: 2,
+    breed: 'Maine Coon',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CatsService],
+    }).compile();
+
+    service = module.get<CatsService>(CatsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should add a cat and return it', () => {
+      const result = service.create(createCatDto);
+      expect(result).toEqual(createCatDto);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return undefined when no cats exist', () => {
+      expect(service.findOne(0)).toBeUndefined();
+    });
+
+    it('should return the cat at the given index after creation', () => {
+      service.create(createCatDto);
+      expect(service.findOne(0)).toEqual(createCatDto);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing unit and e2e tests to sample application

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1539

## What is the new behavior?

Added unit tests (`CatsController`, `CatsService`) and e2e tests (`cats.e2e-spec.ts`) to the `11-swagger` sample application to ensure the API endpoints and Swagger integration work as expected

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Related to testing improvements across sample applications
