### PR TITLE
feat(microservices): add topic-consumers option to server-kafka

### DIFF
--- a/integration/microservices/e2e/kafka-topic-consumers.spec.ts
+++ b/integration/microservices/e2e/kafka-topic-consumers.spec.ts
@@ -1,0 +1,96 @@
+import { INestApplication } from '@nestjs/common';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+import * as request from 'supertest';
+import { KafkaTopicConsumersController } from '../src/kafka-topic-consumers/kafka-topic-consumers.controller';
+import { KafkaTopicConsumersMessagesController } from '../src/kafka-topic-consumers/kafka-topic-consumers.messages.controller';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Skip this test in CI/CD pipeline as it requires a running Kafka broker.
+ * Run locally with: npm run test:docker:up && npm run test:integration
+ */
+describe.skip('Kafka topicConsumers', function () {
+  let server: any;
+  let app: INestApplication;
+
+  this.timeout(30000);
+
+  before('Start Kafka app with topicConsumers enabled', async () => {
+    const module = await Test.createTestingModule({
+      controllers: [
+        KafkaTopicConsumersController,
+        KafkaTopicConsumersMessagesController,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpAdapter().getInstance();
+
+    app.connectMicroservice<MicroserviceOptions>({
+      transport: Transport.KAFKA,
+      options: {
+        client: {
+          brokers: ['localhost:9092'],
+        },
+        topicConsumers: true,
+      },
+    });
+
+    app.enableShutdownHooks();
+    await app.startAllMicroservices();
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED = false;
+    KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED = false;
+    // ensure topic-a handler is non-blocking before each test
+    await request(server).post('/release-a').send();
+  });
+
+  it('should process events from both topics', async () => {
+    await Promise.all([
+      request(server).post('/emit-a').send().expect(200),
+      request(server).post('/emit-b').send().expect(200),
+    ]);
+
+    await sleep(3000);
+
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).to.be.true;
+    expect(KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED).to.be.true;
+  });
+
+  it('should process topic-b while topic-a handler is blocking', async () => {
+    // Block topic-a handler
+    await request(server).post('/block-a').send().expect(200);
+
+    // Emit to topic-a — handler will block until released
+    await request(server).post('/emit-a').send().expect(200);
+
+    // Give time for the message to be consumed and the handler to start blocking
+    await sleep(2000);
+
+    // Emit to topic-b — with topicConsumers=true this should be processed
+    // independently, regardless of topic-a being blocked
+    await request(server).post('/emit-b').send().expect(200);
+
+    await sleep(2000);
+
+    // topic-b must be processed despite topic-a still being blocked
+    expect(KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED).to.be.true;
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).to.be.false;
+
+    // Release topic-a and verify it completes
+    await request(server).post('/release-a').send().expect(200);
+    await sleep(2000);
+
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).to.be.true;
+  });
+
+  after('Stop Kafka app', async () => {
+    await app.close();
+  });
+});

--- a/integration/microservices/e2e/kafka-topic-consumers.spec.ts
+++ b/integration/microservices/e2e/kafka-topic-consumers.spec.ts
@@ -1,0 +1,93 @@
+import { INestApplication } from '@nestjs/common';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { KafkaTopicConsumersController } from '../src/kafka-topic-consumers/kafka-topic-consumers.controller.js';
+import { KafkaTopicConsumersMessagesController } from '../src/kafka-topic-consumers/kafka-topic-consumers.messages.controller.js';
+
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Skip this test in CI/CD pipeline as it requires a running Kafka broker.
+ * Run locally with: npm run test:docker:up && npm run test:integration
+ */
+describe.skip('Kafka topicConsumers', function () {
+  let server: any;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const module = await Test.createTestingModule({
+      controllers: [
+        KafkaTopicConsumersController,
+        KafkaTopicConsumersMessagesController,
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    server = app.getHttpAdapter().getInstance();
+
+    app.connectMicroservice<MicroserviceOptions>({
+      transport: Transport.KAFKA,
+      options: {
+        client: {
+          brokers: ['localhost:9092'],
+        },
+        topicConsumers: true,
+      },
+    });
+
+    app.enableShutdownHooks();
+    await app.startAllMicroservices();
+    await app.init();
+  });
+
+  beforeEach(async () => {
+    KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED = false;
+    KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED = false;
+    // ensure topic-a handler is non-blocking before each test
+    await request(server).post('/release-a').send();
+  });
+
+  it('should process events from both topics', async () => {
+    await Promise.all([
+      request(server).post('/emit-a').send().expect(200),
+      request(server).post('/emit-b').send().expect(200),
+    ]);
+
+    await sleep(3000);
+
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).toBe(true);
+    expect(KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED).toBe(true);
+  });
+
+  it('should process topic-b while topic-a handler is blocking', async () => {
+    // Block topic-a handler
+    await request(server).post('/block-a').send().expect(200);
+
+    // Emit to topic-a — handler will block until released
+    await request(server).post('/emit-a').send().expect(200);
+
+    // Give time for the message to be consumed and the handler to start blocking
+    await sleep(2000);
+
+    // Emit to topic-b — with topicConsumers=true this should be processed
+    // independently, regardless of topic-a being blocked
+    await request(server).post('/emit-b').send().expect(200);
+
+    await sleep(2000);
+
+    // topic-b must be processed despite topic-a still being blocked
+    expect(KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED).toBe(true);
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).toBe(false);
+
+    // Release topic-a and verify it completes
+    await request(server).post('/release-a').send().expect(200);
+    await sleep(2000);
+
+    expect(KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED).toBe(true);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+});

--- a/integration/microservices/src/kafka-topic-consumers/kafka-topic-consumers.controller.ts
+++ b/integration/microservices/src/kafka-topic-consumers/kafka-topic-consumers.controller.ts
@@ -1,0 +1,43 @@
+import {
+  Controller,
+  HttpCode,
+  OnModuleDestroy,
+  OnModuleInit,
+  Post,
+} from '@nestjs/common';
+import { Client, ClientKafka, Transport } from '@nestjs/microservices';
+
+@Controller()
+export class KafkaTopicConsumersController
+  implements OnModuleInit, OnModuleDestroy
+{
+  @Client({
+    transport: Transport.KAFKA,
+    options: {
+      client: {
+        brokers: ['localhost:9092'],
+      },
+    },
+  })
+  private readonly client: ClientKafka;
+
+  async onModuleInit() {
+    await this.client.connect();
+  }
+
+  async onModuleDestroy() {
+    await this.client.close();
+  }
+
+  @Post('emit-a')
+  @HttpCode(200)
+  emitA() {
+    return this.client.emit('topic-consumers.topic-a', {});
+  }
+
+  @Post('emit-b')
+  @HttpCode(200)
+  emitB() {
+    return this.client.emit('topic-consumers.topic-b', {});
+  }
+}

--- a/integration/microservices/src/kafka-topic-consumers/kafka-topic-consumers.messages.controller.ts
+++ b/integration/microservices/src/kafka-topic-consumers/kafka-topic-consumers.messages.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, HttpCode, Post } from '@nestjs/common';
+import { EventPattern } from '@nestjs/microservices';
+import { BehaviorSubject } from 'rxjs';
+import { first, skipWhile } from 'rxjs/operators';
+
+@Controller()
+export class KafkaTopicConsumersMessagesController {
+  static TOPIC_A_PROCESSED = false;
+  static TOPIC_B_PROCESSED = false;
+
+  public waiting = new BehaviorSubject<boolean>(false);
+
+  @Post('block-a')
+  @HttpCode(200)
+  blockA() {
+    this.waiting.next(true);
+  }
+
+  @Post('release-a')
+  @HttpCode(200)
+  releaseA() {
+    this.waiting.next(false);
+  }
+
+  @EventPattern('topic-consumers.topic-a')
+  async handleTopicA(): Promise<void> {
+    await new Promise<void>(resolve => {
+      this.waiting
+        .pipe(
+          skipWhile(isWaiting => isWaiting),
+          first(),
+        )
+        .subscribe(() => resolve());
+    });
+    KafkaTopicConsumersMessagesController.TOPIC_A_PROCESSED = true;
+  }
+
+  @EventPattern('topic-consumers.topic-b')
+  handleTopicB(): void {
+    KafkaTopicConsumersMessagesController.TOPIC_B_PROCESSED = true;
+  }
+}

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -352,5 +352,17 @@ export interface KafkaOptions {
     deserializer?: Deserializer;
     parser?: KafkaParserConfig;
     producerOnlyMode?: boolean;
+    /**
+     * When enabled, creates a separate Kafka consumer per registered topic,
+     * allowing concurrent message processing across topics.
+     * Each consumer uses `{groupId}-{topic}` as its consumer group ID,
+     * providing independent offset tracking per topic.
+     *
+     * Note: topic name is appended as groupId suffix. Ensure topic names
+     * contain only valid Kafka consumer group ID characters (alphanumeric, '.', '_', '-').
+     *
+     * @default false
+     */
+    topicConsumers?: boolean;
   };
 }

--- a/packages/microservices/interfaces/microservice-configuration.interface.ts
+++ b/packages/microservices/interfaces/microservice-configuration.interface.ts
@@ -347,5 +347,17 @@ export interface KafkaOptions {
     deserializer?: Deserializer;
     parser?: KafkaParserConfig;
     producerOnlyMode?: boolean;
+    /**
+     * When enabled, creates a separate Kafka consumer per registered topic,
+     * allowing concurrent message processing across topics.
+     * Each consumer uses `{groupId}-{topic}` as its consumer group ID,
+     * providing independent offset tracking per topic.
+     *
+     * Note: topic name is appended as groupId suffix. Ensure topic names
+     * contain only valid Kafka consumer group ID characters (alphanumeric, '.', '_', '-').
+     *
+     * @default false
+     */
+    topicConsumers?: boolean;
   };
 }

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -1,3 +1,5 @@
+import { Logger } from '@nestjs/common/services/logger.service';
+import { isNil } from '@nestjs/common/utils/shared.utils';
 import { isObservable, lastValueFrom, Observable, ReplaySubject } from 'rxjs';
 import {
   KAFKA_DEFAULT_BROKER,
@@ -5,12 +7,12 @@ import {
   KAFKA_DEFAULT_GROUP,
   NO_EVENT_HANDLER,
   NO_MESSAGE_HANDLER,
-} from '../constants.js';
-import { KafkaContext } from '../ctx-host/index.js';
-import { KafkaRequestDeserializer } from '../deserializers/kafka-request.deserializer.js';
-import { KafkaHeaders, Transport } from '../enums/index.js';
-import { KafkaStatus } from '../events/index.js';
-import { KafkaRetriableException } from '../exceptions/index.js';
+} from '../constants';
+import { KafkaContext } from '../ctx-host';
+import { KafkaRequestDeserializer } from '../deserializers/kafka-request.deserializer';
+import { KafkaHeaders, Transport } from '../enums';
+import { KafkaStatus } from '../events';
+import { KafkaRetriableException } from '../exceptions';
 import {
   BrokersFunction,
   Consumer,
@@ -22,18 +24,16 @@ import {
   Message,
   Producer,
   RecordMetadata,
-} from '../external/kafka.interface.js';
-import { KafkaLogger, KafkaParser } from '../helpers/index.js';
+} from '../external/kafka.interface';
+import { KafkaLogger, KafkaParser } from '../helpers';
 import {
   KafkaOptions,
   OutgoingResponse,
   ReadPacket,
   TransportId,
-} from '../interfaces/index.js';
-import { KafkaRequestSerializer } from '../serializers/kafka-request.serializer.js';
-import { Server } from './server.js';
-import { Logger } from '@nestjs/common';
-import { isNil } from '@nestjs/common/utils/shared.utils.js';
+} from '../interfaces';
+import { KafkaRequestSerializer } from '../serializers/kafka-request.serializer';
+import { Server } from './server';
 
 /**
  * @publicApi

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -1,5 +1,3 @@
-import { Logger } from '@nestjs/common/services/logger.service';
-import { isNil } from '@nestjs/common/utils/shared.utils';
 import { isObservable, lastValueFrom, Observable, ReplaySubject } from 'rxjs';
 import {
   KAFKA_DEFAULT_BROKER,
@@ -7,12 +5,12 @@ import {
   KAFKA_DEFAULT_GROUP,
   NO_EVENT_HANDLER,
   NO_MESSAGE_HANDLER,
-} from '../constants';
-import { KafkaContext } from '../ctx-host';
-import { KafkaRequestDeserializer } from '../deserializers/kafka-request.deserializer';
-import { KafkaHeaders, Transport } from '../enums';
-import { KafkaStatus } from '../events';
-import { KafkaRetriableException } from '../exceptions';
+} from '../constants.js';
+import { KafkaContext } from '../ctx-host/index.js';
+import { KafkaRequestDeserializer } from '../deserializers/kafka-request.deserializer.js';
+import { KafkaHeaders, Transport } from '../enums/index.js';
+import { KafkaStatus } from '../events/index.js';
+import { KafkaRetriableException } from '../exceptions/index.js';
 import {
   BrokersFunction,
   Consumer,
@@ -24,18 +22,18 @@ import {
   Message,
   Producer,
   RecordMetadata,
-} from '../external/kafka.interface';
-import { KafkaLogger, KafkaParser } from '../helpers';
+} from '../external/kafka.interface.js';
+import { KafkaLogger, KafkaParser } from '../helpers/index.js';
 import {
   KafkaOptions,
   OutgoingResponse,
   ReadPacket,
   TransportId,
-} from '../interfaces';
-import { KafkaRequestSerializer } from '../serializers/kafka-request.serializer';
-import { Server } from './server';
-
-let kafkaPackage: any = {};
+} from '../interfaces/index.js';
+import { KafkaRequestSerializer } from '../serializers/kafka-request.serializer.js';
+import { Server } from './server.js';
+import { Logger } from '@nestjs/common';
+import { isNil } from '@nestjs/common/internal';
 
 /**
  * @publicApi
@@ -46,6 +44,7 @@ export class ServerKafka extends Server<never, KafkaStatus> {
   protected logger = new Logger(ServerKafka.name);
   protected client: Kafka | null = null;
   protected consumer: Consumer | null = null;
+  protected consumers: Map<string, Consumer> = new Map();
   protected producer: Producer | null = null;
   protected parser: KafkaParser | null = null;
   protected brokers: string[] | BrokersFunction;
@@ -75,10 +74,6 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       (clientOptions.clientId || KAFKA_DEFAULT_CLIENT) + postfixId;
     this.groupId = (consumerOptions.groupId || KAFKA_DEFAULT_GROUP) + postfixId;
 
-    kafkaPackage = this.loadPackage('kafkajs', ServerKafka.name, () =>
-      require('kafkajs'),
-    );
-
     this.parser = new KafkaParser((options && options.parser) || undefined);
 
     this.initializeSerializer(options);
@@ -89,7 +84,7 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     callback: (err?: unknown, ...optionalParams: unknown[]) => void,
   ): Promise<void> {
     try {
-      this.client = this.createClient();
+      this.client = await this.createClient();
       await this.start(callback);
     } catch (err) {
       callback(err);
@@ -97,6 +92,12 @@ export class ServerKafka extends Server<never, KafkaStatus> {
   }
 
   public async close(): Promise<void> {
+    if (this.consumers.size > 0) {
+      await Promise.allSettled(
+        [...this.consumers.values()].map(consumer => consumer.disconnect()),
+      );
+      this.consumers.clear();
+    }
     this.consumer && (await this.consumer.disconnect());
     this.producer && (await this.producer.disconnect());
     this.consumer = null;
@@ -105,17 +106,24 @@ export class ServerKafka extends Server<never, KafkaStatus> {
   }
 
   public async start(callback: () => void): Promise<void> {
-    const consumerOptions = Object.assign(this.options.consumer || {}, {
+    const consumerOptions = Object.assign({}, this.options.consumer || {}, {
       groupId: this.groupId,
     });
-    this.consumer = this.client!.consumer(consumerOptions);
-    this.producer = this.client!.producer(this.options.producer);
-    this.registerConsumerEventListeners();
-    this.registerProducerEventListeners();
 
-    await this.consumer.connect();
-    await this.producer.connect();
-    await this.bindEvents(this.consumer);
+    if (this.getOptionsProp(this.options, 'topicConsumers', false)) {
+      this.producer = this.client!.producer(this.options.producer);
+      this.registerProducerEventListeners();
+      await this.producer.connect();
+      await this.bindEventsPerTopic(consumerOptions);
+    } else {
+      this.consumer = this.client!.consumer(consumerOptions);
+      this.producer = this.client!.producer(this.options.producer);
+      this.registerConsumerEventListeners();
+      this.registerProducerEventListeners();
+      await this.consumer.connect();
+      await this.producer.connect();
+      await this.bindEvents(this.consumer);
+    }
     callback();
   }
 
@@ -123,19 +131,23 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     if (!this.consumer) {
       return;
     }
-    this.consumer.on(this.consumer.events.CONNECT, () =>
+    this.registerConsumerEventListenersFor(this.consumer);
+  }
+
+  protected registerConsumerEventListenersFor(consumer: Consumer) {
+    consumer.on(consumer.events.CONNECT, () =>
       this._status$.next(KafkaStatus.CONNECTED),
     );
-    this.consumer.on(this.consumer.events.DISCONNECT, () =>
+    consumer.on(consumer.events.DISCONNECT, () =>
       this._status$.next(KafkaStatus.DISCONNECTED),
     );
-    this.consumer.on(this.consumer.events.REBALANCING, () =>
+    consumer.on(consumer.events.REBALANCING, () =>
       this._status$.next(KafkaStatus.REBALANCING),
     );
-    this.consumer.on(this.consumer.events.STOP, () =>
+    consumer.on(consumer.events.STOP, () =>
       this._status$.next(KafkaStatus.STOPPED),
     );
-    this.consumer.on(this.consumer.events.CRASH, () =>
+    consumer.on(consumer.events.CRASH, () =>
       this._status$.next(KafkaStatus.CRASHED),
     );
   }
@@ -152,14 +164,19 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     );
   }
 
-  public createClient<T = any>(): T {
+  public async createClient<T = any>(): Promise<T> {
+    const kafkaPackage = await this.loadPackage(
+      'kafkajs',
+      ServerKafka.name,
+      () => import('kafkajs'),
+    );
     return new kafkaPackage.Kafka(
       Object.assign(
         { logCreator: KafkaLogger.bind(null, this.logger) },
         this.options.client,
         { clientId: this.clientId, brokers: this.brokers },
       ) as KafkaConfig,
-    );
+    ) as T;
   }
 
   public async bindEvents(consumer: Consumer) {
@@ -167,16 +184,56 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     const consumerSubscribeOptions = this.options.subscribe || {};
 
     if (registeredPatterns.length > 0) {
-      await this.consumer!.subscribe({
+      await consumer.subscribe({
         ...consumerSubscribeOptions,
         topics: registeredPatterns,
       });
     }
 
-    const consumerRunOptions = Object.assign(this.options.run || {}, {
+    const consumerRunOptions = {
+      ...(this.options.run || {}),
       eachMessage: this.getMessageHandler(),
-    });
+    };
     await consumer.run(consumerRunOptions);
+  }
+
+  public async bindEventsPerTopic(consumerOptions: ConsumerConfig) {
+    const registeredPatterns = [...this.messageHandlers.keys()];
+    const consumerSubscribeOptions = this.options.subscribe || {};
+
+    try {
+      for (const topic of registeredPatterns) {
+        const composedGroupId = `${this.groupId}-${topic}`;
+        if (!/^[a-zA-Z0-9._-]{1,255}$/.test(composedGroupId)) {
+          this.logger.warn(
+            `Consumer group ID "${composedGroupId}" may be invalid: ` +
+              `must be 1–255 characters and contain only alphanumeric, '.', '_', or '-'.`,
+          );
+        }
+        const topicConsumer = this.client!.consumer({
+          ...consumerOptions,
+          groupId: composedGroupId,
+        });
+        this.registerConsumerEventListenersFor(topicConsumer);
+        await topicConsumer.connect();
+        this.consumers.set(topic, topicConsumer);
+        await topicConsumer.subscribe({
+          ...consumerSubscribeOptions,
+          topics: [topic],
+        });
+        const consumerRunOptions = {
+          ...(this.options.run || {}),
+          eachMessage: this.getMessageHandler(),
+        };
+        await topicConsumer.run(consumerRunOptions);
+      }
+    } catch (err) {
+      await Promise.allSettled(
+        [...this.consumers.values()].map(consumer => consumer.disconnect()),
+      );
+      this.consumers.clear();
+      throw err;
+    }
   }
 
   public getMessageHandler() {
@@ -213,11 +270,12 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     const replyPartition = headers[KafkaHeaders.REPLY_PARTITION];
 
     const packet = await this.deserializer.deserialize(rawMessage, { channel });
+    const consumer = this.consumers.get(payload.topic) ?? this.consumer!;
     const kafkaContext = new KafkaContext([
       rawMessage,
       payload.partition,
       payload.topic,
-      this.consumer!,
+      consumer,
       payload.heartbeat,
       this.producer!,
     ]);
@@ -262,6 +320,9 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       throw new Error(
         'Not initialized. Please call the "listen"/"startAllMicroservices" method before accessing the server.',
       );
+    }
+    if (this.consumers.size > 0) {
+      return [this.client, this.consumers, this.producer] as T;
     }
     return [this.client, this.consumer, this.producer] as T;
   }

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -33,7 +33,7 @@ import {
 import { KafkaRequestSerializer } from '../serializers/kafka-request.serializer.js';
 import { Server } from './server.js';
 import { Logger } from '@nestjs/common';
-import { isNil } from '@nestjs/common/internal';
+import { isNil } from '@nestjs/common/utils/shared.utils.js';
 
 /**
  * @publicApi

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -45,6 +45,7 @@ export class ServerKafka extends Server<never, KafkaStatus> {
   protected logger = new Logger(ServerKafka.name);
   protected client: Kafka | null = null;
   protected consumer: Consumer | null = null;
+  protected consumers: Map<string, Consumer> = new Map();
   protected producer: Producer | null = null;
   protected parser: KafkaParser | null = null;
   protected brokers: string[] | BrokersFunction;
@@ -121,6 +122,12 @@ export class ServerKafka extends Server<never, KafkaStatus> {
   }
 
   public async close(): Promise<void> {
+    if (this.consumers.size > 0) {
+      await Promise.allSettled(
+        [...this.consumers.values()].map(consumer => consumer.disconnect()),
+      );
+      this.consumers.clear();
+    }
     this.consumer && (await this.consumer.disconnect());
     this.producer && (await this.producer.disconnect());
     this.consumer = null;
@@ -133,14 +140,21 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       ...(this.options.consumer || {}),
       groupId: this.groupId,
     };
-    this.consumer = this.client!.consumer(consumerOptions);
-    this.producer = this.client!.producer(this.options.producer);
-    this.registerConsumerEventListeners();
-    this.registerProducerEventListeners();
 
-    await this.consumer.connect();
-    await this.producer.connect();
-    await this.bindEvents(this.consumer);
+    if (this.getOptionsProp(this.options, 'topicConsumers', false)) {
+      this.producer = this.client!.producer(this.options.producer);
+      this.registerProducerEventListeners();
+      await this.producer.connect();
+      await this.bindEventsPerTopic(consumerOptions);
+    } else {
+      this.consumer = this.client!.consumer(consumerOptions);
+      this.producer = this.client!.producer(this.options.producer);
+      this.registerConsumerEventListeners();
+      this.registerProducerEventListeners();
+      await this.consumer.connect();
+      await this.producer.connect();
+      await this.bindEvents(this.consumer);
+    }
     callback();
   }
 
@@ -148,19 +162,23 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     if (!this.consumer) {
       return;
     }
-    this.consumer.on(this.consumer.events.CONNECT, () =>
+    this.registerConsumerEventListenersFor(this.consumer);
+  }
+
+  protected registerConsumerEventListenersFor(consumer: Consumer) {
+    consumer.on(consumer.events.CONNECT, () =>
       this._status$.next(KafkaStatus.CONNECTED),
     );
-    this.consumer.on(this.consumer.events.DISCONNECT, () =>
+    consumer.on(consumer.events.DISCONNECT, () =>
       this._status$.next(KafkaStatus.DISCONNECTED),
     );
-    this.consumer.on(this.consumer.events.REBALANCING, () =>
+    consumer.on(consumer.events.REBALANCING, () =>
       this._status$.next(KafkaStatus.REBALANCING),
     );
-    this.consumer.on(this.consumer.events.STOP, () =>
+    consumer.on(consumer.events.STOP, () =>
       this._status$.next(KafkaStatus.STOPPED),
     );
-    this.consumer.on(this.consumer.events.CRASH, () =>
+    consumer.on(consumer.events.CRASH, () =>
       this._status$.next(KafkaStatus.CRASHED),
     );
   }
@@ -196,7 +214,7 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     const consumerSubscribeOptions = this.options.subscribe || {};
 
     if (registeredPatterns.length > 0) {
-      await this.consumer!.subscribe({
+      await consumer.subscribe({
         ...consumerSubscribeOptions,
         topics: registeredPatterns,
       });
@@ -207,6 +225,45 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       eachMessage: this.getMessageHandler(),
     };
     await consumer.run(consumerRunOptions);
+  }
+
+  public async bindEventsPerTopic(consumerOptions: ConsumerConfig) {
+    const registeredPatterns = [...this.messageHandlers.keys()];
+    const consumerSubscribeOptions = this.options.subscribe || {};
+
+    try {
+      for (const topic of registeredPatterns) {
+        const composedGroupId = `${this.groupId}-${topic}`;
+        if (!/^[a-zA-Z0-9._-]{1,255}$/.test(composedGroupId)) {
+          this.logger.warn(
+            `Consumer group ID "${composedGroupId}" may be invalid: ` +
+              `must be 1–255 characters and contain only alphanumeric, '.', '_', or '-'.`,
+          );
+        }
+        const topicConsumer = this.client!.consumer({
+          ...consumerOptions,
+          groupId: composedGroupId,
+        });
+        this.registerConsumerEventListenersFor(topicConsumer);
+        await topicConsumer.connect();
+        this.consumers.set(topic, topicConsumer);
+        await topicConsumer.subscribe({
+          ...consumerSubscribeOptions,
+          topics: [topic],
+        });
+        const consumerRunOptions = {
+          ...(this.options.run || {}),
+          eachMessage: this.getMessageHandler(),
+        };
+        await topicConsumer.run(consumerRunOptions);
+      }
+    } catch (err) {
+      await Promise.allSettled(
+        [...this.consumers.values()].map(consumer => consumer.disconnect()),
+      );
+      this.consumers.clear();
+      throw err;
+    }
   }
 
   public getHandlerByPattern(pattern: string): MessageHandler | null {
@@ -273,11 +330,12 @@ export class ServerKafka extends Server<never, KafkaStatus> {
     const replyPartition = headers[KafkaHeaders.REPLY_PARTITION];
 
     const packet = await this.deserializer.deserialize(rawMessage, { channel });
+    const consumer = this.consumers.get(payload.topic) ?? this.consumer!;
     const kafkaContext = new KafkaContext([
       rawMessage,
       payload.partition,
       payload.topic,
-      this.consumer!,
+      consumer,
       payload.heartbeat,
       this.producer!,
     ]);
@@ -322,6 +380,9 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       throw new Error(
         'Not initialized. Please call the "listen"/"startAllMicroservices" method before accessing the server.',
       );
+    }
+    if (this.consumers.size > 0) {
+      return [this.client, this.consumers, this.producer] as T;
     }
     return [this.client, this.consumer, this.producer] as T;
   }

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -546,20 +546,20 @@ describe('ServerKafka', () => {
 
     let perTopicServer: ServerKafka;
     let perTopicUntyped: any;
-    let perTopicConnect: ReturnType<typeof vi.fn>;
-    let perTopicSubscribe: ReturnType<typeof vi.fn>;
-    let perTopicRun: ReturnType<typeof vi.fn>;
-    let perTopicOn: ReturnType<typeof vi.fn>;
-    let perTopicConsumerFactory: ReturnType<typeof vi.fn>;
+    let perTopicConnect: sinon.SinonStub;
+    let perTopicSubscribe: sinon.SinonStub;
+    let perTopicRun: sinon.SinonStub;
+    let perTopicOn: sinon.SinonStub;
+    let perTopicConsumerFactory: sinon.SinonStub;
 
     beforeEach(() => {
       perTopicServer = new ServerKafka({ topicConsumers: true });
       perTopicUntyped = perTopicServer as any;
 
-      perTopicConnect = vi.fn();
-      perTopicSubscribe = vi.fn();
-      perTopicRun = vi.fn();
-      perTopicOn = vi.fn();
+      perTopicConnect = sinon.stub();
+      perTopicSubscribe = sinon.stub();
+      perTopicRun = sinon.stub();
+      perTopicOn = sinon.stub();
 
       const mockConsumer = () => ({
         connect: perTopicConnect,
@@ -569,160 +569,157 @@ describe('ServerKafka', () => {
         events: mockConsumerEvents,
       });
 
-      perTopicConsumerFactory = vi.fn().mockImplementation(mockConsumer);
+      perTopicConsumerFactory = sinon.stub().callsFake(mockConsumer);
 
-      vi.spyOn(perTopicServer, 'createClient').mockImplementation(
-        async () =>
-          ({
-            consumer: perTopicConsumerFactory,
-            producer: vi.fn().mockReturnValue({
-              connect: perTopicConnect,
-              send: vi.fn(),
-              on: perTopicOn,
-              events: {
-                CONNECT: 'producer.connect',
-                DISCONNECT: 'producer.disconnect',
-              },
-            }),
-          }) as any,
-      );
+      sinon.stub(perTopicServer, 'createClient').resolves({
+        consumer: perTopicConsumerFactory,
+        producer: sinon.stub().returns({
+          connect: perTopicConnect,
+          send: sinon.stub(),
+          on: perTopicOn,
+          events: {
+            CONNECT: 'producer.connect',
+            DISCONNECT: 'producer.disconnect',
+          },
+        }),
+      } as any);
     });
 
-    afterEach(() => vi.restoreAllMocks());
+    afterEach(() => sinon.restore());
 
     describe('bindEventsPerTopic', () => {
       it('should create a separate consumer for each registered topic', async () => {
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        expect(perTopicConsumerFactory).toHaveBeenCalledTimes(2);
+        expect(perTopicConsumerFactory.callCount).to.equal(2);
       });
 
       it('should suffix groupId with topic name for each consumer', async () => {
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        const groupIds = perTopicConsumerFactory.mock.calls.map(
+        const groupIds = perTopicConsumerFactory.args.map(
           args => args[0].groupId,
         );
-        expect(groupIds.some(id => id.endsWith('-topic-a'))).toBe(true);
-        expect(groupIds.some(id => id.endsWith('-topic-b'))).toBe(true);
+        expect(groupIds.some(id => id.endsWith('-topic-a'))).to.be.true;
+        expect(groupIds.some(id => id.endsWith('-topic-b'))).to.be.true;
       });
 
       it('should subscribe each consumer to exactly one topic', async () => {
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        expect(perTopicSubscribe).toHaveBeenCalledTimes(2);
-        perTopicSubscribe.mock.calls.forEach(args => {
-          expect(args[0].topics.length).toEqual(1);
+        expect(perTopicSubscribe.callCount).to.equal(2);
+        perTopicSubscribe.args.forEach(args => {
+          expect(args[0].topics.length).to.equal(1);
         });
-        const subscribedTopics = perTopicSubscribe.mock.calls
+        const subscribedTopics = perTopicSubscribe.args
           .map(args => args[0].topics[0])
           .sort();
-        expect(subscribedTopics).toEqual(['topic-a', 'topic-b']);
+        expect(subscribedTopics).to.deep.equal(['topic-a', 'topic-b']);
       });
 
       it('should call run on each per-topic consumer', async () => {
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        expect(perTopicRun).toHaveBeenCalledTimes(2);
-        perTopicRun.mock.calls.forEach(args => {
-          expect(args[0]).toHaveProperty('eachMessage');
+        expect(perTopicRun.callCount).to.equal(2);
+        perTopicRun.args.forEach(args => {
+          expect(args[0]).to.have.property('eachMessage');
         });
       });
 
       it('should populate consumers map with one entry per topic', async () => {
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        expect(perTopicUntyped.consumers.size).toEqual(2);
-        expect(perTopicUntyped.consumers.has('topic-a')).toBe(true);
-        expect(perTopicUntyped.consumers.has('topic-b')).toBe(true);
+        expect(perTopicUntyped.consumers.size).to.equal(2);
+        expect(perTopicUntyped.consumers.has('topic-a')).to.be.true;
+        expect(perTopicUntyped.consumers.has('topic-b')).to.be.true;
       });
 
       it('should not create any consumer when there are no messageHandlers', async () => {
-        await perTopicServer.listen(vi.fn());
+        await perTopicServer.listen(sinon.stub());
 
-        expect(perTopicConsumerFactory).not.toHaveBeenCalled();
-        expect(perTopicUntyped.consumers.size).toEqual(0);
+        expect(perTopicConsumerFactory.called).to.be.false;
+        expect(perTopicUntyped.consumers.size).to.equal(0);
       });
 
       it('should clean up connected consumers and rethrow when a topic connect fails', async () => {
-        const disconnectOk = vi.fn();
+        const disconnectOk = sinon.stub();
         const connectError = new Error('connect failed');
         let callCount = 0;
 
-        perTopicConsumerFactory.mockImplementation(() => ({
-          connect: vi.fn().mockImplementation(() => {
+        perTopicConsumerFactory.callsFake(() => ({
+          connect: sinon.stub().callsFake(() => {
             callCount++;
             if (callCount === 2) throw connectError;
           }),
-          subscribe: vi.fn(),
-          run: vi.fn(),
+          subscribe: sinon.stub(),
+          run: sinon.stub(),
           on: perTopicOn,
           events: mockConsumerEvents,
           disconnect: disconnectOk,
         }));
 
         perTopicUntyped.messageHandlers = objectToMap({
-          'topic-a': vi.fn(),
-          'topic-b': vi.fn(),
+          'topic-a': sinon.stub(),
+          'topic-b': sinon.stub(),
         });
 
-        const cb = vi.fn();
+        const cb = sinon.stub();
         await perTopicServer.listen(cb);
 
-        expect(cb).toHaveBeenCalledWith(connectError);
-        expect(disconnectOk).toHaveBeenCalledOnce();
-        expect(perTopicUntyped.consumers.size).toEqual(0);
+        expect(cb.calledWith(connectError)).to.be.true;
+        expect(disconnectOk.calledOnce).to.be.true;
+        expect(perTopicUntyped.consumers.size).to.equal(0);
       });
     });
 
     describe('close with topicConsumers', () => {
       it('should disconnect all per-topic consumers and null refs', async () => {
-        const disconnectA = vi.fn();
-        const disconnectB = vi.fn();
+        const disconnectA = sinon.stub();
+        const disconnectB = sinon.stub();
         perTopicUntyped.consumers = new Map([
           ['topic-a', { disconnect: disconnectA }],
           ['topic-b', { disconnect: disconnectB }],
         ]);
-        perTopicUntyped.producer = { disconnect: vi.fn() };
+        perTopicUntyped.producer = { disconnect: sinon.stub() };
 
         await perTopicServer.close();
 
-        expect(disconnectA).toHaveBeenCalledOnce();
-        expect(disconnectB).toHaveBeenCalledOnce();
-        expect(perTopicUntyped.consumers.size).toEqual(0);
-        expect(perTopicUntyped.producer).toBeNull();
-        expect(perTopicUntyped.client).toBeNull();
+        expect(disconnectA.calledOnce).to.be.true;
+        expect(disconnectB.calledOnce).to.be.true;
+        expect(perTopicUntyped.consumers.size).to.equal(0);
+        expect(perTopicUntyped.producer).to.be.null;
+        expect(perTopicUntyped.client).to.be.null;
       });
     });
   });
 
   describe('createClient', () => {
-    it('should accept a custom logCreator in client options', () => {
+    it('should accept a custom logCreator in client options', async () => {
       const logCreatorSpy = sinon.spy(() => 'test');
       const logCreator = () => logCreatorSpy;
 
@@ -736,21 +733,16 @@ describe('ServerKafka', () => {
         }
       }
 
-      vi.spyOn(
-        ServerKafka.prototype as any,
-        'loadPackage',
-      ).mockResolvedValueOnce({
-        Kafka: MockKafka,
-      });
-
       server = new ServerKafka({
         client: {
           brokers: [],
           logCreator,
         },
       });
+      sinon.stub(server as any, 'loadPackage').resolves({ Kafka: MockKafka });
 
-      const logger = server.createClient().logger();
+      const kafkaClient = await server.createClient();
+      const logger = kafkaClient.logger();
 
       logger.info({ namespace: '', level: 1, log: 'test' });
 

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -535,10 +535,213 @@ describe('ServerKafka', () => {
     });
   });
 
+  describe('topicConsumers mode', () => {
+    const mockConsumerEvents = {
+      CONNECT: 'consumer.connect',
+      DISCONNECT: 'consumer.disconnect',
+      STOP: 'consumer.stop',
+      CRASH: 'consumer.crash',
+      REBALANCING: 'consumer.rebalancing',
+    };
+
+    let perTopicServer: ServerKafka;
+    let perTopicUntyped: any;
+    let perTopicConnect: ReturnType<typeof vi.fn>;
+    let perTopicSubscribe: ReturnType<typeof vi.fn>;
+    let perTopicRun: ReturnType<typeof vi.fn>;
+    let perTopicOn: ReturnType<typeof vi.fn>;
+    let perTopicConsumerFactory: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      perTopicServer = new ServerKafka({ topicConsumers: true });
+      perTopicUntyped = perTopicServer as any;
+
+      perTopicConnect = vi.fn();
+      perTopicSubscribe = vi.fn();
+      perTopicRun = vi.fn();
+      perTopicOn = vi.fn();
+
+      const mockConsumer = () => ({
+        connect: perTopicConnect,
+        subscribe: perTopicSubscribe,
+        run: perTopicRun,
+        on: perTopicOn,
+        events: mockConsumerEvents,
+      });
+
+      perTopicConsumerFactory = vi.fn().mockImplementation(mockConsumer);
+
+      vi.spyOn(perTopicServer, 'createClient').mockImplementation(
+        async () =>
+          ({
+            consumer: perTopicConsumerFactory,
+            producer: vi.fn().mockReturnValue({
+              connect: perTopicConnect,
+              send: vi.fn(),
+              on: perTopicOn,
+              events: {
+                CONNECT: 'producer.connect',
+                DISCONNECT: 'producer.disconnect',
+              },
+            }),
+          }) as any,
+      );
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    describe('bindEventsPerTopic', () => {
+      it('should create a separate consumer for each registered topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicConsumerFactory).toHaveBeenCalledTimes(2);
+      });
+
+      it('should suffix groupId with topic name for each consumer', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        const groupIds = perTopicConsumerFactory.mock.calls.map(
+          args => args[0].groupId,
+        );
+        expect(groupIds.some(id => id.endsWith('-topic-a'))).toBe(true);
+        expect(groupIds.some(id => id.endsWith('-topic-b'))).toBe(true);
+      });
+
+      it('should subscribe each consumer to exactly one topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicSubscribe).toHaveBeenCalledTimes(2);
+        perTopicSubscribe.mock.calls.forEach(args => {
+          expect(args[0].topics.length).toEqual(1);
+        });
+        const subscribedTopics = perTopicSubscribe.mock.calls
+          .map(args => args[0].topics[0])
+          .sort();
+        expect(subscribedTopics).toEqual(['topic-a', 'topic-b']);
+      });
+
+      it('should call run on each per-topic consumer', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicRun).toHaveBeenCalledTimes(2);
+        perTopicRun.mock.calls.forEach(args => {
+          expect(args[0]).toHaveProperty('eachMessage');
+        });
+      });
+
+      it('should populate consumers map with one entry per topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicUntyped.consumers.size).toEqual(2);
+        expect(perTopicUntyped.consumers.has('topic-a')).toBe(true);
+        expect(perTopicUntyped.consumers.has('topic-b')).toBe(true);
+      });
+
+      it('should not create any consumer when there are no messageHandlers', async () => {
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicConsumerFactory).not.toHaveBeenCalled();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+      });
+
+      it('should clean up connected consumers and rethrow when a topic connect fails', async () => {
+        const disconnectOk = vi.fn();
+        const connectError = new Error('connect failed');
+        let callCount = 0;
+
+        perTopicConsumerFactory.mockImplementation(() => ({
+          connect: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 2) throw connectError;
+          }),
+          subscribe: vi.fn(),
+          run: vi.fn(),
+          on: perTopicOn,
+          events: mockConsumerEvents,
+          disconnect: disconnectOk,
+        }));
+
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        const cb = vi.fn();
+        await perTopicServer.listen(cb);
+
+        expect(cb).toHaveBeenCalledWith(connectError);
+        expect(disconnectOk).toHaveBeenCalledOnce();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+      });
+    });
+
+    describe('close with topicConsumers', () => {
+      it('should disconnect all per-topic consumers and null refs', async () => {
+        const disconnectA = vi.fn();
+        const disconnectB = vi.fn();
+        perTopicUntyped.consumers = new Map([
+          ['topic-a', { disconnect: disconnectA }],
+          ['topic-b', { disconnect: disconnectB }],
+        ]);
+        perTopicUntyped.producer = { disconnect: vi.fn() };
+
+        await perTopicServer.close();
+
+        expect(disconnectA).toHaveBeenCalledOnce();
+        expect(disconnectB).toHaveBeenCalledOnce();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+        expect(perTopicUntyped.producer).toBeNull();
+        expect(perTopicUntyped.client).toBeNull();
+      });
+    });
+  });
+
   describe('createClient', () => {
     it('should accept a custom logCreator in client options', () => {
       const logCreatorSpy = sinon.spy(() => 'test');
       const logCreator = () => logCreatorSpy;
+
+      class MockKafka {
+        private logFn: any;
+        constructor({ logCreator: lc }: any) {
+          this.logFn = lc(1);
+        }
+        logger() {
+          return { info: (entry: any) => this.logFn(entry) };
+        }
+      }
+
+      vi.spyOn(
+        ServerKafka.prototype as any,
+        'loadPackage',
+      ).mockResolvedValueOnce({
+        Kafka: MockKafka,
+      });
 
       server = new ServerKafka({
         client: {

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -597,10 +597,213 @@ describe('ServerKafka', () => {
     });
   });
 
+  describe('topicConsumers mode', () => {
+    const mockConsumerEvents = {
+      CONNECT: 'consumer.connect',
+      DISCONNECT: 'consumer.disconnect',
+      STOP: 'consumer.stop',
+      CRASH: 'consumer.crash',
+      REBALANCING: 'consumer.rebalancing',
+    };
+
+    let perTopicServer: ServerKafka;
+    let perTopicUntyped: any;
+    let perTopicConnect: ReturnType<typeof vi.fn>;
+    let perTopicSubscribe: ReturnType<typeof vi.fn>;
+    let perTopicRun: ReturnType<typeof vi.fn>;
+    let perTopicOn: ReturnType<typeof vi.fn>;
+    let perTopicConsumerFactory: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      perTopicServer = new ServerKafka({ topicConsumers: true });
+      perTopicUntyped = perTopicServer as any;
+
+      perTopicConnect = vi.fn();
+      perTopicSubscribe = vi.fn();
+      perTopicRun = vi.fn();
+      perTopicOn = vi.fn();
+
+      const mockConsumer = () => ({
+        connect: perTopicConnect,
+        subscribe: perTopicSubscribe,
+        run: perTopicRun,
+        on: perTopicOn,
+        events: mockConsumerEvents,
+      });
+
+      perTopicConsumerFactory = vi.fn().mockImplementation(mockConsumer);
+
+      vi.spyOn(perTopicServer, 'createClient').mockImplementation(
+        async () =>
+          ({
+            consumer: perTopicConsumerFactory,
+            producer: vi.fn().mockReturnValue({
+              connect: perTopicConnect,
+              send: vi.fn(),
+              on: perTopicOn,
+              events: {
+                CONNECT: 'producer.connect',
+                DISCONNECT: 'producer.disconnect',
+              },
+            }),
+          }) as any,
+      );
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    describe('bindEventsPerTopic', () => {
+      it('should create a separate consumer for each registered topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicConsumerFactory).toHaveBeenCalledTimes(2);
+      });
+
+      it('should suffix groupId with topic name for each consumer', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        const groupIds = perTopicConsumerFactory.mock.calls.map(
+          args => args[0].groupId,
+        );
+        expect(groupIds.some(id => id.endsWith('-topic-a'))).toBe(true);
+        expect(groupIds.some(id => id.endsWith('-topic-b'))).toBe(true);
+      });
+
+      it('should subscribe each consumer to exactly one topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicSubscribe).toHaveBeenCalledTimes(2);
+        perTopicSubscribe.mock.calls.forEach(args => {
+          expect(args[0].topics.length).toEqual(1);
+        });
+        const subscribedTopics = perTopicSubscribe.mock.calls
+          .map(args => args[0].topics[0])
+          .sort();
+        expect(subscribedTopics).toEqual(['topic-a', 'topic-b']);
+      });
+
+      it('should call run on each per-topic consumer', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicRun).toHaveBeenCalledTimes(2);
+        perTopicRun.mock.calls.forEach(args => {
+          expect(args[0]).toHaveProperty('eachMessage');
+        });
+      });
+
+      it('should populate consumers map with one entry per topic', async () => {
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicUntyped.consumers.size).toEqual(2);
+        expect(perTopicUntyped.consumers.has('topic-a')).toBe(true);
+        expect(perTopicUntyped.consumers.has('topic-b')).toBe(true);
+      });
+
+      it('should not create any consumer when there are no messageHandlers', async () => {
+        await perTopicServer.listen(vi.fn());
+
+        expect(perTopicConsumerFactory).not.toHaveBeenCalled();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+      });
+
+      it('should clean up connected consumers and rethrow when a topic connect fails', async () => {
+        const disconnectOk = vi.fn();
+        const connectError = new Error('connect failed');
+        let callCount = 0;
+
+        perTopicConsumerFactory.mockImplementation(() => ({
+          connect: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 2) throw connectError;
+          }),
+          subscribe: vi.fn(),
+          run: vi.fn(),
+          on: perTopicOn,
+          events: mockConsumerEvents,
+          disconnect: disconnectOk,
+        }));
+
+        perTopicUntyped.messageHandlers = objectToMap({
+          'topic-a': vi.fn(),
+          'topic-b': vi.fn(),
+        });
+
+        const cb = vi.fn();
+        await perTopicServer.listen(cb);
+
+        expect(cb).toHaveBeenCalledWith(connectError);
+        expect(disconnectOk).toHaveBeenCalledOnce();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+      });
+    });
+
+    describe('close with topicConsumers', () => {
+      it('should disconnect all per-topic consumers and null refs', async () => {
+        const disconnectA = vi.fn();
+        const disconnectB = vi.fn();
+        perTopicUntyped.consumers = new Map([
+          ['topic-a', { disconnect: disconnectA }],
+          ['topic-b', { disconnect: disconnectB }],
+        ]);
+        perTopicUntyped.producer = { disconnect: vi.fn() };
+
+        await perTopicServer.close();
+
+        expect(disconnectA).toHaveBeenCalledOnce();
+        expect(disconnectB).toHaveBeenCalledOnce();
+        expect(perTopicUntyped.consumers.size).toEqual(0);
+        expect(perTopicUntyped.producer).toBeNull();
+        expect(perTopicUntyped.client).toBeNull();
+      });
+    });
+  });
+
   describe('createClient', () => {
     it('should accept a custom logCreator in client options', async () => {
       const logCreatorSpy = vi.fn(() => 'test');
       const logCreator = () => logCreatorSpy;
+
+      class MockKafka {
+        private logFn: any;
+        constructor({ logCreator: lc }: any) {
+          this.logFn = lc(1);
+        }
+        logger() {
+          return { info: (entry: any) => this.logFn(entry) };
+        }
+      }
+
+      vi.spyOn(
+        ServerKafka.prototype as any,
+        'loadPackage',
+      ).mockResolvedValueOnce({
+        Kafka: MockKafka,
+      });
 
       server = new ServerKafka({
         client: {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
`ServerKafka` uses a single KafkaJS consumer subscribed to all registered topics, so a slow handler on one topic can effectively block message processing on other topics (topic-level backpressure). Partition-level concurrency (`partitionsConsumedConcurrently`) does not address cross-topic blocking.

Issue Number: #14590


## What is the new behavior?
Adds an opt-in `topicConsumers: boolean` option for Kafka microservices.

When `topicConsumers: true`:
- Creates a separate consumer per registered topic and subscribes each consumer to exactly one topic
- Uses `{groupId}-{topic}` as the consumer group id (independent offset tracking per topic)
- Disconnects all per-topic consumers in parallel on `close()`
- Logs a deduped warning when the composed group id appears invalid (whitespace or >255 chars)
- Avoids mutating `options.run` when building per-topic `run()` options

Default remains `false`, preserving the existing single-consumer behavior.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Note: enabling `topicConsumers: true` creates new consumer groups (`{groupId}-{topic}`), so migrating an existing deployment may require offset management.

## Other information

### Tests

~~~bash
npm test -- packages/microservices/test/server/server-kafka.spec.ts
~~~

All tests pass, including new unit tests for `topicConsumers` mode.