### PR TITLE
fix(microservices): reject pending Redis requests on close

### DIFF
--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -62,6 +62,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
   public async close() {
     this.isManuallyClosed = true;
+    this.handleClose();
     this.pubClient && (await this.pubClient.quit());
     this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
@@ -162,6 +163,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
         return;
       }
       this._status$.next(RedisStatus.DISCONNECTED);
+      this.handleClose();
 
       if (this.getOptionsProp(this.options, 'retryAttempts') === undefined) {
         // When retryAttempts is not specified, the connection will not be re-established
@@ -179,6 +181,17 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
         this.connectionPromise.catch(() => {});
       }
     });
+  }
+
+  public handleClose() {
+    if (this.routingMap.size > 0) {
+      const err = new Error('Connection closed');
+      for (const callback of this.routingMap.values()) {
+        callback({ err });
+      }
+      this.routingMap.clear();
+    }
+    this.subscriptionsCount.clear();
   }
 
   public getClientOptions(): Partial<RedisOptions['options']> {

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -211,15 +211,21 @@ describe('ClientRedis', () => {
 
     let pubClose: sinon.SinonSpy;
     let subClose: sinon.SinonSpy;
+    let callback: sinon.SinonSpy;
+    let routingMap: Map<string, Function>;
     let pub: any, sub: any;
 
     beforeEach(() => {
       pubClose = sinon.spy();
       subClose = sinon.spy();
+      callback = sinon.spy();
+      routingMap = new Map<string, Function>();
+      routingMap.set('some id', callback);
       pub = { quit: pubClose };
       sub = { quit: subClose };
       untypedClient.pubClient = pub;
       untypedClient.subClient = sub;
+      untypedClient.routingMap = routingMap;
     });
     it('should close "pub" when it is not null', async () => {
       await client.close();
@@ -238,6 +244,18 @@ describe('ClientRedis', () => {
       untypedClient.subClient = null;
       await client.close();
       expect(subClose.called).to.be.false;
+    });
+    it('should clear out the routing map', async () => {
+      await client.close();
+      expect(untypedClient.routingMap.size).to.be.eq(0);
+    });
+    it('should call pending callbacks with connection closed error', async () => {
+      await client.close();
+      expect(
+        callback.calledWith({
+          err: sinon.match({ message: 'Connection closed' }),
+        }),
+      ).to.be.true;
     });
     it('should have isManuallyClosed set to true when "end" event is handled during close', async () => {
       let endHandler: Function | undefined;
@@ -318,6 +336,27 @@ describe('ClientRedis', () => {
       };
       client.registerEndListener(emitter as any);
       expect(callback.getCall(0).args[0]).to.be.eql(RedisEventsMap.END);
+    });
+    it('should call pending callbacks when connection ends unexpectedly', () => {
+      const client = new ClientRedis({});
+      const callback = sinon.spy();
+      const emitter = {
+        on: sinon.stub().callsFake((_, fn) => fn()),
+      };
+
+      client['routingMap'].set('some id', callback);
+      client['subscriptionsCount'].set('channel', 1);
+      (client as any).isManuallyClosed = false;
+
+      client.registerEndListener(emitter as any);
+
+      expect(client['routingMap'].size).to.be.eq(0);
+      expect(client['subscriptionsCount'].size).to.be.eq(0);
+      expect(
+        callback.calledWith({
+          err: sinon.match({ message: 'Connection closed' }),
+        }),
+      ).to.be.true;
     });
   });
   describe('registerReadyListener', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When a Redis client closes while request/response messages are still pending, `ClientRedis` leaves callbacks in `routingMap`. The returned `send()` observable can remain pending instead of receiving a connection-closed error.

Issue Number: Fixes #17016


## What is the new behavior?
`ClientRedis` now rejects pending request callbacks with `Connection closed` when Redis closes manually or emits `end`, clears `routingMap`, and resets Redis response subscription counters so later requests do not reuse stale state.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Validation:

- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/microservices/test/client/client-redis.spec.ts`
- `node --max-old-space-size=4096 ./node_modules/.bin/eslint packages/microservices/client/client-redis.ts packages/microservices/test/client/client-redis.spec.ts`
- `npx prettier --check packages/microservices/client/client-redis.ts packages/microservices/test/client/client-redis.spec.ts`
- `npm run build -- --pretty false`
- `git diff --check`

Docs were not updated because this is a transport bug fix with regression coverage and no public API change.
