### PR TITLE
test(common): Add unit tests for assignCustomParameterMetadata

### DIFF
--- a/packages/common/test/utils/assign-custom-metadata.util.spec.ts
+++ b/packages/common/test/utils/assign-custom-metadata.util.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import { assignCustomParameterMetadata } from '../../utils/assign-custom-metadata.util';
+
+describe('assignCustomParameterMetadata', () => {
+  const factory = (data: any, context: any) => data;
+  const mockPipe = { transform: () => null };
+
+  it('should use the correct composite key format', () => {
+    const args = {};
+    const result = assignCustomParameterMetadata(args, 'abc', 2, factory);
+    expect(result).to.have.property('abc__customRouteArgs__:2');
+  });
+
+  it('should preserve existing args in the returned object', () => {
+    const args = { 0: { index: 0, data: 'existing' } };
+    const result = assignCustomParameterMetadata(args, 'xyz', 1, factory);
+    expect(result['0']).to.be.eql({ index: 0, data: 'existing' });
+  });
+
+  it('should store index, factory, data, and pipes in the entry', () => {
+    const data = { param: 'value' };
+    const pipes = [mockPipe];
+    const result = assignCustomParameterMetadata(
+      {},
+      'def',
+      3,
+      factory,
+      data,
+      ...pipes,
+    );
+    const entry = result['def__customRouteArgs__:3'];
+    expect(entry.index).to.equal(3);
+    expect(entry.factory).to.equal(factory);
+    expect(entry.data).to.equal(data);
+    expect(entry.pipes).to.be.eql(pipes);
+  });
+
+  it('should set data to undefined when not provided', () => {
+    const result = assignCustomParameterMetadata({}, 'a', 0, factory);
+    expect(result['a__customRouteArgs__:0'].data).to.be.undefined;
+  });
+
+  it('should set pipes to an empty array when not provided', () => {
+    const result = assignCustomParameterMetadata({}, 'b', 1, factory);
+    expect(result['b__customRouteArgs__:1'].pipes).to.be.eql([]);
+  });
+
+  it('should accept a numeric paramtype', () => {
+    const result = assignCustomParameterMetadata({}, 123, 0, factory);
+    expect(result).to.have.property('123__customRouteArgs__:0');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add unit test coverage for assignCustomParameterMetadata utility

## What is the current behavior?
`assignCustomParameterMetadata` has no unit tests. This utility constructs
the composite metadata key for custom parameter decorators (created via
`createParamDecorator`) and stores the factory, data, and pipes in the
route args metadata — yet its core logic is untested. A regression here
would silently break every custom parameter decorator (`@User()`, `@Ip()`,
`@CurrentUser()`, etc.) across all NestJS applications.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/common/test/utils/assign-custom-metadata.util.spec.ts` covering:
- Composite key format (`${paramtype}__customRouteArgs__:${index}`) - the
  sentinel that distinguishes custom decorators from built-in route params
- Preserving existing args via spread (supports stacking decorators)
- Correct storage of index, factory, data, and pipes in the entry
- Optional `data` parameter (undefined when omitted)
- Optional `pipes` rest parameter (empty array when omitted)
- Numeric paramtype support (type union `number | string`)

Follows the same mocha/chai pattern as previous test PRs.



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change only adds test coverage and does not modify runtime behavior.