### PR TITLE
fix(common): exclude reverse-mapped keys from numeric enum validation in ParseEnumPipe

### DIFF
--- a/packages/common/pipes/parse-enum.pipe.ts
+++ b/packages/common/pipes/parse-enum.pipe.ts
@@ -77,9 +77,9 @@ export class ParseEnumPipe<T = any> implements PipeTransform<T> {
   }
 
   protected isEnum(value: T): boolean {
-    const enumValues = Object.keys(this.enumType as object).map(
-      item => this.enumType[item],
-    );
+    const enumValues = Object.keys(this.enumType as object)
+      .filter(item => isNaN(Number(item)))
+      .map(item => this.enumType[item]);
     return enumValues.includes(value);
   }
 }

--- a/packages/common/pipes/parse-enum.pipe.ts
+++ b/packages/common/pipes/parse-enum.pipe.ts
@@ -78,8 +78,14 @@ export class ParseEnumPipe<T = any> implements PipeTransform<T> {
 
   protected isEnum(value: T): boolean {
     const enumValues = Object.keys(this.enumType as object)
-      .filter(item => isNaN(Number(item)))
-      .map(item => this.enumType[item]);
+      .filter(key => {
+        const enumValue = (this.enumType as any)[key];
+        return !(
+          typeof enumValue === 'string' &&
+          typeof (this.enumType as any)[enumValue] === 'number'
+        );
+      })
+      .map(key => (this.enumType as any)[key]);
     return enumValues.includes(value);
   }
 }

--- a/packages/common/test/pipes/parse-enum.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-enum.pipe.spec.ts
@@ -66,4 +66,40 @@ describe('ParseEnumPipe', () => {
       }
     });
   });
+
+  describe('when enum is numeric', () => {
+    enum Status {
+      Active = 0,
+      Inactive = 1,
+    }
+    let numericTarget: ParseEnumPipe;
+
+    beforeEach(() => {
+      numericTarget = new ParseEnumPipe(Status);
+    });
+
+    it('should return numeric enum value when the numeric value is passed', async () => {
+      expect(
+        await numericTarget.transform(
+          Status.Active as any,
+          {} as ArgumentMetadata,
+        ),
+      ).to.equal(Status.Active);
+      expect(
+        await numericTarget.transform(
+          Status.Inactive as any,
+          {} as ArgumentMetadata,
+        ),
+      ).to.equal(Status.Inactive);
+    });
+
+    it('should throw when a reverse-mapped key name is passed instead of the value', async () => {
+      try {
+        await numericTarget.transform('Active' as any, {} as ArgumentMetadata);
+        expect.fail('expected transform to throw');
+      } catch (err) {
+        expect(err).to.be.instanceOf(HttpException);
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Problem

TypeScript numeric enums have a reverse mapping at runtime. For example:

```ts
enum Status {
  Active = 0,
  Inactive = 1,
}
```

compiles to an object with both forward and reverse entries:

```js
{ '0': 'Active', '1': 'Inactive', Active: 0, Inactive: 1 }
```

`ParseEnumPipe.isEnum` iterates all keys and maps them to their values, which produces `['Active', 'Inactive', 0, 1]` — so the string `'Active'` passes validation even though it is only a reverse-mapped key name, not a valid enum value. This means a route parameter value of `"Active"` passes the pipe when the expected valid values are only `0` and `1`.

## Fix

Filter out numeric-string keys before mapping to values. Numeric-string keys are the reverse-mapping entries that TypeScript adds; the named keys are the authoritative ones. The change is a one-liner in `isEnum`:

```ts
const enumValues = Object.keys(this.enumType as object)
  .filter(item => isNaN(Number(item)))
  .map(item => this.enumType[item]);
```

This has no effect on string enums (none of their keys are numeric strings) and no effect on the numeric values accepted from the named keys.

## Tests

Added two tests in `parse-enum.pipe.spec.ts` covering a numeric enum:

- numeric values `0` and `1` still pass validation
- the reverse-mapped key name `'Active'` now correctly throws a `BadRequestException`

Both new tests pass. The two pre-existing failing tests in that file (`rejectedWith` without chai-as-promised) are unrelated to this change.