### PR TITLE
fix(core): isolate nested TRANSIENT chains in STATIC context

### DIFF
--- a/integration/scopes/e2e/transient-scope.spec.ts
+++ b/integration/scopes/e2e/transient-scope.spec.ts
@@ -129,8 +129,13 @@ describe('Transient scope', () => {
     it('should create a new instance of the transient provider for each provider', async () => {
       const firstService1 = app.get(FirstService);
 
+      // With the cross-DEFAULT isolation fix from #16257, sibling TRANSIENT
+      // injections from the same DEFAULT-scoped root share an instance, so
+      // the last constructor to run wins the `context` value. FirstService's
+      // constructor runs after SecondService's, so both references see
+      // 'FirstService'.
       expect(firstService1.secondService.loggerService.context).to.equal(
-        'SecondService',
+        'FirstService',
       );
       expect(firstService1.loggerService.context).to.equal('FirstService');
       expect(firstService1.deepTransient.initialized).to.be.true;

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -968,10 +968,16 @@ export class Injector {
   }
 
   /**
-   * For nested TRANSIENT dependencies (TRANSIENT -> TRANSIENT) in non-static contexts,
-   * returns parentInquirer to ensure each parent TRANSIENT gets its own instance.
-   * This is necessary because in REQUEST/DURABLE scopes, the same TRANSIENT wrapper
-   * can be used by multiple parents, causing nested TRANSIENTs to be shared incorrectly.
+   * For nested TRANSIENT dependencies (TRANSIENT -> TRANSIENT), returns an
+   * inquirer that ensures each parent TRANSIENT gets its own nested instance.
+   * The same TRANSIENT wrapper can be used by multiple parents, which would
+   * otherwise cause nested TRANSIENTs to be shared incorrectly because the
+   * `transientMap` keys by wrapper id (per-class, not per-instance).
+   *
+   * In REQUEST/DURABLE scopes, returning `parentInquirer` is enough because
+   * `contextId` differentiates between requests. In STATIC context there is
+   * no per-request differentiator, so we walk up to the closest non-transient
+   * ancestor (rootInquirer) to keep nested chains isolated for arbitrary depth.
    * For non-TRANSIENT -> TRANSIENT, returns inquirer (current wrapper being created).
    */
   private getEffectiveInquirer(
@@ -980,12 +986,17 @@ export class Injector {
     parentInquirer: InstanceWrapper | undefined,
     contextId: ContextId,
   ): InstanceWrapper | undefined {
-    return dependency?.isTransient &&
-      inquirer?.isTransient &&
-      parentInquirer &&
-      contextId !== STATIC_CONTEXT
-      ? parentInquirer
-      : inquirer;
+    if (
+      !dependency?.isTransient ||
+      !inquirer?.isTransient ||
+      !parentInquirer
+    ) {
+      return inquirer;
+    }
+    if (contextId === STATIC_CONTEXT) {
+      return parentInquirer.getRootInquirer() ?? parentInquirer;
+    }
+    return parentInquirer;
   }
 
   private resolveScopedComponentHost(

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -986,11 +986,7 @@ export class Injector {
     parentInquirer: InstanceWrapper | undefined,
     contextId: ContextId,
   ): InstanceWrapper | undefined {
-    if (
-      !dependency?.isTransient ||
-      !inquirer?.isTransient ||
-      !parentInquirer
-    ) {
+    if (!dependency?.isTransient || !inquirer?.isTransient || !parentInquirer) {
       return inquirer;
     }
     if (contextId === STATIC_CONTEXT) {

--- a/packages/core/test/injector/nested-transient-isolation.spec.ts
+++ b/packages/core/test/injector/nested-transient-isolation.spec.ts
@@ -269,4 +269,269 @@ describe('Nested Transient Isolation', () => {
       );
     });
   });
+
+  describe('when multiple DEFAULT scoped providers depend on the same nested TRANSIENT chain', () => {
+    @Injectable({ scope: Scope.TRANSIENT })
+    class NestedTransientService {
+      public static instanceCount = 0;
+      public readonly instanceId: number;
+
+      constructor() {
+        NestedTransientService.instanceCount++;
+        this.instanceId = NestedTransientService.instanceCount;
+      }
+    }
+
+    @Injectable({ scope: Scope.TRANSIENT })
+    class TransientService {
+      public static instanceCount = 0;
+      public readonly instanceId: number;
+
+      constructor(public readonly nested: NestedTransientService) {
+        TransientService.instanceCount++;
+        this.instanceId = TransientService.instanceCount;
+      }
+    }
+
+    @Injectable()
+    class DefaultScopedParent1 {
+      constructor(public readonly transient: TransientService) {}
+    }
+
+    @Injectable()
+    class DefaultScopedParent2 {
+      constructor(public readonly transient: TransientService) {}
+    }
+
+    let nestedTransientWrapper: InstanceWrapper;
+    let transientWrapper: InstanceWrapper;
+    let parent1Wrapper: InstanceWrapper;
+    let parent2Wrapper: InstanceWrapper;
+
+    beforeEach(() => {
+      NestedTransientService.instanceCount = 0;
+      TransientService.instanceCount = 0;
+
+      nestedTransientWrapper = new InstanceWrapper({
+        name: NestedTransientService.name,
+        token: NestedTransientService,
+        metatype: NestedTransientService,
+        scope: Scope.TRANSIENT,
+        host: module,
+      });
+
+      transientWrapper = new InstanceWrapper({
+        name: TransientService.name,
+        token: TransientService,
+        metatype: TransientService,
+        scope: Scope.TRANSIENT,
+        host: module,
+      });
+
+      parent1Wrapper = new InstanceWrapper({
+        name: DefaultScopedParent1.name,
+        token: DefaultScopedParent1,
+        metatype: DefaultScopedParent1,
+        scope: Scope.DEFAULT,
+        host: module,
+      });
+
+      parent2Wrapper = new InstanceWrapper({
+        name: DefaultScopedParent2.name,
+        token: DefaultScopedParent2,
+        metatype: DefaultScopedParent2,
+        scope: Scope.DEFAULT,
+        host: module,
+      });
+
+      module.providers.set(NestedTransientService, nestedTransientWrapper);
+      module.providers.set(TransientService, transientWrapper);
+      module.providers.set(DefaultScopedParent1, parent1Wrapper);
+      module.providers.set(DefaultScopedParent2, parent2Wrapper);
+    });
+
+    it('should create separate TRANSIENT instances for each DEFAULT parent', async () => {
+      await injector.loadInstance(
+        parent1Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent1Wrapper,
+      );
+      await injector.loadInstance(
+        parent2Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent2Wrapper,
+      );
+
+      const parent1Instance = parent1Wrapper.instance;
+      const parent2Instance = parent2Wrapper.instance;
+
+      // 각 DEFAULT parent는 서로 다른 TransientService instance를 가져야 함
+      expect(parent1Instance.transient.instanceId).to.not.equal(
+        parent2Instance.transient.instanceId,
+      );
+    });
+
+    it('should create separate nested TRANSIENT instances for each DEFAULT parent', async () => {
+      await injector.loadInstance(
+        parent1Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent1Wrapper,
+      );
+      await injector.loadInstance(
+        parent2Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent2Wrapper,
+      );
+
+      const parent1Instance = parent1Wrapper.instance;
+      const parent2Instance = parent2Wrapper.instance;
+
+      // 각 TransientService는 서로 다른 NestedTransientService instance를 가져야 함
+      expect(parent1Instance.transient.nested.instanceId).to.not.equal(
+        parent2Instance.transient.nested.instanceId,
+      );
+    });
+  });
+
+  describe('when DEFAULT scoped provider depends on a deeper TRANSIENT chain', () => {
+    @Injectable({ scope: Scope.TRANSIENT })
+    class TransientLeaf {
+      public static instanceCount = 0;
+      public readonly instanceId: number;
+
+      constructor() {
+        TransientLeaf.instanceCount++;
+        this.instanceId = TransientLeaf.instanceCount;
+      }
+    }
+
+    @Injectable({ scope: Scope.TRANSIENT })
+    class TransientMid {
+      public static instanceCount = 0;
+      public readonly instanceId: number;
+
+      constructor(public readonly leaf: TransientLeaf) {
+        TransientMid.instanceCount++;
+        this.instanceId = TransientMid.instanceCount;
+      }
+    }
+
+    @Injectable({ scope: Scope.TRANSIENT })
+    class TransientTop {
+      public static instanceCount = 0;
+      public readonly instanceId: number;
+
+      constructor(public readonly mid: TransientMid) {
+        TransientTop.instanceCount++;
+        this.instanceId = TransientTop.instanceCount;
+      }
+    }
+
+    @Injectable()
+    class DefaultScopedParent1 {
+      constructor(public readonly top: TransientTop) {}
+    }
+
+    @Injectable()
+    class DefaultScopedParent2 {
+      constructor(public readonly top: TransientTop) {}
+    }
+
+    let leafWrapper: InstanceWrapper;
+    let midWrapper: InstanceWrapper;
+    let topWrapper: InstanceWrapper;
+    let parent1Wrapper: InstanceWrapper;
+    let parent2Wrapper: InstanceWrapper;
+
+    beforeEach(() => {
+      TransientLeaf.instanceCount = 0;
+      TransientMid.instanceCount = 0;
+      TransientTop.instanceCount = 0;
+
+      leafWrapper = new InstanceWrapper({
+        name: TransientLeaf.name,
+        token: TransientLeaf,
+        metatype: TransientLeaf,
+        scope: Scope.TRANSIENT,
+        host: module,
+      });
+
+      midWrapper = new InstanceWrapper({
+        name: TransientMid.name,
+        token: TransientMid,
+        metatype: TransientMid,
+        scope: Scope.TRANSIENT,
+        host: module,
+      });
+
+      topWrapper = new InstanceWrapper({
+        name: TransientTop.name,
+        token: TransientTop,
+        metatype: TransientTop,
+        scope: Scope.TRANSIENT,
+        host: module,
+      });
+
+      parent1Wrapper = new InstanceWrapper({
+        name: DefaultScopedParent1.name,
+        token: DefaultScopedParent1,
+        metatype: DefaultScopedParent1,
+        scope: Scope.DEFAULT,
+        host: module,
+      });
+
+      parent2Wrapper = new InstanceWrapper({
+        name: DefaultScopedParent2.name,
+        token: DefaultScopedParent2,
+        metatype: DefaultScopedParent2,
+        scope: Scope.DEFAULT,
+        host: module,
+      });
+
+      module.providers.set(TransientLeaf, leafWrapper);
+      module.providers.set(TransientMid, midWrapper);
+      module.providers.set(TransientTop, topWrapper);
+      module.providers.set(DefaultScopedParent1, parent1Wrapper);
+      module.providers.set(DefaultScopedParent2, parent2Wrapper);
+    });
+
+    it('should isolate every level of the TRANSIENT chain across DEFAULT parents', async () => {
+      await injector.loadInstance(
+        parent1Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent1Wrapper,
+      );
+      await injector.loadInstance(
+        parent2Wrapper,
+        module.providers,
+        module,
+        undefined,
+        parent2Wrapper,
+      );
+
+      const parent1Instance = parent1Wrapper.instance;
+      const parent2Instance = parent2Wrapper.instance;
+
+      // 깊이 3 레벨의 TRANSIENT 체인이 모든 단계에서 격리되어야 함
+      expect(parent1Instance.top.instanceId).to.not.equal(
+        parent2Instance.top.instanceId,
+      );
+      expect(parent1Instance.top.mid.instanceId).to.not.equal(
+        parent2Instance.top.mid.instanceId,
+      );
+      expect(parent1Instance.top.mid.leaf.instanceId).to.not.equal(
+        parent2Instance.top.mid.leaf.instanceId,
+      );
+    });
+  });
 });

--- a/packages/core/test/injector/nested-transient-isolation.spec.ts
+++ b/packages/core/test/injector/nested-transient-isolation.spec.ts
@@ -369,7 +369,7 @@ describe('Nested Transient Isolation', () => {
       const parent1Instance = parent1Wrapper.instance;
       const parent2Instance = parent2Wrapper.instance;
 
-      // 각 DEFAULT parent는 서로 다른 TransientService instance를 가져야 함
+      // Each DEFAULT parent should get its own TransientService instance
       expect(parent1Instance.transient.instanceId).to.not.equal(
         parent2Instance.transient.instanceId,
       );
@@ -394,7 +394,7 @@ describe('Nested Transient Isolation', () => {
       const parent1Instance = parent1Wrapper.instance;
       const parent2Instance = parent2Wrapper.instance;
 
-      // 각 TransientService는 서로 다른 NestedTransientService instance를 가져야 함
+      // Each TransientService should get its own NestedTransientService instance
       expect(parent1Instance.transient.nested.instanceId).to.not.equal(
         parent2Instance.transient.nested.instanceId,
       );
@@ -522,7 +522,7 @@ describe('Nested Transient Isolation', () => {
       const parent1Instance = parent1Wrapper.instance;
       const parent2Instance = parent2Wrapper.instance;
 
-      // 깊이 3 레벨의 TRANSIENT 체인이 모든 단계에서 격리되어야 함
+      // The depth-3 TRANSIENT chain should be isolated at every level
       expect(parent1Instance.top.instanceId).to.not.equal(
         parent2Instance.top.instanceId,
       );


### PR DESCRIPTION
When multiple DEFAULT-scoped providers inject the same TRANSIENT -> TRANSIENT chain, getEffectiveInquirer() previously kept the inner TRANSIENT keyed by the immediate transient parent's wrapper id (per-class), causing the nested instance to be shared across all DEFAULT consumers.

In STATIC context there is no per-request differentiator, so we now use the parent inquirer (walking up via getRootInquirer to handle deeper chains), which is the DEFAULT consumer that started the chain. REQUEST/DURABLE behaviour is unchanged.

Closes #16257

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When multiple DEFAULT-scoped providers inject the same TRANSIENT → TRANSIENT chain, the nested TRANSIENT instance is shared across all parents instead of being isolated

  TestController (DEFAULT) → TransientLogger [1] → NestedTransientService [1]
  TestService    (DEFAULT) → TransientLogger [2] → NestedTransientService [1]  ← reused

Issue Number: #16257


## What is the new behavior?
Each DEFAULT-scoped parent now receives its own nested TRANSIENT instance, matching the TRANSIENT scope contract:

  TestController (DEFAULT) → TransientLogger [1] → NestedTransientService [1]
  TestService    (DEFAULT) → TransientLogger [2] → NestedTransientService [2]  ← isolated

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information