### PR TITLE
fix(microservices): notify pending callbacks on ClientRedis disconnect

### DIFF
--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -62,14 +62,14 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
   public async close() {
     this.isManuallyClosed = true;
+    this.handleClose();
     this.pubClient && (await this.pubClient.quit());
     this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
     this.pendingEventListeners = [];
-    this.handleDisconnect();
   }
 
-  public handleDisconnect() {
+  public handleClose() {
     if (this.routingMap.size > 0) {
       const err = new Error('Connection closed');
       for (const callback of this.routingMap.values()) {
@@ -77,6 +77,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
       }
       this.routingMap.clear();
     }
+    this.subscriptionsCount.clear();
   }
 
   public async connect(): Promise<any> {
@@ -173,6 +174,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
         return;
       }
       this._status$.next(RedisStatus.DISCONNECTED);
+      this.handleClose();
 
       if (this.getOptionsProp(this.options, 'retryAttempts') === undefined) {
         // When retryAttempts is not specified, the connection will not be re-established
@@ -180,7 +182,6 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
         // Clean up client instances and just recreate them when connect is called
         this.pubClient = this.subClient = null;
-        this.handleDisconnect();
       } else {
         this.logger.error('Disconnected from Redis.');
         this.connectionPromise = Promise.reject(
@@ -189,7 +190,6 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
         // Prevent unhandled rejections
         this.connectionPromise.catch(() => {});
-        this.handleDisconnect();
       }
     });
   }

--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -66,6 +66,17 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
     this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
     this.pendingEventListeners = [];
+    this.handleDisconnect();
+  }
+
+  public handleDisconnect() {
+    if (this.routingMap.size > 0) {
+      const err = new Error('Connection closed');
+      for (const callback of this.routingMap.values()) {
+        callback({ err });
+      }
+      this.routingMap.clear();
+    }
   }
 
   public async connect(): Promise<any> {
@@ -169,6 +180,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
         // Clean up client instances and just recreate them when connect is called
         this.pubClient = this.subClient = null;
+        this.handleDisconnect();
       } else {
         this.logger.error('Disconnected from Redis.');
         this.connectionPromise = Promise.reject(
@@ -177,6 +189,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
 
         // Prevent unhandled rejections
         this.connectionPromise.catch(() => {});
+        this.handleDisconnect();
       }
     });
   }
@@ -327,7 +340,7 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
     this.subscriptionsCount.set(channel, subscriptionCount - 1);
 
     if (subscriptionCount - 1 <= 0) {
-      this.subClient.unsubscribe(channel);
+      this.subClient?.unsubscribe(channel);
     }
   }
 }

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -329,12 +329,12 @@ describe('ClientRedis', () => {
       expect(callback.getCall(0).args[0]).to.be.eql(RedisEventsMap.ERROR);
     });
   });
-  describe('handleDisconnect', () => {
+  describe('handleClose', () => {
     it('should clear the routing map', () => {
       const routingMap = new Map<string, Function>();
       routingMap.set('id1', sinon.spy());
       untypedClient.routingMap = routingMap;
-      client.handleDisconnect();
+      client.handleClose();
       expect(untypedClient.routingMap.size).to.be.eq(0);
     });
     it('should call each pending callback with a "Connection closed" error', () => {
@@ -342,16 +342,21 @@ describe('ClientRedis', () => {
       const routingMap = new Map<string, Function>();
       routingMap.set('id1', callback);
       untypedClient.routingMap = routingMap;
-      client.handleDisconnect();
+      client.handleClose();
       expect(
         callback.calledWith(
           sinon.match({ err: sinon.match({ message: 'Connection closed' }) }),
         ),
       ).to.be.true;
     });
+    it('should clear subscriptionsCount', () => {
+      untypedClient.subscriptionsCount.set('some-channel', 2);
+      client.handleClose();
+      expect(untypedClient.subscriptionsCount.size).to.be.eq(0);
+    });
     it('should do nothing when the routing map is empty', () => {
       untypedClient.routingMap = new Map();
-      expect(() => client.handleDisconnect()).not.to.throw();
+      expect(() => client.handleClose()).not.to.throw();
     });
   });
   describe('registerEndListener', () => {
@@ -363,9 +368,9 @@ describe('ClientRedis', () => {
       client.registerEndListener(emitter as any);
       expect(callback.getCall(0).args[0]).to.be.eql(RedisEventsMap.END);
     });
-    it('should call handleDisconnect on unexpected disconnect (no retryAttempts)', () => {
+    it('should call handleClose on unexpected disconnect (no retryAttempts)', () => {
       const localClient = new ClientRedis({});
-      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      const handleCloseSpy = sinon.spy(localClient, 'handleClose');
       let endHandler: Function;
       const emitter = {
         on: (event: string, fn: Function) => {
@@ -374,11 +379,11 @@ describe('ClientRedis', () => {
       };
       localClient.registerEndListener(emitter as any);
       endHandler!();
-      expect(handleDisconnectSpy.called).to.be.true;
+      expect(handleCloseSpy.called).to.be.true;
     });
-    it('should call handleDisconnect on unexpected disconnect (with retryAttempts)', () => {
+    it('should call handleClose on unexpected disconnect (with retryAttempts)', () => {
       const localClient = new ClientRedis({ retryAttempts: 3 });
-      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      const handleCloseSpy = sinon.spy(localClient, 'handleClose');
       let endHandler: Function;
       const emitter = {
         on: (event: string, fn: Function) => {
@@ -387,12 +392,12 @@ describe('ClientRedis', () => {
       };
       localClient.registerEndListener(emitter as any);
       endHandler!();
-      expect(handleDisconnectSpy.called).to.be.true;
+      expect(handleCloseSpy.called).to.be.true;
     });
-    it('should not call handleDisconnect when isManuallyClosed is true', () => {
+    it('should not call handleClose when isManuallyClosed is true', () => {
       const localClient = new ClientRedis({});
       (localClient as any).isManuallyClosed = true;
-      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      const handleCloseSpy = sinon.spy(localClient, 'handleClose');
       let endHandler: Function;
       const emitter = {
         on: (event: string, fn: Function) => {
@@ -401,7 +406,7 @@ describe('ClientRedis', () => {
       };
       localClient.registerEndListener(emitter as any);
       endHandler!();
-      expect(handleDisconnectSpy.called).to.be.false;
+      expect(handleCloseSpy.called).to.be.false;
     });
   });
   describe('registerReadyListener', () => {

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -239,6 +239,25 @@ describe('ClientRedis', () => {
       await client.close();
       expect(subClose.called).to.be.false;
     });
+    it('should clear out the routing map', async () => {
+      const routingMap = new Map<string, Function>();
+      routingMap.set('some id', sinon.spy());
+      untypedClient.routingMap = routingMap;
+      await client.close();
+      expect(untypedClient.routingMap.size).to.be.eq(0);
+    });
+    it('should call pending routingMap callbacks with "Connection closed" error', async () => {
+      const callback = sinon.spy();
+      const routingMap = new Map<string, Function>();
+      routingMap.set('some id', callback);
+      untypedClient.routingMap = routingMap;
+      await client.close();
+      expect(
+        callback.calledWith(
+          sinon.match({ err: sinon.match({ message: 'Connection closed' }) }),
+        ),
+      ).to.be.true;
+    });
     it('should have isManuallyClosed set to true when "end" event is handled during close', async () => {
       let endHandler: Function | undefined;
       sub.on = (event, handler) => {
@@ -310,6 +329,31 @@ describe('ClientRedis', () => {
       expect(callback.getCall(0).args[0]).to.be.eql(RedisEventsMap.ERROR);
     });
   });
+  describe('handleDisconnect', () => {
+    it('should clear the routing map', () => {
+      const routingMap = new Map<string, Function>();
+      routingMap.set('id1', sinon.spy());
+      untypedClient.routingMap = routingMap;
+      client.handleDisconnect();
+      expect(untypedClient.routingMap.size).to.be.eq(0);
+    });
+    it('should call each pending callback with a "Connection closed" error', () => {
+      const callback = sinon.spy();
+      const routingMap = new Map<string, Function>();
+      routingMap.set('id1', callback);
+      untypedClient.routingMap = routingMap;
+      client.handleDisconnect();
+      expect(
+        callback.calledWith(
+          sinon.match({ err: sinon.match({ message: 'Connection closed' }) }),
+        ),
+      ).to.be.true;
+    });
+    it('should do nothing when the routing map is empty', () => {
+      untypedClient.routingMap = new Map();
+      expect(() => client.handleDisconnect()).not.to.throw();
+    });
+  });
   describe('registerEndListener', () => {
     it('should bind end event handler', () => {
       const callback = sinon.stub().callsFake((_, fn) => fn({ code: 'test' }));
@@ -318,6 +362,46 @@ describe('ClientRedis', () => {
       };
       client.registerEndListener(emitter as any);
       expect(callback.getCall(0).args[0]).to.be.eql(RedisEventsMap.END);
+    });
+    it('should call handleDisconnect on unexpected disconnect (no retryAttempts)', () => {
+      const localClient = new ClientRedis({});
+      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      let endHandler: Function;
+      const emitter = {
+        on: (event: string, fn: Function) => {
+          if (event === 'end') endHandler = fn;
+        },
+      };
+      localClient.registerEndListener(emitter as any);
+      endHandler!();
+      expect(handleDisconnectSpy.called).to.be.true;
+    });
+    it('should call handleDisconnect on unexpected disconnect (with retryAttempts)', () => {
+      const localClient = new ClientRedis({ retryAttempts: 3 });
+      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      let endHandler: Function;
+      const emitter = {
+        on: (event: string, fn: Function) => {
+          if (event === 'end') endHandler = fn;
+        },
+      };
+      localClient.registerEndListener(emitter as any);
+      endHandler!();
+      expect(handleDisconnectSpy.called).to.be.true;
+    });
+    it('should not call handleDisconnect when isManuallyClosed is true', () => {
+      const localClient = new ClientRedis({});
+      (localClient as any).isManuallyClosed = true;
+      const handleDisconnectSpy = sinon.spy(localClient, 'handleDisconnect');
+      let endHandler: Function;
+      const emitter = {
+        on: (event: string, fn: Function) => {
+          if (event === 'end') endHandler = fn;
+        },
+      };
+      localClient.registerEndListener(emitter as any);
+      endHandler!();
+      expect(handleDisconnectSpy.called).to.be.false;
     });
   });
   describe('registerReadyListener', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When a Redis connection drops or `close()` is called while there are in-flight `send()` requests, the pending callbacks in routingMap are never invoked. The observables returned by send() hang indefinitely — no error, no completion — causing a memory leak.

Issue Number: #17016


## What is the new behavior?
Added `handleClose()` (mirrors `ClientTCP.handleClose()`) which notifies all pending routingMap callbacks with a "Connection closed" error and clears the map. Also clears subscriptionsCount to avoid stale state on reconnect.

`close()` calls `handleClose()` before `quit()` so that in-flight unsubscribes are actually sent to Redis before the connection drops
registerEndListener calls `handleClose()` once before the retry/no-retry branch
`unsubscribeFromChannel()` uses optional chaining`this.subClient?.unsubscribe()` as a defensive guard

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
`ClientTCP` already handles this via `handleClose()` — this brings `ClientRedis` in line with the same pattern.