### PR TITLE
test(sample/33): add e2e tests for graphql-mercurius sample

### DIFF
--- a/sample/33-graphql-mercurius/e2e/jest-e2e.json
+++ b/sample/33-graphql-mercurius/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/33-graphql-mercurius/e2e/recipes/recipes.e2e-spec.ts
+++ b/sample/33-graphql-mercurius/e2e/recipes/recipes.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { INestApplication } from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+import { RecipesService } from '../../src/recipes/recipes.service';
+
+describe('GraphQL Mercurius Recipes (e2e)', () => {
+  let app: INestApplication;
+
+  const mockRecipes = [
+    {
+      id: '1',
+      title: 'Test Recipe',
+      description: 'A test recipe',
+      creationDate: new Date('2024-01-01'),
+      ingredients: ['ingredient1', 'ingredient2'],
+    },
+  ];
+
+  const mockRecipesService = {
+    findAll: jest.fn().mockResolvedValue(mockRecipes),
+    findOneById: jest.fn().mockResolvedValue(mockRecipes[0]),
+    create: jest.fn().mockResolvedValue(mockRecipes[0]),
+    remove: jest.fn().mockResolvedValue(true),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideProvider(RecipesService)
+      .useValue(mockRecipesService)
+      .compile();
+
+    app = moduleRef.createNestApplication<NestFastifyApplication>(
+      new FastifyAdapter(),
+    );
+    await app.init();
+    await app.getHttpAdapter().getInstance().ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should query recipes', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: '{ recipes { id title description ingredients } }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.recipes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: '1',
+              title: 'Test Recipe',
+              description: 'A test recipe',
+              ingredients: ['ingredient1', 'ingredient2'],
+            }),
+          ]),
+        );
+      });
+  });
+
+  it('should query a single recipe by id', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: '{ recipe(id: "1") { id title description } }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.recipe).toEqual(
+          expect.objectContaining({
+            id: '1',
+            title: 'Test Recipe',
+            description: 'A test recipe',
+          }),
+        );
+      });
+  });
+
+  it('should add a new recipe', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: `mutation {
+          addRecipe(newRecipeData: {
+            title: "Test Recipe"
+            ingredients: ["ingredient1", "ingredient2"]
+          }) {
+            id
+            title
+            ingredients
+          }
+        }`,
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.addRecipe).toBeDefined();
+        expect(res.body.data.addRecipe.id).toBe('1');
+        expect(res.body.data.addRecipe.title).toBe('Test Recipe');
+      });
+  });
+
+  it('should remove a recipe', () => {
+    return request(app.getHttpServer())
+      .post('/graphql')
+      .send({
+        query: 'mutation { removeRecipe(id: "1") }',
+      })
+      .expect(200)
+      .expect(res => {
+        expect(res.body.data.removeRecipe).toBe(true);
+      });
+  });
+});

--- a/sample/33-graphql-mercurius/package.json
+++ b/sample/33-graphql-mercurius/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `33-graphql-mercurius`:
- **Query recipes**: Verifies list of recipes is returned via GraphQL query
- **Query recipe by id**: Verifies single recipe lookup by id
- **Mutation addRecipe**: Verifies recipe creation via GraphQL mutation
- **Mutation removeRecipe**: Verifies recipe removal returns true

Uses `FastifyAdapter` with `--experimental-vm-modules` flag required by Mercurius, and overrides `RecipesService` with mock data.

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```