### PR TITLE
docs: fix 'does not supports' grammar in node22 ESM sample README

### DIFF
--- a/sample/35-use-esm-package-after-node22/README.md
+++ b/sample/35-use-esm-package-after-node22/README.md
@@ -6,4 +6,4 @@ Check out the `package.json` file.
 
 ## About automated tests with Jest
 
-While Jest [does not supports](https://github.com/jestjs/jest/issues/15275) the `--experimental-require-module` flag, we cannot use Jest in this project!
+While Jest [does not support](https://github.com/jestjs/jest/issues/15275) the `--experimental-require-module` flag, we cannot use Jest in this project!


### PR DESCRIPTION
## PR Type
Documentation fix.

## What

In `sample/35-use-esm-package-after-node22/README.md`, the sentence has a subject-verb agreement typo:

> While Jest [does not ~~supports~~ **support**](...) the `--experimental-require-module` flag, we cannot use Jest in this project!

Fixed `does not supports` → `does not support`. Docs-only, one word.
