### PR TITLE
refactor(core): centralize headers for streamable file responses

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -108,25 +108,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
       return response.send();
     }
     if (body instanceof StreamableFile) {
-      const streamHeaders = body.getHeaders();
-      if (
-        response.getHeader('Content-Type') === undefined &&
-        streamHeaders.type !== undefined
-      ) {
-        response.setHeader('Content-Type', streamHeaders.type);
-      }
-      if (
-        response.getHeader('Content-Disposition') === undefined &&
-        streamHeaders.disposition !== undefined
-      ) {
-        response.setHeader('Content-Disposition', streamHeaders.disposition);
-      }
-      if (
-        response.getHeader('Content-Length') === undefined &&
-        streamHeaders.length !== undefined
-      ) {
-        response.setHeader('Content-Length', streamHeaders.length);
-      }
+      this.applyStreamHeaders(response, body);
       const stream = body.getStream();
       stream.once('error', err => {
         body.errorHandler(err, response);
@@ -514,5 +496,28 @@ export class ExpressAdapter extends AbstractHttpAdapter<
         (layer: any) => layer && layer.handle && layer.handle.name === name,
       )
     );
+  }
+
+  private setHeaderIfNotExists(
+    response: any,
+    name: string,
+    value?: string | string[] | number,
+  ) {
+    if (value !== undefined && response.getHeader(name) === undefined) {
+      const headerValue = Array.isArray(value) ? value.join(',') : value;
+      response.setHeader(name, headerValue);
+    }
+  }
+
+  private applyStreamHeaders(response: any, streamable: StreamableFile) {
+    const headers = streamable.getHeaders();
+
+    this.setHeaderIfNotExists(response, 'Content-Type', headers.type);
+    this.setHeaderIfNotExists(
+      response,
+      'Content-Disposition',
+      headers.disposition,
+    );
+    this.setHeaderIfNotExists(response, 'Content-Length', headers.length);
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, StreamableFile responses have headers set directly in multiple places in the ExpressAdapter, which leads to duplicate logic and ill maintained and lengthy method.

Issue Number: N/A


## What is the new behavior?
Headers for StreamableFile responses are now centralized into private helper methods (setHeaderIfNotExists and applyStreamHeaders).
-Makes it easier to maintain and extend header logic in the future
-Reduce duplicate code

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This is purely a refactor. No new features or bug fixes included.