### PR TITLE
fix(fastify): apply middleware to plugin routes

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -1,15 +1,18 @@
 import {
   Controller,
   Get,
+  Injectable,
   MiddlewareConsumer,
   Module,
   NestMiddleware,
   NestModule,
+  OnModuleInit,
   Param,
   Query,
   Req,
   RequestMethod,
 } from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
 import {
   FastifyAdapter,
   NestFastifyApplication,
@@ -791,6 +794,82 @@ describe('Middleware (FastifyAdapter)', () => {
       afterEach(async () => {
         await app.close();
       });
+    });
+  });
+
+  describe('when route is registered through a Fastify plugin', () => {
+    const MIDDLEWARE_HEADER = 'x-plugin-middleware';
+    const MIDDLEWARE_VALUE = 'applied';
+    const PLUGIN_RESPONSE = 'plugin-response';
+
+    @Injectable()
+    class FastifyPluginRegistrar implements OnModuleInit {
+      constructor(private readonly adapterHost: HttpAdapterHost) {}
+
+      onModuleInit() {
+        this.adapterHost.httpAdapter.getInstance().register(
+          (instance, _options, done) => {
+            instance.get('/', (_request, reply) => reply.send(PLUGIN_RESPONSE));
+            instance.get('/child', (_request, reply) =>
+              reply.send(PLUGIN_RESPONSE),
+            );
+            done();
+          },
+          { prefix: '/plugin' },
+        );
+      }
+    }
+
+    @Module({
+      providers: [FastifyPluginRegistrar],
+    })
+    class TestModule implements NestModule {
+      configure(consumer: MiddlewareConsumer) {
+        consumer
+          .apply((req, res, next) => {
+            res.setHeader(MIDDLEWARE_HEADER, MIDDLEWARE_VALUE);
+            next();
+          })
+          .forRoutes('/plugin', 'plugin', '/plugin/*');
+      }
+    }
+
+    beforeEach(async () => {
+      app = (
+        await Test.createTestingModule({
+          imports: [TestModule],
+        }).compile()
+      ).createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+      await app.init();
+    });
+
+    it('should apply middleware to the plugin route', () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/plugin',
+        })
+        .then(({ headers, payload }) => {
+          expect(payload).to.be.eql(PLUGIN_RESPONSE);
+          expect(headers[MIDDLEWARE_HEADER]).to.be.eql(MIDDLEWARE_VALUE);
+        });
+    });
+
+    it('should apply middleware to nested plugin routes', () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/plugin/child',
+        })
+        .then(({ headers, payload }) => {
+          expect(payload).to.be.eql(PLUGIN_RESPONSE);
+          expect(headers[MIDDLEWARE_HEADER]).to.be.eql(MIDDLEWARE_VALUE);
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
     });
   });
 });

--- a/packages/platform-fastify/adapters/middie/fastify-middie.ts
+++ b/packages/platform-fastify/adapters/middie/fastify-middie.ts
@@ -302,16 +302,23 @@ function fastifyMiddie(
       path = prefix + (path === '/' && prefix.length > 0 ? '' : path);
     }
 
-    this[kMiddlewares].push([path, fn]);
+    addMiddleware(this, path, fn);
+    return this;
+  }
 
+  function addMiddleware(
+    instance: FastifyInstance,
+    path: string | null,
+    fn?: Function,
+  ) {
+    instance[kMiddlewares].push([path, fn]);
     if (fn == null) {
-      this[kMiddie].use(path);
+      instance[kMiddie].use(path);
     } else {
-      this[kMiddie].use(path, fn);
+      instance[kMiddie].use(path, fn);
     }
 
-    this[kMiddieHasMiddlewares] = true;
-    return this;
+    instance[kMiddieHasMiddlewares] = true;
   }
 
   function runMiddie(
@@ -362,8 +369,8 @@ function fastifyMiddie(
     instance[kMiddie] = middie(onMiddieEnd, instance.initialConfig);
     instance[kMiddieHasMiddlewares] = false;
     instance.decorate('use', use as any);
-    for (const middleware of middlewares) {
-      (instance.use as any)(...middleware);
+    for (const [path, fn] of middlewares) {
+      addMiddleware(instance, path as string | null, fn as Function);
     }
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Fastify middleware registered for a prefix does not run for routes registered by a Fastify plugin under that same prefix. The middleware is inherited by the child plugin context, but the copied path is passed back through instance.use(), causing the child prefix to be applied again.

Issue Number: Fixes #11802

## What is the new behavior?
Inherited middie middleware is copied into child Fastify plugin contexts using the already-prefixed path. This prevents double-prefixing and lets middleware registered for /plugin, plugin, or /plugin/* run for routes registered by a plugin with prefix /plugin.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Docs were not updated because this is a platform-fastify bug fix covered by integration tests.

Validated with:

- node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js integration/hello-world/e2e/middleware-fastify.spec.ts --grep "Fastify plugin|plugin route"
- npm run build -- --pretty false
- npx eslint packages/platform-fastify/adapters/middie/fastify-middie.ts integration/hello-world/e2e/middleware-fastify.spec.ts

Note: running the entire integration/hello-world/e2e/middleware-fastify.spec.ts file in my local environment still has existing supertest failures around app.getHttpServer() without listen, unrelated to this change; the new plugin-route cases pass.