### PR TITLE
feat(core): warn on late websocket adapter registration

### DIFF
--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -69,6 +69,7 @@ export class NestApplication
   private readonly microservices: any[] = [];
   private httpServer: any;
   private isListening = false;
+  private isWsModuleRegistered = false;
 
   constructor(
     container: NestContainer,
@@ -171,6 +172,7 @@ export class NestApplication
       this.appOptions,
       this.httpServer,
     );
+    this.isWsModuleRegistered = true;
   }
 
   public async init(): Promise<this> {
@@ -389,6 +391,11 @@ export class NestApplication
   }
 
   public useWebSocketAdapter(adapter: WebSocketAdapter): this {
+    if (this.isWsModuleRegistered) {
+      this.logger.warn(
+        'useWebSocketAdapter() was called after WebSocket gateways were already initialized. The provided adapter will be stored but will NOT be applied to existing gateways — they remain bound to the previously installed adapter. To install a custom adapter, call app.useWebSocketAdapter(...) BEFORE app.init() (or app.listen()).',
+      );
+    }
     this.config.setIoAdapter(adapter);
     return this;
   }

--- a/packages/core/test/nest-application.spec.ts
+++ b/packages/core/test/nest-application.spec.ts
@@ -144,4 +144,51 @@ describe('NestApplication', () => {
       expect(httpAdapterSpy.init.calledOnce).to.be.true;
     });
   });
+  describe('useWebSocketAdapter', () => {
+    function createInstance(): NestApplication {
+      const noopHttpAdapter = new NoopHttpAdapter({});
+      const applicationConfig = new ApplicationConfig();
+      const container = new NestContainer(applicationConfig);
+      container.setHttpAdapter(noopHttpAdapter);
+      return new NestApplication(
+        container,
+        noopHttpAdapter,
+        applicationConfig,
+        new GraphInspector(container),
+        {},
+      );
+    }
+
+    it('should not warn when called before WS module registration', () => {
+      const instance = createInstance();
+      const warnSpy = sinon.spy((instance as any).logger, 'warn');
+
+      instance.useWebSocketAdapter({} as any);
+
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('should warn when called after WS module registration', () => {
+      const instance = createInstance();
+      instance.registerWsModule();
+      const warnSpy = sinon.spy((instance as any).logger, 'warn');
+
+      instance.useWebSocketAdapter({} as any);
+
+      expect(warnSpy.calledOnce).to.be.true;
+      expect(warnSpy.firstCall.args[0]).to.match(
+        /useWebSocketAdapter\(\) was called after WebSocket gateways were already initialized/,
+      );
+    });
+
+    it('should still set the adapter on ApplicationConfig even when called too late', () => {
+      const instance = createInstance();
+      instance.registerWsModule();
+      const adapter = { create: () => undefined } as any;
+
+      instance.useWebSocketAdapter(adapter);
+
+      expect((instance as any).config.getIoAdapter()).to.equal(adapter);
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## What is the current behavior?

`app.useWebSocketAdapter(adapter)` called after `app.init()` has run (for example, from any module's `OnModuleInit` hook) silently no-ops. By the time the lifecycle hook fires, `NestApplication.init()` has already executed `registerModules() → registerWsModule() → socketModule.register(...)`, which captured the active `IoAdapter` from `ApplicationConfig` and bootstrapped the gateways with it. The adapter passed to the late `useWebSocketAdapter(...)` call is stored on the config but never applied — gateways remain bound to whatever adapter was active during `init()`, which in practice is the default `IoAdapter`.

There is currently no log line, warning, or error to indicate the call had no effect. Features carried by the intended adapter (Redis pub/sub fan-out via `@socket.io/redis-adapter`, custom engine `path`, TLS-bound HTTP server, observability hooks, …) silently stay inert.

Issue Number: #16992

## What is the new behavior?

`NestApplication` now tracks an internal `isWsModuleRegistered` flag flipped after `socketModule.register(...)` succeeds. `useWebSocketAdapter(...)` checks the flag and, if the websockets module has already been bootstrapped, emits a `Logger.warn` explaining that the adapter swap is ineffective and pointing the consumer at the correct timing (between `NestFactory.create()` and `app.init()` / `app.listen()`).

The adapter is still set on `ApplicationConfig` after the warning, preserving today's behaviour for any code path that inspects it post-hoc — only the new log line is added. No public API change, no breaking change.

Three tests added under `packages/core/test/nest-application.spec.ts`:

- does not warn when `useWebSocketAdapter` is called before WS module registration
- warns once when called after `registerWsModule()`
- still stores the adapter on `ApplicationConfig` even when called too late

All 785 existing core tests continue to pass; `npm run lint:packages` reports 0 errors (the 4 pre-existing warnings in `packages/microservices` are unrelated).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The change is purely additive — only consumers who were silently broken get a new log line; correct usage is unaffected.

## Other information

Confirmed by @kamilmysliwiec in #16992: "_Sounds great, I'd be more than happy to merge it!_"

Warning text:

> `useWebSocketAdapter() was called after WebSocket gateways were already initialized. The provided adapter will be stored but will NOT be applied to existing gateways — they remain bound to the previously installed adapter. To install a custom adapter, call app.useWebSocketAdapter(...) BEFORE app.init() (or app.listen()).`