### PR TITLE
test(common): Add unit tests for validateModuleKeys

### DIFF
--- a/packages/common/test/utils/validate-module-keys.util.spec.ts
+++ b/packages/common/test/utils/validate-module-keys.util.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import {
+  validateModuleKeys,
+  INVALID_MODULE_CONFIG_MESSAGE,
+} from '../../utils/validate-module-keys.util';
+
+describe('validateModuleKeys', () => {
+  describe('when all keys are valid', () => {
+    it('should not throw for all valid module metadata keys', () => {
+      expect(() =>
+        validateModuleKeys(['imports', 'exports', 'controllers', 'providers']),
+      ).to.not.throw();
+    });
+
+    it('should not throw for a single valid key', () => {
+      expect(() => validateModuleKeys(['imports'])).to.not.throw();
+    });
+
+    it('should not throw for an empty array', () => {
+      expect(() => validateModuleKeys([])).to.not.throw();
+    });
+  });
+
+  describe('when any key is invalid', () => {
+    it('should throw an error for an unknown property', () => {
+      expect(() => validateModuleKeys(['invalid'])).to.throw();
+    });
+
+    it('should include the invalid property name in the error message', () => {
+      expect(() => validateModuleKeys(['xyz'])).to.throw("'xyz'");
+    });
+
+    it('should throw when mixing valid and invalid keys', () => {
+      expect(() =>
+        validateModuleKeys(['imports', 'exports', 'bogus']),
+      ).to.throw(Error);
+    });
+  });
+
+  describe('INVALID_MODULE_CONFIG_MESSAGE', () => {
+    it('should produce a formatted error string when used as a tagged template', () => {
+      const result = INVALID_MODULE_CONFIG_MESSAGE`${'typo_prop'}`;
+      expect(result).to.equal(
+        "Invalid property 'typo_prop' passed into the @Module() decorator.",
+      );
+    });
+  });
+});

--- a/packages/common/test/utils/validate-module-keys.util.spec.ts
+++ b/packages/common/test/utils/validate-module-keys.util.spec.ts
@@ -22,18 +22,18 @@ describe('validateModuleKeys', () => {
   });
 
   describe('when any key is invalid', () => {
-    it('should throw an error for an unknown property', () => {
-      expect(() => validateModuleKeys(['invalid'])).to.throw();
-    });
-
-    it('should include the invalid property name in the error message', () => {
-      expect(() => validateModuleKeys(['xyz'])).to.throw("'xyz'");
+    it('should throw with the invalid key name in the message', () => {
+      expect(() => validateModuleKeys(['invalid'])).to.throw(
+        "Invalid property 'invalid' passed into the @Module() decorator.",
+      );
     });
 
     it('should throw when mixing valid and invalid keys', () => {
       expect(() =>
         validateModuleKeys(['imports', 'exports', 'bogus']),
-      ).to.throw(Error);
+      ).to.throw(
+        "Invalid property 'bogus' passed into the @Module() decorator.",
+      );
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:  Unit test coverage for `validateModuleKeys` utility

## What is the current behavior?
`validateModuleKeys` has no unit tests. The function validates keys passed to the `@Module()` decorator, but its behavior — valid keys pass, invalid keys throw — is untested.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/common/test/utils/validate-module-keys.util.spec.ts` covering:
- All valid module metadata keys (`imports`, `exports`, `controllers`, `providers`)
- Single valid key, empty array
- Invalid unknown properties throw
- Error message includes the invalid property name
- Mixed valid + invalid keys
- `INVALID_MODULE_CONFIG_MESSAGE` tagged template output

Follows the same mocha/chai patterns as `validate-each.util.spec.ts`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change only adds test coverage and does not modify runtime behavior.