### PR TITLE
fix(socket.io): Deduplicate disconnect listener in bindMessageHandlers

### DIFF
--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -12,6 +12,8 @@ import { Server, ServerOptions, Socket } from 'socket.io';
  * @publicApi
  */
 export class IoAdapter extends AbstractWsAdapter {
+  private readonly disconnectMap = new WeakMap<Socket, Observable<any>>();
+
   public create(
     port: number,
     options?: ServerOptions & { namespace?: string; server?: any },
@@ -39,10 +41,11 @@ export class IoAdapter extends AbstractWsAdapter {
     handlers: MessageMappingProperties[],
     transform: (data: any) => Observable<any>,
   ) {
-    const disconnect$ = fromEvent(socket, DISCONNECT_EVENT).pipe(
-      share(),
-      first(),
-    );
+    let disconnect$ = this.disconnectMap.get(socket);
+    if (!disconnect$) {
+      disconnect$ = fromEvent(socket, DISCONNECT_EVENT).pipe(share(), first());
+      this.disconnectMap.set(socket, disconnect$);
+    }
 
     handlers.forEach(({ message, callback, isAckHandledManually }) => {
       const source$ = fromEvent(socket, message).pipe(

--- a/packages/platform-socket.io/test/io-adapter.spec.ts
+++ b/packages/platform-socket.io/test/io-adapter.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { IoAdapter } from '../adapters/io-adapter';
+import { of } from 'rxjs';
+
+describe('IoAdapter', () => {
+  let adapter: IoAdapter;
+
+  beforeEach(() => {
+    adapter = new IoAdapter();
+  });
+
+  describe('bindMessageHandlers', () => {
+    it('should register only one disconnect listener regardless of call count', () => {
+      const addListenerSpy = sinon.spy();
+      const fakeSocket = {
+        on: addListenerSpy,
+        off: sinon.stub(),
+        addListener: addListenerSpy,
+        removeListener: sinon.stub(),
+      } as any;
+
+      const handler = {
+        message: 'test-event',
+        methodName: 'handleTestEvent',
+        callback: sinon.stub().returns({ data: 'response' }),
+        isAckHandledManually: false,
+      };
+
+      const transform = (data: any) => of(data);
+
+      // Call bindMessageHandlers twice on the same socket
+      // (simulates two gateways sharing the same socket)
+      adapter.bindMessageHandlers(fakeSocket, [handler], transform);
+      adapter.bindMessageHandlers(fakeSocket, [handler], transform);
+
+      const disconnectCalls = addListenerSpy
+        .getCalls()
+        .filter(call => call.args[0] === 'disconnect');
+
+      expect(disconnectCalls).to.have.lengthOf(1);
+
+      // message handlers should still be registered per call
+      const messageCalls = addListenerSpy
+        .getCalls()
+        .filter(call => call.args[0] === 'test-event');
+      expect(messageCalls).to.have.lengthOf(2);
+    });
+  });
+});

--- a/packages/platform-socket.io/test/tsconfig.json
+++ b/packages/platform-socket.io/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.spec.json"
+}


### PR DESCRIPTION
## Summary
Cache the `disconnect$` observable per socket using a `WeakMap` so that multiple gateways sharing the same Socket.IO server register only one `disconnect` listener per client socket instead of one per gateway.

## Changes
- Added a `WeakMap<Socket, Observable>` to `IoAdapter` to cache `disconnect$` per socket.
- `bindMessageHandlers` now reuses the cached observable on subsequent calls for the same socket.
- Added unit test verifying a single `disconnect` listener is registered regardless of call count.

## Manual test / verification
- `npm run test` — all 2003 unit tests passing.
- `npx prettier --check` — formatting OK.
- `npm run lint:packages` — no errors.

Fixes #7249