### PR TITLE
test(sample/15): add e2e tests for mvc sample

### DIFF
--- a/sample/15-mvc/e2e/app/app.e2e-spec.ts
+++ b/sample/15-mvc/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,34 @@
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { Test } from '@nestjs/testing';
+import { join } from 'path';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('MVC (e2e)', () => {
+  let app: NestExpressApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication<NestExpressApplication>();
+    app.setBaseViewsDir(join(__dirname, '../../views'));
+    app.setViewEngine('hbs');
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET / should render the index template with hello message', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Hello world!');
+      });
+  });
+});

--- a/sample/15-mvc/e2e/jest-e2e.json
+++ b/sample/15-mvc/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": ["ts-jest", { "diagnostics": false }]
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/15-mvc/package.json
+++ b/sample/15-mvc/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/15-mvc` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added an e2e test that verifies `GET /` renders the Handlebars index template with the expected "Hello world!" message. The test configures the `NestExpressApplication` with the hbs view engine and views directory, matching the setup in `main.ts`.

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No