### PR TITLE
fix(core): use strict null check for SSE message id

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -101,7 +101,10 @@ export class SseStream extends Transform {
       String(val).replace(/[\r\n]/g, '');
 
     let data = message.type ? `event: ${sanitize(message.type)}\n` : '';
-    data += message.id ? `id: ${sanitize(message.id)}\n` : '';
+    data +=
+      message.id !== undefined && message.id !== null
+        ? `id: ${sanitize(message.id)}\n`
+        : '';
     data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
     data += message.data ? toDataString(message.data) : '';
     data += '\n';
@@ -116,7 +119,7 @@ export class SseStream extends Transform {
     message: MessageEvent,
     cb: (error: Error | null | undefined) => void,
   ) {
-    if (!message.id) {
+    if (message.id === undefined || message.id === null) {
       this.lastEventId!++;
       message.id = this.lastEventId!.toString();
     }

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -188,6 +188,49 @@ data: hello
     sse.pipe(sink);
   });
 
+  it('preserves explicit id of 0 in writeMessage', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage(
+      {
+        id: '0',
+        data: 'first',
+      },
+      noop,
+    );
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      `
+id: 0
+data: first
+
+`,
+    );
+  });
+
+  it('serializes id of 0 in _transform', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage(
+      {
+        id: '0',
+        type: 'ping',
+        data: 'hello',
+      },
+      noop,
+    );
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.contain('id: 0\n');
+  });
+
   it('allows an eventsource to connect', callback => {
     let sse: SseStream;
     const server = createServer((req, res) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`SseStream.writeMessage` uses `if (!message.id)` to decide whether to auto-generate an event ID. Because this is a falsy check, an explicitly provided `id: 0` (or `id: ""`) is treated as absent and silently overwritten with an auto-incremented value.

There is a parallel issue in `_transform`: `data += message.id ? ... : ''` — meaning `id: 0` is also dropped from the serialized SSE frame entirely.

Both violate the [W3C SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html), under which `0` is a valid event ID. An SSE client that disconnects and reconnects with `Last-Event-ID: 0` will resume from the wrong event.


Issue Number: N/A


## What is the new behavior?
Both checks are replaced with strict null/undefined guards:

- `writeMessage`: `if (message.id === undefined || message.id === null)`
- `_transform`: `message.id !== undefined && message.id !== null`

An explicitly set `id: 0` now serializes as `id: 0\n` in the event frame, and `writeMessage` preserves it without triggering auto-increment. Only a truly absent (`undefined` or `null`) id triggers auto-generation.

Two new test cases verify:
1. `writeMessage` with `id: '0'` preserves the id without overwriting
2. `_transform` with `id: '0'` includes `id: 0` in the serialized output


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Any code passing `id: 0` was already broken (silently getting an auto-incremented id instead). This fix makes it behave correctly per the W3C spec. Code passing no id or a truthy id is unaffected.

## Other information
W3C SSE spec reference: https://html.spec.whatwg.org/multipage/server-sent-events.html. The spec defines the event ID as a string that may be any value, including `"0"`.