### PR TITLE
test(sample/09): add e2e tests for babel-example sample

### DIFF
--- a/sample/09-babel-example/e2e/cats/cats.e2e-spec.js
+++ b/sample/09-babel-example/e2e/cats/cats.e2e-spec.js
@@ -1,0 +1,47 @@
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('Babel Cats (e2e)', () => {
+  let app;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/cats (GET) should return empty array initially', () => {
+    return request(app.getHttpServer())
+      .get('/cats')
+      .expect(200)
+      .expect((res) => {
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body).toEqual([]);
+      });
+  });
+
+  it('/cats (POST) should create a cat', () => {
+    return request(app.getHttpServer())
+      .post('/cats')
+      .send({ name: 'Kitty', age: 2, breed: 'Maine Coon' })
+      .expect(201);
+  });
+
+  it('/cats (GET) should return cats after creation', () => {
+    return request(app.getHttpServer())
+      .get('/cats')
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.length).toBe(1);
+        expect(res.body[0].name).toBe('Kitty');
+      });
+  });
+});

--- a/sample/09-babel-example/e2e/jest-e2e.json
+++ b/sample/09-babel-example/e2e/jest-e2e.json
@@ -1,0 +1,11 @@
+{
+  "moduleFileExtensions": ["js", "json"],
+  "rootDir": "..",
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).js$",
+  "collectCoverageFrom": [
+    "src/**/*.js",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/09-babel-example/package.json
+++ b/sample/09-babel-example/package.json
@@ -10,7 +10,7 @@
     "start:dev": "nodemon",
     "test": "jest",
     "test:cov": "jest --coverage",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `09-babel-example`:
- **GET /cats**: Verifies empty array is returned initially
- **POST /cats**: Verifies cat creation returns 201
- **GET /cats**: Verifies cats are returned after creation

The `jest-e2e.json` config uses `rootDir: ".."` so Babel picks up the existing `.babelrc` with decorator support.

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       3 passed, 3 total
```