### PR TITLE
fix(platform-fastify): fix middleware route matching for parameterized paths

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -793,4 +793,73 @@ describe('Middleware (FastifyAdapter)', () => {
       });
     });
   });
+
+  describe('should apply middleware to routes registered via Fastify plugin with prefix', () => {
+    const MIDDLEWARE_VALUE = 'middleware_applied';
+
+    @Controller()
+    class PluginPrefixController {
+      @Get('other')
+      other() {
+        return 'other_route';
+      }
+    }
+
+    @Module({
+      controllers: [PluginPrefixController],
+    })
+    class PluginPrefixModule implements NestModule {
+      configure(consumer: MiddlewareConsumer) {
+        consumer
+          .apply((req, res, next) => {
+            req.middlewareApplied = true;
+            next();
+          })
+          .forRoutes('/my-prefix');
+      }
+    }
+
+    beforeEach(async () => {
+      const fastifyAdapter = new FastifyAdapter();
+
+      app = (
+        await Test.createTestingModule({
+          imports: [PluginPrefixModule],
+        }).compile()
+      ).createNestApplication<NestFastifyApplication>(fastifyAdapter);
+
+      // Register a Fastify plugin with a prefix (simulating third-party plugin)
+      fastifyAdapter
+        .getInstance()
+        .register(
+          async (instance) => {
+            instance.get('/', async () => MIDDLEWARE_VALUE);
+            instance.get('/sub-route', async (req) => {
+              return (req.raw as any).middlewareApplied
+                ? MIDDLEWARE_VALUE
+                : 'no_middleware';
+            });
+          },
+          { prefix: '/my-prefix' },
+        );
+
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    it(`forRoutes('/my-prefix') should match sub-routes under the prefix`, () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/my-prefix/sub-route',
+        })
+        .then(({ payload }) =>
+          expect(payload).to.be.eql(JSON.stringify(MIDDLEWARE_VALUE)),
+        );
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
 });

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -693,10 +693,9 @@ export class FastifyAdapter<
       }
 
       try {
-        let { regexp: re } = pathToRegexp(normalizedPath);
-        re = hasEndOfStringCharacter
-          ? new RegExp(re.source + '$', re.flags)
-          : re;
+        const { regexp: re } = pathToRegexp(normalizedPath, {
+          end: hasEndOfStringCharacter,
+        });
 
         // The following type assertion is valid as we use import('@fastify/middie') rather than require('@fastify/middie')
         // ref https://github.com/fastify/middie/pull/55


### PR DESCRIPTION
## Summary

Fix Fastify middleware route matching for parameterized paths. Middleware was not being applied correctly when routes contained parameters.

Fixes #11802

## PR Checklist

- [x] Addresses an existing open issue
- [x] Tests included