### PR TITLE
test(sample/10): add unit and e2e tests for fastify sample

### DIFF
--- a/sample/10-fastify/e2e/cats/cats.e2e-spec.ts
+++ b/sample/10-fastify/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { ValidationPipe } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+import { RolesGuard } from '../../src/common/guards/roles.guard.js';
+import { CanActivate } from '@nestjs/common';
+
+describe('CatsController (e2e)', () => {
+  let app: NestFastifyApplication;
+
+  const mockRolesGuard: CanActivate = { canActivate: () => true };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue(mockRolesGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    app.useGlobalPipes(new ValidationPipe());
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /cats', () => {
+    it('should return an empty array when no cats exist', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/cats')
+        .expect(200);
+
+      expect(response.body).toMatchObject({ data: [] });
+    });
+  });
+
+  describe('POST /cats', () => {
+    it('should create a cat', async () => {
+      const createCatDto = { name: 'Whiskers', age: 3, breed: 'Persian' };
+
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+    });
+
+    it('should return the created cat in findAll', async () => {
+      const createCatDto = { name: 'Luna', age: 2, breed: 'Siamese' };
+
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+
+      const response = await request(app.getHttpServer())
+        .get('/cats')
+        .expect(200);
+
+      expect(response.body.data).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ name: 'Luna', breed: 'Siamese' }),
+        ]),
+      );
+    });
+
+    it('should reject invalid cat data', async () => {
+      const invalidCatDto = {
+        name: 'Whiskers',
+        age: 'not-a-number',
+        breed: 'Persian',
+      };
+
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send(invalidCatDto)
+        .expect(400);
+    });
+  });
+});

--- a/sample/10-fastify/src/cats/cats.controller.spec.ts
+++ b/sample/10-fastify/src/cats/cats.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CatsController } from './cats.controller.js';
+import { CatsService } from './cats.service.js';
+import { RolesGuard } from '../common/guards/roles.guard.js';
+import { Reflector } from '@nestjs/core';
+
+describe('CatsController', () => {
+  let controller: CatsController;
+  let service: CatsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CatsController],
+      providers: [CatsService, RolesGuard, Reflector],
+    }).compile();
+
+    controller = module.get<CatsController>(CatsController);
+    service = module.get<CatsService>(CatsService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('findAll()', () => {
+    it('should return an array of cats', async () => {
+      const result: { name: string; age: number; breed: string }[] = [
+        { name: 'Whiskers', age: 3, breed: 'Persian' },
+      ];
+      vi.spyOn(service, 'findAll').mockImplementation(() => result);
+
+      expect(await controller.findAll()).toBe(result);
+    });
+  });
+
+  describe('create()', () => {
+    it('should create a cat', async () => {
+      const createCatDto = { name: 'Whiskers', age: 3, breed: 'Persian' };
+      const createSpy = vi.spyOn(service, 'create');
+
+      await controller.create(createCatDto);
+      expect(createSpy).toHaveBeenCalledWith(createCatDto);
+    });
+  });
+});

--- a/sample/10-fastify/src/cats/cats.service.spec.ts
+++ b/sample/10-fastify/src/cats/cats.service.spec.ts
@@ -1,0 +1,44 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CatsService } from './cats.service.js';
+
+describe('CatsService', () => {
+  let service: CatsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CatsService],
+    }).compile();
+
+    service = module.get<CatsService>(CatsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create()', () => {
+    it('should add a cat to the list', () => {
+      const cat = { name: 'Whiskers', age: 3, breed: 'Persian' };
+      service.create(cat);
+
+      expect(service.findAll()).toContainEqual(cat);
+    });
+  });
+
+  describe('findAll()', () => {
+    it('should return an empty array initially', () => {
+      expect(service.findAll()).toEqual([]);
+    });
+
+    it('should return all created cats', () => {
+      const cat1 = { name: 'Whiskers', age: 3, breed: 'Persian' };
+      const cat2 = { name: 'Luna', age: 2, breed: 'Siamese' };
+
+      service.create(cat1);
+      service.create(cat2);
+
+      expect(service.findAll()).toHaveLength(2);
+      expect(service.findAll()).toEqual(expect.arrayContaining([cat1, cat2]));
+    });
+  });
+});

--- a/sample/10-fastify/vitest.config.e2e.mts
+++ b/sample/10-fastify/vitest.config.e2e.mts
@@ -1,0 +1,12 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+    hookTimeout: 30000,
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated


## PR Type

- [x] Other... Please describe: Add missing unit and e2e tests for sample applications


## What is the current behavior?

The 10-fastify sample does not include unit or e2e tests.

Issue Number: #1539


## What is the new behavior?

Adds unit tests for CatsController and CatsService, and e2e tests for the cats endpoints (POST /cats, GET /cats) using FastifyAdapter and mocking the RolesGuard.

Closes #1539


## Does this PR introduce a breaking change?

- [x] No


## Other information