### PR TITLE
fix(microservices): use isNil instead of isUndefined in getReplyTopic…

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -378,7 +378,7 @@ export class ClientKafka
 
   protected getReplyTopicPartition(topic: string): string {
     const minimumPartition = this.consumerAssignments[topic];
-    if (isUndefined(minimumPartition)) {
+    if (isNil(minimumPartition)) {
       throw new InvalidKafkaClientTopicException(topic);
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

In `client-kafka.ts`, the `getReplyTopicPartition` method uses `isUndefined()` to guard against missing partition assignments. If `this.consumerAssignments[topic]` is `null` (rather than `undefined`), the check is bypassed and `null.toString()` throws a raw `TypeError` instead of the intended `InvalidKafkaClientTopicException`.

Issue Number: N/A


## What is the new behavior?

The guard now uses `isNil()` (which checks for both `null` and `undefined`), consistent with similar checks elsewhere in the same file (e.g. line 266). This ensures `InvalidKafkaClientTopicException` is thrown correctly for both `null` and `undefined` partition values.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
N/A