### PR TITLE
fix(platform-fastify): replace process.exit(1) with thrown error in setViewEngine

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -566,10 +566,7 @@ export class FastifyAdapter<
 
   public setViewEngine(options: FastifyViewOptions | string) {
     if (isString(options)) {
-      new Logger('FastifyAdapter').error(
-        "setViewEngine() doesn't support a string argument.",
-      );
-      process.exit(1);
+      throw new Error("setViewEngine() doesn't support a string argument.");
     }
     return this.register(
       loadPackage('@fastify/view', 'FastifyAdapter.setViewEngine()', () =>

--- a/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
+++ b/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
@@ -1,0 +1,13 @@
+import { FastifyAdapter } from '@nestjs/platform-fastify';
+import { expect } from 'chai';
+
+describe('FastifyAdapter', () => {
+  describe('setViewEngine', () => {
+    it('should throw when called with a string argument', () => {
+      const adapter = new FastifyAdapter();
+      expect(() => adapter.setViewEngine('ejs')).to.throw(
+        "setViewEngine() doesn't support a string argument.",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
process.exit(1) is called when setViewEngine() receives a string argument, which terminates the process immediately, preventing applications from handling the error gracefully.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
A descriptive Error is thrown instead: "setViewEngine() doesn't support a string argument."

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information