### PR TITLE
test(sample/30): add e2e tests for event-emitter sample

### DIFF
--- a/sample/30-event-emitter/e2e/jest-e2e.json
+++ b/sample/30-event-emitter/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/30-event-emitter/e2e/orders/orders.e2e-spec.ts
+++ b/sample/30-event-emitter/e2e/orders/orders.e2e-spec.ts
@@ -1,0 +1,53 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+import { OrderCreatedListener } from '../../src/orders/listeners/order-created.listener';
+
+describe('EventEmitter Orders (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/orders (POST) should create an order', () => {
+    return request(app.getHttpServer())
+      .post('/orders')
+      .send({ name: 'Order #3', description: 'New test order' })
+      .expect(201)
+      .expect((res) => {
+        expect(res.body.id).toBeDefined();
+        expect(res.body.name).toBe('Order #3');
+        expect(res.body.description).toBe('New test order');
+      });
+  });
+
+  it('/orders (POST) should trigger event listener', async () => {
+    const listener = app.get(OrderCreatedListener);
+    const spy = jest.spyOn(listener, 'handleOrderCreatedEvent');
+
+    await request(app.getHttpServer())
+      .post('/orders')
+      .send({ name: 'Order #4', description: 'Event test order' })
+      .expect(201);
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Order #4',
+        description: 'Event test order',
+      }),
+    );
+
+    spy.mockRestore();
+  });
+});

--- a/sample/30-event-emitter/package.json
+++ b/sample/30-event-emitter/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `30-event-emitter`:
- **POST /orders**: Verifies order creation returns the created entity with an id
- **POST /orders**: Verifies that the `OrderCreatedListener` is triggered with the correct event data when an order is created

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
```