### PR TITLE
test(integration): wait for rabbitmq before tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,9 +155,7 @@ jobs:
       - *install-deps
       - run:
           name: Prepare tests
-          command: |
-            bash ./scripts/prepare.sh
-            sleep 10
+          command: bash ./scripts/prepare.sh
       - run:
           name: List containers
           command: docker ps
@@ -209,4 +207,3 @@ workflows:
       - samples:
           requires:
             - build
-

--- a/integration/microservices/e2e/fanout-exchange-rmq.spec.ts
+++ b/integration/microservices/e2e/fanout-exchange-rmq.spec.ts
@@ -24,7 +24,7 @@ describe('RabbitMQ transport (Fanout Exchange)', () => {
     appConsumer = consumerModule.createNestMicroservice<MicroserviceOptions>({
       transport: Transport.RMQ,
       options: {
-        urls: [`amqp://0.0.0.0:5672`],
+        urls: [`amqp://localhost:5672`],
         queue: '',
         exchange: 'test.fanout',
         exchangeType: 'fanout',

--- a/integration/microservices/e2e/sum-rmq.spec.ts
+++ b/integration/microservices/e2e/sum-rmq.spec.ts
@@ -5,9 +5,7 @@ import { expect } from 'chai';
 import * as request from 'supertest';
 import { RMQController } from '../src/rmq/rmq.controller';
 
-describe('RabbitMQ transport', function () {
-  this.timeout(10000);
-
+describe('RabbitMQ transport', () => {
   let server;
   let app: INestApplication;
 
@@ -22,9 +20,9 @@ describe('RabbitMQ transport', function () {
     app.connectMicroservice<MicroserviceOptions>({
       transport: Transport.RMQ,
       options: {
-        urls: [`amqp://0.0.0.0:5672`],
+        urls: [`amqp://localhost:5672`],
         queue: 'test',
-        queueOptions: { durable: false },
+        queueOptions: { durable: true },
         socketOptions: { noDelay: true },
       },
     });
@@ -84,7 +82,7 @@ describe('RabbitMQ transport', function () {
       .post('/multiple-urls')
       .send([1, 2, 3, 4, 5])
       .expect(200, '15');
-  });
+  }).timeout(10000);
 
   it(`/POST (event notification)`, done => {
     void request(server)

--- a/integration/microservices/e2e/sum-rmq.spec.ts
+++ b/integration/microservices/e2e/sum-rmq.spec.ts
@@ -5,7 +5,9 @@ import { expect } from 'chai';
 import * as request from 'supertest';
 import { RMQController } from '../src/rmq/rmq.controller';
 
-describe('RabbitMQ transport', () => {
+describe('RabbitMQ transport', function () {
+  this.timeout(10000);
+
   let server;
   let app: INestApplication;
 
@@ -82,7 +84,7 @@ describe('RabbitMQ transport', () => {
       .post('/multiple-urls')
       .send([1, 2, 3, 4, 5])
       .expect(200, '15');
-  }).timeout(10000);
+  });
 
   it(`/POST (event notification)`, done => {
     void request(server)

--- a/integration/microservices/e2e/topic-exchange-rmq.spec.ts
+++ b/integration/microservices/e2e/topic-exchange-rmq.spec.ts
@@ -19,7 +19,7 @@ describe('RabbitMQ transport (Topic Exchange - wildcards)', () => {
     app.connectMicroservice<MicroserviceOptions>({
       transport: Transport.RMQ,
       options: {
-        urls: [`amqp://0.0.0.0:5672`],
+        urls: [`amqp://localhost:5672`],
         queue: 'test2',
         wildcards: true,
       },

--- a/integration/microservices/src/rmq/rmq-broadcast.controller.ts
+++ b/integration/microservices/src/rmq/rmq-broadcast.controller.ts
@@ -18,7 +18,7 @@ export class RMQBroadcastController {
       options: {
         urls: [`amqp://localhost:5672`],
         queue: 'test_broadcast',
-        queueOptions: { durable: false },
+        queueOptions: { durable: true },
         socketOptions: { noDelay: true },
       },
     });

--- a/integration/microservices/src/rmq/rmq.controller.ts
+++ b/integration/microservices/src/rmq/rmq.controller.ts
@@ -25,7 +25,7 @@ export class RMQController {
       options: {
         urls: [`amqp://localhost:5672`],
         queue: 'test',
-        queueOptions: { durable: false },
+        queueOptions: { durable: true },
         socketOptions: { noDelay: true },
       },
     });
@@ -69,7 +69,7 @@ export class RMQController {
       options: {
         urls: [`amqp://localhost:5671`, `amqp://localhost:5672`],
         queue: 'test',
-        queueOptions: { durable: false },
+        queueOptions: { durable: true },
         socketOptions: { noDelay: true },
       },
     });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:cov": "nyc mocha packages/**/*.spec.ts --reporter spec",
     "test:integration": "mocha --reporter-option maxDiffSize=0 \"integration/*/{,!(node_modules)/**/}/*.spec.ts\"",
     "test:docker:up": "node scripts/docker-compose.js -f integration/docker-compose.yml up -d",
+    "test:docker:wait:rmq": "node scripts/wait-for-rabbitmq.js",
     "test:docker:down": "node scripts/docker-compose.js -f integration/docker-compose.yml down",
     "lint": "concurrently 'npm run lint:packages' 'npm run lint:integration' 'npm run lint:spec'",
     "lint:fix": "concurrently 'npm run lint:packages -- --fix' 'npm run lint:integration -- --fix' 'npm run lint:spec -- --fix'",

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -3,3 +3,6 @@ npm run build &>/dev/null
 
 # 2. Start docker containers to perform integration tests
 npm run test:docker:up
+
+# 3. Wait for RabbitMQ to accept AMQP connections
+npm run test:docker:wait:rmq

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -4,5 +4,8 @@ npm run build &>/dev/null
 # 2. Start docker containers to perform integration tests
 npm run test:docker:up
 
-# 3. Run integration tests
+# 3. Wait for RabbitMQ to accept AMQP connections
+npm run test:docker:wait:rmq
+
+# 4. Run integration tests
 npm run test:integration

--- a/scripts/wait-for-rabbitmq.js
+++ b/scripts/wait-for-rabbitmq.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const amqp = require('amqplib');
+
+const url = process.env.RABBITMQ_URL || 'amqp://localhost:5672';
+const readPositiveInteger = (value, fallback) => {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+const timeoutMs = readPositiveInteger(
+  process.env.RABBITMQ_WAIT_TIMEOUT_MS,
+  60000,
+);
+const intervalMs = readPositiveInteger(
+  process.env.RABBITMQ_WAIT_INTERVAL_MS,
+  1000,
+);
+const startedAt = Date.now();
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+async function waitForRabbitMQ() {
+  let lastError;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      const connection = await amqp.connect(url);
+      await connection.close();
+      console.log(`[rabbitmq] Ready at ${url}`);
+      return;
+    } catch (err) {
+      lastError = err;
+      console.log(`[rabbitmq] Waiting for ${url}...`);
+      await sleep(intervalMs);
+    }
+  }
+
+  console.error(
+    `[rabbitmq] Timed out waiting for ${url} after ${timeoutMs}ms.`,
+  );
+  if (lastError) {
+    console.error(lastError);
+  }
+  process.exit(1);
+}
+
+void waitForRabbitMQ();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The CircleCI integration test setup starts the Docker services and then waits for a fixed 10 seconds before running the integration suite.
Recent RabbitMQ versions can also reject transient non-exclusive queues, causing the RMQ integration setup to reconnect until Mocha times out.

Issue Number: N/A


## What is the new behavior?
The integration setup now waits for RabbitMQ to accept an AMQP connection before running the integration tests.
This replaces the fixed CircleCI `sleep 10` with a readiness check using the existing `amqplib` dependency. The script uses defaults and does not require any new CI environment variables.
The RMQ integration fixtures now connect to `localhost` and use durable queues, avoiding RabbitMQ's deprecated `transient_nonexcl_queues` feature while keeping the tests focused on RMQ message flow.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No



## Other information
Verified locally with:

- `node --check scripts/wait-for-rabbitmq.js`
- `git diff --check`
- `npm run test:docker:wait:rmq`
- `./node_modules/.bin/mocha --reporter-option maxDiffSize=0 integration/microservices/e2e/sum-rmq.spec.ts`
- `./node_modules/.bin/mocha --reporter-option maxDiffSize=0 integration/microservices/e2e/fanout-exchange-rmq.spec.ts integration/microservices/e2e/topic-exchange-rmq.spec.ts`
- `npm run lint:integration -- --fix=false`
- `npm run lint:packages -- --fix=false`

`npm run lint:packages -- --fix=false` passes with existing warnings unrelated to this change.