### PR TITLE
Add ParseIPPipe for IP address validation

### DIFF
--- a/packages/common/pipes/index.ts
+++ b/packages/common/pipes/index.ts
@@ -5,6 +5,7 @@ export * from './parse-bool.pipe';
 export * from './parse-date.pipe';
 export * from './parse-enum.pipe';
 export * from './parse-float.pipe';
+export * from './parse-ip.pipe';
 export * from './parse-int.pipe';
 export * from './parse-uuid.pipe';
 export * from './validation.pipe';

--- a/packages/common/pipes/parse-ip.pipe.ts
+++ b/packages/common/pipes/parse-ip.pipe.ts
@@ -1,0 +1,97 @@
+import { Injectable } from '../decorators/core/injectable.decorator';
+import { Optional } from '../decorators/core/optional.decorator';
+import { HttpStatus } from '../enums/http-status.enum';
+import {
+  ArgumentMetadata,
+  PipeTransform,
+} from '../interfaces/features/pipe-transform.interface';
+import {
+  ErrorHttpStatusCode,
+  HttpErrorByCode,
+} from '../utils/http-error-by-code.util';
+import { isNil, isString } from '../utils/shared.utils';
+
+/**
+ * @publicApi
+ */
+export interface ParseIPPipeOptions {
+  /**
+   * IP version to validate
+   */
+  version?: '4' | '6';
+  /**
+   * The HTTP status code to be used in the response when the validation fails.
+   */
+  errorHttpStatusCode?: ErrorHttpStatusCode;
+  /**
+   * A factory function that returns an exception object to be thrown
+   * if validation fails.
+   * @param error Error message
+   * @returns The exception object
+   */
+  exceptionFactory?: (error: string) => any;
+  /**
+   * If true, the pipe will return null or undefined if the value is not provided
+   * @default false
+   */
+  optional?: boolean;
+}
+
+/**
+ * Defines the built-in ParseIP Pipe
+ *
+ * @see [Built-in Pipes](https://docs.nestjs.com/pipes#built-in-pipes)
+ *
+ * @publicApi
+ */
+@Injectable()
+export class ParseIPPipe implements PipeTransform<string> {
+  protected static ipv4Regex =
+    /^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])$/;
+
+  protected static ipv6Regex =
+    /^(?:(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,7}:|(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|(?:[0-9a-fA-F]{1,4}:){1,5}(?::[0-9a-fA-F]{1,4}){1,2}|(?:[0-9a-fA-F]{1,4}:){1,4}(?::[0-9a-fA-F]{1,4}){1,3}|(?:[0-9a-fA-F]{1,4}:){1,3}(?::[0-9a-fA-F]{1,4}){1,4}|(?:[0-9a-fA-F]{1,4}:){1,2}(?::[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:(?::[0-9a-fA-F]{1,4}){1,6}|::(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){0,6})|::|::(?:ffff:){0,1}(?:(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9]))$/i;
+
+  private readonly version: '4' | '6' | undefined;
+  protected exceptionFactory: (error: string) => any;
+
+  constructor(@Optional() protected readonly options?: ParseIPPipeOptions) {
+    options = options || {};
+    const {
+      exceptionFactory,
+      errorHttpStatusCode = HttpStatus.BAD_REQUEST,
+      version,
+    } = options;
+
+    this.version = version;
+    this.exceptionFactory =
+      exceptionFactory ||
+      (error => new HttpErrorByCode[errorHttpStatusCode](error));
+  }
+
+  async transform(value: string, metadata: ArgumentMetadata): Promise<string> {
+    if (isNil(value) && this.options?.optional) {
+      return value;
+    }
+    if (!this.isIP(value, this.version)) {
+      const versionMsg = this.version ? ` v${this.version}` : '';
+      throw this.exceptionFactory(
+        `Validation failed (ip${versionMsg} address is expected)`,
+      );
+    }
+    return value;
+  }
+
+  protected isIP(str: unknown, version?: '4' | '6') {
+    if (!isString(str)) {
+      throw this.exceptionFactory('The value passed as IP is not a string');
+    }
+    if (!version) {
+      return ParseIPPipe.ipv4Regex.test(str) || ParseIPPipe.ipv6Regex.test(str);
+    }
+    if (version === '4') {
+      return ParseIPPipe.ipv4Regex.test(str);
+    }
+    return ParseIPPipe.ipv6Regex.test(str);
+  }
+}

--- a/packages/common/test/pipes/parse-ip.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-ip.pipe.spec.ts
@@ -1,0 +1,197 @@
+import * as chai from 'chai';
+import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import { HttpStatus } from '../../enums';
+import { HttpException } from '../../exceptions';
+import { ArgumentMetadata } from '../../interfaces';
+import { ParseIPPipe } from '../../pipes/parse-ip.pipe';
+chai.use(chaiAsPromised);
+
+class TestException extends HttpException {
+  constructor() {
+    super('This is a TestException', HttpStatus.I_AM_A_TEAPOT);
+  }
+}
+
+describe('ParseIPPipe', () => {
+  let target: ParseIPPipe;
+  const exceptionFactory = (error: any) => new TestException();
+
+  describe('transform', () => {
+    const validIPv4 = [
+      '192.168.1.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '255.255.255.255',
+      '0.0.0.0',
+      '1.1.1.1',
+    ];
+    const validIPv6 = [
+      '2001:0db8:85a3:0000:0000:8a2e:0370:7334',
+      '2001:db8:85a3::8a2e:370:7334',
+      '::1',
+      '::',
+      'fe80::1',
+      '2001:db8::',
+      '::ffff:192.0.2.1',
+    ];
+    const invalidIPs = [
+      'not-an-ip',
+      '192.168.1',
+      '192.168.1.256',
+      '192.168.01.1',
+      '192.168.1.1.1',
+      '2001:db8::8a2e:370:7334:1234:5678:9abc',
+      '2001:db8:::1',
+      'g:g:g:g:g:g:g:g',
+    ];
+
+    describe('when validation passes', () => {
+      it('should return string if value is valid IPv4', async () => {
+        target = new ParseIPPipe({ exceptionFactory });
+        for (const ip of validIPv4) {
+          expect(await target.transform(ip, {} as ArgumentMetadata)).to.equal(
+            ip,
+          );
+        }
+      });
+
+      it('should return string if value is valid IPv6', async () => {
+        target = new ParseIPPipe({ exceptionFactory });
+        for (const ip of validIPv6) {
+          expect(await target.transform(ip, {} as ArgumentMetadata)).to.equal(
+            ip,
+          );
+        }
+      });
+
+      it('should return string if value is valid IPv4 and version is 4', async () => {
+        target = new ParseIPPipe({ version: '4', exceptionFactory });
+        for (const ip of validIPv4) {
+          expect(await target.transform(ip, {} as ArgumentMetadata)).to.equal(
+            ip,
+          );
+        }
+      });
+
+      it('should return string if value is valid IPv6 and version is 6', async () => {
+        target = new ParseIPPipe({ version: '6', exceptionFactory });
+        for (const ip of validIPv6) {
+          expect(await target.transform(ip, {} as ArgumentMetadata)).to.equal(
+            ip,
+          );
+        }
+      });
+
+      it('should not throw an error if the value is undefined and optional is true', async () => {
+        const target = new ParseIPPipe({ optional: true });
+        const value = await target.transform(
+          undefined!,
+          {} as ArgumentMetadata,
+        );
+        expect(value).to.equal(undefined);
+      });
+
+      it('should not throw an error if the value is null and optional is true', async () => {
+        const target = new ParseIPPipe({ optional: true });
+        const value = await target.transform(null!, {} as ArgumentMetadata);
+        expect(value).to.equal(null);
+      });
+    });
+
+    describe('when validation fails', () => {
+      it('should throw an error for invalid IP strings', async () => {
+        target = new ParseIPPipe({ exceptionFactory });
+        for (const ip of invalidIPs) {
+          await expect(
+            target.transform(ip, {} as ArgumentMetadata),
+          ).to.be.rejectedWith(TestException);
+        }
+      });
+
+      it('should throw an error for IPv6 when version is 4', async () => {
+        target = new ParseIPPipe({ version: '4', exceptionFactory });
+        for (const ip of validIPv6) {
+          await expect(
+            target.transform(ip, {} as ArgumentMetadata),
+          ).to.be.rejectedWith(TestException);
+        }
+      });
+
+      it('should throw an error for IPv4 when version is 6', async () => {
+        target = new ParseIPPipe({ version: '6', exceptionFactory });
+        for (const ip of validIPv4) {
+          await expect(
+            target.transform(ip, {} as ArgumentMetadata),
+          ).to.be.rejectedWith(TestException);
+        }
+      });
+
+      it('should throw an error - not a string', async () => {
+        target = new ParseIPPipe({ exceptionFactory });
+        await expect(
+          target.transform(undefined!, {} as ArgumentMetadata),
+        ).to.be.rejectedWith(TestException);
+        await expect(
+          target.transform(null!, {} as ArgumentMetadata),
+        ).to.be.rejectedWith(TestException);
+      });
+
+      it('should use custom exceptionFactory', async () => {
+        const customExceptionFactory = (error: string) => {
+          return new HttpException(
+            'Custom error: ' + error,
+            HttpStatus.BAD_REQUEST,
+          );
+        };
+        target = new ParseIPPipe({ exceptionFactory: customExceptionFactory });
+        try {
+          await target.transform('invalid-ip', {} as ArgumentMetadata);
+          expect.fail('Should have thrown an exception');
+        } catch (error: any) {
+          expect(error.message).to.include('Custom error');
+          expect(error.getStatus()).to.equal(HttpStatus.BAD_REQUEST);
+        }
+      });
+
+      it('should have correct error message without version', async () => {
+        let caughtError: any;
+        target = new ParseIPPipe();
+        try {
+          await target.transform('invalid-ip', {} as ArgumentMetadata);
+        } catch (error: any) {
+          caughtError = error;
+        }
+        expect(caughtError.message).to.equal(
+          'Validation failed (ip address is expected)',
+        );
+      });
+
+      it('should have correct error message with version 4', async () => {
+        let caughtError: any;
+        target = new ParseIPPipe({ version: '4' });
+        try {
+          await target.transform('2001:db8::1', {} as ArgumentMetadata);
+        } catch (error: any) {
+          caughtError = error;
+        }
+        expect(caughtError.message).to.equal(
+          'Validation failed (ip v4 address is expected)',
+        );
+      });
+
+      it('should have correct error message with version 6', async () => {
+        let caughtError: any;
+        target = new ParseIPPipe({ version: '6' });
+        try {
+          await target.transform('192.168.1.1', {} as ArgumentMetadata);
+        } catch (error: any) {
+          caughtError = error;
+        }
+        expect(caughtError.message).to.equal(
+          'Validation failed (ip v6 address is expected)',
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Introduces ParseIPPipe to @nestjs/common, following the existing parse-* pipe conventions. Supports IPv4, IPv6 (full and compressed forms including ::X trailing notation and IPv4-mapped ::ffff:d.d.d.d), and an optional version lock ('4' | '6'). Exposes the same options interface as ParseUUIDPipe: errorHttpStatusCode, exceptionFactory, and optional nil-passthrough.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information