### PR TITLE
fix(microservices): fix double callback when isdisposed or err is truthy

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -338,7 +338,7 @@ export class ClientRMQ extends ClientProxy<RmqEvents, RmqStatus> {
       options,
     );
     if (isDisposed || err) {
-      callback?.({
+      return callback?.({
         err,
         response,
         isDisposed: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
when isDisposed or err is truthy, the callback is invoked twice. Can cause duplicate message processing.
<img width="1378" height="414" alt="Screenshot from 2026-03-04 20-59-47" src="https://github.com/user-attachments/assets/d856fcd6-9061-4413-ba0c-ed87a272ef57" />


Issue Number: N/A

## What is the new behavior?

If  isDisposed or err is truthy, returns the callback, so the callback below it does not get executed.

<img width="1378" height="414" alt="Screenshot from 2026-03-04 21-00-25" src="https://github.com/user-attachments/assets/22e120af-d486-4cfd-93e9-36c104e886aa" />


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information