### PR TITLE
fix(common): include field paths in standard schema validation errors

### DIFF
--- a/packages/common/pipes/standard-schema-validation.pipe.ts
+++ b/packages/common/pipes/standard-schema-validation.pipe.ts
@@ -92,9 +92,24 @@ export class StandardSchemaValidationPipe implements PipeTransform {
     this.exceptionFactory =
       exceptionFactory ||
       (issues => {
-        const messages = issues.map(issue => issue.message);
+        const messages = this.formatIssueMessages(issues);
         return new HttpErrorByCode[errorHttpStatusCode](messages);
       });
+  }
+
+  /**
+   * Formats Standard Schema validation issues into a flat list of error messages.
+   * When an issue includes a path, the path is prefixed to the message.
+   */
+  protected formatIssueMessages(
+    issues: readonly StandardSchemaV1.Issue[],
+  ): string[] {
+    return issues.map(issue => {
+      if (issue.path?.length) {
+        return `${issue.path.map(String).join('.')}: ${issue.message}`;
+      }
+      return issue.message;
+    });
   }
 
   /**

--- a/packages/common/test/pipes/standard-schema-validation.pipe.spec.ts
+++ b/packages/common/test/pipes/standard-schema-validation.pipe.spec.ts
@@ -93,7 +93,33 @@ describe('StandardSchemaValidationPipe', () => {
           );
           expect((error as HttpException).getResponse()).toEqual({
             statusCode: HttpStatus.BAD_REQUEST,
-            message: ['field is required', 'must be a string'],
+            message: ['name: field is required', 'must be a string'],
+            error: 'Bad Request',
+          });
+        }
+      });
+
+      it('should prefix nested paths in issue messages', async () => {
+        const schema = createSchema(() => ({
+          issues: [
+            {
+              message: 'Invalid input: expected string, received boolean',
+              path: ['address', 'line1'],
+            },
+          ],
+        }));
+
+        try {
+          await pipe.transform({}, {
+            type: 'body',
+            schema,
+          } as ArgumentMetadata);
+        } catch (error) {
+          expect((error as HttpException).getResponse()).toEqual({
+            statusCode: HttpStatus.BAD_REQUEST,
+            message: [
+              'address.line1: Invalid input: expected string, received boolean',
+            ],
             error: 'Bad Request',
           });
         }


### PR DESCRIPTION
## Problem

With the default pipe (`new StandardSchemaValidationPipe()`), invalid requests return `400` with a flat `message` array and **no field/key paths**, even for nested fields like `address.line1`.

Standard Schema issues already include optional `path` data, but the default factory was mapping only `issue.message`, dropping path context entirely.

Without paths, clients cannot tell which message belongs to `emailAddress`, `lastName`, `address.line1`, or `address.postalCode` fields.

Minimal repro (NestJS 12 + Zod 4, ESM): https://github.com/bence-sebok/nestjs-12-standard-schema-validation-pipe

Example: `POST /users` with several invalid nested fields returns messages that cannot be mapped back to `emailAddress`, `lastName`, `address.line1`, or `address.postalCode`.

## Fix

The PR fix the default `StandardSchemaValidationPipe` exception factory so validation errors include field paths as flattened strings, matching the spirit of `ValidationPipe`'s list format.

- Prefixes Standard Schema `issue.path` (when present) onto `issue.message`
- Keeps `message` as `string[]` — no response shape change, only richer strings

## Before / after

**Before** (current behavior on `v12.0.0`):

```json
{
  "message": [
    "Invalid email address",
    "Too small: expected string to have >=1 characters",
    "Invalid input: expected string, received boolean",
    "Invalid input: expected string, received number"
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

**After** (with this PR):

```json
{
  "message": [
    "emailAddress: Invalid email address",
    "lastName: Too small: expected string to have >=1 characters",
    "address.line1: Invalid input: expected string, received boolean",
    "address.postalCode: Invalid input: expected string, received number"
  ],
  "error": "Bad Request",
  "statusCode": 400
}
```

(Exact Zod message strings may vary; path prefix format is `{dot.joined.path}: {message}`.)

## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been updated
- [ ] Docs have been added / updated (not needed — aligns with existing ValidationPipe expectations)

## Test plan

- [x] Run the following local testing from the [CONTRIBUTING.md](https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md#development) file

```bash
npm ci --legacy-peer-deps
sh scripts/prepare.sh
npm run build
npm run test
# "npm run test" included the updated test of the changed feature: packages/common/test/pipes/standard-schema-validation.pipe.spec.ts
sh scripts/run-integration.sh
npm run lint
npm run build:prod
# everything important from these have passed locally (everything passed in the CI), some of the e2e integration tests failed which are not related to my changes I think
```
