### PR TITLE
feat(common): Console Logger colored context enhancement 

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -1,6 +1,6 @@
 import { inspect, InspectOptions } from 'util';
 import { Injectable, Optional } from '../decorators/core';
-import { clc, yellow, isColorAllowed } from '../utils/cli-colors.util';
+import { clc, isColorAllowed, colorText } from '../utils/cli-colors.util';
 import {
   isFunction,
   isPlainObject,
@@ -329,7 +329,7 @@ export class ConsoleLogger implements LoggerService {
       }
       const pidMessage = this.formatPid(process.pid);
       const contextMessage = this.formatContext(context);
-      const timestampDiff = this.updateAndGetTimestampDiff();
+      const timestampDiff = this.updateAndGetTimestampDiff(context);
       const formattedLogLevel = logLevel.toUpperCase().padStart(7, ' ');
       const formattedMessage = this.formatMessage(
         logLevel,
@@ -423,8 +423,10 @@ export class ConsoleLogger implements LoggerService {
       return '';
     }
 
-    context = `[${context}] `;
-    return this.options.colors ? yellow(context) : context;
+    const formattedContext = `[${context}] `;
+    return this.options.colors
+      ? colorText(context, formattedContext)
+      : formattedContext;
   }
 
   protected formatMessage(
@@ -486,19 +488,24 @@ export class ConsoleLogger implements LoggerService {
     }
   }
 
-  protected updateAndGetTimestampDiff(): string {
+  protected updateAndGetTimestampDiff(context: string): string {
     const includeTimestamp =
       ConsoleLogger.lastTimestampAt && this.options?.timestamp;
     const result = includeTimestamp
-      ? this.formatTimestampDiff(Date.now() - ConsoleLogger.lastTimestampAt!)
+      ? this.formatTimestampDiff(
+          context,
+          Date.now() - ConsoleLogger.lastTimestampAt!,
+        )
       : '';
     ConsoleLogger.lastTimestampAt = Date.now();
     return result;
   }
 
-  protected formatTimestampDiff(timestampDiff: number) {
+  protected formatTimestampDiff(context: string, timestampDiff: number) {
     const formattedDiff = ` +${timestampDiff}ms`;
-    return this.options.colors ? yellow(formattedDiff) : formattedDiff;
+    return this.options.colors
+      ? colorText(context, formattedDiff)
+      : formattedDiff;
   }
 
   protected getInspectOptions() {

--- a/packages/common/test/services/logger.service.spec.ts
+++ b/packages/common/test/services/logger.service.spec.ts
@@ -1016,6 +1016,90 @@ describe('Logger', () => {
       expect(consoleLoggerSpy.getCall(4).returnValue).to.equal('null');
       expect(consoleLoggerSpy.getCall(5).returnValue).to.equal('1');
     });
+
+    describe('colorText feature', () => {
+      const noColorEnv = 'NO_COLOR';
+
+      beforeEach(() => {
+        delete process.env[noColorEnv];
+      });
+
+      it('should output plain context and no ANSI when colors is false', () => {
+        const logger = new ConsoleLogger({ colors: false });
+        const context = 'PlainContext';
+        const message = 'test message';
+
+        logger.log(message, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+        const output = processStdoutWriteSpy.firstCall.firstArg;
+        expect(output).to.include(`[${context}]`);
+        expect(output).to.include(message);
+        expect(output).not.to.include('\x1B[');
+      });
+
+      it('should output context with ANSI color (via colorText) when colors is true', () => {
+        const logger = new ConsoleLogger({ colors: true });
+        const context = 'ColoredContext';
+        const message = 'test message';
+
+        logger.log(message, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+        const output = processStdoutWriteSpy.firstCall.firstArg;
+        expect(output).to.include(`[${context}]`);
+        expect(output).to.include(message);
+        expect(output).to.include('\x1B[');
+        expect(output).to.include('\x1B[39m');
+      });
+
+      it('should output plain timestamp diff when colors is false and timestamp is true', () => {
+        const logger = new ConsoleLogger({
+          colors: false,
+          timestamp: true,
+        });
+        const message = 'first';
+
+        logger.log(message);
+        logger.log('second');
+
+        expect(processStdoutWriteSpy.calledTwice).to.be.true;
+        const secondOutput = processStdoutWriteSpy.secondCall.firstArg;
+        expect(secondOutput).to.match(/ \+?\d+ms/);
+        expect(secondOutput).not.to.include('\x1B[');
+      });
+
+      it('should output timestamp diff with ANSI color (via colorText) when colors and timestamp are true', () => {
+        const logger = new ConsoleLogger({
+          colors: true,
+          timestamp: true,
+        });
+        const context = 'TimestampContext';
+
+        logger.log('first', context);
+        logger.log('second', context);
+
+        expect(processStdoutWriteSpy.calledTwice).to.be.true;
+        const secondOutput = processStdoutWriteSpy.secondCall.firstArg;
+        expect(secondOutput).to.match(/ \+?\d+ms/);
+        expect(secondOutput).to.include('\x1B[');
+        expect(secondOutput).to.include('\x1B[39m');
+      });
+
+      it('should not apply colorText when NO_COLOR is set even if options.colors is true', () => {
+        process.env[noColorEnv] = '1';
+        const logger = new ConsoleLogger({ colors: true });
+        const context = 'NoColorEnv';
+        const message = 'test';
+
+        logger.log(message, context);
+
+        expect(processStdoutWriteSpy.calledOnce).to.be.true;
+        const output = processStdoutWriteSpy.firstCall.firstArg;
+        expect(output).to.include(`[${context}]`);
+        expect(output).not.to.include('\x1B[');
+      });
+    });
   });
 });
 

--- a/packages/common/test/utils/cli-colors.util.spec.ts
+++ b/packages/common/test/utils/cli-colors.util.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { colorText, isColorAllowed, clc } from '../../utils/cli-colors.util';
+
+describe('cli-colors.util', () => {
+  const noColorEnv = 'NO_COLOR';
+
+  describe('isColorAllowed', () => {
+    beforeEach(() => {
+      delete process.env[noColorEnv];
+    });
+
+    it('should return false when NO_COLOR is set', () => {
+      process.env[noColorEnv] = '1';
+      expect(isColorAllowed()).to.be.false;
+    });
+
+    it('should return true when NO_COLOR is not set', () => {
+      expect(isColorAllowed()).to.be.true;
+    });
+  });
+
+  describe('colorText', () => {
+    beforeEach(() => {
+      delete process.env[noColorEnv];
+    });
+
+    it('should return plain text when NO_COLOR is set', () => {
+      process.env[noColorEnv] = '1';
+      expect(colorText('MyContext', 'hello')).to.equal('hello');
+    });
+
+    it('should return text wrapped with ANSI escape codes when colors are allowed', () => {
+      const result = colorText('MyContext', 'hello');
+      expect(result).to.include('\x1B[');
+      expect(result).to.include('hello');
+      expect(result).to.include('\x1B[39m');
+    });
+
+    it('should produce deterministic color for the same context', () => {
+      const a = colorText('SameContext', 'text');
+      const b = colorText('SameContext', 'text');
+      expect(a).to.equal(b);
+    });
+
+    it('should produce different colors for different contexts', () => {
+      const a = colorText('ContextA', 'text');
+      const b = colorText('ContextB', 'text');
+      expect(a).not.to.equal(b);
+    });
+
+    it('should color the given text only (second argument)', () => {
+      const text = 'message';
+      const result = colorText('Context', text);
+      const reset = '\x1B[39m';
+      const openingCode = colorText('Context', '').slice(0, -reset.length);
+      const expected = `${openingCode}${text}${reset}`;
+      expect(result).to.equal(expected);
+    });
+  });
+});

--- a/packages/common/utils/cli-colors.util.ts
+++ b/packages/common/utils/cli-colors.util.ts
@@ -12,6 +12,30 @@ export const clc = {
   magentaBright: colorIfAllowed((text: string) => `\x1B[95m${text}\x1B[39m`),
   cyanBright: colorIfAllowed((text: string) => `\x1B[96m${text}\x1B[39m`),
 };
-export const yellow = colorIfAllowed(
-  (text: string) => `\x1B[38;5;3m${text}\x1B[39m`,
-);
+
+const colors = [
+  20, 21, 26, 27, 32, 33, 38, 39, 40, 41, 42, 43, 44, 45, 56, 57, 62, 63, 68,
+  69, 74, 75, 76, 77, 78, 79, 80, 81, 92, 93, 98, 99, 112, 113, 128, 129, 134,
+  135, 148, 149, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171,
+  172, 173, 178, 179, 184, 185, 196, 197, 198, 199, 200, 201, 202, 203, 204,
+  205, 206, 207, 208, 209, 214, 215, 220, 221,
+];
+
+function selectColor(context = '') {
+  let hash = 0;
+
+  for (let i = 0; i < context.length; i++) {
+    hash = (hash << 5) - hash + context.charCodeAt(i);
+    hash |= 0; // Convert to 32bit integer
+  }
+
+  return colors[Math.abs(hash) % colors.length];
+}
+
+export function colorText(context: string, text: string) {
+  if (!isColorAllowed()) return text;
+
+  const c = selectColor(context);
+  const colorCode = '\x1B[3' + (c < 8 ? c : '8;5;' + c) + 'm';
+  return `${colorCode}${text}\x1B[39m`;
+}


### PR DESCRIPTION
Enhance Console Logger context coloring

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
It can be visually hard to distinguish log messages from different contexts with the console logger,
<img width="790" height="164" alt="image" src="https://github.com/user-attachments/assets/c91db2f2-761f-4f94-a8e8-eb59cbeb7add" />


Issue Number: N/A

## What is the new behavior?
<img width="644" height="171" alt="Screenshot 2026-03-01 212033" src="https://github.com/user-attachments/assets/1159fd6a-6409-42fe-ae9b-e8eb99e23ea2" />

console-logger messages will have colored context and timestamp according to the context. I've been using [this ](https://www.npmjs.com/package/nestjs-color-logger) for a while, but I think the feature could be merged in to nestjs if others like the feature.


## Does this PR introduce a breaking change?
- [x] No


## Other information

Implemenation based on [debug](https://github.com/debug-js/debug/blob/master/src/common.js#L41). That library seems to have a good color pallet, so using that as a base.

I also think that the message bodies are easier to read if they were white, but did not make that change in this PR:

<img width="714" height="203" alt="image" src="https://github.com/user-attachments/assets/35d1a5c4-6a23-4581-aa10-219c52d8cf80" />

I can make this change configurable to allow the old color behavior if desired.