### PR TITLE
test(sample/11): add e2e tests for swagger sample

### DIFF
--- a/sample/11-swagger/e2e/cats/cats.e2e-spec.ts
+++ b/sample/11-swagger/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+
+describe('CatsController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+
+    const options = new DocumentBuilder()
+      .setTitle('Cats example')
+      .setDescription('The cats API description')
+      .setVersion('1.0')
+      .addTag('cats')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, options);
+    SwaggerModule.setup('api', app, document);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('POST /cats', () => {
+    it('should create a cat', async () => {
+      const createCatDto = { name: 'Whiskers', age: 3, breed: 'Persian' };
+
+      const response = await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+
+      expect(response.body).toMatchObject(createCatDto);
+    });
+
+    it('should reject invalid cat data', async () => {
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send({ name: 123, age: 'not-a-number' })
+        .expect(400);
+    });
+  });
+
+  describe('GET /cats/:id', () => {
+    it('should return a cat by index', async () => {
+      const createCatDto = { name: 'Milo', age: 2, breed: 'Siamese' };
+
+      await request(app.getHttpServer())
+        .post('/cats')
+        .send(createCatDto)
+        .expect(201);
+
+      const response = await request(app.getHttpServer())
+        .get('/cats/1')
+        .expect(200);
+
+      expect(response.body).toMatchObject(createCatDto);
+    });
+  });
+
+  describe('Swagger documentation', () => {
+    it('should serve the Swagger JSON document at /api-json', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api-json')
+        .expect(200);
+
+      expect(response.body.info.title).toBe('Cats example');
+      expect(response.body.info.version).toBe('1.0');
+      expect(response.body.paths['/cats']).toBeDefined();
+      expect(response.body.paths['/cats/{id}']).toBeDefined();
+    });
+
+    it('should serve the Swagger UI at /api/', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api/')
+        .expect(200);
+
+      expect(response.text).toContain('swagger');
+    });
+  });
+});

--- a/sample/11-swagger/vitest.config.e2e.mts
+++ b/sample/11-swagger/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 11-swagger sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the 11-swagger sample, covering:

- `POST /cats`: create a cat and verify response shape
- `POST /cats`: reject invalid data with 400 (ValidationPipe)
- `GET /cats/:id`: retrieve a cat by index
- `GET /api-json`: verify Swagger/OpenAPI JSON document (title, version, paths)
- `GET /api/`: verify Swagger UI is served

Test setup configures `ValidationPipe` globally and sets up Swagger via `DocumentBuilder` + `SwaggerModule`, mirroring `main.ts`.

## Does this PR introduce a breaking change?
- [x] No