### PR TITLE
test(sample/27): add e2e tests for scheduling sample

### DIFF
--- a/sample/27-scheduling/e2e/app/app.e2e-spec.ts
+++ b/sample/27-scheduling/e2e/app/app.e2e-spec.ts
@@ -1,0 +1,45 @@
+import { INestApplication } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { Test } from '@nestjs/testing';
+import { AppModule } from '../../src/app.module';
+import { TasksService } from '../../src/tasks/tasks.service';
+
+describe('Scheduling (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should resolve TasksService from the application context', () => {
+    const tasksService = app.get(TasksService);
+    expect(tasksService).toBeDefined();
+  });
+
+  it('should register cron jobs via SchedulerRegistry', () => {
+    const schedulerRegistry = app.get(SchedulerRegistry);
+    const cronJobs = schedulerRegistry.getCronJobs();
+    expect(cronJobs.size).toBeGreaterThan(0);
+  });
+
+  it('should register intervals via SchedulerRegistry', () => {
+    const schedulerRegistry = app.get(SchedulerRegistry);
+    const intervals = schedulerRegistry.getIntervals();
+    expect(intervals.length).toBeGreaterThan(0);
+  });
+
+  it('should register timeouts via SchedulerRegistry', () => {
+    const schedulerRegistry = app.get(SchedulerRegistry);
+    const timeouts = schedulerRegistry.getTimeouts();
+    expect(timeouts.length).toBeGreaterThan(0);
+  });
+});

--- a/sample/27-scheduling/e2e/jest-e2e.json
+++ b/sample/27-scheduling/e2e/jest-e2e.json
@@ -1,0 +1,14 @@
+{
+    "moduleFileExtensions": [
+        "ts",
+        "tsx",
+        "js",
+        "json"
+    ],
+    "transform": {
+        "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+    "collectCoverageFrom" : ["src/**/*.{js,jsx,tsx,ts}", "!**/node_modules/**", "!**/vendor/**"],
+    "coverageReporters": ["json", "lcov"]
+}

--- a/sample/27-scheduling/package.json
+++ b/sample/27-scheduling/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Adding missing e2e tests

## What is the current behavior?
The `sample/27-scheduling` application has no e2e tests. The `test:e2e` script in `package.json` outputs "No e2e tests implemented yet."

## What is the new behavior?
Added e2e tests that verify the `@nestjs/schedule` integration:
- `TasksService` is resolved from the application context
- Cron jobs are registered via `SchedulerRegistry` (from `@Cron` decorator)
- Intervals are registered via `SchedulerRegistry` (from `@Interval` decorator)
- Timeouts are registered via `SchedulerRegistry` (from `@Timeout` decorator)

Also updated the `test:e2e` script to use the jest configuration.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No