### PR TITLE
feat(core): export `IEntryNestModule` type

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -18,7 +18,7 @@ export * from './metadata-scanner';
 export * from './middleware';
 export * from './nest-application';
 export * from './nest-application-context';
-export { NestFactory } from './nest-factory';
+export { IEntryNestModule, NestFactory } from './nest-factory';
 export * from './repl';
 export * from './router';
 export * from './services';

--- a/packages/core/nest-factory.ts
+++ b/packages/core/nest-factory.ts
@@ -31,7 +31,12 @@ import { NestApplication } from './nest-application';
 import { NestApplicationContext } from './nest-application-context';
 import { DependenciesScanner } from './scanner';
 
-type IEntryNestModule =
+/**
+ * Represents the entry (root) module type accepted by the NestFactory methods.
+ *
+ * @publicApi
+ */
+export type IEntryNestModule =
   | Type<any>
   | DynamicModule
   | ForwardReference


### PR DESCRIPTION
## Summary

- Export the `IEntryNestModule` type alias from `@nestjs/core` so consumers can use it to properly type wrapper functions around `NestFactory.create()`, `NestFactory.createMicroservice()`, and `NestFactory.createApplicationContext()`
- Added `@publicApi` JSDoc tag to the type definition for consistency with other public API exports
- The type was previously internal (`type` without `export`) in `nest-factory.ts`; this change makes it `export type` and adds it to the barrel export in `index.ts`

Closes #16633

## Test plan

- [x] Verified TypeScript compilation passes (`tsc --noEmit`)
- [x] Verified all 762 existing unit tests pass (`mocha packages/**/*.spec.ts`)
- [x] Verified ESLint passes on modified files
- [x] Verified the type is now importable: `import { IEntryNestModule } from '@nestjs/core'`
- [x] This is a purely additive change (new export); no existing behavior is modified