### PR TITLE
fix(platform-fastify): middleware execution for encapsulated Fastify plugins

### DIFF
--- a/packages/platform-fastify/adapters/middie/fastify-middie.ts
+++ b/packages/platform-fastify/adapters/middie/fastify-middie.ts
@@ -320,21 +320,41 @@ function fastifyMiddie(
     reply: FastifyReply,
     next: HookHandlerDoneFunction,
   ) {
-    if (this[kMiddieHasMiddlewares]) {
-      const raw = req.raw as any;
-      raw.id = req.id;
-      raw.hostname = req.hostname;
-      raw.protocol = req.protocol;
-      raw.ip = req.ip;
-      raw.ips = req.ips;
-      raw.log = req.log;
-      (req.raw as any).query = req.query;
-      (reply.raw as any).log = req.log;
-      if (req.body !== undefined) (req.raw as any).body = req.body;
-      this[kMiddie].run(req.raw, reply.raw, next);
-    } else {
-      next();
+    const engines: any[] = [];
+    let current: any = this;
+    while (current && current[kMiddie]) {
+      if (
+        Object.prototype.hasOwnProperty.call(current, kMiddieHasMiddlewares)
+      ) {
+        if (current[kMiddieHasMiddlewares]) {
+          engines.push(current[kMiddie]);
+        }
+      }
+      current = Object.getPrototypeOf(current);
     }
+
+    if (engines.length === 0) {
+      return next();
+    }
+
+    const raw = req.raw as any;
+    raw.id = req.id;
+    raw.hostname = req.hostname;
+    raw.protocol = req.protocol;
+    raw.ip = req.ip;
+    raw.ips = req.ips;
+    raw.log = req.log;
+    (req.raw as any).query = req.query;
+    (reply.raw as any).log = req.log;
+    if (req.body !== undefined) (req.raw as any).body = req.body;
+
+    let i = engines.length - 1;
+    function executeEngine(err?: unknown) {
+      if (err) return next(err as Error);
+      if (i < 0) return next();
+      engines[i--].run(req.raw, reply.raw, executeEngine);
+    }
+    executeEngine();
   }
 
   function runMiddieWithPayload(
@@ -357,14 +377,10 @@ function fastifyMiddie(
   }
 
   function onRegister(instance: FastifyInstance) {
-    const middlewares = instance[kMiddlewares].slice() as Array<Array<unknown>>;
     instance[kMiddlewares] = [];
     instance[kMiddie] = middie(onMiddieEnd, instance.initialConfig);
     instance[kMiddieHasMiddlewares] = false;
     instance.decorate('use', use as any);
-    for (const middleware of middlewares) {
-      (instance.use as any)(...middleware);
-    }
   }
 
   next();


### PR DESCRIPTION
In fastify-middie, avoid eagerly copying the middlewares array into child plugin instances during onRegister. Instead, traverse the prototype chain dynamically per request to ensure that middlewares added late (via NestJS MiddlewareConsumer) are reliably inherited and executed for encapsulated plugin routes.

Resolves #11802

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Middleware registered via MiddlewareConsumer (or app.use) often fails to trigger for routes defined within encapsulated Fastify plugins (e.g., plugins registered with a prefix). This happens because the fastify-middie adapter eagerly copies the parent's middleware array at the moment of plugin registration. Since NestJS usually initializes modules and their Fastify plugins before the middleware mapping is fully completed, these plugins end up with a stale (often empty) copy of the middleware list, ignoring any middleware added to the root instance afterwards.

Issue Number: 11802

## What is the new behavior?
The fastify-middie adapter has been refactored to traverse the prototype chain of Fastify instances dynamically at request time. It collects and executes middleware engines from the root instance down to the specific plugin instance. This ensures that any middleware added to the parent context even after a plugin has been registered is correctly inherited and executed for routes within that plugin. The eager copying of the middleware array in onRegister has been removed to prevent duplicate executions and support dynamic inheritance.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information