### PR TITLE
test(sample/05): add e2e tests for sql-typeorm sample

### DIFF
--- a/sample/05-sql-typeorm/e2e/jest-e2e.json
+++ b/sample/05-sql-typeorm/e2e/jest-e2e.json
@@ -1,0 +1,18 @@
+{
+  "moduleFileExtensions": ["ts", "tsx", "js", "json"],
+  "transform": {
+    "^.+\\.tsx?$": [
+      "ts-jest",
+      {
+        "diagnostics": false
+      }
+    ]
+  },
+  "testRegex": "/e2e/.*\\.(e2e-test|e2e-spec).(ts|tsx|js)$",
+  "collectCoverageFrom": [
+    "src/**/*.{js,jsx,tsx,ts}",
+    "!**/node_modules/**",
+    "!**/vendor/**"
+  ],
+  "coverageReporters": ["json", "lcov"]
+}

--- a/sample/05-sql-typeorm/e2e/users/users.e2e-spec.ts
+++ b/sample/05-sql-typeorm/e2e/users/users.e2e-spec.ts
@@ -1,0 +1,84 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import * as request from 'supertest';
+import { UsersController } from '../../src/users/users.controller';
+import { UsersService } from '../../src/users/users.service';
+
+describe('SQL TypeORM Users (e2e)', () => {
+  let app: INestApplication;
+
+  const mockUsers = [
+    { id: 1, firstName: 'John', lastName: 'Doe', isActive: true },
+    { id: 2, firstName: 'Jane', lastName: 'Smith', isActive: true },
+  ];
+
+  const mockUsersService = {
+    create: jest
+      .fn()
+      .mockImplementation(dto =>
+        Promise.resolve({ id: 3, ...dto, isActive: true }),
+      ),
+    findAll: jest.fn().mockResolvedValue(mockUsers),
+    findOne: jest
+      .fn()
+      .mockImplementation((id: number) =>
+        Promise.resolve(mockUsers.find(u => u.id === id)),
+      ),
+    remove: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UsersController],
+      providers: [
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
+        },
+      ],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('/users (POST)', () => {
+    return request(app.getHttpServer())
+      .post('/users')
+      .send({ firstName: 'Alice', lastName: 'Wonder' })
+      .expect(201)
+      .expect(res => {
+        expect(res.body.firstName).toBe('Alice');
+        expect(res.body.lastName).toBe('Wonder');
+        expect(res.body.id).toBeDefined();
+      });
+  });
+
+  it('/users (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/users')
+      .expect(200)
+      .expect(res => {
+        expect(Array.isArray(res.body)).toBe(true);
+        expect(res.body.length).toBe(2);
+      });
+  });
+
+  it('/users/:id (GET)', () => {
+    return request(app.getHttpServer())
+      .get('/users/1')
+      .expect(200)
+      .expect(res => {
+        expect(res.body.firstName).toBe('John');
+        expect(res.body.lastName).toBe('Doe');
+      });
+  });
+
+  it('/users/:id (DELETE)', () => {
+    return request(app.getHttpServer()).delete('/users/1').expect(200);
+  });
+});

--- a/sample/05-sql-typeorm/package.json
+++ b/sample/05-sql-typeorm/package.json
@@ -16,7 +16,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "echo 'No e2e tests implemented yet.'"
+    "test:e2e": "jest --config ./e2e/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "11.1.16",


### PR DESCRIPTION
## PR Checklist
- [x] Tests added for the changes
- [x] Tests pass (`npm run test:e2e` in sample directory)
- [x] Follows existing code patterns from other sample e2e tests

## Description

Add end-to-end tests for sample `05-sql-typeorm`:
- **POST /users**: Verifies user creation returns the created entity with id
- **GET /users**: Verifies listing all users
- **GET /users/:id**: Verifies finding a user by id
- **DELETE /users/:id**: Verifies user deletion

Uses a mocked `UsersService` to avoid requiring a MySQL database connection, testing the controller endpoints independently.

## Test Output
```
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
```