### PR TITLE
test(sample/21): add e2e tests for serializer sample

### DIFF
--- a/sample/21-serializer/e2e/app/app.e2e-spec.ts
+++ b/sample/21-serializer/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /', () => {
+    it('should return a serialized user with expected fields', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.body).toMatchObject({
+        id: 1,
+        firstName: 'Kamil',
+        lastName: 'Mysliwiec',
+      });
+    });
+
+    it('should exclude the password field', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.body).not.toHaveProperty('password');
+    });
+
+    it('should expose the computed fullName field', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.body.fullName).toBe('Kamil Mysliwiec');
+    });
+
+    it('should transform the role to its name string', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.body.role).toBe('admin');
+    });
+  });
+});

--- a/sample/21-serializer/vitest.config.e2e.mts
+++ b/sample/21-serializer/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 21-serializer sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the `GET /` endpoint in the 21-serializer sample, verifying all `class-transformer` features:

- `@Exclude()`: password field is excluded from the response
- `@Expose()`: computed `fullName` field is present
- `@Transform()`: role is transformed to its name string

## Does this PR introduce a breaking change?
- [x] No