### PR TITLE
feat(common): add structured logging params support

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -481,7 +481,11 @@ export class ConsoleLogger implements LoggerService {
   }
 
   protected stringifyParams(params: Record<string, any>): string {
-    return inspect(params, this.inspectOptions);
+    return inspect(params, {
+      ...this.inspectOptions,
+      compact: true,
+      breakLength: Infinity,
+    });
   }
 
   protected stringifyMessage(message: unknown, logLevel: LogLevel) {
@@ -644,6 +648,19 @@ export class ConsoleLogger implements LoggerService {
         };
       }
       return { ...this.getContextAndMessagesToPrint(args) };
+    }
+
+    const trailingArg = args[args.length - 1];
+    if (this.isStackFormat(trailingArg)) {
+      const { messages, context, params } = this.getContextAndMessagesToPrint(
+        args.slice(0, -1),
+      );
+      return {
+        messages,
+        context,
+        stack: trailingArg as string,
+        params,
+      };
     }
 
     const { messages, context, params } =

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -1006,25 +1006,38 @@ describe('Logger', () => {
     });
 
     describe('text mode', () => {
+      class DeterministicConsoleLogger extends ConsoleLogger {
+        protected formatPid() {
+          return '[Nest] 123  - ';
+        }
+
+        protected getTimestamp(): string {
+          return '01/01/2026, 12:00:00 AM';
+        }
+
+        protected updateAndGetTimestampDiff(): string {
+          return '';
+        }
+      }
+
       it('should inline single plain object as params after message', () => {
-        const logger = new ConsoleLogger({ colors: false });
+        const logger = new DeterministicConsoleLogger({ colors: false });
         logger.log('User created', { userId: 1 });
 
         expect(processStdoutWriteSpy).toHaveBeenCalledOnce();
-        const output = processStdoutWriteSpy.mock.calls[0][0];
-        expect(output).toContain('User created');
-        expect(output).toContain('userId: 1');
+        expect(processStdoutWriteSpy.mock.calls[0][0]).toBe(
+          '[Nest] 123  - 01/01/2026, 12:00:00 AM     LOG User created { userId: 1 }\n',
+        );
       });
 
       it('should merge multiple plain objects into single params', () => {
-        const logger = new ConsoleLogger({ colors: false });
+        const logger = new DeterministicConsoleLogger({ colors: false });
         logger.log('Request', { userId: 1 }, { reqId: 'abc' });
 
         expect(processStdoutWriteSpy).toHaveBeenCalledOnce();
-        const output = processStdoutWriteSpy.mock.calls[0][0];
-        expect(output).toContain('Request');
-        expect(output).toContain('userId: 1');
-        expect(output).toContain("reqId: 'abc'");
+        expect(processStdoutWriteSpy.mock.calls[0][0]).toBe(
+          "[Nest] 123  - 01/01/2026, 12:00:00 AM     LOG Request { userId: 1, reqId: 'abc' }\n",
+        );
       });
 
       it('should treat plain object as first arg as message, not params', () => {
@@ -1038,15 +1051,17 @@ describe('Logger', () => {
       });
 
       it('should keep strings as messages and extract objects as params', () => {
-        const logger = new ConsoleLogger({ colors: false });
+        const logger = new DeterministicConsoleLogger({ colors: false });
         logger.log('msg1', 'msg2', { meta: true }, 'Context');
 
         // msg1 and msg2 are messages, { meta: true } is params, 'Context' is context
         expect(processStdoutWriteSpy).toHaveBeenCalledTimes(2);
-        expect(processStdoutWriteSpy.mock.calls[0][0]).toContain('msg1');
-        expect(processStdoutWriteSpy.mock.calls[0][0]).toContain('[Context]');
-        expect(processStdoutWriteSpy.mock.calls[0][0]).toContain('meta: true');
-        expect(processStdoutWriteSpy.mock.calls[1][0]).toContain('msg2');
+        expect(processStdoutWriteSpy.mock.calls[0][0]).toBe(
+          '[Nest] 123  - 01/01/2026, 12:00:00 AM     LOG [Context] msg1 { meta: true }\n',
+        );
+        expect(processStdoutWriteSpy.mock.calls[1][0]).toBe(
+          '[Nest] 123  - 01/01/2026, 12:00:00 AM     LOG [Context] msg2 { meta: true }\n',
+        );
       });
 
       it('should not treat arrays as params', () => {
@@ -1092,6 +1107,21 @@ describe('Logger', () => {
         expect(json.params).toEqual({ reqId: 'abc' });
       });
 
+      it('should keep reserved keys nested under params by default', () => {
+        const logger = new ConsoleLogger({ json: true });
+        logger.log(
+          'User created',
+          { message: 'override', level: 'debug' },
+          'UserService',
+        );
+
+        const json = JSON.parse(processStdoutWriteSpy.mock.calls[0][0]);
+        expect(json.level).toBe('log');
+        expect(json.message).toBe('User created');
+        expect(json.context).toBe('UserService');
+        expect(json.params).toEqual({ message: 'override', level: 'debug' });
+      });
+
       it('should flatten params to root when flattenParams is true', () => {
         const logger = new ConsoleLogger({ json: true, flattenParams: true });
         logger.log('User created', { userId: 1, action: 'create' }, 'Svc');
@@ -1113,6 +1143,18 @@ describe('Logger', () => {
         expect(json.context).toBe('AppService');
         expect(json.params).toEqual({ reqId: 'abc' });
         expect(json.stack).toBeUndefined();
+      });
+
+      it('should treat trailing stack-like string as stack when params are present', () => {
+        const logger = new ConsoleLogger({ json: true });
+        const stack = 'Error: test\n    at AppService.run (app.ts:1:1)';
+        logger.error('fail', { reqId: 'abc' }, stack);
+
+        const json = JSON.parse(processStderrWriteSpy.mock.calls[0][0]);
+        expect(json.message).toBe('fail');
+        expect(json.context).toBeUndefined();
+        expect(json.params).toEqual({ reqId: 'abc' });
+        expect(json.stack).toBe(stack);
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

`ConsoleLogger` currently treats plain objects passed after the first message argument as separate log entries instead of metadata attached to the same log record.

For example:

```ts
const logger = new Logger('UserService');
logger.log('User created', { userId: 1, email: 'foo@bar.com' });
```

In text mode, this produces two detached log lines:

```text
[Nest] 3785  - 02/26/2026, 10:04:41 AM     LOG [UserService] User created
[Nest] 3785  - 02/26/2026, 10:04:41 AM     LOG [UserService] Object(2) { userId: 1, email: 'foo@bar.com' }
```

In JSON mode, it produces two separate JSON records:

```json
{"level":"log","pid":3785,"timestamp":1772089691769,"message":"User created","context":"UserService"}
{"level":"log","pid":3785,"timestamp":1772089691769,"message":{"userId":1,"email":"foo@bar.com"},"context":"UserService"}
```

This makes the metadata detached from the original message, which is not suitable for structured logging workflows.

Issue Number: 16454


## What is the new behavior?

Plain objects passed after the first message argument are treated as structured params and attached to the same log entry.

### Text mode

Structured params are appended inline to the same formatted log line:

```ts
logger.log('User created', { userId: 1, email: 'foo@bar.com' });
```

```text
[Nest] 3785  - 02/26/2026, 10:04:41 AM     LOG [UserService] User created { userId: 1, email: 'foo@bar.com' }
```

When multiple plain objects are passed, they are merged:

```ts
logger.log('Request handled', { method: 'GET' }, { path: '/api', duration: 42 });
```

```text
[Nest] 3785  - 02/26/2026, 10:04:41 AM     LOG [UserService] Request handled { method: 'GET', path: '/api', duration: 42 }
```

### JSON mode

By default, structured params are nested under a `params` key:

```ts
logger.log('User created', { userId: 1 }, 'UserService');
```

```json
{"level":"log","pid":3785,"timestamp":1772089691769,"message":"User created","context":"UserService","params":{"userId":1}}
```

If `flattenParams: true` is enabled, params are spread into the root object:

```ts
new ConsoleLogger({ json: true, flattenParams: true });
```

```json
{"level":"log","pid":3785,"timestamp":1772089691769,"message":"User created","context":"UserService","userId":1}
```

### Compatibility

- `structuredParams` defaults to `true` for `v12`
- setting `structuredParams: false` restores the legacy behavior
- non-plain-object values (arrays, strings, numbers, class instances, `null`) continue to be treated as separate messages
- plain objects passed as the first argument are still treated as the message itself, preserving existing behavior for object messages

### Additional fix included

This PR also fixes `error()` parsing when structured params are followed by a trailing stack-like string, so:

```ts
logger.error('fail', { reqId: 'abc' }, stack);
```

correctly treats the trailing string as `stack` instead of `context`.


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: plain objects passed after the first message argument are no longer emitted as separate log entries by default. In `v12`, they are attached to the same log entry as structured params. Users can set `structuredParams: false` to preserve the legacy behavior.


## Other information

- Added support for `structuredParams` in `ConsoleLoggerOptions`
- Added support for `flattenParams` in JSON mode
- Ensured text-mode params are rendered inline as part of the same log entry
- Updated logger tests to assert actual formatted output in text mode using deterministic formatter overrides
- Added tests for:
  - inline text formatting
  - merged params
  - mixed message/params/context handling
  - nested `params` in JSON mode
  - `flattenParams: true`
  - legacy behavior with `structuredParams: false`
  - reserved-key safety in nested JSON mode
  - `error()` handling with params and trailing stack-like strings

### Validation

The structured logging test suite passes:

```bash
npx vitest run packages/common/test/services/logger.service.spec.ts -t "ConsoleLogger - structured logging params"
```

Note: the full `logger.service.spec.ts` file still contains one unrelated pre-existing failure in an older ANSI-color expectation, outside the scope of this PR.