### PR TITLE
test(core,common): register chai-as-promised in async-rejection specs

### DIFF
--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -1,7 +1,11 @@
 import { HttpStatus } from '../../../enums';
 import { BadRequestException, ConflictException } from '../../../exceptions';
 import { FileValidator, ParseFilePipe } from '../../../pipes';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
+
+chai.use(chaiAsPromised);
 
 class AlwaysValidValidator extends FileValidator {
   isValid(): boolean {

--- a/packages/common/test/pipes/parse-array.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-array.pipe.spec.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import { expect } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised = require('chai-as-promised');
 import { Type } from 'class-transformer';
 import {
   IsBoolean,

--- a/packages/common/test/pipes/parse-enum.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-enum.pipe.spec.ts
@@ -1,7 +1,11 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import { HttpException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseEnumPipe } from '../../pipes/parse-enum.pipe';
+
+chai.use(chaiAsPromised);
 
 class CustomTestError extends HttpException {
   constructor() {

--- a/packages/common/test/pipes/parse-float.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-float.pipe.spec.ts
@@ -1,7 +1,11 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import { HttpException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseFloatPipe } from '../../pipes/parse-float.pipe';
+
+chai.use(chaiAsPromised);
 
 class CustomTestError extends HttpException {
   constructor() {

--- a/packages/common/test/pipes/parse-int.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-int.pipe.spec.ts
@@ -1,7 +1,11 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import { HttpException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseIntPipe } from '../../pipes/parse-int.pipe';
+
+chai.use(chaiAsPromised);
 
 class CustomTestError extends HttpException {
   constructor() {

--- a/packages/common/test/pipes/parse-uuid.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-uuid.pipe.spec.ts
@@ -1,8 +1,12 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import { HttpStatus } from '../../enums';
 import { HttpException } from '../../exceptions';
 import { ArgumentMetadata } from '../../interfaces';
 import { ParseUUIDPipe } from '../../pipes/parse-uuid.pipe';
+
+chai.use(chaiAsPromised);
 
 class TestException extends HttpException {
   constructor() {

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import { expect } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised = require('chai-as-promised');
 import { Exclude, Expose, Type } from 'class-transformer';
 import {
   IsArray,

--- a/packages/core/test/errors/test/exceptions-zone.spec.ts
+++ b/packages/core/test/errors/test/exceptions-zone.spec.ts
@@ -1,7 +1,11 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import * as sinon from 'sinon';
 import { Logger } from '@nestjs/common';
 import { ExceptionsZone } from '../../../errors/exceptions-zone';
+
+chai.use(chaiAsPromised);
 
 describe('ExceptionsZone', () => {
   const rethrow = err => {

--- a/packages/core/test/helpers/barrier.spec.ts
+++ b/packages/core/test/helpers/barrier.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Barrier } from '../../../core/helpers/barrier';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised = require('chai-as-promised');
 import { setTimeout } from 'timers/promises';
 chai.use(chaiAsPromised);
 

--- a/packages/core/test/injector/container.spec.ts
+++ b/packages/core/test/injector/container.spec.ts
@@ -1,4 +1,6 @@
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import * as sinon from 'sinon';
 import { Module } from '../../../common/decorators/modules/module.decorator';
 import { Global } from '../../../common/index';
@@ -6,6 +8,8 @@ import { CircularDependencyException } from '../../errors/exceptions/circular-de
 import { UnknownModuleException } from '../../errors/exceptions/unknown-module.exception';
 import { NestContainer } from '../../injector/container';
 import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
+
+chai.use(chaiAsPromised);
 
 describe('NestContainer', () => {
   let container: NestContainer;

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -2,7 +2,7 @@ import { Optional } from '@nestjs/common';
 import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
 import * as chai from 'chai';
 import { expect } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised = require('chai-as-promised');
 import * as sinon from 'sinon';
 import { Inject } from '../../../common/decorators/core/inject.decorator';
 import { Injectable } from '../../../common/decorators/core/injectable.decorator';

--- a/packages/core/test/middleware/middleware-module.spec.ts
+++ b/packages/core/test/middleware/middleware-module.spec.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { RouteInfoPathExtractor } from '@nestjs/core/middleware/route-info-path-extractor';
 import * as chai from 'chai';
 import { expect } from 'chai';
-import * as chaiAsPromised from 'chai-as-promised';
+import chaiAsPromised = require('chai-as-promised');
 import * as sinon from 'sinon';
 import { Controller } from '../../../common/decorators/core/controller.decorator';
 import { RequestMapping } from '../../../common/decorators/http/request-mapping.decorator';

--- a/packages/core/test/scanner.spec.ts
+++ b/packages/core/test/scanner.spec.ts
@@ -1,5 +1,7 @@
 import { Catch, Injectable } from '@nestjs/common';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import chaiAsPromised = require('chai-as-promised');
 import * as sinon from 'sinon';
 import { GUARDS_METADATA } from '../../common/constants';
 import { Controller } from '../../common/decorators/core/controller.decorator';
@@ -18,6 +20,8 @@ import { ModuleOverride } from '../interfaces/module-override.interface';
 import { MetadataScanner } from '../metadata-scanner';
 import { DependenciesScanner } from '../scanner';
 import Sinon = require('sinon');
+
+chai.use(chaiAsPromised);
 
 describe('DependenciesScanner', () => {
   class Guard {}


### PR DESCRIPTION
Several spec files use chai-as-promised idioms (.rejectedWith, .fulfilled, .eventually) without calling chai.use(chaiAsPromised) in the file. Today these tests still pass in npm run test because some other spec alphabetically earlier in the glob registers the plugin, and the registration leaks into the shared chai instance for subsequent files.

Running any of these specs in isolation (e.g. mocha packages/core/test/scanner.spec.ts) fails with Invalid Chai property: rejectedWith. The assertion silently returns undefined, so the tests pass without actually asserting anything.

This PR follows the existing convention used by injector.spec.ts, middleware-module.spec.ts, and others: each affected spec now imports and registers chai-as-promised itself. 13 previously inert assertions across 8 files now actually run.