### PR TITLE
fix(core): fix @Sse losing events on complete

### DIFF
--- a/integration/nest-application/sse/e2e/express.spec.ts
+++ b/integration/nest-application/sse/e2e/express.spec.ts
@@ -125,4 +125,37 @@ describe('Sse (Express Application)', () => {
       );
     });
   });
+
+  describe('backpressure', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestExpressApplication>({
+        forceCloseConnections: true,
+      });
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should deliver all events when bursting large payloads', async () => {
+      const url = await app.getUrl();
+      const n = 50;
+      const size = 65536;
+
+      const response = await fetch(`${url}/sse/burst?n=${n}&size=${size}`);
+      const body = await response.text();
+
+      const dataLines = body
+        .split('\n')
+        .filter(line => line.startsWith('data: '));
+
+      expect(dataLines).to.have.lengthOf(n);
+    });
+  });
 });

--- a/integration/nest-application/sse/e2e/fastify.spec.ts
+++ b/integration/nest-application/sse/e2e/fastify.spec.ts
@@ -132,4 +132,39 @@ describe('Sse (Fastify Application)', () => {
       );
     });
   });
+
+  describe('backpressure', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter({
+          forceCloseConnections: true,
+        }),
+      );
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should deliver all events when bursting large payloads', async () => {
+      const url = await app.getUrl();
+      const n = 50;
+      const size = 65536;
+
+      const response = await fetch(`${url}/sse/burst?n=${n}&size=${size}`);
+      const body = await response.text();
+
+      const dataLines = body
+        .split('\n')
+        .filter(line => line.startsWith('data: '));
+
+      expect(dataLines).to.have.lengthOf(n);
+    });
+  });
 });

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -22,4 +22,20 @@ export class AppController {
   sseWithValidatedQuery(@Query() query: SseQueryDto): Observable<MessageEvent> {
     return of({ data: { limit: query.limit } });
   }
+
+  @Sse('sse/burst')
+  sseBurst(
+    @Query('n') n = '20',
+    @Query('size') size = '65536',
+  ): Observable<MessageEvent> {
+    const count = parseInt(n, 10);
+    const payload = 'X'.repeat(parseInt(size, 10));
+
+    return new Observable(subscriber => {
+      for (let i = 0; i < count; i++) {
+        subscriber.next({ data: payload });
+      }
+      subscriber.complete();
+    });
+  }
 }

--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -131,7 +131,6 @@ export class RouterResponseController {
     stream.pipe(response, {
       additionalHeaders: options?.additionalHeaders,
       statusCode,
-      end: false,
     });
 
     return new Promise<void>((resolve, reject) => {
@@ -192,7 +191,6 @@ export class RouterResponseController {
             if (!stream.writableEnded) {
               stream.end();
             }
-            response.end();
             resolve();
           },
         });


### PR DESCRIPTION
This fixes a bug where `@Sse` could lose events if the observable ends immediately after sending many large payloads.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`@Sse` loses events if the observable ends.

## What is the new behavior?
It doesn't.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
I have not added a test, because I was not able to reproduce the bug on localhost. I'm guessing everything is too fast here, and the buffers never fill up.  The bug can be reliably reproduced with an actual network hop.

## Steps to reproduce:
`server.ts`
```typescript
import "reflect-metadata";
import { Controller, Get, Module, Sse, Query } from "@nestjs/common";
import { NestFactory } from "@nestjs/core";
import { Observable } from "rxjs";

@Controller()
class AppController {
  @Get("sse")
  @Sse()
  sse(
    @Query("n") n = "20",
    @Query("size") size = "65536",
    @Query("delay") delayMs = "0",
  ): Observable<any> {
    const count = parseInt(n);
    const payloadSize = parseInt(size);
    const completeDelay = parseInt(delayMs);
    const payload = "X".repeat(payloadSize);

    return new Observable((subscriber) => {
      for (let i = 0; i < count; i++) {
        subscriber.next({ data: payload });
      }

      setTimeout(() => subscriber.complete(), completeDelay);
    });
  }
}

@Module({ controllers: [AppController] })
class AppModule {}

async function main() {
  const app = await NestFactory.create(AppModule, { logger: false });
  await app.listen(8017);
  console.log("Listening on :8017");
}
main();
```

`client.ts`
```typescript
const SERVER = "http://SERVER_IP:8017";

async function test(n: number, size: number, delay = 0): Promise<void> {
  const res = await fetch(`${SERVER}/sse?n=${n}&size=${size}&delay=${delay}`);
  const body = await res.text();
  const messages = Array.from(parseEventStream(body));

  const result = messages.length;
  console.log(
    `n=${String(n).padStart(3)} r=${String(result).padStart(3)}${result === n ? "" : " FAILED"}`,
  );
}

function* parseEventStream(body: string) {
  for (const line of body.split("\n")) {
    if (line.startsWith("data: ")) {
      yield line.slice(6);
    }
  }
}

async function main() {
  const size = 65536;
  for (const n of [3, 5, 10, 20, 50, 100, 200]) {
    await test(n, size);
  }
}

main();
```

- Run `server.ts`
- Run `client.ts` on a different machine
- Alternatively, run both on your dev machine, and get a server to bounce messages back via `sudo socat TCP-LISTEN:8017,fork TCP-CONNECT:<your-dev-machine>:8017`

The output looks something like
```
n=  3 r=  3
n=  5 r=  3 FAILED
n= 10 r=  2 FAILED
n= 20 r= 20
n= 50 r= 50
n=100 r= 75 FAILED
n=200 r=170 FAILED
```
where the larger tests usually fail.