### PR TITLE
test(common): Add unit tests for extendArrayMetadata

### DIFF
--- a/packages/common/test/utils/extend-metadata.util.spec.ts
+++ b/packages/common/test/utils/extend-metadata.util.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { extendArrayMetadata } from '../../utils/extend-metadata.util';
+
+describe('extendArrayMetadata', () => {
+  it('should set metadata when no previous metadata exists', () => {
+    const target = () => {};
+    extendArrayMetadata('test:key', ['a', 'b'], target);
+    expect(Reflect.getMetadata('test:key', target)).to.be.eql(['a', 'b']);
+  });
+
+  it('should extend existing metadata array', () => {
+    const target = () => {};
+    Reflect.defineMetadata('test:key', ['a'], target);
+    extendArrayMetadata('test:key', ['b', 'c'], target);
+    expect(Reflect.getMetadata('test:key', target)).to.be.eql(['a', 'b', 'c']);
+  });
+
+  it('should accept an empty metadata array', () => {
+    const target = () => {};
+    Reflect.defineMetadata('test:key', ['a'], target);
+    extendArrayMetadata('test:key', [], target);
+    expect(Reflect.getMetadata('test:key', target)).to.be.eql(['a']);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add unit test coverage for extendArrayMetadata utility

## What is the current behavior?
`extendArrayMetadata` has no unit tests. This utility is used by 5 core
decorators (`@UsePipes`, `@UseInterceptors`, `@UseGuards`, `@UseFilters`,
`@Header`) — 21 import sites — yet its core array-merge logic is untested.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/common/test/utils/extend-metadata.util.spec.ts` covering:
- Setting metadata when no previous metadata exists (coercion from undefined)
- Extending an existing metadata array (merge correctness)
- Accepting an empty metadata array (no-op edge case)

Follows the same mocha/chai pattern as `validate-each.util.spec.ts`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change only adds test coverage and does not modify runtime behavior.