### PR TITLE
fix(microservices): preserve packet headers in nats serializer

### DIFF
--- a/packages/microservices/serializers/nats-record.serializer.ts
+++ b/packages/microservices/serializers/nats-record.serializer.ts
@@ -24,7 +24,9 @@ export class NatsRecordSerializer implements Serializer<
     const natsMessage =
       packet?.data && isObject(packet.data) && packet.data instanceof NatsRecord
         ? packet.data
-        : new NatsRecordBuilder(packet?.data).build();
+        : new NatsRecordBuilder(packet?.data)
+            .setHeaders(packet?.headers)
+            .build();
 
     return {
       data: this.jsonCodec.encode({ ...packet, data: natsMessage.data }),

--- a/packages/microservices/test/serializers/nats-record.serializer.spec.ts
+++ b/packages/microservices/test/serializers/nats-record.serializer.spec.ts
@@ -61,6 +61,26 @@ describe('NatsRecordSerializer', () => {
       });
     });
 
+    it('applies packet headers when data is not a NatsRecord', () => {
+      const natsHeaders = nats.headers();
+      natsHeaders.set('x-response', 'enabled');
+
+      expect(
+        instance.serialize({
+          data: { value: 'string' },
+          headers: natsHeaders,
+        }),
+      ).to.deep.eq({
+        headers: natsHeaders,
+        data: jsonCodec.encode({
+          data: {
+            value: 'string',
+          },
+          headers: natsHeaders,
+        }),
+      });
+    });
+
     it('nats message with data and nats headers', () => {
       const natsHeaders = nats.headers();
       natsHeaders.set('1', 'header_1');


### PR DESCRIPTION
## Summary
Preserve `packet.headers` when a NATS response payload is a plain value/object instead of a `NatsRecord`.

## Changes
- Updated `NatsRecordSerializer.serialize()` to carry `packet.headers` into the fallback `NatsRecordBuilder` path.
- Added serializer test coverage for the non-`NatsRecord` path with explicit NATS headers.

## Manual test / verification
- Ran targeted test suite:
  - `npx mocha packages/microservices/test/serializers/nats-record.serializer.spec.ts`
- Verified the new test `applies packet headers when data is not a NatsRecord` passes.
- Existing serializer tests continue passing.

Fixes #10273
