### PR TITLE
test(sample/15): add e2e tests for mvc sample

### DIFF
--- a/sample/15-mvc/e2e/app/app.e2e-spec.ts
+++ b/sample/15-mvc/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import request from 'supertest';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { AppModule } from '../../src/app.module.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('AppController (e2e)', () => {
+  let app: NestExpressApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestExpressApplication>();
+    app.setBaseViewsDir(join(__dirname, '..', '..', 'views'));
+    app.setViewEngine('hbs');
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /', () => {
+    it('should return HTML content', async () => {
+      await request(app.getHttpServer())
+        .get('/')
+        .expect(200)
+        .expect('Content-Type', /html/);
+    });
+
+    it('should render the template with the message variable', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.text).toContain('Hello world!');
+    });
+
+    it('should return a valid HTML document', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.text).toContain('<!DOCTYPE html>');
+      expect(response.text).toContain('<html');
+    });
+  });
+});

--- a/sample/15-mvc/vitest.config.e2e.mts
+++ b/sample/15-mvc/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 15-mvc sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the `GET /` endpoint in the 15-mvc sample, verifying:

- HTML content-type response header
- Handlebars template rendering with variable interpolation (`{{ message }}` → "Hello world!")
- Valid HTML document structure (`<!DOCTYPE html>`, `<html>`)

Test setup mirrors `main.ts` by configuring `NestExpressApplication` with `setBaseViewsDir` and `setViewEngine('hbs')`.

## Does this PR introduce a breaking change?
- [x] No