### PR TITLE
fix(common): filetype validator buffer message

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -80,6 +80,21 @@ export class FileTypeValidator extends FileValidator<
         : errorMessage;
     }
 
+    /**
+     * If the file buffer is not available, and fallbackToMimetype is not enabled,
+     * we cannot perform magic number validation,
+     * so we return a specific error message indicating
+     * that validation could not be performed due to missing buffer.
+     */
+    if (
+      file?.mimetype &&
+      !file.buffer &&
+      !this.validationOptions?.fallbackToMimetype &&
+      !this.validationOptions?.skipMagicNumbersValidation
+    ) {
+      return `Validation failed (file buffer is not available; file type validation could not be performed; expected type is ${this.validationOptions.fileType})`;
+    }
+
     if (file?.mimetype) {
       const baseMessage = `Validation failed (current file type is ${file.mimetype}, expected type is ${this.validationOptions.fileType})`;
 

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -15,6 +15,10 @@ const jpegBuffer = Buffer.from([
   0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46,
 ]);
 
+const pdfBuffer = Buffer.from([
+  0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x0a,
+]);
+
 describe('FileTypeValidator', () => {
   describe('isValid', () => {
     describe('support file types', () => {
@@ -280,7 +284,7 @@ describe('FileTypeValidator', () => {
         fileType,
       });
 
-      const file = { mimetype: currentFileType } as IFile;
+      const file = { mimetype: currentFileType, buffer: pngBuffer } as IFile;
 
       expect(fileTypeValidator.buildErrorMessage(file)).to.equal(
         `Validation failed (current file type is ${currentFileType}, expected type is ${fileType})`,
@@ -291,7 +295,7 @@ describe('FileTypeValidator', () => {
       const fileTypeValidator = new FileTypeValidator({
         fileType: /^image\//,
       });
-      const file = { mimetype: 'application/pdf' } as IFile;
+      const file = { mimetype: 'application/pdf', buffer: pdfBuffer } as IFile;
 
       expect(fileTypeValidator.buildErrorMessage(file)).to.equal(
         `Validation failed (current file type is application/pdf, expected type is /^image\\//)`,
@@ -302,10 +306,25 @@ describe('FileTypeValidator', () => {
       const fileTypeValidator = new FileTypeValidator({
         fileType: 'jpeg',
       });
-      const file = { mimetype: 'image/png' } as IFile;
+      const file = { mimetype: 'image/png', buffer: pngBuffer } as IFile;
 
       expect(fileTypeValidator.buildErrorMessage(file)).to.equal(
         'Validation failed (current file type is image/png, expected type is jpeg)',
+      );
+    });
+
+    it('should return a specific error message when file buffer is not available and fallbackToMimetype is not enabled', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'image/jpeg',
+        fallbackToMimetype: false,
+      });
+
+      const file = {
+        mimetype: 'image/jpeg',
+      } as IFile;
+
+      expect(fileTypeValidator.buildErrorMessage(file)).to.equal(
+        `Validation failed (file buffer is not available; file type validation could not be performed; expected type is image/jpeg)`,
       );
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16892 


## What is the new behavior?
`FileTypeValidator` now explicitly returns an error message indicating that the file buffer is missing when validation fails due to a missing buffer.

Previously, this scenario triggered a generic type-mismatch error. By accurately reporting the missing buffer, developers can more easily identify integration issues (such as using `DiskStorage` without a fallback) without being misled by an irrelevant "wrong file type" message.


## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information