### PR TITLE
test(common): Add unit tests for HttpErrorByCode

### DIFF
--- a/packages/common/test/utils/http-error-by-code.util.spec.ts
+++ b/packages/common/test/utils/http-error-by-code.util.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import { HttpStatus } from '../../enums';
+import { HttpErrorByCode } from '../../utils/http-error-by-code.util';
+import { BadGatewayException } from '../../exceptions/bad-gateway.exception';
+import { BadRequestException } from '../../exceptions/bad-request.exception';
+import { ConflictException } from '../../exceptions/conflict.exception';
+import { ForbiddenException } from '../../exceptions/forbidden.exception';
+import { GatewayTimeoutException } from '../../exceptions/gateway-timeout.exception';
+import { GoneException } from '../../exceptions/gone.exception';
+import { ImATeapotException } from '../../exceptions/im-a-teapot.exception';
+import { InternalServerErrorException } from '../../exceptions/internal-server-error.exception';
+import { MethodNotAllowedException } from '../../exceptions/method-not-allowed.exception';
+import { NotAcceptableException } from '../../exceptions/not-acceptable.exception';
+import { NotFoundException } from '../../exceptions/not-found.exception';
+import { NotImplementedException } from '../../exceptions/not-implemented.exception';
+import { PayloadTooLargeException } from '../../exceptions/payload-too-large.exception';
+import { PreconditionFailedException } from '../../exceptions/precondition-failed.exception';
+import { RequestTimeoutException } from '../../exceptions/request-timeout.exception';
+import { ServiceUnavailableException } from '../../exceptions/service-unavailable.exception';
+import { UnauthorizedException } from '../../exceptions/unauthorized.exception';
+import { UnprocessableEntityException } from '../../exceptions/unprocessable-entity.exception';
+import { UnsupportedMediaTypeException } from '../../exceptions/unsupported-media-type.exception';
+
+describe('HttpErrorByCode', () => {
+  const testCases: [HttpStatus, new (...args: unknown[]) => unknown][] = [
+    [HttpStatus.BAD_GATEWAY, BadGatewayException],
+    [HttpStatus.BAD_REQUEST, BadRequestException],
+    [HttpStatus.CONFLICT, ConflictException],
+    [HttpStatus.FORBIDDEN, ForbiddenException],
+    [HttpStatus.GATEWAY_TIMEOUT, GatewayTimeoutException],
+    [HttpStatus.GONE, GoneException],
+    [HttpStatus.I_AM_A_TEAPOT, ImATeapotException],
+    [HttpStatus.INTERNAL_SERVER_ERROR, InternalServerErrorException],
+    [HttpStatus.METHOD_NOT_ALLOWED, MethodNotAllowedException],
+    [HttpStatus.NOT_ACCEPTABLE, NotAcceptableException],
+    [HttpStatus.NOT_FOUND, NotFoundException],
+    [HttpStatus.NOT_IMPLEMENTED, NotImplementedException],
+    [HttpStatus.PAYLOAD_TOO_LARGE, PayloadTooLargeException],
+    [HttpStatus.PRECONDITION_FAILED, PreconditionFailedException],
+    [HttpStatus.REQUEST_TIMEOUT, RequestTimeoutException],
+    [HttpStatus.SERVICE_UNAVAILABLE, ServiceUnavailableException],
+    [HttpStatus.UNAUTHORIZED, UnauthorizedException],
+    [HttpStatus.UNPROCESSABLE_ENTITY, UnprocessableEntityException],
+    [HttpStatus.UNSUPPORTED_MEDIA_TYPE, UnsupportedMediaTypeException],
+  ];
+
+  it('should map each HTTP status code to the correct exception class', () => {
+    testCases.forEach(([code, ExceptionClass]) => {
+      expect(HttpErrorByCode[code]).to.equal(ExceptionClass);
+    });
+  });
+
+  it('should have exactly one entry per test case', () => {
+    expect(Object.keys(HttpErrorByCode).length).to.equal(testCases.length);
+  });
+
+  it('each mapped exception should be constructible', () => {
+    testCases.forEach(([, ExceptionClass]) => {
+      expect(() => new ExceptionClass()).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Add unit test coverage for HttpErrorByCode utility

## What is the current behavior?
`HttpErrorByCode` has no unit tests. This utility maps 19 HTTP status codes
to their corresponding exception classes (e.g. `400` → `BadRequestException`).
It is used by 8 built-in pipes (validation, parse-int, parse-uuid, parse-float,
parse-enum, parse-date, parse-bool, parse-file) to throw the correct HTTP
exception on validation failure. A wrong mapping silently causes all these
pipes to throw the wrong exception across every NestJS application.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/common/test/utils/http-error-by-code.util.spec.ts` covering:
- Each of the 19 status codes maps to the correct exception class
  (verified by reference equality)
- Total entry count is exactly 19 (catches silent additions or deletions)
- Each exception class is constructible (imports resolve at runtime)

Follows the same `testCases.forEach` data-driven pattern used in
`http.exception.spec.ts`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change only adds test coverage and does not modify runtime behavior.