### PR TITLE
fix(fastify): preserve middleware paths in plugin scopes

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -613,6 +613,59 @@ describe('Middleware (FastifyAdapter)', () => {
     });
   });
 
+  describe('should apply to routes registered via fastify.register() with prefix', () => {
+    @Module({})
+    class PluginPrefixModule implements NestModule {
+      configure(consumer: MiddlewareConsumer) {
+        consumer
+          .apply((req, res, next) => {
+            res.setHeader('x-middleware', 'middleware_hit');
+            next();
+          })
+          .forRoutes('/my-prefix', 'my-prefix', '/my-prefix/*');
+      }
+    }
+
+    beforeEach(async () => {
+      app = (
+        await Test.createTestingModule({
+          imports: [PluginPrefixModule],
+        }).compile()
+      ).createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+      await app.init();
+
+      await app
+        .getHttpAdapter()
+        .getInstance()
+        .register(
+          async (instance: any) => {
+            instance.get('/test', async () => 'plugin_route');
+          },
+          { prefix: '/my-prefix' },
+        );
+
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    it('GET /my-prefix/test runs Nest middleware and the plugin route', () => {
+      return app
+        .inject({
+          method: 'GET',
+          url: '/my-prefix/test',
+        })
+        .then(({ statusCode, payload, headers }) => {
+          expect(statusCode).to.equal(200);
+          expect(payload).to.equal('plugin_route');
+          expect(headers['x-middleware']).to.equal('middleware_hit');
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+
   describe('should respect fastify routing options', () => {
     const MIDDLEWARE_RETURN_VALUE = 'middleware_return';
 

--- a/packages/platform-fastify/adapters/middie/fastify-middie.ts
+++ b/packages/platform-fastify/adapters/middie/fastify-middie.ts
@@ -357,13 +357,25 @@ function fastifyMiddie(
   }
 
   function onRegister(instance: FastifyInstance) {
-    const middlewares = instance[kMiddlewares].slice() as Array<Array<unknown>>;
+    const middlewares = instance[kMiddlewares].slice() as Array<
+      [string | null, Function | undefined]
+    >;
     instance[kMiddlewares] = [];
     instance[kMiddie] = middie(onMiddieEnd, instance.initialConfig);
     instance[kMiddieHasMiddlewares] = false;
     instance.decorate('use', use as any);
-    for (const middleware of middlewares) {
-      (instance.use as any)(...middleware);
+    // Inherited middlewares already carry an absolute path. Re-applying them
+    // through `instance.use` would prepend the child context's prefix again,
+    // double-prefixing the path and preventing matches for plugin routes
+    // registered with `fastify.register(plugin, { prefix })`.
+    for (const [path, fn] of middlewares) {
+      instance[kMiddlewares].push([path, fn]);
+      if (fn == null) {
+        instance[kMiddie].use(path);
+      } else {
+        instance[kMiddie].use(path, fn);
+      }
+      instance[kMiddieHasMiddlewares] = true;
     }
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Middleware registered for a prefixed route may not run when the route is registered inside a Fastify plugin scope with `fastify.register(..., { prefix })`.

Inherited middleware entries are replayed into encapsulated Fastify plugin instances through `instance.use()`, which can prepend the child prefix again and prevent matching the originally registered middleware path.

Closes #11802

## What is the new behavior?

Inherited middleware paths are preserved when propagated into encapsulated Fastify plugin scopes.

This allows Nest middleware configured for a prefixed route to run correctly for routes registered through `fastify.register(..., { prefix })`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No public API changes. This only adjusts Fastify middleware propagation inside plugin scopes.

## Verification

```bash
npm test -- integration/hello-world/e2e/middleware-fastify.spec.ts
node --max-old-space-size=8192 ./node_modules/.bin/eslint packages/platform-fastify/adapters/middie/fastify-middie.ts
node --max-old-space-size=8192 ./node_modules/.bin/eslint integration/hello-world/e2e/middleware-fastify.spec.ts
git diff --check