### PR TITLE
fix(core): defer sse writehead until after lifecycle completes

### DIFF
--- a/integration/nest-application/sse/e2e/express.spec.ts
+++ b/integration/nest-application/sse/e2e/express.spec.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
@@ -15,6 +16,7 @@ describe('Sse (Express Application)', () => {
       }).compile();
 
       app = moduleFixture.createNestApplication<NestExpressApplication>();
+      app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
       await app.listen(3000);
       const url = await app.getUrl();
@@ -48,6 +50,22 @@ describe('Sse (Express Application)', () => {
         done();
       });
     });
+
+    it('returns a validation error status before opening the SSE stream', async () => {
+      const response = await fetch(
+        `${await app.getUrl()}/sse/validated?limit=invalid`,
+        {
+          headers: {
+            accept: 'text/event-stream',
+          },
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('content-type')).to.contain(
+        'application/json',
+      );
+    });
   });
 
   describe('with forceCloseConnections', () => {
@@ -59,6 +77,7 @@ describe('Sse (Express Application)', () => {
       app = moduleFixture.createNestApplication<NestExpressApplication>({
         forceCloseConnections: true,
       });
+      app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
       await app.listen(3000);
       const url = await app.getUrl();
@@ -88,6 +107,22 @@ describe('Sse (Express Application)', () => {
         });
         done();
       });
+    });
+
+    it('returns a validation error status before opening the SSE stream', async () => {
+      const response = await fetch(
+        `${await app.getUrl()}/sse/validated?limit=invalid`,
+        {
+          headers: {
+            accept: 'text/event-stream',
+          },
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('content-type')).to.contain(
+        'application/json',
+      );
     });
   });
 });

--- a/integration/nest-application/sse/e2e/fastify.spec.ts
+++ b/integration/nest-application/sse/e2e/fastify.spec.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -20,6 +21,7 @@ describe('Sse (Fastify Application)', () => {
       app = moduleFixture.createNestApplication<NestFastifyApplication>(
         new FastifyAdapter(),
       );
+      app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
       await app.listen(3000);
       const url = await app.getUrl();
@@ -53,6 +55,22 @@ describe('Sse (Fastify Application)', () => {
         done();
       });
     });
+
+    it('returns a validation error status before opening the SSE stream', async () => {
+      const response = await fetch(
+        `${await app.getUrl()}/sse/validated?limit=invalid`,
+        {
+          headers: {
+            accept: 'text/event-stream',
+          },
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('content-type')).to.contain(
+        'application/json',
+      );
+    });
   });
 
   describe('with forceCloseConnections', () => {
@@ -66,6 +84,7 @@ describe('Sse (Fastify Application)', () => {
           forceCloseConnections: true,
         }),
       );
+      app.useGlobalPipes(new ValidationPipe({ transform: true }));
 
       await app.listen(3000);
       const url = await app.getUrl();
@@ -95,6 +114,22 @@ describe('Sse (Fastify Application)', () => {
         });
         done();
       });
+    });
+
+    it('returns a validation error status before opening the SSE stream', async () => {
+      const response = await fetch(
+        `${await app.getUrl()}/sse/validated?limit=invalid`,
+        {
+          headers: {
+            accept: 'text/event-stream',
+          },
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      expect(response.headers.get('content-type')).to.contain(
+        'application/json',
+      );
     });
   });
 });

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -1,5 +1,13 @@
-import { Controller, MessageEvent, Sse } from '@nestjs/common';
-import { interval, map, Observable } from 'rxjs';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+import { Controller, MessageEvent, Query, Sse } from '@nestjs/common';
+import { interval, map, Observable, of } from 'rxjs';
+
+class SseQueryDto {
+  @Type(() => Number)
+  @IsInt()
+  limit!: number;
+}
 
 @Controller()
 export class AppController {
@@ -8,5 +16,10 @@ export class AppController {
     return interval(1000).pipe(
       map(() => ({ data: { hello: 'world' } }) as MessageEvent),
     );
+  }
+
+  @Sse('sse/validated')
+  sseWithValidatedQuery(@Query() query: SseQueryDto): Observable<MessageEvent> {
+    return of({ data: { limit: query.limit } });
   }
 }

--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -443,11 +443,17 @@ export class RouterExecutionContext {
         res: TResponse,
         req: TRequest,
       ) => {
+        const rawResponse = (res as { raw?: TResponse }).raw ?? res;
         await this.responseController.sse(
           result,
-          (res as any).raw || res,
+          rawResponse,
           (req as any).raw || req,
-          { additionalHeaders: res.getHeaders?.() as any },
+          {
+            additionalHeaders: res.getHeaders?.(),
+            statusCode:
+              (res as { statusCode?: number }).statusCode ??
+              (rawResponse as { statusCode?: number }).statusCode,
+          },
         );
       };
     }

--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -107,7 +107,10 @@ export class RouterResponseController {
     result: TInput | Promise<TInput>,
     response: TResponse,
     request: TRequest,
-    options?: { additionalHeaders: AdditionalHeaders },
+    options?: {
+      additionalHeaders?: AdditionalHeaders;
+      statusCode?: number;
+    },
   ) {
     // It's possible that we sent headers already so don't use a stream
     if (response.writableEnded) {
@@ -120,52 +123,92 @@ export class RouterResponseController {
 
     const stream = new SseStream(request);
 
-    // Extract custom status code from response if it was set
-    const customStatusCode = (response as any).statusCode;
-    const pipeOptions =
-      typeof customStatusCode !== 'undefined'
-        ? { ...options, statusCode: customStatusCode }
-        : options;
+    const statusCode =
+      options?.statusCode ??
+      (response as { statusCode?: number }).statusCode ??
+      200;
 
-    stream.pipe(response, pipeOptions);
+    stream.pipe(response, {
+      additionalHeaders: options?.additionalHeaders,
+      statusCode,
+      end: false,
+    });
 
-    const subscription = observableResult
-      .pipe(
-        map((message): MessageEvent => {
-          if (isObject(message)) {
-            return message as MessageEvent;
-          }
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
 
-          return { data: message as object | string };
-        }),
-        concatMap(
-          message =>
-            new Promise<void>(resolve =>
-              stream.writeMessage(message, () => resolve()),
-            ),
-        ),
-        catchError(err => {
-          const data = err instanceof Error ? err.message : err;
-          stream.writeMessage({ type: 'error', data }, writeError => {
-            if (writeError) {
-              this.logger.error(writeError);
+      const onClose = () => {
+        settled = true;
+        subscription.unsubscribe();
+        if (!stream.writableEnded) {
+          stream.end();
+        }
+        response.end();
+        resolve();
+      };
+
+      const subscription = observableResult
+        .pipe(
+          map((message): MessageEvent => {
+            if (isObject(message)) {
+              return message as MessageEvent;
             }
-          });
 
-          return EMPTY;
-        }),
-      )
-      .subscribe({
-        complete: () => {
-          response.end();
-        },
-      });
+            return { data: message as object | string };
+          }),
+          concatMap(
+            message =>
+              new Promise<void>(resolve =>
+                stream.writeMessage(message, () => resolve()),
+              ),
+          ),
+          catchError(err => {
+            if (!stream.headersCommitted) {
+              throw err;
+            }
 
-    request.on('close', () => {
-      subscription.unsubscribe();
-      if (!stream.writableEnded) {
-        stream.end();
-      }
+            const data = err instanceof Error ? err.message : err;
+            stream.writeMessage({ type: 'error', data }, writeError => {
+              if (writeError) {
+                this.logger.error(writeError);
+              }
+            });
+
+            return EMPTY;
+          }),
+        )
+        .subscribe({
+          error: err => {
+            settled = true;
+            request.removeListener('close', onClose);
+            if (!stream.writableEnded) {
+              stream.end();
+            }
+            reject(err);
+          },
+          complete: () => {
+            settled = true;
+            request.removeListener('close', onClose);
+            if (!stream.writableEnded) {
+              stream.end();
+            }
+            response.end();
+            resolve();
+          },
+        });
+
+      // Commit SSE headers on the next macrotask. Pipe validation errors
+      // propagate through microtasks (which complete before macrotasks),
+      // so if the lifecycle errored, `settled` is already true and we
+      // skip the write. Otherwise headers are sent immediately rather
+      // than waiting for the first Observable emission.
+      setTimeout(() => {
+        if (!settled) {
+          stream.commitHeaders();
+        }
+      }, 0);
+
+      request.on('close', onClose);
     });
   }
 

--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -52,6 +52,10 @@ export type HeaderStream = WritableHeaderStream & ReadHeaders;
  */
 export class SseStream extends Transform {
   private lastEventId: number | null = null;
+  private _headersCommitted = false;
+  private _destination: WritableHeaderStream | null = null;
+  private _statusCode = 200;
+  private _additionalHeaders: AdditionalHeaders | undefined;
 
   constructor(req?: IncomingMessage) {
     super({ objectMode: true });
@@ -62,6 +66,10 @@ export class SseStream extends Transform {
     }
   }
 
+  get headersCommitted(): boolean {
+    return this._headersCommitted;
+  }
+
   pipe<T extends WritableHeaderStream>(
     destination: T,
     options?: {
@@ -70,10 +78,31 @@ export class SseStream extends Transform {
       end?: boolean;
     },
   ): T {
-    if (destination.writeHead) {
-      const statusCode = options?.statusCode ?? 200;
-      destination.writeHead(statusCode, {
-        ...options?.additionalHeaders,
+    this._destination = destination;
+    this._statusCode = options?.statusCode ?? 200;
+    this._additionalHeaders = options?.additionalHeaders;
+    return super.pipe(destination, options);
+  }
+
+  /**
+   * Writes SSE headers to the destination if they have not been sent yet.
+   * Headers are deferred until the first message so that, if the observable
+   * errors before any data is emitted, the HTTP status code can still be
+   * changed by an exception filter.
+   */
+  commitHeaders(): void {
+    if (this._headersCommitted || !this._destination) {
+      return;
+    }
+    if (this._destination.writableEnded) {
+      return;
+    }
+    this._headersCommitted = true;
+    const statusCode = this._statusCode ?? 200;
+    const additionalHeaders = this._additionalHeaders;
+    if (this._destination.writeHead) {
+      this._destination.writeHead(statusCode, {
+        ...additionalHeaders,
         // See https://github.com/dunglas/mercure/blob/master/hub/subscribe.go#L124-L130
         'Content-Type': 'text/event-stream',
         Connection: 'keep-alive',
@@ -85,11 +114,9 @@ export class SseStream extends Transform {
         // NGINX support https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
         'X-Accel-Buffering': 'no',
       });
-      destination.flushHeaders?.();
+      this._destination.flushHeaders?.();
     }
-
-    destination.write('\n');
-    return super.pipe(destination, options);
+    this._destination.write('\n');
   }
 
   _transform(
@@ -97,6 +124,8 @@ export class SseStream extends Transform {
     encoding: string,
     callback: (error?: Error | null, data?: any) => void,
   ) {
+    this.commitHeaders();
+
     const sanitize = (val: string | number) =>
       String(val).replace(/[\r\n]/g, '');
 

--- a/packages/core/test/router/router-execution-context.spec.ts
+++ b/packages/core/test/router/router-execution-context.spec.ts
@@ -511,6 +511,43 @@ describe('RouterExecutionContext', () => {
           ),
         ).to.be.true;
       });
+
+      it('should pass through status and headers from the wrapper response at handle time', async () => {
+        const rawResponse = new PassThrough() as HeaderStream;
+        rawResponse.write = sinon.spy();
+        rawResponse.writeHead = sinon.spy();
+        rawResponse.flushHeaders = sinon.spy();
+
+        const response = {
+          raw: rawResponse,
+          statusCode: 203,
+          getHeaders: sinon
+            .stub()
+            .returns({ 'access-control-headers': 'at-handle-time' }),
+        };
+        const result = of('test');
+
+        const request = new PassThrough();
+        request.on = sinon.spy();
+
+        sinon.stub(contextCreator, 'reflectRenderTemplate').returns(undefined!);
+        sinon.stub(contextCreator, 'reflectSse').returns('/');
+
+        const handler = contextCreator.createHandleResponseFn(
+          null!,
+          true,
+          undefined,
+          200,
+        ) as HandlerResponseBasicFn;
+        await handler(result, response as any, request);
+
+        expect(
+          (rawResponse.writeHead as sinon.SinonSpy).calledWith(
+            203,
+            sinon.match.hasNested('access-control-headers', 'at-handle-time'),
+          ),
+        ).to.be.true;
+      });
     });
   });
 });

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -268,6 +268,7 @@ describe('RouterResponseController', () => {
           {} as unknown as ServerResponse,
           {} as unknown as IncomingMessage,
         );
+        expect.fail('should have thrown');
       } catch (e) {
         expect(e.message).to.eql(
           'You must return an Observable stream to use Server-Sent Events (SSE).',
@@ -510,25 +511,67 @@ data: test
       });
     });
 
-    describe('when there is an error', () => {
-      it('should close the request', done => {
+    it('should commit headers on next tick without waiting for first emission', async () => {
+      class SinkWithWriteHead extends Writable {
+        writeHead = sinon.spy();
+        flushHeaders = sinon.spy();
+
+        _write(
+          chunk: any,
+          encoding: string,
+          callback: (error?: Error | null) => void,
+        ): void {
+          callback();
+        }
+      }
+
+      const result = new Subject();
+      const response = new SinkWithWriteHead();
+      const request = new PassThrough();
+
+      void routerResponseController.sse(
+        result,
+        response as unknown as ServerResponse,
+        request as unknown as IncomingMessage,
+      );
+
+      // Wait for microtasks (subscription) + macrotask (setTimeout(0))
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(response.writeHead.called).to.be.true;
+      expect(response.writeHead.firstCall.args[0]).to.equal(200);
+
+      result.complete();
+      request.destroy();
+    });
+
+    describe('when there is an error before headers are committed', () => {
+      it('should reject the promise so the exception filter can set the status', async () => {
         const result = new Subject();
         const response = new Writable();
-        response.end = done as any;
         response._write = () => {};
 
         const request = new Writable();
         request._write = () => {};
 
-        void routerResponseController.sse(
+        const ssePromise = routerResponseController.sse(
           result,
           response as unknown as ServerResponse,
           request as unknown as IncomingMessage,
         );
 
         result.error(new Error('Some error'));
-      });
 
+        try {
+          await ssePromise;
+          expect.fail('should have rejected');
+        } catch (e) {
+          expect(e.message).to.equal('Some error');
+        }
+      });
+    });
+
+    describe('when there is an error after headers are committed', () => {
       it('should write the error message to the stream', async () => {
         class Sink extends Writable {
           private readonly chunks: string[] = [];
@@ -561,18 +604,19 @@ data: test
           request as unknown as IncomingMessage,
         );
 
+        // Yield so the internal `await Promise.resolve(result)` completes
+        // and the subscription is active before we emit.
+        await Promise.resolve();
+
+        result.next('first');
+        // Let the concatMap inner Promise resolve
+        await new Promise(resolve => setTimeout(resolve, 10));
         result.error(new Error('Some error'));
         request.destroy();
 
         await written(response);
-        expect(response.content).to.eql(
-          `
-event: error
-id: 1
-data: Some error
-
-`,
-        );
+        expect(response.content).to.contain('event: error');
+        expect(response.content).to.contain('data: Some error');
       });
     });
   });

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -124,7 +124,18 @@ data: hello
     );
   });
 
-  it('sets headers on destination when it looks like a HTTP Response', callback => {
+  it('does not write headers eagerly in pipe()', () => {
+    const sse = new SseStream();
+    let writeHeadCalled = false;
+    const sink = new Sink(() => {
+      writeHeadCalled = true;
+    });
+    sse.pipe(sink);
+    expect(writeHeadCalled).to.equal(false);
+    expect(sse.headersCommitted).to.equal(false);
+  });
+
+  it('sets headers on first message when destination looks like a HTTP Response', callback => {
     const sse = new SseStream();
     const sink = new Sink(
       (status: number, headers: string | OutgoingHttpHeaders) => {
@@ -142,6 +153,7 @@ data: hello
       },
     );
     sse.pipe(sink);
+    sse.writeMessage({ data: 'trigger' }, noop);
   });
 
   it('sets additional headers when provided', callback => {
@@ -158,6 +170,7 @@ data: hello
     sse.pipe(sink, {
       additionalHeaders: { 'access-control-headers': 'some-cors-value' },
     });
+    sse.writeMessage({ data: 'trigger' }, noop);
   });
 
   it('sets custom status code when provided', callback => {
@@ -173,6 +186,7 @@ data: hello
     sse.pipe(sink, {
       statusCode: 404,
     });
+    sse.writeMessage({ data: 'trigger' }, noop);
   });
 
   it('defaults to 200 status code when not provided', callback => {
@@ -186,6 +200,18 @@ data: hello
     );
 
     sse.pipe(sink);
+    sse.writeMessage({ data: 'trigger' }, noop);
+  });
+
+  it('does not throw when destination is ended before first message', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+    sink.end();
+    await written(sink);
+
+    sse.writeMessage({ data: 'ignored' }, noop);
+    expect(sse.headersCommitted).to.equal(false);
   });
 
   it('allows an eventsource to connect', callback => {
@@ -193,6 +219,7 @@ data: hello
     const server = createServer((req, res) => {
       sse = new SseStream(req);
       sse.pipe(res);
+      sse.writeMessage({ data: 'hello' }, noop);
     });
 
     server.listen(() => {
@@ -204,7 +231,6 @@ data: hello
         es.close();
         server.close(callback);
       };
-      es.onopen = () => sse.writeMessage({ data: 'hello' }, noop);
       es.onerror = e =>
         callback(new Error(`Error from EventSource: ${JSON.stringify(e)}`));
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using `@Sse()` endpoints with `ValidationPipe`, pipe errors (e.g. `BadRequestException`) were returned with HTTP 200 because `SseStream.pipe()` eagerly called `writeHead(200)` before the interceptor chain had finished subscribing and running pipes. Once headers were sent, exception filters could not override the status code.

Issue Number: N/A


## What is the new behavior?
- **`SseStream`**: `writeHead` is no longer called from `pipe()`; it runs only via `commitHeaders()` (also invoked from `_transform()` when data is written).
- **`RouterResponseController.sse()`**: Subscribes with `catchError` so errors before headers are committed propagate to exception filters; after commit, errors become SSE `error` events. Uses `pipe(..., { end: false })` and a `setTimeout(0)` call to `commitHeaders()` so validation/pipe failures (microtasks) skip sending headers, while successful routes open the stream quickly without waiting for the first emission.
- **`RouterExecutionContext`**: Passes `statusCode` and `getHeaders()` from the response at handle time.
- **Tests**: Unit tests for the above paths; Express/Fastify integration tests assert **400** + JSON for validation errors before the SSE stream opens.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Previously, mutating `response.statusCode` or `getHeaders()` only inside the returned observable (after the handle ran) could affect which values were sent with SSE headers. Status and headers are now captured when the SSE response handler runs, consistent with the rest of the HTTP pipeline.


## Other information