### PR TITLE
test(sample/14): add e2e tests for mongoose-base sample

### DIFF
--- a/sample/14-mongoose-base/e2e/cats/cats.e2e-spec.ts
+++ b/sample/14-mongoose-base/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,100 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import * as mongoose from 'mongoose';
+import request from 'supertest';
+import { CatsModule } from '../../src/cats/cats.module.js';
+import { DatabaseModule } from '../../src/database/database.module.js';
+
+describe('CatsController (e2e)', () => {
+  let app: INestApplication;
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [CatsModule],
+    })
+      .overrideProvider('DATABASE_CONNECTION')
+      .useFactory({
+        factory: async () => await mongoose.connect(mongoUri),
+      })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  }, 30000);
+
+  afterEach(async () => {
+    const collections = mongoose.connection.collections;
+    for (const key in collections) {
+      await collections[key].deleteMany({});
+    }
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  describe('POST /cats', () => {
+    it('should create a new cat and return it', async () => {
+      const createCatDto = { name: 'Whiskers', age: 3, breed: 'Persian' };
+
+      const response = await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+
+      expect(response.body).toMatchObject(createCatDto);
+      expect(response.body._id).toBeDefined();
+    });
+
+    it('should persist the cat to the database', async () => {
+      const createCatDto = { name: 'Luna', age: 2, breed: 'Siamese' };
+
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+
+      const catInDb = await mongoose.connection
+        .collection('cats')
+        .findOne({ name: 'Luna' });
+      expect(catInDb).not.toBeNull();
+      expect(catInDb?.breed).toBe('Siamese');
+    });
+  });
+
+  describe('GET /cats', () => {
+    it('should return an empty array when no cats exist', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/cats')
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+
+    it('should return all cats', async () => {
+      await mongoose.connection.collection('cats').insertMany([
+        { name: 'Whiskers', age: 3, breed: 'Persian' },
+        { name: 'Luna', age: 2, breed: 'Siamese' },
+      ]);
+
+      const response = await request(app.getHttpServer())
+        .get('/cats')
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Whiskers', breed: 'Persian' }),
+          expect.objectContaining({ name: 'Luna', breed: 'Siamese' }),
+        ]),
+      );
+    });
+  });
+});

--- a/sample/14-mongoose-base/package.json
+++ b/sample/14-mongoose-base/package.json
@@ -33,12 +33,14 @@
     "@nestjs/cli": "11.0.16",
     "@nestjs/schematics": "11.0.9",
     "@nestjs/testing": "11.1.13",
+    "@swc/core": "1.13.1",
     "@types/express": "5.0.6",
     "@types/node": "24.10.11",
     "@types/supertest": "6.0.3",
     "eslint": "9.39.2",
     "eslint-plugin-prettier": "5.5.5",
     "globals": "17.3.0",
+    "mongodb-memory-server": "^11.0.1",
     "prettier": "3.8.1",
     "supertest": "7.2.2",
     "ts-loader": "9.5.4",
@@ -46,9 +48,8 @@
     "tsconfig-paths": "4.2.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
-    "vitest": "3.2.4",
     "unplugin-swc": "1.5.5",
-    "@swc/core": "1.13.1"
+    "vitest": "3.2.4"
   },
   "type": "module"
 }

--- a/sample/14-mongoose-base/vitest.config.e2e.mts
+++ b/sample/14-mongoose-base/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 14-mongoose-base sample does not include e2e tests.

Issue Number: #1539


## What is the new behavior?

Adds e2e tests for all endpoints in the 14-mongoose-base sample (POST, GET).

Closes #1539


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

MongoMemoryServer is added as a dev dependency to enable running e2e tests without an external database.