### PR TITLE
fix(microservices): ServerRMQ crashes at boot when @MessagePattern(undefined) is combined with wildcards: true

### DIFF
--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -440,6 +440,10 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     const handlers = this.getHandlers();
 
     handlers.forEach((handler, pattern) => {
+      if (typeof pattern !== 'string') {
+        return;
+      }
+
       if (
         pattern.includes(RMQ_WILDCARD_ALL) ||
         pattern.includes(RMQ_WILDCARD_SINGLE)

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -2,6 +2,7 @@ import { assert, expect } from 'chai';
 import * as sinon from 'sinon';
 import { NO_MESSAGE_HANDLER, RQM_DEFAULT_QUEUE } from '../../constants';
 import { RmqContext } from '../../ctx-host';
+import { MessageHandler } from '../../interfaces/message-handler.interface';
 import { ServerRMQ } from '../../server/server-rmq';
 import { objectToMap } from './utils/object-to-map';
 
@@ -486,6 +487,25 @@ describe('ServerRMQ', () => {
         expect(matchRmqPattern('$SYS.#', '$SYS.broker.load.messages.received'))
           .to.be.true;
       });
+    });
+  });
+
+  describe('initializeWildcardHandlersIfExist', () => {
+    it('skips non-string handler keys without throwing', () => {
+      const handlers = new Map<unknown, MessageHandler>();
+      handlers.set(undefined, () => Promise.resolve());
+      handlers.set(0, () => Promise.resolve());
+      handlers.set('orders.*', () => Promise.resolve());
+      handlers.set('orders.created', () => Promise.resolve());
+      sinon
+        .stub(server, 'getHandlers')
+        .returns(handlers as Map<string, MessageHandler>);
+
+      expect(() =>
+        untypedServer.initializeWildcardHandlersIfExist(),
+      ).to.not.throw();
+      expect(untypedServer.wildcardHandlers.size).to.equal(1);
+      expect(untypedServer.wildcardHandlers.has('orders.*')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When `ServerRMQ` is started with `wildcards: true`, `initializeWildcardHandlersIfExist()` iterates every registered `@MessagePattern` / `@EventPattern` handler key and calls `pattern.includes(...)` on it. The method assumes every key is a string, but the decorators accept non-string values — most notably `@MessagePattern(undefined)`, which is a publicly supported way to register a handler for messages that arrive without a `pattern` field (e.g. when the publisher is not NestJS-aware and emits raw payloads).

Booting an app that mixes any non-string handler key with `wildcards: true` crashes with:

```
TypeError: Cannot read properties of undefined (reading 'includes')
```

Issue Number: N/A

## What is the new behavior?

`initializeWildcardHandlersIfExist()` now skips handler keys that aren't strings. Non-string keys cannot syntactically contain the AMQP wildcards `#` or `*`, so they are not candidates for wildcard matching. They continue to be dispatched normally via reference-equality lookup in `getHandlerByPattern` → `super.getHandlerByPattern` (Map equality), so no messages are lost.

A regression test was added under `describe('initializeWildcardHandlersIfExist', ...)` covering mixed string + non-string handler keys.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Real-world trigger: a [Haraka SMTP RabbitMQ-plugin adapter](https://github.com/haraka/haraka-plugin-queue-rabbitmq) publishes raw EML payloads with no `pattern` field on the message; the consumer declares `@MessagePattern(undefined)` to route those messages. The moment any other handler in the same app uses `wildcards: true` for legitimate wildcard-routed traffic, boot crashes inside `initializeWildcardHandlersIfExist`.
