### PR TITLE
test(sample/27): add e2e tests for scheduling sample

### DIFF
--- a/sample/27-scheduling/e2e/app/app.e2e-spec.ts
+++ b/sample/27-scheduling/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,46 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { AppModule } from '../../src/app.module.js';
+import { TasksService } from '../../src/tasks/tasks.service.js';
+
+describe('TasksService (e2e)', () => {
+  let app: INestApplication;
+  let module: TestingModule;
+  let schedulerRegistry: SchedulerRegistry;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    schedulerRegistry = module.get(SchedulerRegistry);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should have TasksService registered', () => {
+    const tasksService = module.get(TasksService);
+    expect(tasksService).toBeDefined();
+  });
+
+  it('should register a cron job', () => {
+    const cronJobs = schedulerRegistry.getCronJobs();
+    expect(cronJobs.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should register an interval', () => {
+    const intervals = schedulerRegistry.getIntervals();
+    expect(intervals.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should register a timeout', () => {
+    const timeouts = schedulerRegistry.getTimeouts();
+    expect(timeouts.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/sample/27-scheduling/vitest.config.e2e.mts
+++ b/sample/27-scheduling/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 27-scheduling sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the 27-scheduling sample, verifying:

- `TasksService` is registered in the DI container
- `@Cron()` decorator registers at least one cron job via `SchedulerRegistry`
- `@Interval()` decorator registers at least one interval
- `@Timeout()` decorator registers at least one timeout

## Does this PR introduce a breaking change?
- [x] No