### PR TITLE
fix(core): register SSE close listener before async setup

### DIFF
--- a/integration/nest-application/sse/e2e/express.spec.ts
+++ b/integration/nest-application/sse/e2e/express.spec.ts
@@ -4,6 +4,13 @@ import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import { EventSource } from 'eventsource';
 import { AppModule } from '../src/app.module';
+import {
+  fetchPromiseDelayedSseStats,
+  releasePromiseDelayedSse,
+  sleep,
+  waitForPromiseDelayedSseClose,
+  waitForPromiseDelayedSseRequestStart,
+} from './utils';
 
 describe('Sse (Express Application)', () => {
   let app: NestExpressApplication;
@@ -156,6 +163,53 @@ describe('Sse (Express Application)', () => {
         .filter(line => line.startsWith('data: '));
 
       expect(dataLines).to.have.lengthOf(n);
+    });
+  });
+
+  describe('Promise<Observable> disconnect handling', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestExpressApplication>({
+        forceCloseConnections: true,
+      });
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should not start the SSE subscription if the client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(`${url}/sse/promise-delayed`, {
+        headers: {
+          accept: 'text/event-stream',
+        },
+        signal: abortController.signal,
+      });
+
+      await waitForPromiseDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForPromiseDelayedSseClose(url);
+
+      expect(await releasePromiseDelayedSse(url)).to.equal(1);
+
+      await sleep(50);
+
+      const stats = await fetchPromiseDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.subscriptionsStarted).to.equal(0);
     });
   });
 });

--- a/integration/nest-application/sse/e2e/fastify.spec.ts
+++ b/integration/nest-application/sse/e2e/fastify.spec.ts
@@ -7,6 +7,13 @@ import { Test } from '@nestjs/testing';
 import { expect } from 'chai';
 import { EventSource } from 'eventsource';
 import { AppModule } from '../src/app.module';
+import {
+  fetchPromiseDelayedSseStats,
+  releasePromiseDelayedSse,
+  sleep,
+  waitForPromiseDelayedSseClose,
+  waitForPromiseDelayedSseRequestStart,
+} from './utils';
 
 describe('Sse (Fastify Application)', () => {
   let app: NestFastifyApplication;
@@ -165,6 +172,55 @@ describe('Sse (Fastify Application)', () => {
         .filter(line => line.startsWith('data: '));
 
       expect(dataLines).to.have.lengthOf(n);
+    });
+  });
+
+  describe('Promise<Observable> disconnect handling', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter({
+          forceCloseConnections: true,
+        }),
+      );
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should not start the SSE subscription if the client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(`${url}/sse/promise-delayed`, {
+        headers: {
+          accept: 'text/event-stream',
+        },
+        signal: abortController.signal,
+      });
+
+      await waitForPromiseDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForPromiseDelayedSseClose(url);
+
+      expect(await releasePromiseDelayedSse(url)).to.equal(1);
+
+      await sleep(50);
+
+      const stats = await fetchPromiseDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.subscriptionsStarted).to.equal(0);
     });
   });
 });

--- a/integration/nest-application/sse/e2e/utils.ts
+++ b/integration/nest-application/sse/e2e/utils.ts
@@ -1,0 +1,60 @@
+export interface PromiseDelayedSseStats {
+  closeEventsObserved: number;
+  requestsStarted: number;
+  subscriptionsStarted: number;
+}
+
+export const sleep = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+export const fetchPromiseDelayedSseStats = async (
+  appUrl: string,
+): Promise<PromiseDelayedSseStats> => {
+  const response = await fetch(`${appUrl}/sse/promise-delayed/stats`);
+  return response.json();
+};
+
+export const releasePromiseDelayedSse = async (appUrl: string) => {
+  const response = await fetch(`${appUrl}/sse/promise-delayed/release`, {
+    method: 'POST',
+  });
+  const { released } = await response.json();
+
+  return released as number;
+};
+
+const waitForPromiseDelayedSseStat = async (
+  appUrl: string,
+  predicate: (stats: PromiseDelayedSseStats) => boolean,
+  timeoutErrorMessage: string,
+) => {
+  const deadline = Date.now() + 2_000;
+
+  while (Date.now() < deadline) {
+    const stats = await fetchPromiseDelayedSseStats(appUrl);
+
+    if (predicate(stats)) {
+      return;
+    }
+
+    await sleep(20);
+  }
+
+  throw new Error(timeoutErrorMessage);
+};
+
+export const waitForPromiseDelayedSseRequestStart = async (appUrl: string) => {
+  await waitForPromiseDelayedSseStat(
+    appUrl,
+    stats => stats.requestsStarted > 0,
+    'Timed out waiting for the delayed SSE request to start.',
+  );
+};
+
+export const waitForPromiseDelayedSseClose = async (appUrl: string) => {
+  await waitForPromiseDelayedSseStat(
+    appUrl,
+    stats => stats.closeEventsObserved > 0,
+    'Timed out waiting for the delayed SSE request to close.',
+  );
+};

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -1,6 +1,15 @@
+import { IncomingMessage } from 'node:http';
 import { Type } from 'class-transformer';
 import { IsInt } from 'class-validator';
-import { Controller, MessageEvent, Query, Sse } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  MessageEvent,
+  Post,
+  Query,
+  Req,
+  Sse,
+} from '@nestjs/common';
 import { interval, map, Observable, of } from 'rxjs';
 
 class SseQueryDto {
@@ -11,6 +20,11 @@ class SseQueryDto {
 
 @Controller()
 export class AppController {
+  private promiseDelayedRequestsStarted = 0;
+  private promiseDelayedSubscriptionsStarted = 0;
+  private promiseDelayedCloseEventsObserved = 0;
+  private readonly promiseDelayedResolvers: Array<() => void> = [];
+
   @Sse('sse')
   sse(): Observable<MessageEvent> {
     return interval(1000).pipe(
@@ -37,5 +51,52 @@ export class AppController {
       }
       subscriber.complete();
     });
+  }
+
+  @Sse('sse/promise-delayed')
+  ssePromiseDelayed(
+    @Req() request: IncomingMessage & { raw?: IncomingMessage },
+  ): Promise<Observable<MessageEvent>> {
+    this.promiseDelayedRequestsStarted += 1;
+    const rawRequest = request.raw ?? request;
+
+    rawRequest.once('close', () => {
+      this.promiseDelayedCloseEventsObserved += 1;
+    });
+
+    return new Promise(resolve => {
+      this.promiseDelayedResolvers.push(() =>
+        resolve(
+          new Observable<MessageEvent>(subscriber => {
+            this.promiseDelayedSubscriptionsStarted += 1;
+
+            const intervalId = setInterval(() => {
+              subscriber.next({ data: { hello: 'world' } });
+            }, 50);
+
+            return () => clearInterval(intervalId);
+          }),
+        ),
+      );
+    });
+  }
+
+  @Post('sse/promise-delayed/release')
+  releaseSsePromiseDelayed() {
+    const pendingResolvers = this.promiseDelayedResolvers.splice(0);
+    pendingResolvers.forEach(resolve => resolve());
+
+    return {
+      released: pendingResolvers.length,
+    };
+  }
+
+  @Get('sse/promise-delayed/stats')
+  getSsePromiseDelayedStats() {
+    return {
+      closeEventsObserved: this.promiseDelayedCloseEventsObserved,
+      requestsStarted: this.promiseDelayedRequestsStarted,
+      subscriptionsStarted: this.promiseDelayedSubscriptionsStarted,
+    };
   }
 }

--- a/packages/core/helpers/handler-metadata-storage.ts
+++ b/packages/core/helpers/handler-metadata-storage.ts
@@ -28,6 +28,7 @@ export type HandleSseResponseFn = <
 
 export interface HandlerMetadata {
   argsLength: number;
+  isSseHandler: boolean;
   paramtypes: any[];
   httpStatusCode: number;
   responseHeaders: any[];

--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -163,23 +163,15 @@ export class RouterExecutionContext {
       hasCustomHeaders &&
         this.responseController.setHeaders(res, responseHeaders);
 
-      const result = isSseHandler
-        ? this.interceptorsConsumer.intercept(
-            interceptors,
-            [req, res, next],
-            instance,
-            callback,
-            handler(args, req, res, next),
-            contextType,
-          )
-        : await this.interceptorsConsumer.intercept(
-            interceptors,
-            [req, res, next],
-            instance,
-            callback,
-            handler(args, req, res, next),
-            contextType,
-          );
+      const resultOrDeferred = this.interceptorsConsumer.intercept(
+        interceptors,
+        [req, res, next],
+        instance,
+        callback,
+        handler(args, req, res, next),
+        contextType,
+      );
+      const result = isSseHandler ? resultOrDeferred : await resultOrDeferred;
       await (fnHandleResponse as HandlerResponseBasicFn)(result, res, req);
     };
   }

--- a/packages/core/router/router-execution-context.ts
+++ b/packages/core/router/router-execution-context.ts
@@ -90,6 +90,7 @@ export class RouterExecutionContext {
     const {
       argsLength,
       fnHandleResponse,
+      isSseHandler,
       paramtypes,
       getParamsMetadata,
       httpStatusCode,
@@ -162,14 +163,23 @@ export class RouterExecutionContext {
       hasCustomHeaders &&
         this.responseController.setHeaders(res, responseHeaders);
 
-      const result = await this.interceptorsConsumer.intercept(
-        interceptors,
-        [req, res, next],
-        instance,
-        callback,
-        handler(args, req, res, next),
-        contextType,
-      );
+      const result = isSseHandler
+        ? this.interceptorsConsumer.intercept(
+            interceptors,
+            [req, res, next],
+            instance,
+            callback,
+            handler(args, req, res, next),
+            contextType,
+          )
+        : await this.interceptorsConsumer.intercept(
+            interceptors,
+            [req, res, next],
+            instance,
+            callback,
+            handler(args, req, res, next),
+            contextType,
+          );
       await (fnHandleResponse as HandlerResponseBasicFn)(result, res, req);
     };
   }
@@ -231,6 +241,7 @@ export class RouterExecutionContext {
       isResponseHandled,
       httpRedirectResponse,
     );
+    const isSseHandler = !!this.reflectSse(callback);
 
     const httpCode = this.reflectHttpStatusCode(callback);
     const httpStatusCode = httpCode
@@ -242,6 +253,7 @@ export class RouterExecutionContext {
     const handlerMetadata: HandlerMetadata = {
       argsLength,
       fnHandleResponse,
+      isSseHandler,
       paramtypes,
       getParamsMetadata,
       httpStatusCode,

--- a/packages/core/router/router-response-controller.ts
+++ b/packages/core/router/router-response-controller.ts
@@ -117,28 +117,25 @@ export class RouterResponseController {
       return;
     }
 
-    const observableResult = await Promise.resolve(result);
-
-    this.assertObservable(observableResult);
-
     const stream = new SseStream(request);
-
     const statusCode =
       options?.statusCode ??
       (response as { statusCode?: number }).statusCode ??
       200;
 
-    stream.pipe(response, {
-      additionalHeaders: options?.additionalHeaders,
-      statusCode,
-    });
-
     return new Promise<void>((resolve, reject) => {
       let settled = false;
+      let subscription: { unsubscribe(): void } | undefined;
+
+      const cleanup = () => request.removeListener('close', onClose);
 
       const onClose = () => {
+        if (settled) {
+          return;
+        }
         settled = true;
-        subscription.unsubscribe();
+        cleanup();
+        subscription?.unsubscribe();
         if (!stream.writableEnded) {
           stream.end();
         }
@@ -146,67 +143,98 @@ export class RouterResponseController {
         resolve();
       };
 
-      const subscription = observableResult
-        .pipe(
-          map((message): MessageEvent => {
-            if (isObject(message)) {
-              return message as MessageEvent;
-            }
+      request.once('close', onClose);
 
-            return { data: message as object | string };
-          }),
-          concatMap(
-            message =>
-              new Promise<void>(resolve =>
-                stream.writeMessage(message, () => resolve()),
+      Promise.resolve(result)
+        .then(observableResult => {
+          if (settled) {
+            return;
+          }
+
+          this.assertObservable(observableResult);
+
+          stream.pipe(response, {
+            additionalHeaders: options?.additionalHeaders,
+            statusCode,
+          });
+
+          subscription = observableResult
+            .pipe(
+              map((message): MessageEvent => {
+                if (isObject(message)) {
+                  return message as MessageEvent;
+                }
+
+                return { data: message as object | string };
+              }),
+              concatMap(
+                message =>
+                  new Promise<void>(resolve =>
+                    stream.writeMessage(message, () => resolve()),
+                  ),
               ),
-          ),
-          catchError(err => {
-            if (!stream.headersCommitted) {
-              throw err;
-            }
+              catchError(err => {
+                if (!stream.headersCommitted) {
+                  throw err;
+                }
 
-            const data = err instanceof Error ? err.message : err;
-            stream.writeMessage({ type: 'error', data }, writeError => {
-              if (writeError) {
-                this.logger.error(writeError);
-              }
+                const data = err instanceof Error ? err.message : err;
+                stream.writeMessage({ type: 'error', data }, writeError => {
+                  if (writeError) {
+                    this.logger.error(writeError);
+                  }
+                });
+
+                return EMPTY;
+              }),
+            )
+            .subscribe({
+              error: err => {
+                if (settled) {
+                  return;
+                }
+                settled = true;
+                cleanup();
+                if (!stream.writableEnded) {
+                  stream.end();
+                }
+                reject(err);
+              },
+              complete: () => {
+                if (settled) {
+                  return;
+                }
+                settled = true;
+                cleanup();
+                if (!stream.writableEnded) {
+                  stream.end();
+                }
+                resolve();
+              },
             });
 
-            return EMPTY;
-          }),
-        )
-        .subscribe({
-          error: err => {
-            settled = true;
-            request.removeListener('close', onClose);
-            if (!stream.writableEnded) {
-              stream.end();
+          // Commit SSE headers on the next macrotask. Pipe validation errors
+          // propagate through microtasks (which complete before macrotasks),
+          // so if the lifecycle errored, `settled` is already true and we
+          // skip the write. Otherwise headers are sent immediately rather
+          // than waiting for the first Observable emission.
+          setTimeout(() => {
+            if (!settled) {
+              stream.commitHeaders();
             }
-            reject(err);
-          },
-          complete: () => {
-            settled = true;
-            request.removeListener('close', onClose);
-            if (!stream.writableEnded) {
-              stream.end();
-            }
-            resolve();
-          },
+          }, 0);
+        })
+        .catch(err => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cleanup();
+          if (!stream.writableEnded) {
+            stream.end();
+          }
+          reject(err);
         });
-
-      // Commit SSE headers on the next macrotask. Pipe validation errors
-      // propagate through microtasks (which complete before macrotasks),
-      // so if the lifecycle errored, `settled` is already true and we
-      // skip the write. Otherwise headers are sent immediately rather
-      // than waiting for the first Observable emission.
-      setTimeout(() => {
-        if (!settled) {
-          stream.commitHeaders();
-        }
-      }, 0);
-
-      request.on('close', onClose);
     });
   }
 

--- a/packages/core/test/router/router-execution-context.spec.ts
+++ b/packages/core/test/router/router-execution-context.spec.ts
@@ -56,6 +56,31 @@ describe('RouterExecutionContext', () => {
     );
   });
   describe('create', () => {
+    it('should pass an unresolved Promise<Observable> to the SSE response handler', async () => {
+      const result = Promise.resolve(of('test'));
+      const fnHandleResponse = sinon.stub().resolves();
+
+      sinon.stub(contextCreator, 'getMetadata').returns({
+        argsLength: 0,
+        fnHandleResponse,
+        isSseHandler: true,
+        paramtypes: [],
+        getParamsMetadata: sinon.stub().returns([]),
+        httpStatusCode: 200,
+        hasCustomHeaders: false,
+        responseHeaders: [],
+      });
+      sinon.stub(contextCreator, 'createGuardsFn').returns(null as any);
+      sinon.stub(contextCreator, 'createPipesFn').returns(null as any);
+      sinon.stub(interceptorsConsumer, 'intercept').returns(result as any);
+
+      const proxy = contextCreator.create({} as any, callback, '', '', 0);
+      await proxy({}, {}, sinon.stub());
+
+      expect(fnHandleResponse.calledOnce).to.be.true;
+      expect(fnHandleResponse.firstCall.args[0]).to.equal(result);
+    });
+
     describe('when callback metadata is not undefined', () => {
       let metadata: Record<number, RouteParamMetadata>;
       let exchangeKeysForValuesSpy: sinon.SinonSpy;

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -262,11 +262,17 @@ describe('RouterResponseController', () => {
   describe('Server-Sent-Events', () => {
     it('should accept only observables', async () => {
       const result = Promise.resolve('test');
+      const response = new Writable();
+      response._write = () => {};
+
+      const request = new Writable();
+      request._write = () => {};
+
       try {
         await routerResponseController.sse(
           result as unknown as any,
-          {} as unknown as ServerResponse,
-          {} as unknown as IncomingMessage,
+          response as unknown as ServerResponse,
+          request as unknown as IncomingMessage,
         );
         expect.fail('should have thrown');
       } catch (e) {
@@ -372,12 +378,11 @@ data: test
       const result = of('test');
       const response = new Sink();
       const request = new PassThrough();
-      void routerResponseController.sse(
+      await routerResponseController.sse(
         result,
         response as unknown as ServerResponse,
         request as unknown as IncomingMessage,
       );
-      request.destroy();
       await written(response);
       expect(response.content).to.eql(
         `
@@ -405,6 +410,39 @@ data: test
       request.emit('close');
     });
 
+    it('should ignore a Promise<Observable> if request closes before it resolves', async () => {
+      let subscribed = false;
+      const result = new Promise<Observable<string>>(resolve => {
+        setTimeout(() => {
+          resolve(
+            new Observable(() => {
+              subscribed = true;
+            }),
+          );
+        }, 10);
+      });
+      const response = new Writable();
+      const responseEndSpy = sinon.spy();
+      response.end = responseEndSpy as any;
+      response._write = () => {};
+
+      const request = new PassThrough();
+
+      const ssePromise = routerResponseController.sse(
+        result,
+        response as unknown as ServerResponse,
+        request as unknown as IncomingMessage,
+      );
+      request.emit('close');
+
+      await ssePromise;
+      await new Promise(resolve => setTimeout(resolve, 20));
+
+      expect(subscribed).to.equal(false);
+      expect(responseEndSpy.calledOnce).to.be.true;
+      expect(request.listenerCount('close')).to.equal(0);
+    });
+
     it('should close the request when observable completes', done => {
       const result = of('test');
       const response = new Writable();
@@ -419,6 +457,22 @@ data: test
         response as unknown as ServerResponse,
         request as unknown as IncomingMessage,
       );
+    });
+
+    it('should remove the close listener after synchronous completion', async () => {
+      const result = of('test');
+      const response = new Writable();
+      response._write = () => {};
+
+      const request = new PassThrough();
+
+      await routerResponseController.sse(
+        result,
+        response as unknown as ServerResponse,
+        request as unknown as IncomingMessage,
+      );
+
+      expect(request.listenerCount('close')).to.equal(0);
     });
 
     it('should allow to intercept the response', done => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`RouterResponseController.sse()` attaches the request `close` listener after awaiting the handler result and after creating the Observable subscription.

That causes two problems:
- a `Promise<Observable>` SSE handler can miss an early disconnect and still continue setup after the request is already gone
- a synchronously completing Observable can remove the `close` listener before it is added, leaving a stale listener behind

Fixes #17017

## What is the new behavior?

- register the request `close` listener before awaiting the SSE handler result
- skip subscription/setup if the request has already been closed
- clean up the `close` listener on completion, error, and early rejection paths
- add regression tests for both the early-disconnect and synchronous-completion cases

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Verified locally with:

```bash
node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/core/test/router/router-response-controller.spec.ts
./node_modules/.bin/eslint packages/core/router/router-response-controller.ts packages/core/test/router/router-response-controller.spec.ts
```
