### PR TITLE
test(sample/28): add e2e tests for sse sample

### DIFF
--- a/sample/28-sse/e2e/app/app.e2e-spec.ts
+++ b/sample/28-sse/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,48 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as http from 'http';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('SSE (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication({ forceCloseConnections: true });
+    await app.listen(0);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET / should return HTML content', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /html/);
+  });
+
+  it('GET /sse should return event stream with SSE events', (done) => {
+    const server = app.getHttpServer();
+    const address = server.address();
+    const port = typeof address === 'string' ? 3000 : address?.port;
+
+    http.get(`http://127.0.0.1:${port}/sse`, (res) => {
+      expect(res.headers['content-type']).toContain('text/event-stream');
+
+      let received = '';
+      res.on('data', (chunk) => {
+        received += chunk.toString();
+        if (received.includes('"hello":"world"')) {
+          res.destroy();
+          done();
+        }
+      });
+    });
+  }, 10000);
+});

--- a/sample/28-sse/e2e/jest-e2e.json
+++ b/sample/28-sse/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/28-sse/package.json
+++ b/sample/28-sse/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/28-sse` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added e2e tests that verify:
- `GET /` returns HTML content with the correct content type
- `GET /sse` returns a `text/event-stream` response and emits SSE events with the expected `{ hello: "world" }` data payload

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This follows the same pattern as other recently merged sample test PRs (e.g., #16463, #16460, #16458). The SSE endpoint test uses Node's native `http` module to handle the streaming response, verifying both the response headers and event data.