### PR TITLE
fix(common): accept zero timestamp in parse date pipe

### DIFF
--- a/packages/common/pipes/parse-date.pipe.ts
+++ b/packages/common/pipes/parse-date.pipe.ts
@@ -59,7 +59,7 @@ export class ParseDatePipe implements PipeTransform<
       return this.options.default ? this.options.default() : value;
     }
 
-    if (!value) {
+    if (isNil(value) || value === '') {
       throw this.exceptionFactory('Validation failed (no Date provided)');
     }
 

--- a/packages/common/test/pipes/parse-date.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-date.pipe.spec.ts
@@ -24,6 +24,13 @@ describe('ParseDatePipe', () => {
         expect(transformedNumber.getTime()).to.equal(asNumber);
       });
 
+      it('should parse zero timestamp as a valid date', () => {
+        const transformedDate = target.transform(0)!;
+
+        expect(transformedDate).to.be.instanceOf(Date);
+        expect(transformedDate.getTime()).to.equal(0);
+      });
+
       it('should not throw an error if the value is undefined/null and optional is true', () => {
         const target = new ParseDatePipe({ optional: true });
         const value = target.transform(undefined);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`ParseDatePipe` rejects `0` as "no Date provided", even though `0` is a valid timestamp and `new Date(0)` is a valid date.

Issue Number: N/A


## What is the new behavior?
`ParseDatePipe` now accepts `0` and parses it as the Unix epoch date. A regression test covers this case.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information
Verified with targeted unit tests, `npm run lint:packages`, `npm run lint:spec`, and `npm run build`.