### PR TITLE
refactor(common): change ConsoleLogger helpers to protected

### DIFF
--- a/packages/common/services/console-logger.service.ts
+++ b/packages/common/services/console-logger.service.ts
@@ -551,7 +551,7 @@ export class ConsoleLogger implements LoggerService {
     return value;
   }
 
-  private getContextAndMessagesToPrint(args: unknown[]) {
+  protected getContextAndMessagesToPrint(args: unknown[]) {
     if (args?.length <= 1) {
       return { messages: args, context: this.context };
     }
@@ -566,7 +566,7 @@ export class ConsoleLogger implements LoggerService {
     };
   }
 
-  private getContextAndStackAndMessagesToPrint(args: unknown[]) {
+  protected getContextAndStackAndMessagesToPrint(args: unknown[]) {
     if (args.length === 2) {
       return this.isStackFormat(args[1])
         ? {
@@ -594,7 +594,7 @@ export class ConsoleLogger implements LoggerService {
     };
   }
 
-  private isStackFormat(stack: unknown) {
+  protected isStackFormat(stack: unknown) {
     if (!isString(stack) && !isUndefined(stack)) {
       return false;
     }
@@ -602,7 +602,7 @@ export class ConsoleLogger implements LoggerService {
     return /^(.)+\n\s+at .+:\d+:\d+/.test(stack!);
   }
 
-  private getColorByLogLevel(level: LogLevel) {
+  protected getColorByLogLevel(level: LogLevel) {
     switch (level) {
       case 'debug':
         return clc.magentaBright;


### PR DESCRIPTION
## Summary

- Change `getContextAndMessagesToPrint`, `getContextAndStackAndMessagesToPrint`, `isStackFormat`, and `getColorByLogLevel` from `private` to `protected` in `ConsoleLogger`
- This allows subclasses to access and override these internal helper methods without needing to re-implement the same argument parsing, stack detection, and color formatting logic
- All other methods in `ConsoleLogger` are already `protected`, so this change makes the class consistently extensible

Closes #16523

## Motivation

As described in #16523, when building custom loggers that extend `ConsoleLogger`, developers currently need to duplicate the argument parsing logic from `getContextAndMessagesToPrint` and `getContextAndStackAndMessagesToPrint` just to extract context, message, and stack in the same way NestJS does internally. Changing these methods to `protected` eliminates this duplication.

`isStackFormat` and `getColorByLogLevel` are also changed to `protected` for consistency, since they are closely related helpers that subclasses may want to override (e.g., custom stack detection or custom color schemes).

## Test plan

- [x] Verified TypeScript compilation passes (`tsc --noEmit`)
- [x] Verified no remaining `private` methods in the class -- all methods are now consistently `protected`
- [x] This is a non-breaking change: changing `private` to `protected` only widens accessibility