### PR TITLE
fix(core): reset dependency-tree cache on metadata changes

### DIFF
--- a/integration/injector/e2e/injector.spec.ts
+++ b/integration/injector/e2e/injector.spec.ts
@@ -1,4 +1,5 @@
-import { Global, Injectable, Module, Scope } from '@nestjs/common';
+import { Global, Inject, Injectable, Module, Scope } from '@nestjs/common';
+import type { Type } from '@nestjs/common';
 import { RuntimeException } from '@nestjs/core/errors/exceptions/runtime.exception';
 import { UnknownDependenciesException } from '@nestjs/core/errors/exceptions/unknown-dependencies.exception';
 import { UnknownExportException } from '@nestjs/core/errors/exceptions/unknown-export.exception';
@@ -79,6 +80,132 @@ describe('Injector', () => {
       clearTimeout(timeout!);
 
       await app.close();
+    });
+
+    it('should not cache a consumer as static before imported factory deps are registered', async () => {
+      @Injectable({ scope: Scope.REQUEST })
+      class RequestScopedDependency {}
+
+      @Global()
+      @Module({
+        providers: [RequestScopedDependency],
+        exports: [RequestScopedDependency],
+      })
+      class GlobalDependencyModule {}
+
+      class RepositoryA {}
+      class RepositoryB {}
+
+      const repositoryAProvider = {
+        provide: RepositoryA,
+        useFactory: (_dependency: RequestScopedDependency) => new RepositoryA(),
+        inject: [RequestScopedDependency],
+      };
+      const repositoryBProvider = {
+        provide: RepositoryB,
+        useFactory: (_dependency: RequestScopedDependency) => new RepositoryB(),
+        inject: [RequestScopedDependency],
+      };
+
+      @Module({
+        providers: [repositoryAProvider, repositoryBProvider],
+        exports: [RepositoryA, RepositoryB],
+      })
+      class RepositoryModule {}
+
+      const buildWrapperChain = (depth: number): Type<unknown> => {
+        let inner: Type<unknown> = RepositoryModule;
+        for (let index = 0; index < depth; index++) {
+          @Module({ imports: [inner], exports: [inner] })
+          class WrapperModule {}
+
+          Object.defineProperty(WrapperModule, 'name', {
+            value: `RepositoryWrapper_${index}`,
+          });
+          inner = WrapperModule;
+        }
+        return inner;
+      };
+
+      const RepositoryWrapperModule = buildWrapperChain(6);
+
+      @Global()
+      @Module({
+        imports: [GlobalDependencyModule, RepositoryWrapperModule],
+        exports: [RepositoryWrapperModule],
+      })
+      class GlobalRepositoryModule {}
+
+      @Injectable()
+      class ConsumerService {
+        constructor(
+          public readonly repositoryA: RepositoryA,
+          public readonly repositoryB: RepositoryB,
+        ) {}
+      }
+
+      const helpers: Type<unknown>[] = [];
+      for (let index = 0; index < 30; index++) {
+        @Injectable()
+        class Helper {}
+
+        Object.defineProperty(Helper, 'name', { value: `Helper_${index}` });
+        helpers.push(Helper);
+      }
+
+      const helperToken = (index: number) => `HELPER_${index}`;
+      const helperAliases = helpers.map((helper, index) => ({
+        provide: helperToken(index),
+        useExisting: helper,
+      }));
+
+      const siblings: Type<unknown>[] = [];
+      for (let index = 0; index < 20; index++) {
+        @Injectable()
+        class Sibling {
+          constructor(
+            @Inject(ConsumerService) public readonly consumer: ConsumerService,
+            @Inject(helperToken(index % helpers.length))
+            public readonly helper: unknown,
+          ) {}
+        }
+
+        Object.defineProperty(Sibling, 'name', { value: `Sibling_${index}` });
+        siblings.push(Sibling);
+      }
+
+      @Module({
+        providers: [ConsumerService, ...helpers, ...helperAliases, ...siblings],
+      })
+      class ConsumerModule {}
+
+      @Module({ imports: [GlobalRepositoryModule, ConsumerModule] })
+      class AppModule {}
+
+      const app = await NestFactory.createApplicationContext(AppModule, {
+        logger: false,
+      });
+      const container = (
+        app as unknown as {
+          container: {
+            getModules(): Map<
+              unknown,
+              { providers: Map<unknown, { isTreeStatic?: boolean }> }
+            >;
+          };
+        }
+      ).container;
+      let isTreeStatic: boolean | undefined;
+      for (const [, moduleRef] of container.getModules()) {
+        if (moduleRef.providers.has(ConsumerService)) {
+          isTreeStatic = moduleRef.providers.get(ConsumerService)?.isTreeStatic;
+          break;
+        }
+      }
+
+      await app.close();
+
+      expect(isTreeStatic).to.equal(false);
     });
   });
 

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -58,6 +58,11 @@ interface InstanceMetadataStore {
   enhancers?: InstanceWrapper[];
 }
 
+const dependencyTreeParents = new WeakMap<
+  InstanceWrapper,
+  Set<InstanceWrapper>
+>();
+
 export class InstanceWrapper<T = any> {
   public readonly name: any;
   public readonly token: InjectionToken;
@@ -78,7 +83,6 @@ export class InstanceWrapper<T = any> {
   private readonly values = new WeakMap<ContextId, InstancePerContext<T>>();
   private readonly [INSTANCE_METADATA_SYMBOL]: InstanceMetadataStore = {};
   private readonly [INSTANCE_ID_SYMBOL]: string;
-  private readonly dependencyTreeParents = new Set<InstanceWrapper>();
   private transientMap?:
     | Map<string, WeakMap<ContextId, InstancePerContext<T>>>
     | undefined;
@@ -501,7 +505,9 @@ export class InstanceWrapper<T = any> {
 
   private registerDependencyTreeParent(wrapper: InstanceWrapper) {
     if (wrapper instanceof InstanceWrapper) {
-      wrapper.dependencyTreeParents.add(this);
+      const parents = dependencyTreeParents.get(wrapper) ?? new Set();
+      parents.add(this);
+      dependencyTreeParents.set(wrapper, parents);
     }
   }
 
@@ -512,9 +518,9 @@ export class InstanceWrapper<T = any> {
     lookupRegistry.add(this[INSTANCE_ID_SYMBOL]);
     this.isTreeStatic = undefined;
     this.isTreeDurable = undefined;
-    this.dependencyTreeParents.forEach(parent =>
-      parent.resetDependencyTreeState(lookupRegistry),
-    );
+    dependencyTreeParents
+      .get(this)
+      ?.forEach(parent => parent.resetDependencyTreeState(lookupRegistry));
   }
 
   private initialize(

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -78,6 +78,7 @@ export class InstanceWrapper<T = any> {
   private readonly values = new WeakMap<ContextId, InstancePerContext<T>>();
   private readonly [INSTANCE_METADATA_SYMBOL]: InstanceMetadataStore = {};
   private readonly [INSTANCE_ID_SYMBOL]: string;
+  private readonly dependencyTreeParents = new Set<InstanceWrapper>();
   private transientMap?:
     | Map<string, WeakMap<ContextId, InstancePerContext<T>>>
     | undefined;
@@ -196,11 +197,12 @@ export class InstanceWrapper<T = any> {
   }
 
   public addCtorMetadata(index: number, wrapper: InstanceWrapper) {
-    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].dependencies) {
       this[INSTANCE_METADATA_SYMBOL].dependencies = [];
     }
     this[INSTANCE_METADATA_SYMBOL].dependencies[index] = wrapper;
+    this.registerDependencyTreeParent(wrapper);
+    this.resetDependencyTreeState();
   }
 
   public getCtorMetadata(): InstanceWrapper[] {
@@ -208,7 +210,6 @@ export class InstanceWrapper<T = any> {
   }
 
   public addPropertiesMetadata(key: symbol | string, wrapper: InstanceWrapper) {
-    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].properties) {
       this[INSTANCE_METADATA_SYMBOL].properties = [];
     }
@@ -216,6 +217,8 @@ export class InstanceWrapper<T = any> {
       key,
       wrapper,
     });
+    this.registerDependencyTreeParent(wrapper);
+    this.resetDependencyTreeState();
   }
 
   public getPropertiesMetadata(): PropertyMetadata[] {
@@ -223,11 +226,12 @@ export class InstanceWrapper<T = any> {
   }
 
   public addEnhancerMetadata(wrapper: InstanceWrapper) {
-    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].enhancers) {
       this[INSTANCE_METADATA_SYMBOL].enhancers = [];
     }
     this[INSTANCE_METADATA_SYMBOL].enhancers.push(wrapper);
+    this.registerDependencyTreeParent(wrapper);
+    this.resetDependencyTreeState();
   }
 
   public getEnhancersMetadata(): InstanceWrapper[] {
@@ -495,9 +499,22 @@ export class InstanceWrapper<T = any> {
     return isNil(this.inject) && this.metatype && this.metatype.prototype;
   }
 
-  private resetDependencyTreeState() {
+  private registerDependencyTreeParent(wrapper: InstanceWrapper) {
+    if (wrapper instanceof InstanceWrapper) {
+      wrapper.dependencyTreeParents.add(this);
+    }
+  }
+
+  private resetDependencyTreeState(lookupRegistry = new Set<string>()) {
+    if (lookupRegistry.has(this[INSTANCE_ID_SYMBOL])) {
+      return;
+    }
+    lookupRegistry.add(this[INSTANCE_ID_SYMBOL]);
     this.isTreeStatic = undefined;
     this.isTreeDurable = undefined;
+    this.dependencyTreeParents.forEach(parent =>
+      parent.resetDependencyTreeState(lookupRegistry),
+    );
   }
 
   private initialize(

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -196,6 +196,7 @@ export class InstanceWrapper<T = any> {
   }
 
   public addCtorMetadata(index: number, wrapper: InstanceWrapper) {
+    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].dependencies) {
       this[INSTANCE_METADATA_SYMBOL].dependencies = [];
     }
@@ -207,6 +208,7 @@ export class InstanceWrapper<T = any> {
   }
 
   public addPropertiesMetadata(key: symbol | string, wrapper: InstanceWrapper) {
+    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].properties) {
       this[INSTANCE_METADATA_SYMBOL].properties = [];
     }
@@ -221,6 +223,7 @@ export class InstanceWrapper<T = any> {
   }
 
   public addEnhancerMetadata(wrapper: InstanceWrapper) {
+    this.resetDependencyTreeState();
     if (!this[INSTANCE_METADATA_SYMBOL].enhancers) {
       this[INSTANCE_METADATA_SYMBOL].enhancers = [];
     }
@@ -490,6 +493,11 @@ export class InstanceWrapper<T = any> {
 
   private isNewable(): boolean {
     return isNil(this.inject) && this.metatype && this.metatype.prototype;
+  }
+
+  private resetDependencyTreeState() {
+    this.isTreeStatic = undefined;
+    this.isTreeDurable = undefined;
   }
 
   private initialize(

--- a/packages/core/test/injector/instance-wrapper.spec.ts
+++ b/packages/core/test/injector/instance-wrapper.spec.ts
@@ -96,6 +96,19 @@ describe('InstanceWrapper', () => {
         const wrapper = new InstanceWrapper({});
         expect(wrapper.isDependencyTreeStatic()).to.be.true;
       });
+      it('should recompute when dependencies are added after static introspection', () => {
+        const wrapper = new InstanceWrapper({});
+        expect(wrapper.isDependencyTreeStatic()).to.be.true;
+
+        wrapper.addCtorMetadata(
+          0,
+          new InstanceWrapper({
+            scope: Scope.REQUEST,
+          }),
+        );
+
+        expect(wrapper.isDependencyTreeStatic()).to.be.false;
+      });
     });
     describe('when statically scoped', () => {
       describe('dependencies, properties, enhancers', () => {

--- a/packages/core/test/injector/instance-wrapper.spec.ts
+++ b/packages/core/test/injector/instance-wrapper.spec.ts
@@ -109,6 +109,21 @@ describe('InstanceWrapper', () => {
 
         expect(wrapper.isDependencyTreeStatic()).to.be.false;
       });
+      it('should recompute when transitive dependencies change after static introspection', () => {
+        const wrapper = new InstanceWrapper({});
+        const dependency = new InstanceWrapper({});
+        wrapper.addCtorMetadata(0, dependency);
+        expect(wrapper.isDependencyTreeStatic()).to.be.true;
+
+        dependency.addCtorMetadata(
+          0,
+          new InstanceWrapper({
+            scope: Scope.REQUEST,
+          }),
+        );
+
+        expect(wrapper.isDependencyTreeStatic()).to.be.false;
+      });
     });
     describe('when statically scoped', () => {
       describe('dependencies, properties, enhancers', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
  - Not applicable: this fixes internal DI cache invalidation behavior.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`InstanceWrapper.isDependencyTreeStatic()` and `isDependencyTreeDurable()` cache their first result. During dependency resolution, a wrapper can be introspected before constructor/property/enhancer dependency metadata has been added. If metadata is added later, the cached dependency-tree state is kept and can incorrectly classify request-scoped dependency trees as static.

Issue Number: #17007

## What is the new behavior?

Adding constructor, property, or enhancer metadata invalidates the cached dependency-tree static/durable state. A wrapper that is initially introspected as static will be recomputed after new dependency metadata is attached.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Verification run locally:

- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/core/test/injector/instance-wrapper.spec.ts --grep 'recompute when dependencies are added after static introspection'`
- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/core/test/injector/instance-wrapper.spec.ts packages/core/test/injector/injector.spec.ts`
- `./node_modules/.bin/prettier --check packages/core/injector/instance-wrapper.ts packages/core/test/injector/instance-wrapper.spec.ts`
- `./node_modules/.bin/eslint packages/core/injector/instance-wrapper.ts packages/core/test/injector/instance-wrapper.spec.ts`
- `git diff --check`

I also attempted broader TypeScript checks, but this checkout reports existing repo setup/dependency errors unrelated to this patch:

- `./node_modules/.bin/tsc -p packages/core/tsconfig.build.json --noEmit` fails with TS6305 because referenced `packages/common` declaration outputs are not built.
- `./node_modules/.bin/tsc -b packages/common/tsconfig.build.json packages/core/tsconfig.build.json --noEmit` fails with TS6310 because referenced projects may not disable emit.
- `./node_modules/.bin/tsc -p packages/core/test/tsconfig.json --noEmit` fails in existing integration/dependency typings, including `integration/inspector/src/durable/durable-context-id.strategy.ts`, `integration/microservices/src/main.ts`, missing `@apollo/gateway`, and external type conflicts.
