### PR TITLE
feat(common): add payment required exception for http 402

### DIFF
--- a/packages/common/exceptions/index.ts
+++ b/packages/common/exceptions/index.ts
@@ -15,6 +15,7 @@ export * from './not-acceptable.exception';
 export * from './not-found.exception';
 export * from './not-implemented.exception';
 export * from './payload-too-large.exception';
+export * from './payment-required.exception';
 export * from './precondition-failed.exception';
 export * from './request-timeout.exception';
 export * from './service-unavailable.exception';

--- a/packages/common/exceptions/payment-required.exception.ts
+++ b/packages/common/exceptions/payment-required.exception.ts
@@ -1,0 +1,53 @@
+import { HttpStatus } from '../enums/http-status.enum';
+import { HttpException, HttpExceptionOptions } from './http.exception';
+
+/**
+ * Defines an HTTP exception for *Payment Required* type errors.
+ *
+ * @see [Built-in HTTP exceptions](https://docs.nestjs.com/exception-filters#built-in-http-exceptions)
+ *
+ * @publicApi
+ */
+export class PaymentRequiredException extends HttpException {
+  /**
+   * Instantiate a `PaymentRequiredException` Exception.
+   *
+   * @example
+   * `throw new PaymentRequiredException()`
+   *
+   * @usageNotes
+   * The HTTP response status code will be 402.
+   * - The `objectOrError` argument defines the JSON response body or the message string.
+   * - The `descriptionOrOptions` argument contains either a short description of the HTTP error or an options object used to provide an underlying error cause.
+   *
+   * By default, the JSON response body contains two properties:
+   * - `statusCode`: this will be the value 402.
+   * - `message`: the string `'Payment Required'` by default; override this by supplying
+   * a string in the `objectOrError` parameter.
+   *
+   * If the parameter `objectOrError` is a string, the response body will contain an
+   * additional property, `error`, with a short description of the HTTP error. To override the
+   * entire JSON response body, pass an object instead. Nest will serialize the object
+   * and return it as the JSON response body.
+   *
+   * @param objectOrError string or object describing the error condition.
+   * @param descriptionOrOptions either a short description of the HTTP error or an options object used to provide an underlying error cause
+   */
+  constructor(
+    objectOrError?: any,
+    descriptionOrOptions: string | HttpExceptionOptions = 'Payment Required',
+  ) {
+    const { description, httpExceptionOptions } =
+      HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
+
+    super(
+      HttpException.createBody(
+        objectOrError,
+        description!,
+        HttpStatus.PAYMENT_REQUIRED,
+      ),
+      HttpStatus.PAYMENT_REQUIRED,
+      httpExceptionOptions,
+    );
+  }
+}

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -17,6 +17,7 @@ import {
   NotFoundException,
   NotImplementedException,
   PayloadTooLargeException,
+  PaymentRequiredException,
   PreconditionFailedException,
   RequestTimeoutException,
   ServiceUnavailableException,
@@ -66,6 +67,7 @@ describe('HttpException', () => {
         const testCases: [Type<HttpException>, number][] = [
           [BadRequestException, 400],
           [UnauthorizedException, 401],
+          [PaymentRequiredException, 402],
           [ForbiddenException, 403],
           [NotFoundException, 404],
           [MethodNotAllowedException, 405],
@@ -98,6 +100,7 @@ describe('HttpException', () => {
         const testCases: [Type<HttpException>, number, string][] = [
           [BadRequestException, 400, 'Bad Request'],
           [UnauthorizedException, 401, 'Unauthorized'],
+          [PaymentRequiredException, 402, 'Payment Required'],
           [ForbiddenException, 403, 'Forbidden'],
           [NotFoundException, 404, 'Not Found'],
           [MethodNotAllowedException, 405, 'Method Not Allowed'],
@@ -248,6 +251,7 @@ describe('HttpException', () => {
         NotFoundException,
         NotImplementedException,
         PayloadTooLargeException,
+        PaymentRequiredException,
         PreconditionFailedException,
         RequestTimeoutException,
         ServiceUnavailableException,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: N/A

`@nestjs/common` exports a dedicated `HttpException` subclass for every standard 4xx status code in the 400-422 range, except 402.

| Status | Class | File |
| --- | --- | --- |
| 400 | `BadRequestException` | `bad-request.exception.ts` |
| 401 | `UnauthorizedException` | `unauthorized.exception.ts` |
| **402** | **(missing)** | **(missing)** |
| 403 | `ForbiddenException` | `forbidden.exception.ts` |
| 404 | `NotFoundException` | `not-found.exception.ts` |
| 405 | `MethodNotAllowedException` | `method-not-allowed.exception.ts` |
| 406 | `NotAcceptableException` | `not-acceptable.exception.ts` |
| 408 | `RequestTimeoutException` | `request-timeout.exception.ts` |
| 409 | `ConflictException` | `conflict.exception.ts` |
| 410 | `GoneException` | `gone.exception.ts` |
| 412 | `PreconditionFailedException` | `precondition-failed.exception.ts` |
| 413 | `PayloadTooLargeException` | `payload-too-large.exception.ts` |
| 415 | `UnsupportedMediaTypeException` | `unsupported-media-type.exception.ts` |
| 418 | `ImATeapotException` | `im-a-teapot.exception.ts` |
| 421 | `MisdirectedException` | `misdirected.exception.ts` |
| 422 | `UnprocessableEntityException` | `unprocessable-entity.exception.ts` |

The status enum already has the entry, `HttpStatus.PAYMENT_REQUIRED = 402`, and decorators consuming it work fine:

```ts
@Get()
@HttpCode(HttpStatus.PAYMENT_REQUIRED) // works today
getPaywalledResource() { ... }
```

But throwing it requires the verbose form:

```ts
throw new HttpException('Payment required', HttpStatus.PAYMENT_REQUIRED);
```

instead of the symmetric form available for every other 4xx:

```ts
throw new PaymentRequiredException('Quota exceeded'); // does not exist
```

Use case: paywalls, quota walls, "subscription required" responses.


## What is the new behavior?

`PaymentRequiredException` is exported from `@nestjs/common` and behaves identically to its siblings:

```ts
import { PaymentRequiredException } from '@nestjs/common';

throw new PaymentRequiredException();
// HTTP 402 { statusCode: 402, message: 'Payment Required' }

throw new PaymentRequiredException('Quota exceeded');
// HTTP 402 { statusCode: 402, message: 'Quota exceeded', error: 'Payment Required' }

throw new PaymentRequiredException({ code: 'QUOTA', remaining: 0 });
// HTTP 402 { code: 'QUOTA', remaining: 0 }
```

The implementation mirrors `ImATeapotException` (same constructor signature, same default-message strategy, same `cause` option support).

Files changed:

- `packages/common/exceptions/payment-required.exception.ts` (new, 55 lines).
- `packages/common/exceptions/index.ts` (one new `export * from` line, alphabetical position).
- `packages/common/test/exceptions/http.exception.spec.ts` (4 one-line insertions: import + `getStatus` table + `getResponse` table + `builtInErrorClasses` array). This extends the existing parametric tests and exercises the same status / default-message / cause-propagation paths every other built-in exception is tested for.

All 16 tests in `http.exception.spec.ts` pass locally; lint is clean.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Pure addition. No existing identifier is renamed or removed.


## Other information

- The "Built-in HTTP exceptions" page on docs.nestjs.com lists each subclass by name. Happy to open a follow-up PR against `nestjs/docs.nestjs.com` once this lands.
- Class name choice: `PaymentRequiredException` matches the `HttpStatus.PAYMENT_REQUIRED` enum entry and the IANA registered status text "Payment Required".
- Subject is lowercase to satisfy commitlint's `subject-case` rule (single casing style required).