### PR TITLE
test(sample/10): add e2e tests for fastify sample

### DIFF
--- a/sample/10-fastify/e2e/cats/cats.e2e-spec.ts
+++ b/sample/10-fastify/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,42 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { CatsModule } from '../../src/cats/cats.module';
+import { CatsService } from '../../src/cats/cats.service';
+import { CoreModule } from '../../src/core/core.module';
+
+describe('Cats (Fastify e2e)', () => {
+  const catsService = { findAll: () => ['test'], create: () => {} };
+
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [CatsModule, CoreModule],
+    })
+      .overrideProvider(CatsService)
+      .useValue(catsService)
+      .compile();
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET /cats should return all cats wrapped by TransformInterceptor', () => {
+    return request(app.getHttpServer())
+      .get('/cats')
+      .expect(200)
+      .expect({ data: catsService.findAll() });
+  });
+});

--- a/sample/10-fastify/e2e/jest-e2e.json
+++ b/sample/10-fastify/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": ["ts-jest", { "diagnostics": false }]
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/10-fastify/package.json
+++ b/sample/10-fastify/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/10-fastify` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added an e2e test for the Fastify platform sample that verifies:
- `GET /cats` returns all cats wrapped by the global `TransformInterceptor` in the `{ data: [...] }` format
- The test uses `FastifyAdapter` matching the sample's runtime configuration
- `CatsService` is overridden with a mock to isolate the test from data persistence

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No