### PR TITLE
sample(sample/33): add example recipe data to GraphQL Mercurius sample

### DIFF
--- a/sample/33-graphql-mercurius/src/recipes/recipes.service.ts
+++ b/sample/33-graphql-mercurius/src/recipes/recipes.service.ts
@@ -11,19 +11,55 @@ export class RecipesService {
    * Left for demonstration purposes
    */
 
+  private readonly recipes: Recipe[] = [
+    {
+      id: '1',
+      title: 'Lentil Soup',
+      description: 'A hearty red lentil soup with warming spices.',
+      creationDate: new Date('2024-01-15'),
+      ingredients: ['red lentils', 'onion', 'garlic', 'cumin', 'tomatoes', 'vegetable broth'],
+    },
+    {
+      id: '2',
+      title: 'Roasted Vegetable Bowl',
+      description: 'Oven-roasted seasonal vegetables over a bed of quinoa.',
+      creationDate: new Date('2024-02-10'),
+      ingredients: ['bell pepper', 'zucchini', 'chickpeas', 'olive oil', 'quinoa', 'lemon'],
+    },
+    {
+      id: '3',
+      title: 'Mushroom Stir Fry',
+      description: 'Umami-rich mushroom and broccoli stir fry with ginger-soy glaze.',
+      creationDate: new Date('2024-03-05'),
+      ingredients: ['shiitake mushrooms', 'broccoli', 'ginger', 'soy sauce', 'sesame oil', 'garlic'],
+    },
+  ];
+
   async create(data: NewRecipeInput): Promise<Recipe> {
-    return {} as any;
+    const recipe: Recipe = {
+      id: String(Date.now()),
+      creationDate: new Date(),
+      ...data,
+    };
+    this.recipes.push(recipe);
+    return recipe;
   }
 
   async findOneById(id: string): Promise<Recipe> {
-    return {} as any;
+    return this.recipes.find(recipe => recipe.id === id);
   }
 
   async findAll(recipesArgs: RecipesArgs): Promise<Recipe[]> {
-    return [] as Recipe[];
+    const { skip, take } = recipesArgs;
+    return this.recipes.slice(skip, skip + take);
   }
 
   async remove(id: string): Promise<boolean> {
+    const index = this.recipes.findIndex(recipe => recipe.id === id);
+    if (index === -1) {
+      return false;
+    }
+    this.recipes.splice(index, 1);
     return true;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: Fix non-functional mock data in sample application

## What is the current behavior?

The `sample/33-graphql-mercurius` sample's `RecipesService` returns empty stubs for every method:

- `findAll` returns `[]`
- `findOneById` returns `{} as any`
- `create` returns `{} as any`
- `remove` always returns `true` regardless of whether the id exists

Developers who run the sample and execute any GraphQL query receive empty or nonsensical responses, making it impossible to see the sample in action without writing their own data first.

## What is the new behavior?

- `RecipesService` now maintains a private in-memory `recipes` array initialized with three example entries.
- `findAll` respects the `skip`/`take` pagination arguments from `RecipesArgs`.
- `findOneById` searches the store by id and returns the matching recipe.
- `create` generates an id, stamps a `creationDate`, pushes the new entry, and returns it.
- `remove` returns `false` when the id is not found instead of silently returning `true`.

The sample now produces real API responses out of the box, which is the expected behavior for a demonstration application.

## Does this PR introduce a breaking change?
- [x] No