### PR TITLE
feat(platform-express): add defParamCharset to MulterOptions

### DIFF
--- a/packages/platform-express/multer/interfaces/multer-options.interface.ts
+++ b/packages/platform-express/multer/interfaces/multer-options.interface.ts
@@ -31,6 +31,9 @@ export interface MulterOptions {
   /** Keep the full path of files instead of just the base name (Default: false) */
   preservePath?: boolean;
 
+  /** Default character set for part header values (e.g. filename) (Default: 'latin1') */
+  defParamCharset?: string;
+
   fileFilter?(
     req: any,
     file: {


### PR DESCRIPTION
Resolves #16843

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) (N/A - type-only addition)
- [ ] Docs have been added / updated (for bug fixes / features) (N/A - delegated to external multer docs)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `MulterOptions` interface currently lacks the `defParamCharset` property, which was introduced in `multer@2.1.0` (upgraded in NestJS PR #16474) to solve encoding issues with non-Latin part header parameters like filenames. Because this property is missing from the types, developers trying to use `{ defParamCharset: 'utf8' }` to prevent filename garbling encounter strict TypeScript compilation errors.

## What is the new behavior?
The `defParamCharset` optional property has been added to the `MulterOptions` interface along with the corresponding JSDoc comment. Developers can now utilize this multer feature in a type-safe manner when registering the `MulterModule` or using the `FileInterceptor`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
No runtime tests or documentation sites were updated for this specific property. 
- **Tests**: Since NestJS directly passes the options object to the underlying `multer` instance, this is strictly a type addition. This perfectly aligns with how other options (e.g., `preservePath` and `limits`) are currently handled.
- **Docs**: In the official NestJS docs, individual properties of `MulterOptions` are not listed. Instead, developers are instructed to refer directly to the official `multer` documentation. Therefore, simply providing standard JSDoc in the interface is sufficient.
