### PR TITLE
perf(core): run lifecycle hooks in parallel for modules at same distance

### DIFF
--- a/integration/hooks/e2e/on-module-init.spec.ts
+++ b/integration/hooks/e2e/on-module-init.spec.ts
@@ -111,4 +111,42 @@ describe('OnModuleInit', () => {
     const instance = module.get(AA);
     expect(instance.field).to.equal('c-field_b-field_a-field');
   });
+
+  it('should run sibling modules onModuleInit concurrently', async () => {
+    @Injectable()
+    class ServiceA implements OnModuleInit {
+      async onModuleInit() {
+        await new Promise(r => setTimeout(r, 200));
+      }
+    }
+
+    @Injectable()
+    class ServiceB implements OnModuleInit {
+      async onModuleInit() {
+        await new Promise(r => setTimeout(r, 200));
+      }
+    }
+
+    @Module({ providers: [ServiceA] })
+    class ModuleA {}
+
+    @Module({ providers: [ServiceB] })
+    class ModuleB {}
+
+    @Module({ imports: [ModuleA, ModuleB] })
+    class AppModule {}
+
+    const module = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+    const app = module.createNestApplication();
+
+    const start = Date.now();
+    await app.init();
+    const elapsed = Date.now() - start;
+
+    // Sequential: ~400ms (200+200), Concurrent: ~200ms (max)
+    expect(elapsed).to.be.lessThan(350);
+    await app.close();
+  });
 });

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -421,8 +421,11 @@ export class NestApplicationContext<
    */
   protected async callInitHook(): Promise<void> {
     const modulesSortedByDistance = this.getModulesToTriggerHooksOn();
-    for (const module of modulesSortedByDistance) {
-      await callModuleInitHook(module);
+    const modulesGroupedByDistance = this.groupModulesByDistance(
+      modulesSortedByDistance,
+    );
+    for (const modules of modulesGroupedByDistance) {
+      await Promise.all(modules.map(module => callModuleInitHook(module)));
     }
   }
 
@@ -446,8 +449,11 @@ export class NestApplicationContext<
    */
   protected async callBootstrapHook(): Promise<void> {
     const modulesSortedByDistance = this.getModulesToTriggerHooksOn();
-    for (const module of modulesSortedByDistance) {
-      await callModuleBootstrapHook(module);
+    const modulesGroupedByDistance = this.groupModulesByDistance(
+      modulesSortedByDistance,
+    );
+    for (const modules of modulesGroupedByDistance) {
+      await Promise.all(modules.map(module => callModuleBootstrapHook(module)));
     }
   }
 
@@ -501,6 +507,18 @@ export class NestApplicationContext<
       ? modulesSortedByDistance.filter(moduleRef => moduleRef.initOnPreview)
       : modulesSortedByDistance;
     return this._moduleRefsForHooksByDistance;
+  }
+
+  private groupModulesByDistance(modules: Module[]): Module[][] {
+    const groupsMap = new Map<number, Module[]>();
+    modules.forEach(moduleRef => {
+      const { distance } = moduleRef;
+      if (!groupsMap.has(distance)) {
+        groupsMap.set(distance, []);
+      }
+      groupsMap.get(distance)!.push(moduleRef);
+    });
+    return Array.from(groupsMap.values());
   }
 
   private printInPreviewModeWarning() {


### PR DESCRIPTION
Group modules by their dependency distance and execute onModuleInit and onApplicationBootstrap hooks concurrently within each distance group. Previously, hooks were called sequentially even for sibling modules that have no dependency relationship, causing unnecessary startup delays.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

During application startup, callInitHook and callBootstrapHook in NestApplicationContext iterate modules sequentially, awaiting onModuleInit / onApplicationBootstrap for each module one at a time — even for sibling modules that share the same dependency distance and have no relationship to each other.

For applications where modules perform real async work in their lifecycle hooks (database connections, cache warmup, gRPC clients, HTTP probes, etc.), the total startup time is the sum of all hook latencies, even though independent siblings could run in parallel.
 
I built a small PoC (adapted from sample/34-using-esm-packages) to reproduce and measure the issue: https://github.com/Fcmam5/nest-perf-async-hook-poc
 

## What is the new behavior?

Modules are grouped by their distance value (already computed by DependenciesScanner.calculateModulesDistance), and onModuleInit / onApplicationBootstrap are dispatched concurrently within each distance group via Promise.all. Groups themselves are still processed sequentially in descending distance order, preserving the existing topological ordering guarantee (deepest modules first, global modules last).


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Disclaimer: I used AI assistance to help identify the bottleneck and draft the fix. I reviewed every line of the resulting change, ran the existing unit and integration test suites for the hooks/ package, and additionally validated the change end-to-end with a real PoC application (linked above).