### PR TITLE
fix(common): collapse duplicate slashes for paths without leading slash

### DIFF
--- a/packages/common/test/utils/shared.utils.spec.ts
+++ b/packages/common/test/utils/shared.utils.spec.ts
@@ -140,6 +140,10 @@ describe('Shared utils', () => {
       expect(normalizePath('///')).to.be.eql('/');
       expect(normalizePath('/path////path///')).to.be.eql('/path/path');
     });
+    it('should collapse duplicate slashes for paths without leading slash', () => {
+      expect(normalizePath('path//path///')).to.be.eql('/path/path');
+      expect(normalizePath('api//v1/users')).to.be.eql('/api/v1/users');
+    });
     it('should return / for empty path', () => {
       expect(normalizePath('')).to.be.eql('/');
       expect(normalizePath(null!)).to.be.eql('/');

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -30,12 +30,16 @@ export const addLeadingSlash = (path?: string): string =>
       : path
     : '';
 
-export const normalizePath = (path?: string): string =>
-  path
-    ? path.startsWith('/')
-      ? ('/' + path.replace(/\/+$/, '')).replace(/\/+/g, '/')
-      : '/' + path.replace(/\/+$/, '')
-    : '/';
+export const normalizePath = (path?: string): string => {
+  if (!path) {
+    return '/';
+  }
+  const normalized = ('/' + path.replace(/^\/+|\/+$/g, '')).replace(
+    /\/+/g,
+    '/',
+  );
+  return normalized || '/';
+};
 
 export const stripEndSlash = (path: string) =>
   path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path;


### PR DESCRIPTION
Paths without a leading slash were not collapsing duplicate slashes in the middle of the path, unlike paths that started with '/'.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`normalizePath` only collapses duplicate slashes when the path starts with `/`.
Paths without a leading slash keep duplicate slashes in the middle:
```ts
normalizePath('////path/');     // '/path'        (correct)
normalizePath('path//path///'); // '/path//path'  (incorrect)
```
## What is the new behavior?

```ts
normalizePath('path//path///'); // '/path/path'
normalizePath('api//v1/users'); // '/api/v1/users'
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information