### PR TITLE
fix(microservices): support regex Kafka patterns

### DIFF
--- a/integration/microservices/e2e/sum-kafka.spec.ts
+++ b/integration/microservices/e2e/sum-kafka.spec.ts
@@ -86,6 +86,14 @@ describe.skip('Kafka transport', function () {
       .expect(200, '15');
   });
 
+  it(`/POST (sync sum regexp message pattern)`, () => {
+    return request(server)
+      .post('/mathSumSyncRegex')
+      .send([1, 2, 3, 4, 5])
+      .expect(200)
+      .expect(200, '15');
+  });
+
   it(`/POST (async event notification)`, () =>
     new Promise<void>(done => {
       void request(server)

--- a/integration/microservices/src/kafka/kafka.controller.ts
+++ b/integration/microservices/src/kafka/kafka.controller.ts
@@ -36,6 +36,7 @@ export class KafkaController implements OnModuleInit, OnModuleDestroy {
       'math.sum.sync.array',
       'math.sum.sync.string',
       'math.sum.sync.number',
+      'math.sum.sync.regex.integration',
       'user.create',
       'business.create',
     ];
@@ -123,6 +124,17 @@ export class KafkaController implements OnModuleInit, OnModuleDestroy {
   async mathSumSyncNumber(@Body() data: number[]): Promise<Observable<any>> {
     const result = await lastValueFrom(
       this.client.send('math.sum.sync.number', data[0]),
+    );
+    return result;
+  }
+
+  @Post('mathSumSyncRegex')
+  @HttpCode(200)
+  async mathSumSyncRegex(@Body() data: number[]): Promise<Observable<any>> {
+    const result = await lastValueFrom(
+      this.client.send('math.sum.sync.regex.integration', {
+        numbers: data,
+      }),
     );
     return result;
   }

--- a/integration/microservices/src/kafka/kafka.messages.controller.ts
+++ b/integration/microservices/src/kafka/kafka.messages.controller.ts
@@ -51,6 +51,11 @@ export class KafkaMessagesController {
       .reduce((a, b) => a + b);
   }
 
+  @MessagePattern(/^math\.sum\.sync\.regex\..+$/)
+  mathSumSyncRegex(data: any) {
+    return (data.value.numbers || []).reduce((a, b) => a + b);
+  }
+
   @EventPattern('notify')
   eventHandler(data: any) {
     KafkaController.IS_NOTIFIED = data.value.notify;

--- a/packages/microservices/interfaces/pattern.interface.ts
+++ b/packages/microservices/interfaces/pattern.interface.ts
@@ -1,7 +1,8 @@
 export type MsFundamentalPattern = string | number;
+export type MsPatternMatch = RegExp;
 
 export interface MsObjectPattern {
   [key: string]: MsFundamentalPattern | MsObjectPattern;
 }
 
-export type MsPattern = MsObjectPattern | MsFundamentalPattern;
+export type MsPattern = MsObjectPattern | MsFundamentalPattern | MsPatternMatch;

--- a/packages/microservices/server/server-kafka.ts
+++ b/packages/microservices/server/server-kafka.ts
@@ -26,6 +26,7 @@ import {
 import { KafkaLogger, KafkaParser } from '../helpers/index.js';
 import {
   KafkaOptions,
+  MessageHandler,
   OutgoingResponse,
   ReadPacket,
   TransportId,
@@ -77,6 +78,35 @@ export class ServerKafka extends Server<never, KafkaStatus> {
 
     this.initializeSerializer(options);
     this.initializeDeserializer(options);
+  }
+
+  public addHandler(
+    pattern: any,
+    callback: MessageHandler,
+    isEventHandler = false,
+    extras: Record<string, any> = {},
+  ) {
+    if (!(pattern instanceof RegExp)) {
+      return super.addHandler(pattern, callback, isEventHandler, extras);
+    }
+
+    const messageHandlers = this.messageHandlers as Map<
+      string | RegExp,
+      MessageHandler
+    >;
+    callback.isEventHandler = isEventHandler;
+    callback.extras = extras;
+
+    if (messageHandlers.has(pattern) && isEventHandler) {
+      const headRef = messageHandlers.get(pattern)!;
+      const getTail = (handler: MessageHandler) =>
+        handler?.next ? getTail(handler.next) : handler;
+
+      const tailRef = getTail(headRef);
+      tailRef.next = callback;
+    } else {
+      messageHandlers.set(pattern, callback);
+    }
   }
 
   public async listen(
@@ -177,6 +207,36 @@ export class ServerKafka extends Server<never, KafkaStatus> {
       eachMessage: this.getMessageHandler(),
     };
     await consumer.run(consumerRunOptions);
+  }
+
+  public getHandlerByPattern(pattern: string): MessageHandler | null {
+    const handler = super.getHandlerByPattern(pattern);
+    if (handler) {
+      return handler;
+    }
+
+    const route = this.getRouteFromPattern(pattern);
+    const messageHandlers = this.messageHandlers as Map<
+      string | RegExp,
+      MessageHandler
+    >;
+    for (const [registeredPattern, registeredHandler] of messageHandlers) {
+      if (
+        registeredPattern instanceof RegExp &&
+        this.isPatternMatch(registeredPattern, route)
+      ) {
+        return registeredHandler;
+      }
+    }
+
+    return null;
+  }
+
+  private isPatternMatch(pattern: RegExp, route: string): boolean {
+    pattern.lastIndex = 0;
+    const isMatch = pattern.test(route);
+    pattern.lastIndex = 0;
+    return isMatch;
   }
 
   public getMessageHandler() {

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -250,6 +250,26 @@ describe('ServerKafka', () => {
       expect(run).toHaveBeenCalled();
       expect(connect).toHaveBeenCalled();
     });
+    it('should subscribe to regex message patterns', async () => {
+      untypedServer.logger = new NoopLogger();
+      await server.listen(callback);
+
+      const pattern = /test\..*/;
+      const handler = sinon.spy();
+      server.addHandler(pattern, handler);
+
+      await server.bindEvents(untypedServer.consumer);
+
+      expect(subscribe.called).to.be.true;
+      expect(
+        subscribe.calledWith({
+          topics: [pattern],
+        }),
+      ).to.be.true;
+
+      expect(run.called).to.be.true;
+      expect(connect.called).to.be.true;
+    });
     it('should pass run options with partitionsConsumedConcurrently to consumer.run()', async () => {
       untypedServer.logger = new NoopLogger();
       untypedServer.options.run = {
@@ -339,6 +359,22 @@ describe('ServerKafka', () => {
         correlationId,
         context,
       );
+    });
+  });
+
+  describe('getHandlerByPattern', () => {
+    it('should return a handler when topic matches a regex pattern', () => {
+      const handler = sinon.spy();
+      server.addHandler(/test\..*/, handler);
+
+      expect(server.getHandlerByPattern(topic)).to.be.equal(handler);
+    });
+
+    it('should return null when topic does not match a regex pattern', () => {
+      const handler = sinon.spy();
+      server.addHandler(/another\..*/, handler);
+
+      expect(server.getHandlerByPattern(topic)).to.be.null;
     });
   });
 
@@ -438,6 +474,14 @@ describe('ServerKafka', () => {
 
       await server.handleMessage(payload);
       expect(handler).toHaveBeenCalled();
+    });
+
+    it('should call handler when topic matches a regex pattern', async () => {
+      const handler = sinon.spy();
+      server.addHandler(/test\..*/, handler);
+
+      await server.handleMessage(payload);
+      expect(handler.called).to.be.true;
     });
   });
 

--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -255,20 +255,18 @@ describe('ServerKafka', () => {
       await server.listen(callback);
 
       const pattern = /test\..*/;
-      const handler = sinon.spy();
+      const handler = vi.fn();
       server.addHandler(pattern, handler);
 
       await server.bindEvents(untypedServer.consumer);
 
-      expect(subscribe.called).to.be.true;
-      expect(
-        subscribe.calledWith({
-          topics: [pattern],
-        }),
-      ).to.be.true;
+      expect(subscribe).toHaveBeenCalled();
+      expect(subscribe).toHaveBeenCalledWith({
+        topics: [pattern],
+      });
 
-      expect(run.called).to.be.true;
-      expect(connect.called).to.be.true;
+      expect(run).toHaveBeenCalled();
+      expect(connect).toHaveBeenCalled();
     });
     it('should pass run options with partitionsConsumedConcurrently to consumer.run()', async () => {
       untypedServer.logger = new NoopLogger();
@@ -364,17 +362,17 @@ describe('ServerKafka', () => {
 
   describe('getHandlerByPattern', () => {
     it('should return a handler when topic matches a regex pattern', () => {
-      const handler = sinon.spy();
+      const handler = vi.fn();
       server.addHandler(/test\..*/, handler);
 
-      expect(server.getHandlerByPattern(topic)).to.be.equal(handler);
+      expect(server.getHandlerByPattern(topic)).toBe(handler);
     });
 
     it('should return null when topic does not match a regex pattern', () => {
-      const handler = sinon.spy();
+      const handler = vi.fn();
       server.addHandler(/another\..*/, handler);
 
-      expect(server.getHandlerByPattern(topic)).to.be.null;
+      expect(server.getHandlerByPattern(topic)).toBeNull();
     });
   });
 
@@ -477,11 +475,11 @@ describe('ServerKafka', () => {
     });
 
     it('should call handler when topic matches a regex pattern', async () => {
-      const handler = sinon.spy();
+      const handler = vi.fn();
       server.addHandler(/test\..*/, handler);
 
       await server.handleMessage(payload);
-      expect(handler.called).to.be.true;
+      expect(handler).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
KafkaJS supports subscribing to topics by RegExp, but Nest normalized RegExp microservice patterns through the default object-pattern route conversion. As a result, a handler registered with @EventPattern(/.../) or @MessagePattern(/.../) was not subscribed as a Kafka RegExp topic and incoming Kafka topics were only looked up by exact route.

Issue Number: Fixes #3083

## What is the new behavior?
ServerKafka now preserves RegExp patterns when registering handlers, passes those RegExp patterns to KafkaJS subscribe(), and falls back to RegExp matching when resolving handlers for incoming Kafka topics. Matching resets lastIndex so global/sticky regexes do not produce stateful misses.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Docs were not updated because this is a Kafka transport bug fix for an already requested decorator pattern shape, covered by unit tests in ServerKafka.

Validated with:

- node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/microservices/test/server/server-kafka.spec.ts packages/microservices/test/server/server.spec.ts
- npm run build -- --pretty false
- npx eslint packages/microservices/interfaces/pattern.interface.ts packages/microservices/server/server-kafka.ts packages/microservices/test/server/server-kafka.spec.ts