### PR TITLE
test(sample/13): add e2e tests for mongo-typeorm sample

### DIFF
--- a/sample/13-mongo-typeorm/e2e/photo/photo.e2e-spec.ts
+++ b/sample/13-mongo-typeorm/e2e/photo/photo.e2e-spec.ts
@@ -1,0 +1,87 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import request from 'supertest';
+import { PhotoModule } from '../../src/photo/photo.module.js';
+import { Photo } from '../../src/photo/photo.entity.js';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { MongoRepository } from 'typeorm';
+
+describe('PhotoController (e2e)', () => {
+  let app: INestApplication;
+  let mongoServer: MongoMemoryServer;
+  let photoRepository: MongoRepository<Photo>;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'mongodb',
+          url: mongoUri,
+          entities: [Photo],
+          synchronize: true,
+        }),
+        PhotoModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    photoRepository = moduleFixture.get<MongoRepository<Photo>>(
+      getRepositoryToken(Photo),
+    );
+  }, 30000);
+
+  afterEach(async () => {
+    await photoRepository.clear();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await mongoServer.stop();
+  });
+
+  describe('GET /photo', () => {
+    it('should return an empty array when no photos exist', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/photo')
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+
+    it('should return all photos', async () => {
+      await photoRepository.save([
+        {
+          name: 'Photo #1',
+          description: 'Description #1',
+          filename: 'photo1.jpg',
+          isPublished: true,
+        },
+        {
+          name: 'Photo #2',
+          description: 'Description #2',
+          filename: 'photo2.jpg',
+          isPublished: false,
+        },
+      ]);
+
+      const response = await request(app.getHttpServer())
+        .get('/photo')
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Photo #1', filename: 'photo1.jpg' }),
+          expect.objectContaining({ name: 'Photo #2', filename: 'photo2.jpg' }),
+        ]),
+      );
+    });
+  });
+});

--- a/sample/13-mongo-typeorm/package.json
+++ b/sample/13-mongo-typeorm/package.json
@@ -35,12 +35,14 @@
     "@nestjs/cli": "11.0.16",
     "@nestjs/schematics": "11.0.9",
     "@nestjs/testing": "11.1.13",
+    "@swc/core": "1.13.1",
     "@types/express": "5.0.6",
     "@types/node": "24.10.11",
     "@types/supertest": "6.0.3",
     "eslint": "9.39.2",
     "eslint-plugin-prettier": "5.5.5",
     "globals": "17.3.0",
+    "mongodb-memory-server": "^11.0.1",
     "prettier": "3.8.1",
     "supertest": "7.2.2",
     "ts-loader": "9.5.4",
@@ -48,9 +50,8 @@
     "tsconfig-paths": "4.2.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
-    "vitest": "3.2.4",
     "unplugin-swc": "1.5.5",
-    "@swc/core": "1.13.1"
+    "vitest": "3.2.4"
   },
   "type": "module"
 }

--- a/sample/13-mongo-typeorm/vitest.config.e2e.mts
+++ b/sample/13-mongo-typeorm/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing e2e tests for sample applications


## What is the current behavior?

The 13-mongo-typeorm sample does not include e2e tests.

Issue Number: #1539


## What is the new behavior?

Adds e2e tests for all endpoints in the 13-mongo-typeorm sample (GET).

Closes #1539


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

MongoMemoryServer is added as a dev dependency to enable running e2e tests without an external database.