### PR TITLE
test(sample/17): add e2e tests for mvc-fastify sample

### DIFF
--- a/sample/17-mvc-fastify/e2e/app/app.e2e-spec.ts
+++ b/sample/17-mvc-fastify/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import request from 'supertest';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import handlebars from 'handlebars';
+import { AppModule } from '../../src/app.module.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('AppController (e2e)', () => {
+  let app: NestFastifyApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    app.setViewEngine({
+      engine: {
+        handlebars,
+      },
+      templates: join(__dirname, '..', '..', 'views'),
+    });
+
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /', () => {
+    it('should return HTML content', async () => {
+      await request(app.getHttpServer())
+        .get('/')
+        .expect(200)
+        .expect('Content-Type', /html/);
+    });
+
+    it('should render the template with the message variable', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.text).toContain('Hello world!');
+    });
+
+    it('should return a valid HTML document', async () => {
+      const response = await request(app.getHttpServer()).get('/').expect(200);
+
+      expect(response.text).toContain('<!DOCTYPE html>');
+      expect(response.text).toContain('<html');
+    });
+  });
+});

--- a/sample/17-mvc-fastify/vitest.config.e2e.mts
+++ b/sample/17-mvc-fastify/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 17-mvc-fastify sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the `GET /` endpoint in the 17-mvc-fastify sample using Fastify adapter with Handlebars view engine, verifying:

- HTML content-type response header
- Template rendering with variable interpolation (`{{ message }}` → "Hello world!")
- Valid HTML document structure

## Does this PR introduce a breaking change?
- [x] No