### PR TITLE
test(sample/24): add e2e tests for serve-static sample

### DIFF
--- a/sample/24-serve-static/e2e/app/app.e2e-spec.ts
+++ b/sample/24-serve-static/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+
+describe('AppController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.setGlobalPrefix('api');
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /api', () => {
+    it('should return the hello message', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/api')
+        .expect(200);
+
+      expect(response.text).toBe('Hello, world!');
+    });
+  });
+});

--- a/sample/24-serve-static/vitest.config.e2e.mts
+++ b/sample/24-serve-static/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 24-serve-static sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e test for the `GET /api` endpoint in the 24-serve-static sample, verifying the API response with the global prefix configured (mirroring `main.ts`).

## Does this PR introduce a breaking change?
- [x] No