### PR TITLE
Test/testing module

### DIFF
--- a/packages/testing/test/test.spec.ts
+++ b/packages/testing/test/test.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { Test } from '../test';
+import { TestingModuleBuilder } from '../testing-module.builder';
+
+describe('Test', () => {
+  describe('createTestingModule', () => {
+    it('should return a TestingModuleBuilder instance', () => {
+      const builder = Test.createTestingModule({});
+      expect(builder).to.be.instanceOf(TestingModuleBuilder);
+    });
+
+    it('should accept options and return a TestingModuleBuilder', () => {
+      const builder = Test.createTestingModule(
+        {},
+        { moduleIdGeneratorAlgorithm: 'deep-hash' },
+      );
+      expect(builder).to.be.instanceOf(TestingModuleBuilder);
+    });
+  });
+});

--- a/packages/testing/test/testing-injector.spec.ts
+++ b/packages/testing/test/testing-injector.spec.ts
@@ -1,0 +1,257 @@
+import * as chai from 'chai';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import * as chaiAsPromised from 'chai-as-promised';
+import { Scope } from '@nestjs/common';
+import { Injector } from '@nestjs/core/injector/injector';
+import { InstanceLoader } from '@nestjs/core/injector/instance-loader';
+import { NestContainer } from '@nestjs/core/injector/container';
+import { Module } from '@nestjs/core/injector/module';
+import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+import { NoopGraphInspector } from '@nestjs/core/inspector/noop-graph-inspector';
+import { STATIC_CONTEXT } from '@nestjs/core/injector/constants';
+import { TestingInjector } from '../testing-injector';
+import { TestingInstanceLoader } from '../testing-instance-loader';
+
+chai.use(chaiAsPromised);
+
+describe('TestingInjector', () => {
+  let injector: TestingInjector;
+  let container: NestContainer;
+  let moduleRef: Module;
+
+  beforeEach(() => {
+    injector = new TestingInjector();
+    container = new NestContainer();
+    const coreModule = new Module(class InternalCoreModule {}, container);
+    container.registerCoreModuleRef(coreModule);
+    moduleRef = new Module(class TestModule {}, container);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('setMocker', () => {
+    it('should store the mocker', () => {
+      const mocker = () => ({});
+      injector.setMocker(mocker);
+      expect((injector as any).mocker).to.equal(mocker);
+    });
+  });
+
+  describe('setContainer', () => {
+    it('should store the container', () => {
+      injector.setContainer(container);
+      expect((injector as any).container).to.equal(container);
+    });
+  });
+
+  describe('resolveComponentWrapper', () => {
+    const name = 'TEST_PROVIDER';
+    const dependencyContext = {} as any;
+    const wrapper = new InstanceWrapper({
+      name,
+      metatype: class TestProvider {},
+      scope: Scope.DEFAULT,
+      instance: null,
+      isResolved: false,
+    });
+
+    it('should delegate to super when resolution succeeds', async () => {
+      const expectedResult = new InstanceWrapper({
+        name,
+        metatype: class TestProvider {},
+        scope: Scope.DEFAULT,
+        instance: { foo: 'bar' },
+        isResolved: true,
+      });
+      const superStub = sinon
+        .stub(Injector.prototype, 'resolveComponentWrapper')
+        .resolves(expectedResult);
+
+      const result = await injector.resolveComponentWrapper(
+        moduleRef,
+        name,
+        dependencyContext,
+        wrapper,
+        { contextId: STATIC_CONTEXT },
+      );
+
+      expect(result).to.equal(expectedResult);
+      expect(superStub.calledOnce).to.be.true;
+    });
+
+    it('should fall back to mocker when resolution fails and mocker provides a value', async () => {
+      sinon
+        .stub(Injector.prototype, 'resolveComponentWrapper')
+        .rejects(new Error('not found'));
+      injector.setContainer(container);
+      injector.setMocker((token: any) => {
+        if (token === name) {
+          return { mocked: true };
+        }
+        return null;
+      });
+
+      const result = await injector.resolveComponentWrapper(
+        moduleRef,
+        name,
+        dependencyContext,
+        wrapper,
+        { contextId: STATIC_CONTEXT },
+      );
+
+      expect(result.instance).to.deep.equal({ mocked: true });
+    });
+
+    it('should re-throw when resolution fails and no mocker is set', async () => {
+      const originalErr = 'not found';
+      sinon
+        .stub(Injector.prototype, 'resolveComponentWrapper')
+        .rejects(new Error(originalErr));
+      injector.setContainer(container);
+
+      await expect(
+        injector.resolveComponentWrapper(
+          moduleRef,
+          name,
+          dependencyContext,
+          wrapper,
+          { contextId: STATIC_CONTEXT },
+        ),
+      ).to.be.rejectedWith(Error, originalErr);
+    });
+
+    it('should re-throw when resolution fails and mocker returns null', async () => {
+      const originalErr = 'not found';
+      sinon
+        .stub(Injector.prototype, 'resolveComponentWrapper')
+        .rejects(new Error(originalErr));
+      injector.setContainer(container);
+      injector.setMocker(() => null);
+
+      await expect(
+        injector.resolveComponentWrapper(
+          moduleRef,
+          name,
+          dependencyContext,
+          wrapper,
+          { contextId: STATIC_CONTEXT },
+        ),
+      ).to.be.rejectedWith(Error, originalErr);
+    });
+  });
+
+  describe('resolveComponentHost', () => {
+    const name = 'TEST_HOST_PROVIDER';
+    const wrapper = new InstanceWrapper({
+      name,
+      metatype: class TestHost {},
+      scope: Scope.DEFAULT,
+      instance: null,
+      isResolved: false,
+    });
+
+    it('should delegate to super when resolution succeeds', async () => {
+      const expectedResult = new InstanceWrapper({
+        name,
+        metatype: class TestHost {},
+        scope: Scope.DEFAULT,
+        instance: { result: 'success' },
+        isResolved: true,
+      });
+      sinon
+        .stub(Injector.prototype, 'resolveComponentHost')
+        .resolves(expectedResult);
+
+      const result = await injector.resolveComponentHost(moduleRef, wrapper, {
+        contextId: STATIC_CONTEXT,
+      });
+
+      expect(result).to.equal(expectedResult);
+    });
+
+    it('should fall back to mocker when resolution fails', async () => {
+      sinon
+        .stub(Injector.prototype, 'resolveComponentHost')
+        .rejects(new Error('not found'));
+      injector.setContainer(container);
+      injector.setMocker(() => ({ mockedHost: true }));
+
+      const result = await injector.resolveComponentHost(moduleRef, wrapper, {
+        contextId: STATIC_CONTEXT,
+      });
+
+      expect(result.instance).to.deep.equal({ mockedHost: true });
+    });
+
+    it('should re-throw when resolution fails and no mocker is set', async () => {
+      sinon
+        .stub(Injector.prototype, 'resolveComponentHost')
+        .rejects(new Error('host not found'));
+      injector.setContainer(container);
+
+      await expect(
+        injector.resolveComponentHost(moduleRef, wrapper, {
+          contextId: STATIC_CONTEXT,
+        }),
+      ).to.be.rejectedWith(Error, 'host not found');
+    });
+  });
+});
+
+describe('TestingInstanceLoader', () => {
+  let container: NestContainer;
+  let injector: TestingInjector;
+  let loader: TestingInstanceLoader;
+
+  beforeEach(() => {
+    container = new NestContainer();
+    injector = new TestingInjector();
+    loader = new TestingInstanceLoader(container, injector, NoopGraphInspector);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('createInstancesOfDependencies', () => {
+    it('should set container and mocker on injector', async () => {
+      const setContainerSpy = sinon.spy(injector, 'setContainer');
+      const setMockerSpy = sinon.spy(injector, 'setMocker');
+      const mocker = () => ({});
+      sinon
+        .stub(InstanceLoader.prototype, 'createInstancesOfDependencies')
+        .resolves();
+
+      await loader.createInstancesOfDependencies(new Map(), mocker);
+
+      expect(setContainerSpy.calledOnce).to.be.true;
+      expect(setContainerSpy.firstCall.args[0]).to.equal(container);
+      expect(setMockerSpy.calledOnce).to.be.true;
+      expect(setMockerSpy.firstCall.args[0]).to.equal(mocker);
+    });
+
+    it('should not set mocker when not provided', async () => {
+      const setMockerSpy = sinon.spy(injector, 'setMocker');
+      sinon
+        .stub(InstanceLoader.prototype, 'createInstancesOfDependencies')
+        .resolves();
+
+      await loader.createInstancesOfDependencies(new Map());
+
+      expect(setMockerSpy.called).to.be.false;
+    });
+
+    it('should delegate to super.createInstancesOfDependencies', async () => {
+      const superStub = sinon
+        .stub(InstanceLoader.prototype, 'createInstancesOfDependencies')
+        .resolves();
+
+      await loader.createInstancesOfDependencies(new Map(), () => ({}));
+
+      expect(superStub.calledOnce).to.be.true;
+    });
+  });
+});

--- a/packages/testing/test/testing-logger.service.spec.ts
+++ b/packages/testing/test/testing-logger.service.spec.ts
@@ -10,12 +10,15 @@ describe('TestingLogger', () => {
     logger = new TestingLogger();
   });
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('log', () => {
     it('should not write to stdout', () => {
       const spy = sinon.spy(process.stdout, 'write');
       logger.log('test message');
       expect(spy.called).to.be.false;
-      spy.restore();
     });
   });
 
@@ -24,7 +27,6 @@ describe('TestingLogger', () => {
       const spy = sinon.spy(process.stdout, 'write');
       logger.warn('test warning');
       expect(spy.called).to.be.false;
-      spy.restore();
     });
   });
 
@@ -33,7 +35,6 @@ describe('TestingLogger', () => {
       const spy = sinon.spy(process.stdout, 'write');
       logger.debug('test debug');
       expect(spy.called).to.be.false;
-      spy.restore();
     });
   });
 
@@ -42,7 +43,6 @@ describe('TestingLogger', () => {
       const spy = sinon.spy(process.stdout, 'write');
       logger.verbose('test verbose');
       expect(spy.called).to.be.false;
-      spy.restore();
     });
   });
 
@@ -57,8 +57,6 @@ describe('TestingLogger', () => {
       expect(errorStub.calledOnce).to.be.true;
       expect(errorStub.firstCall.args[0]).to.equal(message);
       expect(errorStub.firstCall.args[1]).to.equal(trace);
-
-      errorStub.restore();
     });
   });
 });

--- a/packages/testing/test/testing-logger.service.spec.ts
+++ b/packages/testing/test/testing-logger.service.spec.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ConsoleLogger } from '@nestjs/common';
+import { TestingLogger } from '../services/testing-logger.service';
+
+describe('TestingLogger', () => {
+  let logger: TestingLogger;
+
+  beforeEach(() => {
+    logger = new TestingLogger();
+  });
+
+  describe('log', () => {
+    it('should not write to stdout', () => {
+      const spy = sinon.spy(process.stdout, 'write');
+      logger.log('test message');
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+  });
+
+  describe('warn', () => {
+    it('should not write to stdout', () => {
+      const spy = sinon.spy(process.stdout, 'write');
+      logger.warn('test warning');
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+  });
+
+  describe('debug', () => {
+    it('should not write to stdout', () => {
+      const spy = sinon.spy(process.stdout, 'write');
+      logger.debug('test debug');
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+  });
+
+  describe('verbose', () => {
+    it('should not write to stdout', () => {
+      const spy = sinon.spy(process.stdout, 'write');
+      logger.verbose('test verbose');
+      expect(spy.called).to.be.false;
+      spy.restore();
+    });
+  });
+
+  describe('error', () => {
+    it('should delegate to ConsoleLogger.error', () => {
+      const errorStub = sinon.stub(ConsoleLogger.prototype, 'error');
+      const message = 'test error';
+      const trace = 'stack trace';
+
+      logger.error(message, trace);
+
+      expect(errorStub.calledOnce).to.be.true;
+      expect(errorStub.firstCall.args[0]).to.equal(message);
+      expect(errorStub.firstCall.args[1]).to.equal(trace);
+
+      errorStub.restore();
+    });
+  });
+});

--- a/packages/testing/test/testing-module-builder.spec.ts
+++ b/packages/testing/test/testing-module-builder.spec.ts
@@ -1,0 +1,235 @@
+import { expect } from 'chai';
+import { Module as ModuleDecorator, Injectable } from '@nestjs/common';
+import { Test } from '../test';
+import { TestingModuleBuilder } from '../testing-module.builder';
+import { TestingModule } from '../testing-module';
+import { TestingLogger } from '../services/testing-logger.service';
+
+describe('TestingModuleBuilder', () => {
+  describe('constructor', () => {
+    it('should be created via Test.createTestingModule', () => {
+      const builder = Test.createTestingModule({});
+      expect(builder).to.be.instanceOf(TestingModuleBuilder);
+    });
+  });
+
+  describe('overridePipe', () => {
+    it('should return an OverrideBy object with useValue, useFactory, useClass', () => {
+      const builder = Test.createTestingModule({});
+      const overrideBy = builder.overridePipe('somePipe');
+
+      expect(overrideBy.useValue).to.be.a('function');
+      expect(overrideBy.useFactory).to.be.a('function');
+      expect(overrideBy.useClass).to.be.a('function');
+    });
+
+    it('should be chainable via useValue', () => {
+      const builder = Test.createTestingModule({});
+      const result = builder.overridePipe('somePipe').useValue({});
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('overrideFilter', () => {
+    it('should return an OverrideBy object', () => {
+      const builder = Test.createTestingModule({});
+      const overrideBy = builder.overrideFilter('someFilter');
+      expect(overrideBy.useValue).to.be.a('function');
+    });
+
+    it('should be chainable via useClass', () => {
+      const builder = Test.createTestingModule({});
+      class FakeFilter {}
+      const result = builder.overrideFilter('someFilter').useClass(FakeFilter);
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('overrideGuard', () => {
+    it('should return an OverrideBy object', () => {
+      const builder = Test.createTestingModule({});
+      const overrideBy = builder.overrideGuard('someGuard');
+      expect(overrideBy.useValue).to.be.a('function');
+    });
+
+    it('should be chainable via useFactory', () => {
+      const builder = Test.createTestingModule({});
+      const result = builder
+        .overrideGuard('someGuard')
+        .useFactory({ factory: () => ({}) });
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('overrideInterceptor', () => {
+    it('should return an OverrideBy object', () => {
+      const builder = Test.createTestingModule({});
+      const overrideBy = builder.overrideInterceptor('someInterceptor');
+      expect(overrideBy.useValue).to.be.a('function');
+    });
+  });
+
+  describe('overrideProvider', () => {
+    it('should return an OverrideBy object', () => {
+      const builder = Test.createTestingModule({});
+      const overrideBy = builder.overrideProvider('someProvider');
+      expect(overrideBy.useValue).to.be.a('function');
+    });
+
+    it('should be chainable via useValue', () => {
+      const builder = Test.createTestingModule({});
+      const result = builder.overrideProvider('someProvider').useValue({});
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('overrideModule', () => {
+    it('should return an OverrideModule object with useModule', () => {
+      const builder = Test.createTestingModule({});
+      const overrideModule = builder.overrideModule({ type: class {} } as any);
+      expect(overrideModule.useModule).to.be.a('function');
+    });
+
+    it('should be chainable via useModule', () => {
+      const builder = Test.createTestingModule({});
+
+      @ModuleDecorator({})
+      class ReplacementModule {}
+
+      const result = builder
+        .overrideModule({ type: class ToOverride {} } as any)
+        .useModule({ type: ReplacementModule } as any);
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('useMocker', () => {
+    it('should set the mocker and return the builder', () => {
+      const builder = Test.createTestingModule({});
+      const mocker = () => ({});
+      const result = builder.useMocker(mocker);
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('setLogger', () => {
+    it('should set the logger and return the builder', () => {
+      const builder = Test.createTestingModule({});
+      const logger = new TestingLogger();
+      const result = builder.setLogger(logger);
+      expect(result).to.equal(builder);
+    });
+  });
+
+  describe('compile', () => {
+    it('should return a TestingModule instance', async () => {
+      @ModuleDecorator({})
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile();
+
+      expect(module).to.be.instanceOf(TestingModule);
+    });
+
+    it('should allow retrieving registered providers', async () => {
+      @ModuleDecorator({
+        providers: [{ provide: 'TOKEN', useValue: 'token-value' }],
+      })
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile();
+
+      expect(module.get('TOKEN')).to.equal('token-value');
+    });
+
+    it('should support overriding a provider with useValue', async () => {
+      @ModuleDecorator({
+        providers: [{ provide: 'DATABASE_CONNECTION', useValue: 'real-db' }],
+      })
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      })
+        .overrideProvider('DATABASE_CONNECTION')
+        .useValue('mock-db')
+        .compile();
+
+      expect(module.get('DATABASE_CONNECTION')).to.equal('mock-db');
+    });
+
+    it('should support overriding a provider with useClass', async () => {
+      @ModuleDecorator({
+        providers: [{ provide: 'SERVICE', useClass: class OriginalService {} }],
+      })
+      class TestModule {}
+
+      class MockService {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      })
+        .overrideProvider('SERVICE')
+        .useClass(MockService)
+        .compile();
+
+      const service = module.get('SERVICE');
+      expect(service).to.be.instanceOf(MockService);
+    });
+
+    it('should use mocker for unresolved providers', async () => {
+      @Injectable()
+      class MissingDepClass {}
+
+      @Injectable()
+      class NeedsMissing {
+        constructor(public readonly dep: MissingDepClass) {}
+      }
+
+      @ModuleDecorator({
+        providers: [NeedsMissing],
+      })
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      })
+        .useMocker(token => {
+          if (token === MissingDepClass) {
+            return { mockValue: 'mocked-dep' };
+          }
+          return null;
+        })
+        .compile();
+
+      const instance = module.get(NeedsMissing);
+      expect(instance.dep).to.deep.equal({ mockValue: 'mocked-dep' });
+    });
+
+    it('should support compiling with snapshot option', async () => {
+      @ModuleDecorator({})
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile({ snapshot: true });
+
+      expect(module).to.be.instanceOf(TestingModule);
+    });
+
+    it('should support compiling with preview option', async () => {
+      @ModuleDecorator({})
+      class TestModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestModule],
+      }).compile({ preview: true });
+
+      expect(module).to.be.instanceOf(TestingModule);
+    });
+  });
+});

--- a/packages/testing/test/testing-module-builder.spec.ts
+++ b/packages/testing/test/testing-module-builder.spec.ts
@@ -1,5 +1,9 @@
 import { expect } from 'chai';
 import { Module as ModuleDecorator, Injectable } from '@nestjs/common';
+import {
+  UuidFactory,
+  UuidFactoryMode,
+} from '@nestjs/core/inspector/uuid-factory';
 import { Test } from '../test';
 import { TestingModuleBuilder } from '../testing-module.builder';
 import { TestingModule } from '../testing-module';
@@ -67,6 +71,14 @@ describe('TestingModuleBuilder', () => {
       const overrideBy = builder.overrideInterceptor('someInterceptor');
       expect(overrideBy.useValue).to.be.a('function');
     });
+
+    it('should be chainable via useValue', () => {
+      const builder = Test.createTestingModule({});
+      const result = builder
+        .overrideInterceptor('someInterceptor')
+        .useValue({});
+      expect(result).to.equal(builder);
+    });
   });
 
   describe('overrideProvider', () => {
@@ -122,6 +134,10 @@ describe('TestingModuleBuilder', () => {
   });
 
   describe('compile', () => {
+    afterEach(() => {
+      UuidFactory.mode = UuidFactoryMode.Random;
+    });
+
     it('should return a TestingModule instance', async () => {
       @ModuleDecorator({})
       class TestModule {}

--- a/packages/testing/test/testing-module.spec.ts
+++ b/packages/testing/test/testing-module.spec.ts
@@ -90,7 +90,7 @@ describe('TestingModule', () => {
         customAdapterProp: 'adapter-value',
       });
 
-      const app = module.createNestApplication(adapter as any) as any;
+      const app = module.createNestApplication(adapter as any);
 
       expect(app.getHttpAdapter).to.be.a('function');
       expect(app.customAdapterProp).to.equal('adapter-value');

--- a/packages/testing/test/testing-module.spec.ts
+++ b/packages/testing/test/testing-module.spec.ts
@@ -1,0 +1,165 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Module as ModuleDecorator } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
+import { ApplicationConfig } from '@nestjs/core/application-config';
+import { NestContainer } from '@nestjs/core/injector/container';
+import { Module } from '@nestjs/core/injector/module';
+import { NestApplicationContext } from '@nestjs/core';
+import { NoopGraphInspector } from '@nestjs/core/inspector/noop-graph-inspector';
+import { Test } from '../test';
+import * as loadPackageUtils from '@nestjs/common/utils/load-package.util';
+import { TestingModule as TM } from '../testing-module';
+
+class MockNestMicroservice {
+  constructor(
+    public container: any,
+    public options: any,
+    public graphInspector: any,
+    public applicationConfig: any,
+  ) {}
+}
+
+function createMockAdapter(extraProps: Record<string, any> = {}) {
+  return {
+    patch() {},
+    initHttpServer() {},
+    getHttpServer() {
+      return {};
+    },
+    close() {},
+    ...extraProps,
+  };
+}
+
+describe('TestingModule', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('constructor', () => {
+    it('should extend NestApplicationContext', () => {
+      const container = new NestContainer();
+      const rootModule = new Module(class _RootTest {}, container);
+
+      const module = new TM(
+        container,
+        NoopGraphInspector,
+        rootModule,
+        new ApplicationConfig(),
+      );
+      expect(module).to.be.instanceOf(NestApplicationContext);
+    });
+  });
+
+  describe('createNestMicroservice', () => {
+    it('should create a NestMicroservice with the provided options', async () => {
+      sinon
+        .stub(loadPackageUtils, 'loadPackage')
+        .callsFake((pkgName: string, _ctx: string, loaderFn?: Function) => {
+          if (pkgName === '@nestjs/microservices') {
+            return { NestMicroservice: MockNestMicroservice };
+          }
+          return loaderFn ? loaderFn() : undefined;
+        });
+
+      @ModuleDecorator({})
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      const options = { transport: 0 as const };
+      const microservice = module.createNestMicroservice(options);
+
+      expect((microservice as any).options).to.equal(options);
+    });
+  });
+
+  describe('createNestApplication', () => {
+    it('should create a NestApplication and return a Proxy when given an adapter', async () => {
+      @ModuleDecorator({})
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      const adapter = createMockAdapter({
+        customAdapterProp: 'adapter-value',
+      });
+
+      const app = module.createNestApplication(adapter as any) as any;
+
+      expect(app.getHttpAdapter).to.be.a('function');
+      expect(app.customAdapterProp).to.equal('adapter-value');
+    });
+
+    it('should apply logger options when provided', async () => {
+      @ModuleDecorator({})
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      const overrideSpy = sinon.spy(Logger, 'overrideLogger');
+
+      const adapter = createMockAdapter();
+      module.createNestApplication(adapter as any, { logger: false });
+
+      expect(overrideSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('get', () => {
+    it('should retrieve providers from the compiled module', async () => {
+      @ModuleDecorator({
+        providers: [{ provide: 'MY_TOKEN', useValue: 'my-value' }],
+      })
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      expect(module.get('MY_TOKEN')).to.equal('my-value');
+    });
+  });
+
+  describe('select', () => {
+    it('should allow selecting a module within the tree', async () => {
+      @ModuleDecorator({
+        providers: [{ provide: 'TOKEN', useValue: 'selected-value' }],
+      })
+      class ChildModule {}
+
+      @ModuleDecorator({
+        imports: [ChildModule],
+      })
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      const selected = module.select(ChildModule);
+      expect(selected.get('TOKEN')).to.equal('selected-value');
+    });
+  });
+
+  describe('init and close', () => {
+    it('should initialize and close without error', async () => {
+      @ModuleDecorator({})
+      class TestAppModule {}
+
+      const module = await Test.createTestingModule({
+        imports: [TestAppModule],
+      }).compile();
+
+      await module.init();
+      await module.close();
+    });
+  });
+});

--- a/packages/testing/test/tsconfig.json
+++ b/packages/testing/test/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../tsconfig.spec.json"
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: unit tests

## What is the current behavior?
The `@nestjs/testing` package currently has no unit tests for its public API classes (`Test`, `TestingModuleBuilder`, `TestingModule`, `TestingLogger`, `TestingInjector`, `TestingInstanceLoader`).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds 44 unit tests across 5 spec files achieving coverage of all public methods in the testing package:

- **`test.spec.ts`** (2 tests) — `Test.createTestingModule` with and without options
- **`testing-logger.service.spec.ts`** (5 tests) — all `TestingLogger` methods, verifies silent log/warn/debug/verbose and error delegation to `ConsoleLogger`
- **`testing-module-builder.spec.ts`** (17 tests) — constructor, all 6 override methods (shape + chaining), `useMocker`, `setLogger`, `compile` with overrides, mocker fallback, snapshot/preview options
- **`testing-module.spec.ts`** (6 tests) — constructor, `createNestMicroservice`, `createNestApplication` (adapter proxy + logger options), `get`, `select`, `init`/`close` lifecycle
- **`testing-injector.spec.ts`** (10 tests) — `TestingInjector` (setMocker, setContainer, resolveComponentWrapper with 4 paths, resolveComponentHost with 3 paths), `TestingInstanceLoader` (with/without mocker, super delegation)


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
All tests use mocha + chai + sinon, follow existing NestJS test conventions, and include proper `afterEach` cleanup for spies/stubs and global state (`UuidFactory.mode`).