### PR TITLE
fix: pin integration test service images for v12.0.0

### DIFF
--- a/integration/docker-compose.yml
+++ b/integration/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   rabbit:
     container_name: test-rabbit
     hostname: rabbit
-    image: "rabbitmq:management"
+    image: "rabbitmq:3.13-management"
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -60,7 +60,7 @@ services:
   kafka:
     container_name: test-kafka
     hostname: kafka
-    image: confluentinc/cp-kafka:8.2.0
+    image: confluentinc/cp-kafka:7.9.6
     depends_on:
       - zookeeper
     ports:


### PR DESCRIPTION
## Summary

- pin RabbitMQ to 3.13 management for integration tests
- pin Confluent Kafka to the latest 7.x image compatible with the existing ZooKeeper setup

## Context

The integration job started failing because floating service images drifted:

- `rabbitmq:management` now rejects deprecated transient non-exclusive queues by default, which makes the RMQ integration specs reconnect repeatedly.
- `confluentinc/cp-kafka:8.2.0` expects KRaft configuration such as `KAFKA_PROCESS_ROLES`, while the current compose file still uses ZooKeeper.

## Verification

- `npm run build`
- `docker-compose -f integration/docker-compose.yml up -d` confirmed RabbitMQ and Kafka containers stay running with the pinned images.

I could not complete the local Vitest integration run because the local machine ran out of disk space while installing the macOS `rolldown` optional native binding; this is unrelated to the compose change.
