### PR TITLE
test(sample/20): add e2e tests for cache sample

### DIFF
--- a/sample/20-cache/e2e/app/app.e2e-spec.ts
+++ b/sample/20-cache/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /', () => {
+    it('should return an array of items and cache the response', async () => {
+      const start1 = Date.now();
+      const first = await request(app.getHttpServer()).get('/').expect(200);
+      const duration1 = Date.now() - start1;
+
+      expect(first.body).toEqual([{ id: 1, name: 'Nest' }]);
+
+      const start2 = Date.now();
+      const second = await request(app.getHttpServer()).get('/').expect(200);
+      const duration2 = Date.now() - start2;
+
+      expect(second.body).toEqual(first.body);
+      expect(duration2).toBeLessThan(duration1);
+    }, 15000);
+
+    it('should consistently return the same cached data', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.body).toEqual([{ id: 1, name: 'Nest' }]);
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toHaveProperty('id');
+      expect(response.body[0]).toHaveProperty('name');
+    });
+  });
+});

--- a/sample/20-cache/vitest.config.e2e.mts
+++ b/sample/20-cache/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 20-cache sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the `GET /` endpoint in the 20-cache sample, verifying:

- Response data shape (`[{ id: 1, name: 'Nest' }]`)
- Cache behavior: second request returns the same data significantly faster than the first (the controller has a deliberate 3-second delay that is bypassed by the `CacheInterceptor`)
- Consistent cached data across multiple requests

## Does this PR introduce a breaking change?
- [x] No