### PR TITLE
test(sample/11): add e2e tests for swagger sample

### DIFF
--- a/sample/11-swagger/e2e/cats/cats.e2e-spec.ts
+++ b/sample/11-swagger/e2e/cats/cats.e2e-spec.ts
@@ -1,0 +1,72 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('Swagger Cats (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+
+    const options = new DocumentBuilder()
+      .setTitle('Cats example')
+      .setDescription('The cats API description')
+      .setVersion('1.0')
+      .addTag('cats')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, options);
+    SwaggerModule.setup('api', app, document);
+
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/cats (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/cats')
+      .send({ name: 'Kitty', age: 2, breed: 'Maine Coon' })
+      .expect(201)
+      .expect(res => {
+        expect(res.body.name).toBe('Kitty');
+        expect(res.body.age).toBe(2);
+        expect(res.body.breed).toBe('Maine Coon');
+      });
+  });
+
+  it('/cats/:id (GET)', async () => {
+    // First create a cat
+    await request(app.getHttpServer())
+      .post('/cats')
+      .send({ name: 'Whiskers', age: 3, breed: 'Persian' })
+      .expect(201);
+
+    return request(app.getHttpServer())
+      .get('/cats/0')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.name).toBe('Kitty');
+      });
+  });
+
+  it('/api-json (GET) should return Swagger JSON', () => {
+    return request(app.getHttpServer())
+      .get('/api-json')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.openapi).toBeDefined();
+        expect(res.body.info.title).toBe('Cats example');
+        expect(res.body.paths['/cats']).toBeDefined();
+        expect(res.body.paths['/cats/{id}']).toBeDefined();
+      });
+  });
+});

--- a/sample/11-swagger/e2e/jest-e2e.json
+++ b/sample/11-swagger/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/11-swagger/package.json
+++ b/sample/11-swagger/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `11-swagger`:
- **POST /cats**: Verifies cat creation returns the created entity with correct fields
- **GET /cats/:id**: Verifies finding a cat by index returns the expected cat
- **GET /api-json**: Verifies Swagger JSON document is served with correct OpenAPI spec, title, and paths

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```