### PR TITLE
test(sample/05): add e2e tests for sql-typeorm sample

### DIFF
--- a/sample/05-sql-typeorm/e2e/users/users.e2e-spec.ts
+++ b/sample/05-sql-typeorm/e2e/users/users.e2e-spec.ts
@@ -1,0 +1,145 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import request from 'supertest';
+import { UsersModule } from '../../src/users/users.module.js';
+import { User } from '../../src/users/user.entity.js';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+describe('UsersController (e2e)', () => {
+  let app: INestApplication;
+  let userRepository: Repository<User>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [User],
+          synchronize: true,
+        }),
+        UsersModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    userRepository = moduleFixture.get<Repository<User>>(
+      getRepositoryToken(User),
+    );
+  }, 30000);
+
+  afterEach(async () => {
+    await userRepository.clear();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /users', () => {
+    it('should create a new user and return it', async () => {
+      const createUserDto = { firstName: 'John', lastName: 'Doe' };
+
+      const response = await request(app.getHttpServer())
+        .post('/users')
+        .send(createUserDto)
+        .expect(201);
+
+      expect(response.body).toMatchObject(createUserDto);
+      expect(response.body.id).toBeDefined();
+    });
+
+    it('should persist the user to the database', async () => {
+      const createUserDto = { firstName: 'Jane', lastName: 'Doe' };
+
+      await request(app.getHttpServer())
+        .post('/users')
+        .send(createUserDto)
+        .expect(201);
+
+      const userInDb = await userRepository.findOneBy({ firstName: 'Jane' });
+      expect(userInDb).not.toBeNull();
+      expect(userInDb?.lastName).toBe('Doe');
+    });
+  });
+
+  describe('GET /users', () => {
+    it('should return an empty array when no users exist', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/users')
+        .expect(200);
+
+      expect(response.body).toEqual([]);
+    });
+
+    it('should return all users', async () => {
+      await userRepository.save([
+        { firstName: 'John', lastName: 'Doe' },
+        { firstName: 'Jane', lastName: 'Doe' },
+      ]);
+
+      const response = await request(app.getHttpServer())
+        .get('/users')
+        .expect(200);
+
+      expect(response.body).toHaveLength(2);
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ firstName: 'John', lastName: 'Doe' }),
+          expect.objectContaining({ firstName: 'Jane', lastName: 'Doe' }),
+        ]),
+      );
+    });
+  });
+
+  describe('GET /users/:id', () => {
+    it('should return a single user by id', async () => {
+      const createdUser = await userRepository.save({
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      const response = await request(app.getHttpServer())
+        .get(`/users/${createdUser.id}`)
+        .expect(200);
+
+      expect(response.body).toMatchObject({
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+    });
+  });
+
+  describe('DELETE /users/:id', () => {
+    it('should delete a user', async () => {
+      const createdUser = await userRepository.save({
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/users/${createdUser.id}`)
+        .expect(200);
+    });
+
+    it('should remove the user from the database', async () => {
+      const createdUser = await userRepository.save({
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      await request(app.getHttpServer())
+        .delete(`/users/${createdUser.id}`)
+        .expect(200);
+
+      const deletedUser = await userRepository.findOneBy({
+        id: createdUser.id,
+      });
+      expect(deletedUser).toBeNull();
+    });
+  });
+});

--- a/sample/05-sql-typeorm/package.json
+++ b/sample/05-sql-typeorm/package.json
@@ -35,22 +35,24 @@
     "@nestjs/cli": "11.0.16",
     "@nestjs/schematics": "11.0.9",
     "@nestjs/testing": "11.1.13",
+    "@swc/core": "1.13.1",
     "@types/express": "5.0.6",
     "@types/node": "24.10.11",
+    "@types/sqlite3": "^3.1.11",
     "@types/supertest": "6.0.3",
     "eslint": "9.39.2",
     "eslint-plugin-prettier": "5.5.5",
     "globals": "17.3.0",
     "prettier": "3.8.1",
+    "sqlite3": "^5.1.7",
     "supertest": "7.2.2",
     "ts-loader": "9.5.4",
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",
-    "vitest": "3.2.4",
     "unplugin-swc": "1.5.5",
-    "@swc/core": "1.13.1"
+    "vitest": "3.2.4"
   },
   "type": "module"
 }

--- a/sample/05-sql-typeorm/vitest.config.e2e.mts
+++ b/sample/05-sql-typeorm/vitest.config.e2e.mts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     root: './',
-    include: ['test/**/*.e2e-spec.ts'],
+    include: ['e2e/**/*.e2e-spec.ts'],
   },
   plugins: [swc.vite()],
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add missing e2e tests for sample applications


## What is the current behavior?

The 05-sql-typeorm sample does not include e2e tests.

Issue Number: #1539


## What is the new behavior?

Adds e2e tests for all endpoints in the 05-sql-typeorm sample (POST, GET, GET/:id, DELETE/:id).

Closes #1539


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

SQLite3 is added as a dev dependency to enable running e2e tests without an external database.