### PR TITLE
feat(common): allow injecting global serializer options

### DIFF
--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -24,8 +24,19 @@ const REFLECTOR = 'Reflector';
 /**
  * @publicApi
  */
-export interface ClassSerializerInterceptorOptions extends ClassTransformOptions {
+export class ClassSerializerInterceptorOptions implements ClassTransformOptions {
   transformerPackage?: TransformerPackage;
+  strategy?: 'excludeAll' | 'exposeAll';
+  groups?: string[];
+  version?: number;
+  excludePrefixes?: string[];
+  ignoreDecorators?: boolean;
+  targetMaps?: any[];
+  enableCircularCheck?: boolean;
+  enableImplicitConversion?: boolean;
+  excludeExtraneousValues?: boolean;
+  exposeDefaultValues?: boolean;
+  exposeUnsetFields?: boolean;
 }
 
 /**

--- a/packages/common/serializer/class-serializer.interceptor.ts
+++ b/packages/common/serializer/class-serializer.interceptor.ts
@@ -24,19 +24,12 @@ const REFLECTOR = 'Reflector';
 /**
  * @publicApi
  */
-export class ClassSerializerInterceptorOptions implements ClassTransformOptions {
+export class ClassSerializerInterceptorOptions {
   transformerPackage?: TransformerPackage;
-  strategy?: 'excludeAll' | 'exposeAll';
-  groups?: string[];
-  version?: number;
-  excludePrefixes?: string[];
-  ignoreDecorators?: boolean;
-  targetMaps?: any[];
-  enableCircularCheck?: boolean;
-  enableImplicitConversion?: boolean;
-  excludeExtraneousValues?: boolean;
-  exposeDefaultValues?: boolean;
-  exposeUnsetFields?: boolean;
+}
+
+export interface ClassSerializerInterceptorOptions extends ClassTransformOptions {
+  transformerPackage?: TransformerPackage;
 }
 
 /**

--- a/packages/common/test/serializer/class-serializer.interceptor.spec.ts
+++ b/packages/common/test/serializer/class-serializer.interceptor.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { of, throwError } from 'rxjs';
-import { ClassSerializerInterceptor } from '../../serializer/class-serializer.interceptor';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ClassSerializerInterceptor,
+  ClassSerializerInterceptorOptions,
+} from '../../serializer/class-serializer.interceptor';
 import { ExecutionContext, CallHandler } from '../../interfaces';
 import { StreamableFile } from '../../file-stream';
 
@@ -50,6 +54,23 @@ describe('ClassSerializerInterceptor', () => {
       };
 
       interceptor = new ClassSerializerInterceptor(mockReflector, options);
+
+      expect(interceptor).to.be.instanceOf(ClassSerializerInterceptor);
+    });
+
+    it('should use options from dependency injection', async () => {
+      const options: ClassSerializerInterceptorOptions = {
+        transformerPackage: mockTransformerPackage,
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          { provide: ClassSerializerInterceptorOptions, useValue: options },
+          ClassSerializerInterceptor,
+        ],
+      }).compile();
+
+      interceptor = module.get(ClassSerializerInterceptor);
 
       expect(interceptor).to.be.instanceOf(ClassSerializerInterceptor);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #16963


## What is the new behavior?
It is now possible to use `ClassSerializerInterceptorOptions` to inject options for `class-serializer` interceptor globally.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information