### PR TITLE
fix(core): include received value type in invalid-module error

### DIFF
--- a/packages/core/errors/exceptions/invalid-module.exception.ts
+++ b/packages/core/errors/exceptions/invalid-module.exception.ts
@@ -2,7 +2,12 @@ import { INVALID_MODULE_MESSAGE } from '../messages';
 import { RuntimeException } from './runtime.exception';
 
 export class InvalidModuleException extends RuntimeException {
-  constructor(parentModule: any, index: number, scope: any[]) {
-    super(INVALID_MODULE_MESSAGE(parentModule, index, scope));
+  constructor(
+    parentModule: any,
+    index: number,
+    scope: any[],
+    receivedValue: unknown,
+  ) {
+    super(INVALID_MODULE_MESSAGE(parentModule, index, scope, receivedValue));
   }
 }

--- a/packages/core/errors/messages.ts
+++ b/packages/core/errors/messages.ts
@@ -157,11 +157,26 @@ export const INVALID_MODULE_MESSAGE = (
   parentModule: any,
   index: number,
   scope: any[],
+  receivedValue: unknown,
 ) => {
   const parentModuleName = parentModule?.name || 'module';
 
+  let formattedValue: string;
+  let receivedType: string;
+  if (receivedValue === null) {
+    formattedValue = 'null';
+    receivedType = 'null';
+  } else if (typeof receivedValue === 'string') {
+    formattedValue = `"${receivedValue}"`;
+    receivedType = 'string';
+  } else {
+    formattedValue = String(receivedValue);
+    receivedType = typeof receivedValue;
+  }
+
   return `Nest cannot create the ${parentModuleName} instance.
 Received an unexpected value at index [${index}] of the ${parentModuleName} "imports" array.
+The received value \`${formattedValue}\` is of type "${receivedType}".
 
 Scope [${stringifyScope(scope)}]`;
 };

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -150,7 +150,12 @@ export class DependenciesScanner {
         throw new UndefinedModuleException(moduleDefinition, index, scope);
       }
       if (!innerModule) {
-        throw new InvalidModuleException(moduleDefinition, index, scope);
+        throw new InvalidModuleException(
+          moduleDefinition,
+          index,
+          scope,
+          innerModule,
+        );
       }
       if (ctxRegistry.includes(innerModule)) {
         continue;

--- a/packages/core/test/errors/test/messages.spec.ts
+++ b/packages/core/test/errors/test/messages.spec.ts
@@ -385,15 +385,61 @@ Scope [AppModule -> CatsModule]`);
   });
 
   describe('INVALID_MODULE_MESSAGE', () => {
-    it('should display the module name with the invalid index and scope', () => {
+    it('should display the received `null` value and its type', () => {
       const expectedMessage =
         stringCleaner(`Nest cannot create the CatsModule instance.
 Received an unexpected value at index [0] of the CatsModule "imports" array.
+The received value \`null\` is of type "null".
 
 Scope [AppModule -> CatsModule]`);
 
       const actualMessage = stringCleaner(
-        INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule]),
+        INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule], null),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+
+    it('should display the received `false` value and its type', () => {
+      const expectedMessage =
+        stringCleaner(`Nest cannot create the CatsModule instance.
+Received an unexpected value at index [0] of the CatsModule "imports" array.
+The received value \`false\` is of type "boolean".
+
+Scope [AppModule -> CatsModule]`);
+
+      const actualMessage = stringCleaner(
+        INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule], false),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+
+    it('should display the received `0` value and its type', () => {
+      const expectedMessage =
+        stringCleaner(`Nest cannot create the CatsModule instance.
+Received an unexpected value at index [0] of the CatsModule "imports" array.
+The received value \`0\` is of type "number".
+
+Scope [AppModule -> CatsModule]`);
+
+      const actualMessage = stringCleaner(
+        INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule], 0),
+      );
+
+      expect(actualMessage).to.be.eq(expectedMessage);
+    });
+
+    it('should display the received empty string value and its type', () => {
+      const expectedMessage =
+        stringCleaner(`Nest cannot create the CatsModule instance.
+Received an unexpected value at index [0] of the CatsModule "imports" array.
+The received value \`""\` is of type "string".
+
+Scope [AppModule -> CatsModule]`);
+
+      const actualMessage = stringCleaner(
+        INVALID_MODULE_MESSAGE(CatsModule, 0, [AppModule, CatsModule], ''),
       );
 
       expect(actualMessage).to.be.eq(expectedMessage);


### PR DESCRIPTION
Fair point — NaN doesn't really show up in practice. The realistic falsy cases are null (from .filter(Boolean) chains or condition ? Module : null) and false (from FLAG && Module when FLAG is the literal false). I've dropped the NaN special case from the message function and removed its test. String(NaN) still produces "NaN" via the default branch if anyone manages to hit it, but it's no longer a code path I'm explicitly testing.

Updated and force-pushed.