### PR TITLE
feat(microservices): handle rmq blocked/unblocked connection events

### DIFF
--- a/packages/microservices/client/client-rmq.ts
+++ b/packages/microservices/client/client-rmq.ts
@@ -14,6 +14,7 @@ import {
 } from 'rxjs';
 import { first, map, retryWhen, scan, skip, switchMap } from 'rxjs/operators';
 import {
+  BLOCKED_RMQ_MESSAGE,
   DISCONNECTED_RMQ_MESSAGE,
   RQM_DEFAULT_IS_GLOBAL_PREFETCH_COUNT,
   RQM_DEFAULT_NO_ASSERT,
@@ -23,6 +24,7 @@ import {
   RQM_DEFAULT_QUEUE,
   RQM_DEFAULT_QUEUE_OPTIONS,
   RQM_DEFAULT_URL,
+  UNBLOCKED_RMQ_MESSAGE,
 } from '../constants';
 import { RmqEvents, RmqEventsMap, RmqStatus } from '../events/rmq.events';
 import { ReadPacket, RmqOptions, WritePacket } from '../interfaces';
@@ -113,6 +115,8 @@ export class ClientRMQ extends ClientProxy<RmqEvents, RmqStatus> {
     this.registerErrorListener(this.client);
     this.registerDisconnectListener(this.client);
     this.registerConnectListener(this.client);
+    this.registerBlockedListener(this.client);
+    this.registerUnblockedListener(this.client);
     this.pendingEventListeners.forEach(({ event, callback }) =>
       this.client!.on(event, callback),
     );
@@ -288,6 +292,23 @@ export class ClientRMQ extends ClientProxy<RmqEvents, RmqStatus> {
       } else {
         this.connectionPromise = Promise.resolve();
       }
+    });
+  }
+
+  public registerBlockedListener(client: AmqpConnectionManager): void {
+    client.addListener(
+      RmqEventsMap.BLOCKED,
+      ({ reason }: { reason: string }) => {
+        this._status$.next(RmqStatus.BLOCKED);
+        this.logger.warn(BLOCKED_RMQ_MESSAGE(reason));
+      },
+    );
+  }
+
+  public registerUnblockedListener(client: AmqpConnectionManager): void {
+    client.addListener(RmqEventsMap.UNBLOCKED, () => {
+      this._status$.next(RmqStatus.UNBLOCKED);
+      this.logger.log(UNBLOCKED_RMQ_MESSAGE);
     });
   }
 

--- a/packages/microservices/constants.ts
+++ b/packages/microservices/constants.ts
@@ -58,5 +58,8 @@ export const NO_MESSAGE_HANDLER = `There is no matching message handler defined 
 export const DISCONNECTED_RMQ_MESSAGE = `Disconnected from RMQ. Trying to reconnect.`;
 export const CONNECTION_FAILED_MESSAGE =
   'Connection to transport failed. Trying to reconnect...';
+export const BLOCKED_RMQ_MESSAGE = (reason: string) =>
+  `RMQ broker has blocked the connection (flow control). Reason: ${reason}`;
+export const UNBLOCKED_RMQ_MESSAGE = 'RMQ broker has unblocked the connection.';
 
 export const NATS_DEFAULT_GRACE_PERIOD = 10000;

--- a/packages/microservices/events/rmq.events.ts
+++ b/packages/microservices/events/rmq.events.ts
@@ -1,15 +1,20 @@
 type VoidCallback = () => void;
 type OnErrorCallback = (error: Error) => void;
+type OnBlockedCallback = (arg: { reason: string }) => void;
 
 export const enum RmqStatus {
   DISCONNECTED = 'disconnected',
   CONNECTED = 'connected',
+  BLOCKED = 'blocked',
+  UNBLOCKED = 'unblocked',
 }
 
 export const enum RmqEventsMap {
   ERROR = 'error',
   DISCONNECT = 'disconnect',
   CONNECT = 'connect',
+  BLOCKED = 'blocked',
+  UNBLOCKED = 'unblocked',
 }
 
 /**
@@ -21,4 +26,6 @@ export type RmqEvents = {
   error: OnErrorCallback;
   disconnect: VoidCallback;
   connect: VoidCallback;
+  blocked: OnBlockedCallback;
+  unblocked: VoidCallback;
 };

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -5,6 +5,7 @@ import {
   isUndefined,
 } from '@nestjs/common/utils/shared.utils';
 import {
+  BLOCKED_RMQ_MESSAGE,
   CONNECTION_FAILED_MESSAGE,
   DISCONNECTED_RMQ_MESSAGE,
   NO_MESSAGE_HANDLER,
@@ -20,6 +21,7 @@ import {
   RQM_DEFAULT_URL,
   RQM_NO_EVENT_HANDLER,
   RQM_NO_MESSAGE_HANDLER,
+  UNBLOCKED_RMQ_MESSAGE,
 } from '../constants';
 import { RmqContext } from '../ctx-host';
 import { Transport } from '../enums';
@@ -132,6 +134,8 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
 
     this.registerConnectListener();
     this.registerDisconnectListener();
+    this.registerBlockedListener();
+    this.registerUnblockedListener();
     this.pendingEventListeners.forEach(({ event, callback }) =>
       this.server!.on(event, callback),
     );
@@ -182,6 +186,20 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
       this._status$.next(RmqStatus.DISCONNECTED);
       this.logger.error(DISCONNECTED_RMQ_MESSAGE);
       this.logger.error(err);
+    });
+  }
+
+  private registerBlockedListener() {
+    this.server!.on(RmqEventsMap.BLOCKED, ({ reason }: { reason: string }) => {
+      this._status$.next(RmqStatus.BLOCKED);
+      this.logger.warn(BLOCKED_RMQ_MESSAGE(reason));
+    });
+  }
+
+  private registerUnblockedListener() {
+    this.server!.on(RmqEventsMap.UNBLOCKED, () => {
+      this._status$.next(RmqStatus.UNBLOCKED);
+      this.logger.log(UNBLOCKED_RMQ_MESSAGE);
     });
   }
 

--- a/packages/microservices/test/client/client-rmq.spec.ts
+++ b/packages/microservices/test/client/client-rmq.spec.ts
@@ -15,6 +15,8 @@ describe('ClientRMQ', function () {
   describe('connect', () => {
     let createClientStub: sinon.SinonStub;
     let registerErrorListenerSpy: sinon.SinonSpy;
+    let registerBlockedListenerSpy: sinon.SinonSpy;
+    let registerUnblockedListenerSpy: sinon.SinonSpy;
     let connect$Stub: sinon.SinonStub;
 
     beforeEach(async () => {
@@ -26,6 +28,11 @@ describe('ClientRMQ', function () {
         removeListener: () => ({}),
       }));
       registerErrorListenerSpy = sinon.spy(client, 'registerErrorListener');
+      registerBlockedListenerSpy = sinon.spy(client, 'registerBlockedListener');
+      registerUnblockedListenerSpy = sinon.spy(
+        client,
+        'registerUnblockedListener',
+      );
       connect$Stub = sinon.stub(client, 'connect$' as any).callsFake(() => ({
         subscribe: resolve => resolve(),
         toPromise() {
@@ -51,6 +58,12 @@ describe('ClientRMQ', function () {
       it('should call "registerErrorListener" once', async () => {
         expect(registerErrorListenerSpy.called).to.be.true;
       });
+      it('should call "registerBlockedListener" once', async () => {
+        expect(registerBlockedListenerSpy.called).to.be.true;
+      });
+      it('should call "registerUnblockedListener" once', async () => {
+        expect(registerUnblockedListenerSpy.called).to.be.true;
+      });
       it('should call "createClient" once', async () => {
         expect(createClientStub.called).to.be.true;
       });
@@ -69,9 +82,59 @@ describe('ClientRMQ', function () {
       it('should not call "registerErrorListener"', () => {
         expect(registerErrorListenerSpy.called).to.be.false;
       });
+      it('should not call "registerBlockedListener"', () => {
+        expect(registerBlockedListenerSpy.called).to.be.false;
+      });
+      it('should not call "registerUnblockedListener"', () => {
+        expect(registerUnblockedListenerSpy.called).to.be.false;
+      });
       it('should not call "connect$"', () => {
         expect(connect$Stub.called).to.be.false;
       });
+    });
+  });
+
+  describe('registerBlockedListener', () => {
+    it('should register a "blocked" listener and push RmqStatus.BLOCKED on fire', () => {
+      client = new ClientRMQ({});
+      untypedClient = client as any;
+
+      const addListener = sinon.stub();
+      const fakeClient: any = { addListener };
+
+      const statusValues: string[] = [];
+      untypedClient._status$.subscribe((s: string) => statusValues.push(s));
+
+      client.registerBlockedListener(fakeClient);
+      expect(addListener.calledOnce).to.be.true;
+      expect(addListener.getCall(0).args[0]).to.be.equal('blocked');
+
+      const registeredCallback = addListener.getCall(0).args[1];
+      registeredCallback({ reason: 'low memory' });
+
+      expect(statusValues[statusValues.length - 1]).to.be.equal('blocked');
+    });
+  });
+
+  describe('registerUnblockedListener', () => {
+    it('should register an "unblocked" listener and push RmqStatus.UNBLOCKED on fire', () => {
+      client = new ClientRMQ({});
+      untypedClient = client as any;
+
+      const addListener = sinon.stub();
+      const fakeClient: any = { addListener };
+
+      const statusValues: string[] = [];
+      untypedClient._status$.subscribe((s: string) => statusValues.push(s));
+
+      client.registerUnblockedListener(fakeClient);
+      expect(addListener.calledOnce).to.be.true;
+      expect(addListener.getCall(0).args[0]).to.be.equal('unblocked');
+
+      const registeredCallback = addListener.getCall(0).args[1];
+      registeredCallback();
+
+      expect(statusValues[statusValues.length - 1]).to.be.equal('unblocked');
     });
   });
 

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -54,9 +54,43 @@ describe('ServerRMQ', () => {
       await server.listen(callbackSpy);
       expect(onStub.getCall(2).args[0]).to.be.equal('disconnect');
     });
+    it('should bind "blocked" event to handler', async () => {
+      await server.listen(callbackSpy);
+      expect(onStub.getCall(3).args[0]).to.be.equal('blocked');
+    });
+    it('should bind "unblocked" event to handler', async () => {
+      await server.listen(callbackSpy);
+      expect(onStub.getCall(4).args[0]).to.be.equal('unblocked');
+    });
     it('should bind "connectFailed" event to handler', async () => {
       await server.listen(callbackSpy);
-      expect(onStub.getCall(3).args[0]).to.be.equal('connectFailed');
+      expect(onStub.getCall(5).args[0]).to.be.equal('connectFailed');
+    });
+    it('should push RmqStatus.BLOCKED when "blocked" fires', async () => {
+      await server.listen(callbackSpy);
+      const blockedCall = onStub
+        .getCalls()
+        .find(call => call.args[0] === 'blocked');
+      expect(blockedCall).to.not.be.undefined;
+
+      const statusValues: string[] = [];
+      untypedServer._status$.subscribe((s: string) => statusValues.push(s));
+
+      blockedCall!.args[1]({ reason: 'low memory' });
+      expect(statusValues[statusValues.length - 1]).to.be.equal('blocked');
+    });
+    it('should push RmqStatus.UNBLOCKED when "unblocked" fires', async () => {
+      await server.listen(callbackSpy);
+      const unblockedCall = onStub
+        .getCalls()
+        .find(call => call.args[0] === 'unblocked');
+      expect(unblockedCall).to.not.be.undefined;
+
+      const statusValues: string[] = [];
+      untypedServer._status$.subscribe((s: string) => statusValues.push(s));
+
+      unblockedCall!.args[1]();
+      expect(statusValues[statusValues.length - 1]).to.be.equal('unblocked');
     });
     describe('when "start" throws an exception', () => {
       it('should call callback with a thrown error as an argument', async () => {


### PR DESCRIPTION
Closes #16809.

  ## PR Checklist
  - [x] The commit message follows our guidelines
  - [x] Tests for the changes have been added
  - [ ] Docs have been added / updated

  ## PR Type
  - [ ] Bugfix
  - [x] Feature
  - [ ] Code style update (formatting, local variables)
  - [ ] Refactoring (no functional changes, no API changes)
  - [ ] Build related changes
  - [ ] CI related changes
  - [ ] Other... Please describe:

  ## What is the current behavior?
  The RMQ transport does not surface RabbitMQ `blocked` / `unblocked` connection events through Nest’s existing RMQ status and event APIs. Applications therefore do not get a clear transport-level
  signal when a broker flow-controls a connection.

  Issue Number: #16809

  ## What is the new behavior?
  This PR adds `BLOCKED` and `UNBLOCKED` to `RmqStatus` and `RmqEventsMap`, extends `RmqEvents` with `blocked` / `unblocked` callbacks, and registers matching listeners in both `ClientRMQ` and
  `ServerRMQ`.

  When those events fire, the RMQ transport now:
  - publishes the new states through the existing `status` observable
  - emits clear blocked/unblocked log messages
  - exposes the events through the existing RMQ event API
  - includes tests covering listener registration and status propagation

  ## Does this PR introduce a breaking change?
  - [ ] Yes
  - [x] No

  ## Other information
  This change is additive and keeps the current API intact while making broker flow-control events observable to applications.