### PR TITLE
test(common): Add unit tests for cli-colors utility

### DIFF
--- a/packages/common/test/utils/cli-colors.util.spec.ts
+++ b/packages/common/test/utils/cli-colors.util.spec.ts
@@ -1,0 +1,50 @@
+import { expect } from 'chai';
+import { clc, isColorAllowed, yellow } from '../../utils/cli-colors.util';
+
+describe('cli-colors', () => {
+  afterEach(() => {
+    delete process.env.NO_COLOR;
+  });
+
+  describe('isColorAllowed', () => {
+    it('should return true by default', () => {
+      expect(isColorAllowed()).to.be.true;
+    });
+
+    it('should return false when NO_COLOR is set', () => {
+      process.env.NO_COLOR = '1';
+      expect(isColorAllowed()).to.be.false;
+    });
+  });
+
+  describe('clc', () => {
+    it('green should wrap text in ANSI green codes', () => {
+      expect(clc.green('text')).to.equal('\x1B[32mtext\x1B[39m');
+    });
+
+    it('bold should wrap text in ANSI bold codes', () => {
+      expect(clc.bold('text')).to.equal('\x1B[1mtext\x1B[0m');
+    });
+
+    it('should return raw text for all methods when NO_COLOR is set', () => {
+      process.env.NO_COLOR = '1';
+      const formatters = [
+        'bold',
+        'green',
+        'yellow',
+        'red',
+        'magentaBright',
+        'cyanBright',
+      ] as const;
+      formatters.forEach(key => {
+        expect(clc[key]('text')).to.equal('text');
+      });
+    });
+  });
+
+  describe('yellow', () => {
+    it('should wrap text in extended ANSI yellow codes', () => {
+      expect(yellow('text')).to.equal('\x1B[38;5;3mtext\x1B[39m');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:  Add unit test coverage for cli-colors utility

## What is the current behavior?
`cli-colors.util.ts` has no unit tests. This utility provides ANSI color
wrapping for NestJS CLI output (logger, REPL, injector) and respects the
`NO_COLOR` environment variable standard — yet its color wrapping and
env-var logic are untested.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/common/test/utils/cli-colors.util.spec.ts` covering:
- `isColorAllowed()` returns `true` by default
- `isColorAllowed()` returns `false` when `NO_COLOR` is set
- `clc.green()` wraps text in ANSI green codes
- `clc.bold()` wraps text in ANSI bold codes (different close sequence)
- All `clc.*` methods return raw text when `NO_COLOR` is set
- Standalone `yellow()` uses extended ANSI codes

Uses `afterEach` cleanup to prevent cross-test env var contamination.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This change only adds test coverage and does not modify runtime behavior.
