### PR TITLE
fix(core): identify decorator type in invalid-class-module error

### DIFF
--- a/packages/core/errors/exceptions/invalid-class-module.exception.ts
+++ b/packages/core/errors/exceptions/invalid-class-module.exception.ts
@@ -2,9 +2,17 @@ import { USING_INVALID_CLASS_AS_A_MODULE_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
 
 export class InvalidClassModuleException extends RuntimeException {
-  constructor(metatypeUsedAsAModule: any, scope: any[]) {
+  constructor(
+    metatypeUsedAsAModule: any,
+    scope: any[],
+    classKind: 'provider' | 'controller' | 'filter',
+  ) {
     super(
-      USING_INVALID_CLASS_AS_A_MODULE_MESSAGE(metatypeUsedAsAModule, scope),
+      USING_INVALID_CLASS_AS_A_MODULE_MESSAGE(
+        metatypeUsedAsAModule,
+        scope,
+        classKind,
+      ),
     );
   }
 }

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -169,11 +169,24 @@ Scope [${stringifyScope(scope)}]`;
 export const USING_INVALID_CLASS_AS_A_MODULE_MESSAGE = (
   metatypeUsedAsAModule: Type | ForwardReference,
   scope: any[],
+  classKind: 'provider' | 'controller' | 'filter',
 ) => {
   const metatypeNameQuote = `"${getInstanceName(metatypeUsedAsAModule)}"`;
 
-  return `Classes annotated with @Injectable(), @Catch(), and @Controller() decorators must not appear in the "imports" array of a module.
-Please remove ${metatypeNameQuote} (including forwarded occurrences, if any) from all of the "imports" arrays.
+  let hint: string;
+  switch (classKind) {
+    case 'controller':
+      hint = `${metatypeNameQuote} is decorated with @Controller() and cannot appear in the "imports" array of a module. Please move ${metatypeNameQuote} to the "controllers" array of the importing module instead.`;
+      break;
+    case 'provider':
+      hint = `${metatypeNameQuote} is decorated with @Injectable() and cannot appear in the "imports" array of a module. Please move ${metatypeNameQuote} to the "providers" array of the importing module instead.`;
+      break;
+    case 'filter':
+      hint = `${metatypeNameQuote} is decorated with @Catch() and cannot appear in the "imports" array of a module. Please move ${metatypeNameQuote} to the "providers" array (using the APP_FILTER token to apply it globally) or apply it via @UseFilters() instead.`;
+      break;
+  }
+
+  return `${hint}
 
 Scope [${stringifyScope(scope)}]
 `;

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -188,12 +188,22 @@ export class DependenciesScanner {
       ? moduleDefinition.forwardRef()
       : moduleDefinition;
 
-    if (
-      this.isInjectable(moduleToAdd) ||
-      this.isController(moduleToAdd) ||
-      this.isExceptionFilter(moduleToAdd)
-    ) {
-      throw new InvalidClassModuleException(moduleDefinition, scope);
+    if (this.isInjectable(moduleToAdd)) {
+      throw new InvalidClassModuleException(
+        moduleDefinition,
+        scope,
+        'provider',
+      );
+    }
+    if (this.isController(moduleToAdd)) {
+      throw new InvalidClassModuleException(
+        moduleDefinition,
+        scope,
+        'controller',
+      );
+    }
+    if (this.isExceptionFilter(moduleToAdd)) {
+      throw new InvalidClassModuleException(moduleDefinition, scope, 'filter');
     }
 
     return this.container.addModule(moduleToAdd, scope);

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -4,6 +4,7 @@ import {
   INVALID_MODULE_MESSAGE,
   UNDEFINED_MODULE_MESSAGE,
   UNKNOWN_EXPORT_MESSAGE,
+  USING_INVALID_CLASS_AS_A_MODULE_MESSAGE,
 } from '../../../errors/messages';
 import { Module } from '../../../injector/module';
 import { stringCleaner } from '../../utils/string.cleaner';
@@ -393,6 +394,61 @@ Scope [AppModule -> CatsModule]`);
 
       const actualMessage = stringCleaner(
         INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule]),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+  });
+
+  describe('USING_INVALID_CLASS_AS_A_MODULE_MESSAGE', () => {
+    class FooClass {}
+
+    it('should identify a class decorated with @Controller() and direct it to the "controllers" array', () => {
+      const expectedMessage =
+        stringCleaner(`"FooClass" is decorated with @Controller() and cannot appear in the "imports" array of a module. Please move "FooClass" to the "controllers" array of the importing module instead.
+
+Scope [AppModule]`);
+
+      const actualMessage = stringCleaner(
+        USING_INVALID_CLASS_AS_A_MODULE_MESSAGE(
+          FooClass,
+          [AppModule],
+          'controller',
+        ),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+
+    it('should identify a class decorated with @Injectable() and direct it to the "providers" array', () => {
+      const expectedMessage =
+        stringCleaner(`"FooClass" is decorated with @Injectable() and cannot appear in the "imports" array of a module. Please move "FooClass" to the "providers" array of the importing module instead.
+
+Scope [AppModule]`);
+
+      const actualMessage = stringCleaner(
+        USING_INVALID_CLASS_AS_A_MODULE_MESSAGE(
+          FooClass,
+          [AppModule],
+          'provider',
+        ),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+
+    it('should identify a class decorated with @Catch() and direct it to the "providers" array or @UseFilters()', () => {
+      const expectedMessage =
+        stringCleaner(`"FooClass" is decorated with @Catch() and cannot appear in the "imports" array of a module. Please move "FooClass" to the "providers" array (using the APP_FILTER token to apply it globally) or apply it via @UseFilters() instead.
+
+Scope [AppModule]`);
+
+      const actualMessage = stringCleaner(
+        USING_INVALID_CLASS_AS_A_MODULE_MESSAGE(
+          FooClass,
+          [AppModule],
+          'filter',
+        ),
       );
 
       expect(actualMessage).to.be.eq(expectedMessage);


### PR DESCRIPTION
Currently when a class decorated with @Injectable(), @Controller(), or @Catch() is mistakenly placed in a module's imports: array, Nest throws an InvalidClassModuleException that lists all three decorators generically and instructs the user to "remove" the class without saying which array it should go in.

This PR makes the error identify the actual decorator the class carries and points the user at the correct array (controllers / providers) or — for filters — @UseFilters() / APP_FILTER. The scanner already distinguishes the three cases at the throw site; this PR just forwards that information into the message.