### PR TITLE
test(sample/23): add e2e tests for graphql-code-first sample

### DIFF
--- a/sample/23-graphql-code-first/e2e/jest-e2e.json
+++ b/sample/23-graphql-code-first/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/23-graphql-code-first/e2e/recipes/recipes.e2e-spec.ts
+++ b/sample/23-graphql-code-first/e2e/recipes/recipes.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+import { RecipesService } from '../../src/recipes/recipes.service';
+
+describe('GraphQL Code-First Recipes (e2e)', () => {
+  let app: INestApplication;
+
+  const mockRecipes = [
+    {
+      id: '1',
+      description: 'A test recipe',
+      creationDate: new Date('2024-01-01'),
+      ingredients: ['ingredient1', 'ingredient2'],
+    },
+  ];
+
+  const mockRecipesService = {
+    findAll: jest.fn().mockResolvedValue(mockRecipes),
+    findOneById: jest.fn().mockResolvedValue(mockRecipes[0]),
+    create: jest.fn().mockResolvedValue(mockRecipes[0]),
+    remove: jest.fn().mockResolvedValue(true),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(RecipesService)
+      .useValue(mockRecipesService)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should query recipes', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: '{ recipes { id description ingredients } }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.recipes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: '1',
+              description: 'A test recipe',
+              ingredients: ['ingredient1', 'ingredient2'],
+            }),
+          ]),
+        );
+      });
+  });
+
+  it('should query a single recipe by id', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: '{ recipe(id: "1") { id description ingredients } }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.recipe).toEqual(
+          expect.objectContaining({
+            id: '1',
+            description: 'A test recipe',
+          }),
+        );
+      });
+  });
+
+  it('should add a new recipe', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: `mutation {
+          addRecipe(newRecipeData: {
+            title: "Test Recipe"
+            ingredients: ["ingredient1", "ingredient2"]
+          }) {
+            id
+            description
+            ingredients
+          }
+        }`,
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.addRecipe).toBeDefined();
+        expect(res.body.data.addRecipe.id).toBe('1');
+      });
+  });
+
+  it('should remove a recipe', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: 'mutation { removeRecipe(id: "1") }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.removeRecipe).toBe(true);
+      });
+  });
+});

--- a/sample/23-graphql-code-first/package.json
+++ b/sample/23-graphql-code-first/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@apollo/server": "5.4.0",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `23-graphql-code-first`:
- **Query recipes**: Verifies list of recipes is returned via GraphQL query
- **Query recipe by id**: Verifies single recipe lookup by id
- **Mutation addRecipe**: Verifies recipe creation via GraphQL mutation
- **Mutation removeRecipe**: Verifies recipe removal returns true

Uses `overrideProvider` to mock `RecipesService` since the sample uses mock data.

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```