### PR TITLE
test(sample/04): add e2e tests for grpc sample

### DIFF
--- a/sample/04-grpc/e2e/hero/hero.e2e-spec.ts
+++ b/sample/04-grpc/e2e/hero/hero.e2e-spec.ts
@@ -1,0 +1,51 @@
+import { INestApplication } from '@nestjs/common';
+import { MicroserviceOptions } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module.js';
+import { grpcClientOptions } from '../../src/grpc-client.options.js';
+
+describe('HeroController (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.connectMicroservice<MicroserviceOptions>(grpcClientOptions);
+
+    await app.startAllMicroservices();
+    await app.listen(3001);
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('GET /hero/:id', () => {
+    it('should return a hero by id', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/hero/1')
+        .expect(200);
+
+      expect(response.body).toMatchObject({ id: 1, name: 'John' });
+    });
+  });
+
+  describe('GET /hero', () => {
+    it('should return multiple heroes', async () => {
+      const response = await request(app.getHttpServer())
+        .get('/hero')
+        .expect(200);
+
+      expect(response.body).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: 1, name: 'John' }),
+          expect.objectContaining({ id: 2, name: 'Doe' }),
+        ]),
+      );
+    });
+  });
+});

--- a/sample/04-grpc/vitest.config.e2e.mts
+++ b/sample/04-grpc/vitest.config.e2e.mts
@@ -1,0 +1,12 @@
+import swc from 'unplugin-swc';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    root: './',
+    include: ['e2e/**/*.e2e-spec.ts'],
+    hookTimeout: 30000,
+  },
+  plugins: [swc.vite()],
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Add missing e2e tests for sample applications

## What is the current behavior?

The 04-grpc sample does not include e2e tests.

Issue Number: #1539

## What is the new behavior?

Adds e2e tests for the 04-grpc sample using a hybrid HTTP + gRPC application setup (`connectMicroservice` + `startAllMicroservices`), verifying:

- `GET /hero/:id` returns a single hero by id
- `GET /hero` returns the full list of heroes

## Does this PR introduce a breaking change?
- [x] No