### PR TITLE
fix(core): dependency injection edge case with moduleref.create

### DIFF
--- a/packages/core/injector/module-ref.ts
+++ b/packages/core/injector/module-ref.ts
@@ -2,6 +2,7 @@ import { IntrospectionResult, Scope, Type } from '@nestjs/common';
 import { getClassScope } from '../helpers/get-class-scope';
 import { isDurable } from '../helpers/is-durable';
 import { AbstractInstanceResolver } from './abstract-instance-resolver';
+import { STATIC_CONTEXT } from './constants';
 import { NestContainer } from './container';
 import { Injector } from './injector';
 import { InstanceLinksHost } from './instance-links-host';
@@ -171,6 +172,14 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
       host: moduleRef,
     });
 
+    if (type?.prototype) {
+      wrapper.setInstanceByContextId(contextId ?? STATIC_CONTEXT, {
+        instance: Object.create(type.prototype),
+        isResolved: false,
+        isPending: false,
+      });
+    }
+
     /* eslint-disable-next-line no-async-promise-executor */
     return new Promise<T>(async (resolve, reject) => {
       try {
@@ -180,6 +189,7 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
             moduleRef,
             undefined,
             contextId,
+            wrapper,
           );
           const instance = new type(...instances);
           this.injector.applyProperties(instance, properties);
@@ -191,6 +201,7 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
           undefined,
           callback,
           contextId,
+          wrapper,
         );
       } catch (err) {
         reject(err);

--- a/packages/core/test/scope/transient-scope.spec.ts
+++ b/packages/core/test/scope/transient-scope.spec.ts
@@ -1,0 +1,83 @@
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { INQUIRER, ModuleRef } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+
+describe('Transient scope', () => {
+  const SOME_TOKEN = Symbol('SomeToken');
+
+  @Injectable({ scope: Scope.TRANSIENT })
+  class TransientService {
+    public context: string;
+
+    constructor(
+      @Inject(INQUIRER) private inquirer: any,
+      @Inject(SOME_TOKEN) public token: string,
+    ) {
+      this.context = inquirer.constructor.name;
+    }
+  }
+
+  @Injectable()
+  class RegularService {
+    constructor(
+      public transient: TransientService,
+      @Inject(SOME_TOKEN) public token: string,
+    ) {}
+  }
+
+  @Injectable()
+  class DynamicService {
+    constructor(
+      public regular: RegularService,
+      public transient: TransientService,
+    ) {}
+  }
+
+  describe('creating an instance with moduleRef.create', () => {
+    let service: DynamicService;
+    let moduleRef: ModuleRef;
+
+    beforeEach(async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          RegularService,
+          TransientService,
+          DynamicService,
+          { provide: SOME_TOKEN, useValue: 'some-value' },
+        ],
+      }).compile();
+
+      moduleRef = module.get(ModuleRef);
+      service = await moduleRef.create(DynamicService);
+    });
+
+    it('should be able to inject a regular dependency', async () => {
+      expect(service.regular.token).to.equal('some-value');
+      expect(service.regular.transient.context).to.equal(RegularService.name);
+    });
+
+    it('should be able to inject a transient-scoped dependency', async () => {
+      expect(service.transient.token).to.equal('some-value');
+      expect(service.transient.context).to.equal(DynamicService.name);
+    });
+
+    it('should work correctly when there is another class that injects the same dependency', async () => {
+      @Injectable()
+      class AnotherDynamicService {
+        constructor(
+          public regular: RegularService,
+          public transient: TransientService,
+        ) {}
+      }
+
+      const service2 = await moduleRef.create(AnotherDynamicService);
+
+      expect(service2.regular.token).to.equal('some-value');
+      expect(service2.regular.transient.context).to.equal(RegularService.name);
+
+      expect(service2.transient.token).to.equal('some-value');
+      expect(service2.transient.context).to.equal(AnotherDynamicService.name);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Injecting a `Scope.TRANSIENT` dependency into a regular `@Injectable` that's instantiated with `ModuleRef.create` results in a "phantom" class, that's not correctly instantiated - the dependencies of the transient service that are not injected.

## What is the new behavior?

The dependencies of the transient service are injected correctly.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Disclaimer: the fix was made by an LLM. I simply provided the `.spec.ts` file and asked it to fix it, I don't understand NestJS deeply enough to understand the fix fully.

Besides that, I didn't know where I should place the test file, open to suggestions if the current place is unfitting 😄 