### PR TITLE
test(sample/18): add e2e tests for context sample

### DIFF
--- a/sample/18-context/e2e/app/app.e2e-spec.ts
+++ b/sample/18-context/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,34 @@
+import { INestApplicationContext } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AppModule, dynamicModule } from '../../src/app.module';
+import { AppService } from '../../src/app.service';
+
+describe('Context (e2e)', () => {
+  let app: INestApplicationContext;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should resolve AppService from the application context', () => {
+    const appService = app.get(AppService);
+    expect(appService).toBeDefined();
+    expect(appService.getHello()).toBe('Hello world!');
+  });
+
+  it('should resolve dynamic provider from the dynamic module', () => {
+    const myDynamicProviderValue = app
+      .select(dynamicModule)
+      .get('MyDynamicProvider');
+    expect(myDynamicProviderValue).toBe('foobar');
+  });
+});

--- a/sample/18-context/e2e/jest-e2e.json
+++ b/sample/18-context/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": ["ts-jest", { "diagnostics": false }]
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/18-context/package.json
+++ b/sample/18-context/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/18-context` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added e2e tests for the standalone application context sample that verify:
- `AppService` is resolved from the application context and returns the expected value
- The dynamic provider registered via `MyDynamicModule.register('foobar')` is correctly resolved using `app.select(dynamicModule).get('MyDynamicProvider')`

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This sample demonstrates `NestFactory.createApplicationContext` (no HTTP server) and dynamic module registration with `app.select()`, so the tests focus on DI resolution rather than HTTP endpoints.