### PR TITLE
fix(core): sanitize sse message

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -97,9 +97,12 @@ export class SseStream extends Transform {
     encoding: string,
     callback: (error?: Error | null, data?: any) => void,
   ) {
-    let data = message.type ? `event: ${message.type}\n` : '';
-    data += message.id ? `id: ${message.id}\n` : '';
-    data += message.retry ? `retry: ${message.retry}\n` : '';
+    const sanitize = (val: string | number) =>
+      String(val).replace(/[\r\n]/g, '');
+
+    let data = message.type ? `event: ${sanitize(message.type)}\n` : '';
+    data += message.id ? `id: ${sanitize(message.id)}\n` : '';
+    data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
     data += message.data ? toDataString(message.data) : '';
     data += '\n';
     this.push(data);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Improves SSE stream security

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`SseStream._transform()`](https://github.com/nestjs/nest/blob/dea5279ef8fcb568de158003e4281759a2cd7675/packages/core/router/sse-stream.ts) interpolates `message.type` and `message.id` directly into Server-Sent Events text protocol output without sanitizing newline characters (`\r`, `\n`). Since the SSE protocol treats both `\r` and `\n` as field delimiters and `\n\n` as event boundaries, an attacker who can influence these fields through upstream data sources can inject arbitrary SSE events, spoof event types, and corrupt reconnection state. Spring Framework's own security patch ([6e97587](https://github.com/spring-projects/spring-framework/commit/6e9758700a4946be1dca85ca937ef2603e291301)) validates these same fields (`id`, `event`) for the same reason.

Reported by lmquan1102@gmail.com


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information