### PR TITLE
feat(common): Add HMAC Guard and Rate Limit Interceptor

### DIFF
--- a/packages/common/guards/hmac.guard.ts
+++ b/packages/common/guards/hmac.guard.ts
@@ -1,0 +1,61 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { createHmac, timingSafeEqual } from 'crypto';
+
+/**
+ * Guard that verifies the authenticity of a request using an HMAC signature.
+ *
+ * @publicApi
+ */
+@Injectable()
+export class HmacGuard implements CanActivate {
+  private readonly secret: string;
+  private readonly hmacHeader: string;
+
+  constructor(options?: { secret?: string; hmacHeader?: string }) {
+    this.secret = options?.secret || '';
+    this.hmacHeader = options?.hmacHeader || 'x-signature';
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    if (!this.secret) {
+      throw new Error('HMAC secret is not configured');
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const signature = request.headers[this.hmacHeader.toLowerCase()];
+
+    if (!signature) {
+      throw new UnauthorizedException('Missing HMAC signature');
+    }
+
+    const payload = request.rawBody
+      ? request.rawBody
+      : JSON.stringify(request.body);
+    const expectedSignature = createHmac('sha256', this.secret)
+      .update(payload)
+      .digest('hex');
+
+    const signatureBuffer = Buffer.from(String(signature), 'utf8');
+    const expectedSignatureBuffer = Buffer.from(expectedSignature, 'utf8');
+
+    if (signatureBuffer.length !== expectedSignatureBuffer.length) {
+      throw new UnauthorizedException('Invalid HMAC signature');
+    }
+
+    const isSignatureValid = timingSafeEqual(
+      signatureBuffer,
+      expectedSignatureBuffer,
+    );
+
+    if (!isSignatureValid) {
+      throw new UnauthorizedException('Invalid HMAC signature');
+    }
+
+    return true;
+  }
+}

--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -68,3 +68,5 @@ export * from './pipes';
 export * from './serializer';
 export * from './services';
 export * from './utils';
+export * from './guards/hmac.guard';
+export * from './interceptors/rate-limit.interceptor';

--- a/packages/common/interceptors/rate-limit.interceptor.ts
+++ b/packages/common/interceptors/rate-limit.interceptor.ts
@@ -1,0 +1,72 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+
+/**
+ * Interceptor that provides basic in-memory rate limiting.
+ *
+ * @publicApi
+ */
+@Injectable()
+export class RateLimitInterceptor implements NestInterceptor {
+  private readonly requestCounts = new Map<
+    string,
+    { count: number; expires: number }
+  >();
+  private readonly limit: number;
+  private readonly windowMs: number;
+
+  constructor(options?: { limit?: number; windowMs?: number }) {
+    this.limit = options?.limit || 10;
+    this.windowMs = options?.windowMs || 60000;
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    this.cleanup();
+    const request = context.switchToHttp().getRequest();
+    const key = this.generateKey(request);
+    const now = Date.now();
+
+    const record = this.requestCounts.get(key) || {
+      count: 0,
+      expires: now + this.windowMs,
+    };
+
+    if (now > record.expires) {
+      record.count = 1;
+      record.expires = now + this.windowMs;
+    } else {
+      record.count++;
+    }
+
+    this.requestCounts.set(key, record);
+
+    if (record.count > this.limit) {
+      throw new HttpException(
+        'Too Many Requests',
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    return next.handle();
+  }
+
+  protected generateKey(request: any): string {
+    return request.ip || 'global';
+  }
+
+  private cleanup() {
+    const now = Date.now();
+    for (const [key, record] of this.requestCounts.entries()) {
+      if (now > record.expires) {
+        this.requestCounts.delete(key);
+      }
+    }
+  }
+}

--- a/packages/common/test/guards/hmac.guard.spec.ts
+++ b/packages/common/test/guards/hmac.guard.spec.ts
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { createHmac } from 'crypto';
+import { ExecutionContext, UnauthorizedException } from '../../index';
+import { HmacGuard } from '../../guards/hmac.guard';
+
+describe('HmacGuard', () => {
+  let guard: HmacGuard;
+  const secret = 'your-shared-secret';
+
+  beforeEach(() => {
+    guard = new HmacGuard({ secret });
+  });
+
+  it('should throw Error if secret is not configured', () => {
+    const invalidGuard = new HmacGuard();
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({}),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => invalidGuard.canActivate(context)).to.throw(
+      'HMAC secret is not configured',
+    );
+  });
+
+  it('should throw UnauthorizedException if signature is missing', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: {},
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => guard.canActivate(context)).to.throw(UnauthorizedException);
+  });
+
+  it('should return true for valid signature', () => {
+    const body = { data: 'test' };
+    const payload = JSON.stringify(body);
+    const signature = createHmac('sha256', secret)
+      .update(payload)
+      .digest('hex');
+
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-signature': signature },
+          body,
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(guard.canActivate(context)).to.be.true;
+  });
+
+  it('should throw UnauthorizedException for invalid signature', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-signature': 'invalid-sig' },
+          body: { data: 'test' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => guard.canActivate(context)).to.throw(UnauthorizedException);
+  });
+
+  it('should throw UnauthorizedException for signature with different length', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          headers: { 'x-signature': 'shrt' },
+          body: { data: 'test' },
+        }),
+      }),
+    } as unknown as ExecutionContext;
+
+    expect(() => guard.canActivate(context)).to.throw(UnauthorizedException);
+  });
+});

--- a/packages/common/test/interceptors/rate-limit.interceptor.spec.ts
+++ b/packages/common/test/interceptors/rate-limit.interceptor.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+import { of } from 'rxjs';
+import { ExecutionContext, HttpException, HttpStatus } from '../../index';
+import { RateLimitInterceptor } from '../../interceptors/rate-limit.interceptor';
+
+describe('RateLimitInterceptor', () => {
+  let interceptor: RateLimitInterceptor;
+
+  beforeEach(() => {
+    interceptor = new RateLimitInterceptor({ limit: 10, windowMs: 60000 });
+  });
+
+  it('should allow requests within limit', done => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ ip: '127.0.0.1' }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const next = {
+      handle: () => of({ success: true }),
+    };
+
+    interceptor.intercept(context, next).subscribe({
+      next: val => {
+        expect(val).to.deep.equal({ success: true });
+        done();
+      },
+    });
+  });
+
+  it('should block requests exceeding limit', () => {
+    const context = {
+      switchToHttp: () => ({
+        getRequest: () => ({ ip: '192.168.1.1' }),
+      }),
+    } as unknown as ExecutionContext;
+
+    const next = {
+      handle: () => of({ success: true }),
+    };
+
+    // Simulate 10 requests
+    for (let i = 0; i < 10; i++) {
+      interceptor.intercept(context, next);
+    }
+
+    // 11th request should fail
+    expect(() => interceptor.intercept(context, next)).to.throw(HttpException);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The @nestjs/common package currently lacks built-in, lightweight utilities for common security tasks like HMAC signature validation and basic in-memory rate limiting, requiring developers to implement these manually or pull in external dependencies.

Issue Number: N/A


## What is the new behavior?

This PR introduces two new security-focused components to @nestjs/common:

1. HmacGuard: A guard that verifies request authenticity using HMAC signatures. It intelligently uses request.rawBody when available to ensure reliable cryptographic verification and employs timingSafeEqual to protect against timing attacks.


2. RateLimitInterceptor: A lightweight, in-memory rate limiting interceptor. It includes a proactive cleanup mechanism to prune expired records, preventing memory leaks in long-running applications.
Both components are exported via the main package index for easy access.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other Information

Detailed JSDoc documentation has been added to the new components. Formal documentation updates for the main website may be required separately.