### PR TITLE
test(sample/06): add e2e tests for mongoose sample

### DIFF
--- a/sample/06-mongoose/e2e/cats/cats.e2e-spec.ts
+++ b/sample/06-mongoose/e2e/cats/cats.e2e-spec.ts
@@ -4,9 +4,9 @@ import { getModelToken } from '@nestjs/mongoose';
 import { MongooseModule } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import * as mongoose from 'mongoose';
-import * as request from 'supertest';
-import { CatsModule } from '../../src/cats/cats.module';
-import { Cat } from '../../src/cats/schemas/cat.schema';
+import request from 'supertest';
+import { CatsModule } from '../../src/cats/cats.module.js';
+import { Cat } from '../../src/cats/schemas/cat.schema.js';
 import { Model } from 'mongoose';
 
 describe('CatsController (e2e)', () => {

--- a/sample/06-mongoose/e2e/jest-e2e.json
+++ b/sample/06-mongoose/e2e/jest-e2e.json
@@ -1,9 +1,0 @@
-{
-  "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
-  "testRegex": "e2e/.*\\.e2e-spec\\.ts$",
-  "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  },
-  "testEnvironment": "node"
-}

--- a/sample/06-mongoose/vitest.config.e2e.mts
+++ b/sample/06-mongoose/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?
The 06-mongoose sample does not include e2e tests.

Issue Number: #1539


## What is the new behavior?

Adds e2e tests for all endpoints in the 06-mongoose sample (POST, GET, GET/:id, POST/:id, DELETE/:id).

Closes #1539


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

MongoMemoryServer is added as a dev dependency to enable running e2e tests without an external database.