### PR TITLE
fix(core): refine unknown dependencies message token display

### DIFF
--- a/integration/injector/e2e/optional-factory-provider-dep.spec.ts
+++ b/integration/injector/e2e/optional-factory-provider-dep.spec.ts
@@ -118,7 +118,7 @@ describe('Optional factory provider deps', () => {
       } catch (err) {
         expect(err).to.be.instanceOf(UnknownDependenciesException);
         expect(err.message).to
-          .equal(`Nest can't resolve dependencies of the POSSIBLY_MISSING_DEP (?). Please make sure that the argument "MISSING_DEP" at index [0] is available in the RootTestModule context.
+          .equal(`Nest can't resolve dependencies of the POSSIBLY_MISSING_DEP (?). Please make sure that the argument "MISSING_DEP" at index [0] is available in the RootTestModule module.
 
 Potential solutions:
 - Is RootTestModule a valid NestJS module?

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -127,9 +127,14 @@ For more common dependency resolution issues, see: https://docs.nestjs.com/faq/c
   );
   dependenciesName[index] = '?';
 
+  const tokenFragment =
+    !isImportTypeIssue && name !== undefined ? ` ${dependencyName}` : '';
+  const contextLabel = isImportTypeIssue ? 'current' : moduleName;
+
   message += ` (`;
   message += dependenciesName.join(', ');
-  message += `). Please make sure that the argument ${isImportTypeIssue ? 'dependency' : dependencyName} at index [${index}] is available in the ${isImportTypeIssue ? 'current' : moduleName} context.`;
+  message += `). Please make sure that the argument${tokenFragment} at index [${index}]`;
+  message += ` is available in the ${contextLabel} module.`;
   message += potentialSolutions;
 
   return message;

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -16,7 +16,7 @@ describe('Error Messages', () => {
     const index = 0;
     it('should display class', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatService). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatService). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -41,7 +41,7 @@ describe('Error Messages', () => {
     });
     it('should display the provide token', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -64,7 +64,7 @@ describe('Error Messages', () => {
     });
     it('should display the provide token as double-quoted string for string-based tokens', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?). Please make sure that the argument "FooRepository" at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?). Please make sure that the argument "FooRepository" at index [0] is available in the current module.
 
       Potential solutions:
       - If "FooRepository" is a provider, is it part of the current Module?
@@ -88,7 +88,7 @@ describe('Error Messages', () => {
     });
     it('should display the function name', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatFunction). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?, CatFunction). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -111,7 +111,7 @@ describe('Error Messages', () => {
     });
     it('should use "+" if unknown dependency name', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?, +). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?, +). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -134,7 +134,7 @@ describe('Error Messages', () => {
     });
     it('should display the module name', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument dependency at index [0] is available in the TestModule context.
+        stringCleaner(`Nest can't resolve dependencies of the CatService (?, MY_TOKEN). Please make sure that the argument at index [0] is available in the TestModule module.
 
       Potential solutions:
       - Is TestModule a valid NestJS module?
@@ -170,7 +170,7 @@ describe('Error Messages', () => {
     });
     it('should display the symbol name of the provider', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the Symbol(CatProvider) (?). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the Symbol(CatProvider) (?). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -193,7 +193,7 @@ describe('Error Messages', () => {
     });
     it('should display the symbol dependency of the provider', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the CatProvider (?, Symbol(DogProvider)). Please make sure that the argument dependency at index [0] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the CatProvider (?, Symbol(DogProvider)). Please make sure that the argument at index [0] is available in the current module.
 
       Potential solutions:
       - If dependency is a provider, is it part of the current Module?
@@ -216,7 +216,7 @@ describe('Error Messages', () => {
     });
     it('should detect likely import type issue and provide specific guidance', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the ResourceController (ResourceService, ?). Please make sure that the argument dependency at index [1] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the ResourceController (ResourceService, ?). Please make sure that the argument at index [1] is available in the current module.
 
       Potential solutions:
       - The dependency at index [1] appears to be undefined at runtime
@@ -242,7 +242,7 @@ describe('Error Messages', () => {
     });
     it('should detect import type issue with mixed dependencies', () => {
       const expectedResult =
-        stringCleaner(`Nest can't resolve dependencies of the ResourceController (ValidService, ?, AnotherService). Please make sure that the argument dependency at index [1] is available in the current context.
+        stringCleaner(`Nest can't resolve dependencies of the ResourceController (ValidService, ?, AnotherService). Please make sure that the argument at index [1] is available in the current module.
 
       Potential solutions:
       - The dependency at index [1] appears to be undefined at runtime
@@ -264,6 +264,82 @@ describe('Error Messages', () => {
           index: 1,
           dependencies: [ValidService, Object, AnotherService], // mixed valid/Object
           name: 'SomeService',
+        }).message,
+      );
+
+      expect(actualMessage).to.equal(expectedResult);
+    });
+    it('should display class token name in argument label when name is provided', () => {
+      class UserRepository {}
+
+      const expectedResult =
+        stringCleaner(`Nest can't resolve dependencies of the UserService (?). Please make sure that the argument UserRepository at index [0] is available in the current module.
+
+      Potential solutions:
+      - If UserRepository is a provider, is it part of the current Module?
+      - If UserRepository is exported from a separate @Module, is that module imported within Module?
+      @Module({
+        imports: [ /* the Module containing UserRepository */ ]
+      })
+
+      For more common dependency resolution issues, see: https://docs.nestjs.com/faq/common-errors
+      `);
+
+      const actualMessage = stringCleaner(
+        new UnknownDependenciesException('UserService', {
+          index: 0,
+          dependencies: [UserRepository],
+          name: UserRepository,
+        }).message,
+      );
+
+      expect(actualMessage).to.equal(expectedResult);
+    });
+    it('should display string token name in argument label when name is provided', () => {
+      const expectedResult =
+        stringCleaner(`Nest can't resolve dependencies of the UserService (?). Please make sure that the argument "DATABASE_URL" at index [0] is available in the current module.
+
+      Potential solutions:
+      - If "DATABASE_URL" is a provider, is it part of the current Module?
+      - If "DATABASE_URL" is exported from a separate @Module, is that module imported within Module?
+      @Module({
+        imports: [ /* the Module containing "DATABASE_URL" */ ]
+      })
+
+      For more common dependency resolution issues, see: https://docs.nestjs.com/faq/common-errors
+      `);
+
+      const actualMessage = stringCleaner(
+        new UnknownDependenciesException('UserService', {
+          index: 0,
+          dependencies: ['DATABASE_URL'],
+          name: 'DATABASE_URL',
+        }).message,
+      );
+
+      expect(actualMessage).to.equal(expectedResult);
+    });
+    it('should display symbol token name in argument label when name is provided', () => {
+      const TOKEN = Symbol('MY_TOKEN');
+
+      const expectedResult =
+        stringCleaner(`Nest can't resolve dependencies of the UserService (?). Please make sure that the argument Symbol(MY_TOKEN) at index [0] is available in the current module.
+
+      Potential solutions:
+      - If Symbol(MY_TOKEN) is a provider, is it part of the current Module?
+      - If Symbol(MY_TOKEN) is exported from a separate @Module, is that module imported within Module?
+      @Module({
+        imports: [ /* the Module containing Symbol(MY_TOKEN) */ ]
+      })
+
+      For more common dependency resolution issues, see: https://docs.nestjs.com/faq/common-errors
+      `);
+
+      const actualMessage = stringCleaner(
+        new UnknownDependenciesException('UserService', {
+          index: 0,
+          dependencies: [TOKEN],
+          name: TOKEN,
         }).message,
       );
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the guidelines
- [x] Tests for the changes have been added / updated
- [ ] Docs have been added / updated (not applicable)

---

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes

---

## What is the current behavior?

When Nest cannot resolve a dependency, the error message produced by
`UNKNOWN_DEPENDENCIES_MESSAGE` has two minor rough edges:

1. For import-type issues (where the dependency name is genuinely unknown),
   the word "dependency" is used as a generic stand-in, resulting in phrasing like:

   > Please make sure that the argument dependency at index [0] …

2. The message ends with "context", while users typically reason
   about their applications in terms of modules, e.g.:

   > … is available in the RootTestModule context.

Discussion reference: #16491

---

## What is the new behavior?

- The token name is displayed only when it is actually defined.
  If the name is unknown, the message now reads:

  > argument at index [N]

  (without a misleading placeholder word)

- "context" is replaced with "module" so the phrasing aligns with
  how users reason about application structure.

### Before

Nest can't resolve dependencies of the CatService (?, CatService).
Please make sure that the argument dependency at index [0] is available in the current context.

### After

Nest can't resolve dependencies of the CatService (?, CatService).
Please make sure that the argument at index [0] is available in the current module.

String and symbol tokens continue to render correctly
(e.g. "FooRepository", Symbol(MY_TOKEN)).

---

## Does this PR introduce a breaking change?

- [x] No

This is strictly a developer-experience wording refinement.
No public APIs, runtime behavior, or error types are changed.

All unit and integration tests pass.