### PR TITLE
test(sample/16): add e2e tests for gateways-ws sample

### DIFF
--- a/sample/16-gateways-ws/e2e/events/events.e2e-spec.ts
+++ b/sample/16-gateways-ws/e2e/events/events.e2e-spec.ts
@@ -1,0 +1,60 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { WsAdapter } from '@nestjs/platform-ws';
+import { WebSocket } from 'ws';
+import { AppModule } from '../../src/app.module.js';
+
+describe('EventsGateway (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.useWebSocketAdapter(new WsAdapter(app));
+    await app.listen(3000);
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('events', () => {
+    it('should receive 3 events', () => {
+      return new Promise<void>((resolve, reject) => {
+        const ws = new WebSocket('ws://localhost:8080');
+        const received: number[] = [];
+
+        ws.on('open', () => {
+          ws.send(JSON.stringify({ event: 'events', data: {} }));
+        });
+
+        ws.on('message', (raw: Buffer) => {
+          const message = JSON.parse(raw.toString());
+          if (message.event === 'events') {
+            received.push(message.data);
+            if (received.length === 3) {
+              try {
+                expect(received).toEqual([1, 2, 3]);
+                ws.close();
+                resolve();
+              } catch (err) {
+                ws.close();
+                reject(err);
+              }
+            }
+          }
+        });
+
+        ws.on('error', reject);
+
+        setTimeout(() => {
+          ws.close();
+          reject(new Error('Timeout waiting for events'));
+        }, 5000);
+      });
+    });
+  });
+});

--- a/sample/16-gateways-ws/vitest.config.e2e.mts
+++ b/sample/16-gateways-ws/vitest.config.e2e.mts
@@ -1,0 +1,12 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+    hookTimeout: 30000,
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 16-gateways-ws sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e test for the 16-gateways-ws sample using the native `ws` WebSocket client and `WsAdapter`, verifying that the `events` handler emits 3 sequential values `[1, 2, 3]`.

## Does this PR introduce a breaking change?
- [x] No