### PR TITLE
test(sample/33): add e2e tests for graphql-mercurius sample

### DIFF
--- a/sample/33-graphql-mercurius/e2e/recipes/recipes.e2e-spec.ts
+++ b/sample/33-graphql-mercurius/e2e/recipes/recipes.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+
+describe('RecipesResolver (e2e)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should return an empty list of recipes', async () => {
+    const query = `
+      query {
+        recipes {
+          id
+          title
+          description
+        }
+      }
+    `;
+
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .send({ query })
+      .expect(200);
+
+    expect(response.body.data.recipes).toEqual([]);
+  });
+
+  it('should remove a recipe', async () => {
+    const query = `
+      mutation {
+        removeRecipe(id: "1")
+      }
+    `;
+
+    const response = await request(app.getHttpServer())
+      .post('/graphql')
+      .send({ query })
+      .expect(200);
+
+    expect(response.body.data.removeRecipe).toBe(true);
+  });
+});

--- a/sample/33-graphql-mercurius/vitest.config.e2e.mts
+++ b/sample/33-graphql-mercurius/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 33-graphql-mercurius sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the 33-graphql-mercurius sample using Fastify adapter, verifying:

- `recipes` query returns an empty list
- `removeRecipe` mutation returns `true`

## Does this PR introduce a breaking change?
- [x] No