### PR TITLE
fix(core): settle skipped provider initialization

### DIFF
--- a/integration/injector/e2e/injector.spec.ts
+++ b/integration/injector/e2e/injector.spec.ts
@@ -1,6 +1,8 @@
+import { Global, Injectable, Module, Scope } from '@nestjs/common';
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 import { UnknownDependenciesException } from '@nestjs/core/errors/exceptions/unknown-dependencies.exception';
 import { UnknownExportException } from '@nestjs/core/errors/exceptions/unknown-export.exception';
+import { NestFactory } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import * as chai from 'chai';
@@ -21,6 +23,65 @@ import {
 chai.use(chaiAsPromised);
 
 describe('Injector', () => {
+  describe('when the same provider class is declared in multiple modules', () => {
+    it('should bootstrap when module-local provider instances have non-static dependency trees', async () => {
+      @Injectable()
+      class FirstGlobalDependency {}
+
+      @Injectable()
+      class SecondGlobalDependency {}
+
+      @Injectable({ scope: Scope.REQUEST })
+      class RequestScopedDependency {}
+
+      @Global()
+      @Module({
+        providers: [FirstGlobalDependency, SecondGlobalDependency],
+        exports: [FirstGlobalDependency, SecondGlobalDependency],
+      })
+      class GlobalDepsModule {}
+
+      @Injectable()
+      class SharedService {
+        constructor(
+          public readonly firstDependency: FirstGlobalDependency,
+          public readonly secondDependency: SecondGlobalDependency,
+          public readonly requestScopedDependency: RequestScopedDependency,
+        ) {}
+      }
+
+      @Module({
+        providers: [SharedService, RequestScopedDependency],
+        exports: [SharedService],
+      })
+      class ModuleA {}
+
+      @Module({
+        providers: [SharedService, RequestScopedDependency],
+      })
+      class ModuleB {}
+
+      @Module({
+        imports: [GlobalDepsModule, ModuleA, ModuleB],
+      })
+      class AppModule {}
+
+      let timeout: NodeJS.Timeout;
+      const app = await Promise.race([
+        NestFactory.create(AppModule, { logger: false }),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error('Application initialization timed out')),
+            1000,
+          );
+        }),
+      ]);
+      clearTimeout(timeout!);
+
+      await app.close();
+    });
+  });
+
   describe('when "providers" and "exports" properties are inconsistent', () => {
     it(`should fail with "UnknownExportException"`, async () => {
       try {

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -208,6 +208,9 @@ export class Injector {
         localResolutionContext,
         resolutionContext.inquirer,
       );
+      if (!instanceHost.isResolved) {
+        settlementSignal.complete();
+      }
     } catch (err) {
       wrapper.removeInstanceByContextId(
         this.getContextId(resolutionContext.contextId, wrapper),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Docs were not updated because this is a runtime regression fix covered by an integration test.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Bootstrapping can leave a provider's settlement signal pending forever when constructor parameter resolution intentionally skips instantiation for a non-static dependency tree. In this state, other providers awaiting that wrapper never unblock, so application initialization can hang silently.

Issue Number: #16947

## What is the new behavior?
When constructor parameter resolution completes without resolving the current instance, the injector now settles the wrapper signal so dependent providers can continue instead of awaiting a never-settled promise.

This also adds an integration regression test for declaring the same provider class in multiple modules when that provider has a non-static dependency tree.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Validated locally:

- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js --reporter-option maxDiffSize=0 integration/injector/e2e/injector.spec.ts`
- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js --reporter-option maxDiffSize=0 packages/core/test/injector/injector.spec.ts`
- `node --max-old-space-size=4096 ./node_modules/.bin/eslint packages/core/injector/injector.ts integration/injector/e2e/injector.spec.ts`
- `npm run build -- --pretty false`

Fixes #16947
