### PR TITLE
test(sample/18): add e2e tests for context sample

### DIFF
--- a/sample/18-context/e2e/app/app.e2e-spec.ts
+++ b/sample/18-context/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppModule, dynamicModule } from '../../src/app.module.js';
+import { AppService } from '../../src/app.service.js';
+
+describe('Application Context (e2e)', () => {
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('AppService', () => {
+    it('should resolve AppService from the container', () => {
+      const appService = module.get(AppService);
+      expect(appService).toBeDefined();
+    });
+
+    it('should return the hello message', () => {
+      const appService = module.get(AppService);
+      expect(appService.getHello()).toBe('Hello world!');
+    });
+  });
+
+  describe('MyDynamicModule', () => {
+    it('should resolve MyDynamicProvider with the registered value', () => {
+      const value = module.select(dynamicModule).get('MyDynamicProvider');
+      expect(value).toBe('foobar');
+    });
+  });
+});

--- a/sample/18-context/vitest.config.e2e.mts
+++ b/sample/18-context/vitest.config.e2e.mts
@@ -1,0 +1,11 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 18-context sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the 18-context sample (standalone application context), verifying:

- `AppService` is resolved from the DI container
- `getHello()` returns the expected "Hello world!" message
- `MyDynamicProvider` from the dynamic module is accessible via `module.select()` and resolves to `'foobar'`

This sample demonstrates standalone application context usage (no HTTP server), so the tests use `TestingModule` directly instead of supertest.

## Does this PR introduce a breaking change?
- [x] No