### PR TITLE
normalize duplicate slashes in relative paths

### DIFF
--- a/packages/common/test/utils/shared.utils.spec.ts
+++ b/packages/common/test/utils/shared.utils.spec.ts
@@ -138,6 +138,7 @@ describe('Shared utils', () => {
     it('should replace all slashes with only one slash', () => {
       expect(normalizePath('////path/')).to.be.eql('/path');
       expect(normalizePath('///')).to.be.eql('/');
+      expect(normalizePath('path////path///')).to.be.eql('/path/path');
       expect(normalizePath('/path////path///')).to.be.eql('/path/path');
     });
     it('should return / for empty path', () => {

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -32,9 +32,7 @@ export const addLeadingSlash = (path?: string): string =>
 
 export const normalizePath = (path?: string): string =>
   path
-    ? path.startsWith('/')
-      ? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
-      : '/' + path.replace(/\/+$/, '')
+    ? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
     : '/';
 
 export const stripEndSlash = (path: string) =>


### PR DESCRIPTION

**Repo:** nestjs/nest (⭐ 66000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +2/-3

## What
This change makes `normalizePath()` collapse duplicate slashes for relative inputs in the same way it already does for absolute inputs. It also adds a focused unit test covering a relative path like `path////path///`, which now normalizes to `/path/path`.

## Why
The previous implementation only deduplicated repeated slashes when the input started with `/`. Relative paths such as `path////child` kept their duplicated internal separators, which made path normalization inconsistent in shared routing helpers used by route flattening and websocket adapter setup. This patch fixes that inconsistency with a minimal, behavior-focused update.

## Testing
Recommended verification: run `npm test -- packages/common/test/utils/shared.utils.spec.ts` in the repo root. I attempted that locally, but the workspace does not currently have `mocha` available on `PATH` (`sh: mocha: command not found`), so no automated test completed in this environment.

## Risk
Low - the change simplifies an existing normalization branch and only affects repeated slash collapsing in route-like path strings.
