### PR TITLE
fix(microservices): use backing field for consumer CRASH event listener

### DIFF
--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -319,7 +319,7 @@ export class ClientKafka
     this._consumer.on(this._consumer.events.STOP, () =>
       this._status$.next(KafkaStatus.STOPPED),
     );
-    this.consumer.on(this._consumer.events.CRASH, () =>
+    this._consumer.on(this._consumer.events.CRASH, () =>
       this._status$.next(KafkaStatus.CRASHED),
     );
   }

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -292,6 +292,45 @@ describe('ClientKafka', () => {
     });
   });
 
+  describe('registerConsumerEventListeners', () => {
+    it('should use the _consumer backing field, not the consumer getter', () => {
+      const consumerOnSpy = sinon.spy();
+      const fakeConsumer = {
+        events: {
+          CONNECT: 'consumer.connect',
+          DISCONNECT: 'consumer.disconnect',
+          REBALANCING: 'consumer.rebalancing',
+          STOP: 'consumer.stop',
+          CRASH: 'consumer.crash',
+        },
+        on: consumerOnSpy,
+      };
+
+      // Set the backing field directly
+      untypedClient._consumer = fakeConsumer;
+
+      // Replace the consumer getter stub with one that throws,
+      // ensuring the method only uses _consumer (backing field)
+      consumerStub.callsFake(() => {
+        throw new Error(
+          'Consumer getter should not be called in registerConsumerEventListeners',
+        );
+      });
+
+      expect(() =>
+        untypedClient.registerConsumerEventListeners(),
+      ).to.not.throw();
+      expect(consumerOnSpy.callCount).to.equal(5);
+
+      const registeredEvents = consumerOnSpy.args.map((args: any[]) => args[0]);
+      expect(registeredEvents).to.include('consumer.connect');
+      expect(registeredEvents).to.include('consumer.disconnect');
+      expect(registeredEvents).to.include('consumer.rebalancing');
+      expect(registeredEvents).to.include('consumer.stop');
+      expect(registeredEvents).to.include('consumer.crash');
+    });
+  });
+
   describe('connect', () => {
     let consumerAssignmentsStub: sinon.SinonStub;
     let bindTopicsStub: sinon.SinonStub;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In `ClientKafka.registerConsumerEventListeners()`, the CRASH event listener on line 322 uses `this.consumer` (the public getter) instead of `this._consumer` (the backing field). The getter throws `"No consumer initialized"` if `_consumer` is null.

All four other event listeners (CONNECT, DISCONNECT, REBALANCING, STOP) correctly use `this._consumer`.

Introduced in 3dfc7fc68.


Issue Number: N/A


## What is the new behavior?

The CRASH event listener now uses `this._consumer`, consistent with all other event listeners in the same method.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The server-side `ServerKafka.registerConsumerEventListeners()` is unaffected; it uses `this.consumer` consistently, which is a regular property (not a throwing getter).