### PR TITLE
test(sample/25): add e2e tests for dynamic-modules sample

### DIFF
--- a/sample/25-dynamic-modules/e2e/app/app.e2e-spec.ts
+++ b/sample/25-dynamic-modules/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,30 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('DynamicModules (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'development';
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET / should return hello message from config', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Hello there, world!');
+  });
+});

--- a/sample/25-dynamic-modules/e2e/jest-e2e.json
+++ b/sample/25-dynamic-modules/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/25-dynamic-modules/package.json
+++ b/sample/25-dynamic-modules/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/25-dynamic-modules` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added an e2e test that verifies `GET /` returns the hello message loaded from the config file via the dynamically registered `ConfigModule`. This validates the core dynamic module registration pattern demonstrated by this sample.

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
The test sets `NODE_ENV=development` explicitly since Jest defaults to `test` and only `development.env` is provided in the sample's config directory.