### PR TITLE
feat(microservices): expose transport server getter

### DIFF
--- a/packages/common/index.ts
+++ b/packages/common/index.ts
@@ -32,6 +32,7 @@ export {
   INestApplication,
   INestApplicationContext,
   INestMicroservice,
+  ITransportServer,
   InjectionToken,
   IntrospectionResult,
   MessageEvent,

--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -17,6 +17,7 @@ export * from './hooks';
 export * from './http';
 export * from './injectable.interface';
 export * from './microservices/nest-hybrid-application-options.interface';
+export * from './microservices/transport-server.interface';
 export * from './middleware';
 export * from './modules';
 export * from './nest-application-context.interface';

--- a/packages/common/interfaces/microservices/transport-server.interface.ts
+++ b/packages/common/interfaces/microservices/transport-server.interface.ts
@@ -1,0 +1,19 @@
+/**
+ * Interface describing the shape of a transport server.
+ * Used as the return type of `getTransportServer()` to provide
+ * autocomplete without creating circular dependencies.
+ *
+ * @publicApi
+ */
+export interface ITransportServer {
+  /**
+   * Starts the transport server.
+   * @param callback Function to be called upon initialization
+   */
+  listen(callback: (...optionalParams: unknown[]) => any): any;
+
+  /**
+   * Closes the transport server (stops listening on port/connection).
+   */
+  close(): any;
+}

--- a/packages/common/interfaces/nest-microservice.interface.ts
+++ b/packages/common/interfaces/nest-microservice.interface.ts
@@ -3,6 +3,7 @@ import { ExceptionFilter } from './exceptions/exception-filter.interface';
 import { CanActivate } from './features/can-activate.interface';
 import { NestInterceptor } from './features/nest-interceptor.interface';
 import { PipeTransform } from './features/pipe-transform.interface';
+import { ITransportServer } from './microservices/transport-server.interface';
 import { INestApplicationContext } from './nest-application-context.interface';
 import { WebSocketAdapter } from './websockets/web-socket-adapter.interface';
 
@@ -89,4 +90,11 @@ export interface INestMicroservice extends INestApplicationContext {
    * or a group of servers if there are more than one.
    */
   unwrap<T>(): T;
+
+  /**
+   * Returns the underlying transport server instance.
+   * Use this to close only the transport (port/connection) without
+   * triggering the full application shutdown lifecycle.
+   */
+  getTransportServer(): ITransportServer;
 }

--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -2,6 +2,7 @@ import {
   CanActivate,
   ExceptionFilter,
   INestMicroservice,
+  ITransportServer,
   NestInterceptor,
   PipeTransform,
   WebSocketAdapter,
@@ -350,7 +351,7 @@ export class NestMicroservice
    * Use this to close only the transport (port/connection) without
    * triggering the full application shutdown lifecycle.
    */
-  public getTransportServer(): Server {
+  public getTransportServer(): ITransportServer {
     return this.serverInstance;
   }
 

--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -345,6 +345,15 @@ export class NestMicroservice
     throw new Error('"unwrap" method not supported by the underlying server');
   }
 
+  /**
+   * Returns the underlying transport server instance.
+   * Use this to close only the transport (port/connection) without
+   * triggering the full application shutdown lifecycle.
+   */
+  public getTransportServer(): Server {
+    return this.serverInstance;
+  }
+
   protected async closeApplication(): Promise<any> {
     this.socketModule && (await this.socketModule.close());
     this.microservicesModule && (await this.microservicesModule.close());

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -1,3 +1,4 @@
+import { ITransportServer } from '@nestjs/common';
 import { Logger, LoggerService } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import {
@@ -47,7 +48,7 @@ import { transformPatternToRoute } from '../utils';
 export abstract class Server<
   EventsMap extends Record<string, Function> = Record<string, Function>,
   Status extends string = string,
-> {
+> implements ITransportServer {
   /**
    * Unique transport identifier.
    */

--- a/packages/microservices/test/nest-microservice.spec.ts
+++ b/packages/microservices/test/nest-microservice.spec.ts
@@ -154,4 +154,22 @@ describe('NestMicroservice', () => {
     instance.on('test:event', cb);
     expect(onStub.calledWith('test:event', cb)).to.be.true;
   });
+
+  it('should return the transport server instance via getTransportServer()', () => {
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = sinon.stub();
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+
+    expect(instance.getTransportServer()).to.equal(strategy);
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently `INestMicroservice `have no way to stop only the transport layer (port/connection) without triggering the full application shutdown lifecycle, when i call `close()` method from `INestMicroservice `stops the transport and triggers the full shutdown lifecycle - which is correct, but my business case is specific: the server has more then one grpc connection: control port (receiving commands), data port (for streaming data). when control sends a new TLS value the component needs to stop only the data port and restart it with new TLS value. Other port should remain active. but `microservice.close() ` tears down everything because lifecycle hooks fire across entire di container

Issue Number: N/A


## What is the new behavior?
Now we can stop listening on the transport layer, no lifecycle hooks, di side effects, so app stays alive
example of using:
`await microservice.getTransportServer().close()`
and of course old one: 
`await microservice().close()` - still shut down everything


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
i am not ai, i am a real person.  the code was tested manually injecting updated nestjs into my infra + runnig tests. 
i am aware of nestjs design - what microservice transport start once and die with the app, BUT i have unusual case where my application is a industrial adapter which needs process tls hot swap without shutdowning because there are another clients which depends on this application. I could probably bypass it using raw gprc lib, but i think it's better solution (also simple one)

i created `ITransportServer` to prevent circular deps between **common** and **microservices** packages. It's second version of my code implementation. In first one i just used "any" without adding new type, but later when i really injected new nest into my services it was inconvenient to use. I am open to discuss about different implementation

in the last commit i marked the abstract **Server** class as `implements ITransportServer` to
enforce the contract at compile time. ts structural typing already handle Server and ITransportServer compatibility , but without the explicit declaration a some new future changes to server.close() or server.listen() could silently break the interface guarantee withou compiler error at the source