### PR TITLE
test(sample/03): add e2e tests for microservices sample

### DIFF
--- a/sample/03-microservices/e2e/jest-e2e.json
+++ b/sample/03-microservices/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/03-microservices/e2e/math/math.e2e-spec.ts
+++ b/sample/03-microservices/e2e/math/math.e2e-spec.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../../src/app.module';
+
+describe('Microservices Math (e2e)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    app.connectMicroservice<MicroserviceOptions>({
+      transport: Transport.TCP,
+      options: { retryAttempts: 5, retryDelay: 3000 },
+    });
+
+    await app.startAllMicroservices();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('GET / should return the sum of [1, 2, 3, 4, 5]', () => {
+    return request(app.getHttpServer())
+      .get('/')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toBe('15');
+      });
+  });
+});

--- a/sample/03-microservices/package.json
+++ b/sample/03-microservices/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `03-microservices`:
- **GET /**: Verifies the hybrid HTTP+TCP microservice correctly computes and returns the sum of `[1, 2, 3, 4, 5]` = `15`

The test sets up a hybrid application with TCP transport, matching the bootstrap configuration in `main.ts`.

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```