### PR TITLE
fix(core): prevent partial resource cleanup when a shutdown hook rejects

### DIFF
--- a/packages/core/hooks/before-app-shutdown.hook.ts
+++ b/packages/core/hooks/before-app-shutdown.hook.ts
@@ -74,6 +74,10 @@ export async function callBeforeAppShutdownHook(
     hasBeforeApplicationShutdownHook(moduleClassInstance) &&
     moduleClassHost.isDependencyTreeStatic()
   ) {
-    await moduleClassInstance.beforeApplicationShutdown(signal);
+    try {
+      await moduleClassInstance.beforeApplicationShutdown(signal);
+    } catch (err) {
+      Logger.error(err, (err as Error)?.stack);
+    }
   }
 }

--- a/packages/core/hooks/before-app-shutdown.hook.ts
+++ b/packages/core/hooks/before-app-shutdown.hook.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import type { BeforeApplicationShutdown } from '@nestjs/common';
 import { isFunction, isNil } from '@nestjs/common/internal';
 import { iterate } from 'iterare';
@@ -55,7 +56,17 @@ export async function callBeforeAppShutdownHook(
 
   const levels = getSortedHierarchyLevels(groupedInstances, 'DESC');
   for (const level of levels) {
-    await Promise.all(callOperator(groupedInstances.get(level)!, signal));
+    const results = await Promise.allSettled(
+      callOperator(groupedInstances.get(level)!, signal),
+    );
+    results
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      .forEach(result =>
+        Logger.error(result.reason, (result.reason as Error)?.stack),
+      );
   }
   const moduleClassInstance = moduleClassHost.instance;
   if (

--- a/packages/core/hooks/on-app-shutdown.hook.ts
+++ b/packages/core/hooks/on-app-shutdown.hook.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import type { OnApplicationShutdown } from '@nestjs/common';
 import { isFunction, isNil } from '@nestjs/common/internal';
 import { iterate } from 'iterare';
@@ -53,7 +54,17 @@ export async function callAppShutdownHook(
 
   const levels = getSortedHierarchyLevels(groupedInstances, 'DESC');
   for (const level of levels) {
-    await Promise.all(callOperator(groupedInstances.get(level)!, signal));
+    const results = await Promise.allSettled(
+      callOperator(groupedInstances.get(level)!, signal),
+    );
+    results
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      .forEach(result =>
+        Logger.error(result.reason, (result.reason as Error)?.stack),
+      );
   }
   // Call the instance itself
   const moduleClassInstance = moduleClassHost.instance;

--- a/packages/core/hooks/on-app-shutdown.hook.ts
+++ b/packages/core/hooks/on-app-shutdown.hook.ts
@@ -73,6 +73,10 @@ export async function callAppShutdownHook(
     hasOnAppShutdownHook(moduleClassInstance) &&
     moduleClassHost.isDependencyTreeStatic()
   ) {
-    await moduleClassInstance.onApplicationShutdown(signal);
+    try {
+      await moduleClassInstance.onApplicationShutdown(signal);
+    } catch (err) {
+      Logger.error(err, (err as Error)?.stack);
+    }
   }
 }

--- a/packages/core/hooks/on-module-destroy.hook.ts
+++ b/packages/core/hooks/on-module-destroy.hook.ts
@@ -70,6 +70,10 @@ export async function callModuleDestroyHook(moduleRef: Module): Promise<any> {
     hasOnModuleDestroyHook(moduleClassInstance) &&
     moduleClassHost.isDependencyTreeStatic()
   ) {
-    await moduleClassInstance.onModuleDestroy();
+    try {
+      await moduleClassInstance.onModuleDestroy();
+    } catch (err) {
+      Logger.error(err, (err as Error)?.stack);
+    }
   }
 }

--- a/packages/core/hooks/on-module-destroy.hook.ts
+++ b/packages/core/hooks/on-module-destroy.hook.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import type { OnModuleDestroy } from '@nestjs/common';
 import { isFunction, isNil } from '@nestjs/common/internal';
 import { iterate } from 'iterare';
@@ -49,7 +50,17 @@ export async function callModuleDestroyHook(moduleRef: Module): Promise<any> {
 
   const levels = getSortedHierarchyLevels(groupedInstances, 'DESC');
   for (const level of levels) {
-    await Promise.all(callOperator(groupedInstances.get(level)!));
+    const results = await Promise.allSettled(
+      callOperator(groupedInstances.get(level)!),
+    );
+    results
+      .filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected',
+      )
+      .forEach(result =>
+        Logger.error(result.reason, (result.reason as Error)?.stack),
+      );
   }
 
   // Call the module instance itself

--- a/packages/core/test/hooks/before-app-shutdown.hook.spec.ts
+++ b/packages/core/test/hooks/before-app-shutdown.hook.spec.ts
@@ -103,5 +103,18 @@ describe('BeforeAppShutdown', () => {
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
+
+    it('should not throw when the module class instance hook rejects', async () => {
+      const moduleWrapperRef = moduleRef.getProviderByKey(SampleModule);
+      moduleWrapperRef.instance = {
+        beforeApplicationShutdown: vi
+          .fn()
+          .mockRejectedValue(new Error('module error')),
+      };
+
+      await expect(
+        callBeforeAppShutdownHook(moduleRef, 'SIGTERM'),
+      ).resolves.not.toThrow();
+    });
   });
 });

--- a/packages/core/test/hooks/before-app-shutdown.hook.spec.ts
+++ b/packages/core/test/hooks/before-app-shutdown.hook.spec.ts
@@ -1,4 +1,4 @@
-import { BeforeApplicationShutdown } from '@nestjs/common';
+import { BeforeApplicationShutdown, Logger } from '@nestjs/common';
 import { callBeforeAppShutdownHook } from '../../hooks/before-app-shutdown.hook.js';
 import { NestContainer } from '../../injector/container.js';
 import { Module } from '../../injector/module.js';
@@ -42,6 +42,66 @@ describe('BeforeAppShutdown', () => {
       await callBeforeAppShutdownHook(moduleRef, signal);
 
       expect(hookSpy).toHaveBeenCalledWith(signal);
+    });
+
+    it('should not throw when a provider beforeApplicationShutdown rejects', async () => {
+      class RejectingProvider implements BeforeApplicationShutdown {
+        async beforeApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: RejectingProvider,
+        useValue: new RejectingProvider(),
+      });
+
+      await expect(
+        callBeforeAppShutdownHook(moduleRef, 'SIGTERM'),
+      ).resolves.not.toThrow();
+    });
+
+    it('should call remaining providers even when one throws', async () => {
+      class FailingProvider implements BeforeApplicationShutdown {
+        async beforeApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      class SuccessProvider implements BeforeApplicationShutdown {
+        beforeApplicationShutdown = vi.fn();
+      }
+
+      const successProvider = new SuccessProvider();
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+      moduleRef.addProvider({
+        provide: SuccessProvider,
+        useValue: successProvider,
+      });
+
+      await callBeforeAppShutdownHook(moduleRef, 'SIGTERM');
+
+      expect(successProvider.beforeApplicationShutdown).toHaveBeenCalled();
+    });
+
+    it('should log errors from failed beforeApplicationShutdown hooks', async () => {
+      const errorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+
+      class FailingProvider implements BeforeApplicationShutdown {
+        async beforeApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+
+      await callBeforeAppShutdownHook(moduleRef, 'SIGTERM');
+
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/core/test/hooks/on-app-shutdown.hook.spec.ts
+++ b/packages/core/test/hooks/on-app-shutdown.hook.spec.ts
@@ -99,5 +99,16 @@ describe('OnApplicationShutdown', () => {
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
+
+    it('should not throw when the module class instance hook rejects', async () => {
+      const moduleWrapperRef = moduleRef.getProviderByKey(SampleModule);
+      moduleWrapperRef.instance = {
+        onApplicationShutdown: vi
+          .fn()
+          .mockRejectedValue(new Error('module error')),
+      };
+
+      await expect(callAppShutdownHook(moduleRef)).resolves.not.toThrow();
+    });
   });
 });

--- a/packages/core/test/hooks/on-app-shutdown.hook.spec.ts
+++ b/packages/core/test/hooks/on-app-shutdown.hook.spec.ts
@@ -1,4 +1,4 @@
-import { OnApplicationShutdown } from '@nestjs/common';
+import { Logger, OnApplicationShutdown } from '@nestjs/common';
 import { callAppShutdownHook } from '../../hooks/on-app-shutdown.hook.js';
 import { NestContainer } from '../../injector/container.js';
 import { Module } from '../../injector/module.js';
@@ -40,6 +40,64 @@ describe('OnApplicationShutdown', () => {
       await callAppShutdownHook(moduleRef);
 
       expect(hookSpy).toHaveBeenCalled();
+    });
+
+    it('should not throw when a provider onApplicationShutdown rejects', async () => {
+      class RejectingProvider implements OnApplicationShutdown {
+        async onApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: RejectingProvider,
+        useValue: new RejectingProvider(),
+      });
+
+      await expect(callAppShutdownHook(moduleRef)).resolves.not.toThrow();
+    });
+
+    it('should call remaining providers even when one throws', async () => {
+      class FailingProvider implements OnApplicationShutdown {
+        async onApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      class SuccessProvider implements OnApplicationShutdown {
+        onApplicationShutdown = vi.fn();
+      }
+
+      const successProvider = new SuccessProvider();
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+      moduleRef.addProvider({
+        provide: SuccessProvider,
+        useValue: successProvider,
+      });
+
+      await callAppShutdownHook(moduleRef);
+
+      expect(successProvider.onApplicationShutdown).toHaveBeenCalled();
+    });
+
+    it('should log errors from failed onApplicationShutdown hooks', async () => {
+      const errorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+
+      class FailingProvider implements OnApplicationShutdown {
+        async onApplicationShutdown() {
+          throw new Error('shutdown error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+
+      await callAppShutdownHook(moduleRef);
+
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/core/test/hooks/on-module-destroy.hook.spec.ts
+++ b/packages/core/test/hooks/on-module-destroy.hook.spec.ts
@@ -1,4 +1,4 @@
-import { OnModuleDestroy } from '@nestjs/common';
+import { Logger, OnModuleDestroy } from '@nestjs/common';
 import { callModuleDestroyHook } from '../../hooks/on-module-destroy.hook.js';
 import { NestContainer } from '../../injector/container.js';
 import { Module } from '../../injector/module.js';
@@ -40,6 +40,64 @@ describe('OnModuleDestroy', () => {
       await callModuleDestroyHook(moduleRef);
 
       expect(hookSpy).toHaveBeenCalled();
+    });
+
+    it('should not throw when a provider onModuleDestroy rejects', async () => {
+      class RejectingProvider implements OnModuleDestroy {
+        async onModuleDestroy() {
+          throw new Error('cleanup error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: RejectingProvider,
+        useValue: new RejectingProvider(),
+      });
+
+      await expect(callModuleDestroyHook(moduleRef)).resolves.not.toThrow();
+    });
+
+    it('should call remaining providers even when one throws', async () => {
+      class FailingProvider implements OnModuleDestroy {
+        async onModuleDestroy() {
+          throw new Error('cleanup error');
+        }
+      }
+      class SuccessProvider implements OnModuleDestroy {
+        onModuleDestroy = vi.fn();
+      }
+
+      const successProvider = new SuccessProvider();
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+      moduleRef.addProvider({
+        provide: SuccessProvider,
+        useValue: successProvider,
+      });
+
+      await callModuleDestroyHook(moduleRef);
+
+      expect(successProvider.onModuleDestroy).toHaveBeenCalled();
+    });
+
+    it('should log errors from failed destroy hooks', async () => {
+      const errorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+
+      class FailingProvider implements OnModuleDestroy {
+        async onModuleDestroy() {
+          throw new Error('cleanup error');
+        }
+      }
+      moduleRef.addProvider({
+        provide: FailingProvider,
+        useValue: new FailingProvider(),
+      });
+
+      await callModuleDestroyHook(moduleRef);
+
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 });

--- a/packages/core/test/hooks/on-module-destroy.hook.spec.ts
+++ b/packages/core/test/hooks/on-module-destroy.hook.spec.ts
@@ -99,5 +99,14 @@ describe('OnModuleDestroy', () => {
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
     });
+
+    it('should not throw when the module class instance hook rejects', async () => {
+      const moduleWrapperRef = moduleRef.getProviderByKey(SampleModule);
+      moduleWrapperRef.instance = {
+        onModuleDestroy: vi.fn().mockRejectedValue(new Error('module error')),
+      };
+
+      await expect(callModuleDestroyHook(moduleRef)).resolves.not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?

Closes #17039.

When a shutdown lifecycle hook (`onModuleDestroy`, `beforeApplicationShutdown`, `onApplicationShutdown`) rejects, `Promise.all` fails fast and all remaining provider cleanup in the same module — as well as all subsequent modules — is silently skipped.

## What is the new behavior?

Replace `Promise.all` with `Promise.allSettled` in the three cleanup hook functions. All providers now run their cleanup regardless of sibling failures. Rejected hooks are logged via `Logger.error` with stack trace. Startup hooks (`onModuleInit`, `onApplicationBootstrap`) are unchanged — fail-fast on startup remains intentional.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
