### PR TITLE
fix(core): stop import lookup after first direct export match

### DIFF
--- a/integration/injector/e2e/for-root-for-feature-resolution.spec.ts
+++ b/integration/injector/e2e/for-root-for-feature-resolution.spec.ts
@@ -1,0 +1,130 @@
+import {
+  Controller,
+  DynamicModule,
+  INestApplication,
+  Injectable,
+  Module,
+} from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { expect } from 'chai';
+
+@Injectable()
+class LoggerService {
+  constructor(public readonly prefix: string) {}
+}
+
+class LoggerModule {
+  static forRoot(prefix: string): DynamicModule {
+    return {
+      module: LoggerModule,
+      global: true,
+      providers: [
+        {
+          provide: LoggerService,
+          useFactory: () => new LoggerService(prefix),
+        },
+      ],
+      exports: [LoggerService],
+    };
+  }
+
+  static forFeature(prefix: string): DynamicModule {
+    return {
+      module: LoggerModule,
+      providers: [
+        {
+          provide: LoggerService,
+          useFactory: () => new LoggerService(prefix),
+        },
+      ],
+      exports: [LoggerService],
+    };
+  }
+}
+
+@Injectable()
+class CatService {
+  constructor(public readonly logger: LoggerService) {}
+}
+
+@Controller('cats')
+class CatController {
+  constructor(
+    public readonly logger: LoggerService,
+    private readonly catService: CatService,
+  ) {}
+
+  findAll() {
+    return [];
+  }
+}
+
+@Module({
+  imports: [LoggerModule.forFeature('Cat')],
+  providers: [CatService],
+  controllers: [CatController],
+})
+class CatModule {}
+
+@Module({ imports: [LoggerModule.forRoot('App'), CatModule] })
+class AppModule {}
+
+@Module({ imports: [CatModule, LoggerModule.forRoot('App')] })
+class AppModuleReversed {}
+
+describe('forRoot / forFeature resolution', () => {
+  let app: INestApplication;
+
+  afterEach(async () => {
+    if (app) {
+      await app.close();
+    }
+  });
+
+  it('should resolve the same LoggerService instance for the controller and the service in a feature module that imports forFeature', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const controller = app.get(CatController);
+    const service = app.get(CatService);
+
+    expect(controller.logger).to.equal(service.logger);
+  });
+
+  it('should prefer the forFeature instance over the global forRoot instance for the same token', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+
+    const controller = app.get(CatController);
+    const service = app.get(CatService);
+
+    expect(controller.logger.prefix).to.equal('Cat');
+    expect(service.logger.prefix).to.equal('Cat');
+  });
+
+  describe('when the global forRoot is imported before the feature module', () => {
+    it('should still resolve the forFeature instance for both consumers', async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModuleReversed],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.init();
+
+      const controller = app.get(CatController);
+      const service = app.get(CatService);
+
+      expect(controller.logger).to.equal(service.logger);
+      expect(controller.logger.prefix).to.equal('Cat');
+      expect(service.logger.prefix).to.equal('Cat');
+    });
+  });
+});

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -706,19 +706,12 @@ export class Injector {
       instanceWrapperRef = providers.get(name)!;
       this.addDependencyMetadata(keyOrIndex!, wrapper, instanceWrapperRef);
 
-      const inquirerId = this.getContextInquirerId(resolutionContext);
-      const instanceHost = instanceWrapperRef.getInstanceByContextId(
-        this.getContextId(resolutionContext.contextId, instanceWrapperRef),
-        inquirerId,
-      );
-      if (!instanceHost.isResolved && !instanceWrapperRef.forwardRef) {
-        /*
-         * Provider will be loaded shortly in resolveComponentHost() once we pass the current
-         * Barrier. We cannot load it here because doing so could incorrectly evaluate the
-         * staticity of the dependency tree and lead to undefined / null injection.
-         */
-        break;
-      }
+      /*
+       * Stop at the first direct export match. Continuing when the provider is
+       * already resolved would let a later import (e.g. a global forRoot module)
+       * override an explicit forFeature import for the same token.
+       */
+      break;
     }
     return instanceWrapperRef;
   }

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -504,6 +504,74 @@ describe('Injector', () => {
         ),
       ).to.eventually.be.eq(null);
     });
+
+    const createImportModule = (
+      id: string,
+      token: string,
+      isResolved: boolean,
+    ) => {
+      const providerWrapper = new InstanceWrapper({
+        token,
+        name: token,
+        isResolved,
+        instance: isResolved ? { id } : null,
+      });
+      return {
+        id,
+        metatype: { name: id },
+        imports: new Set(),
+        providers: new Map([[token, providerWrapper]]),
+        exports: new Set([token]),
+      };
+    };
+
+    it('should stop at the first direct export match when it is already resolved', async () => {
+      const token = 'LoggerService';
+      const featureModule = createImportModule('feature', token, true);
+      const globalModule = createImportModule('global', token, false);
+      const hostModule = {
+        id: 'host',
+        imports: new Set([featureModule, globalModule]),
+        exports: new Set(),
+        providers: new Map(),
+      };
+      const hostWrapper = new InstanceWrapper({
+        token: 'CatController',
+        name: 'CatController',
+      });
+
+      const result = await injector.lookupComponentInImports(
+        hostModule as any,
+        token,
+        hostWrapper,
+      );
+
+      expect(result).to.eq(featureModule.providers.get(token));
+    });
+
+    it('should stop at the first direct export match when only the second is resolved', async () => {
+      const token = 'LoggerService';
+      const featureModule = createImportModule('feature', token, false);
+      const globalModule = createImportModule('global', token, true);
+      const hostModule = {
+        id: 'host',
+        imports: new Set([featureModule, globalModule]),
+        exports: new Set(),
+        providers: new Map(),
+      };
+      const hostWrapper = new InstanceWrapper({
+        token: 'CatService',
+        name: 'CatService',
+      });
+
+      const result = await injector.lookupComponentInImports(
+        hostModule as any,
+        token,
+        hostWrapper,
+      );
+
+      expect(result).to.eq(featureModule.providers.get(token));
+    });
   });
 
   describe('resolveParamToken', () => {


### PR DESCRIPTION
## Summary

Fixes inconsistent dependency injection when a feature module imports `forFeature()` while the same token is also registered globally via `forRoot()`. Controllers and providers in the **same module** could resolve **different instances** of the same token.

Closes #17136

## Reproduction

Minimum reproduction: https://github.com/malekelkssas/nestjs-forroot-forfeature-di-repro

**Stock Nest (before fix):**
```
App Finding all cats (controller)
Cat Finding all cats (service)
```

**After fix:**
```
Cat Finding all cats (controller)
Cat Finding all cats (service)
```

## Root cause

`CatModule` ends up with two imports for the same token:

1. Explicit `LoggerModule.forFeature()` (added during module scan)
2. Global `LoggerModule.forRoot()` (added by `bindGlobalScope()`)

In `lookupComponentInImports()` (`packages/core/injector/injector.ts`), the injector only stopped at the first direct export match when that provider was **not yet resolved**. Providers (e.g. `CatService`) are instantiated before controllers, so they resolve the `forFeature` provider first. When the controller resolves later, the `forFeature` provider is already resolved, the loop continues, and the global `forRoot` import overwrites the match.

## Fix

After a direct export match (`exports.has(name) && providers.has(name)`), always `break` instead of only breaking when the matched provider is still unresolved.

### What the old code did

Previously, after finding a direct export in an import:

```typescript
if (!instanceHost.isResolved && !instanceWrapperRef.forwardRef) {
  break;
}
// otherwise: keep scanning other imports
```

That bundled two ideas:

1. **`!isResolved`** — stop once an unresolved provider is found; return its `InstanceWrapper` and defer instantiation to `resolveComponentHost()` (after the `Barrier` in `resolveConstructorParams`). The comment about staticity / null injection refers to **not calling `loadProvider()` during lookup**. Lookup only selects a wrapper; loading still happens later. That separation is unchanged.

2. **`!forwardRef`** — if the matched wrapper is a forward-ref alias, keep scanning in case a later import has the concrete provider.

The old `break` was not designed to choose the best import among duplicates. It only meant stop early when the first match still needs deferred loading.

### Why that caused the bug

When the first import match was already resolved (because a provider in the same module loaded it first), the condition was false, the loop did not break, and a later import (global `forRoot`) could overwrite `instanceWrapperRef`. Controllers are instantiated after providers, so they hit this path; services do not.

### Why unconditional break is safe

| Case | Old behavior | New behavior |
|------|--------------|--------------|
| First match unresolved | Break; defer load to `resolveComponentHost()` | Same |
| First match resolved | Continue; later import may win | Break; first import wins |
| Loading during lookup | Never happened | Still never happens |

For the `forRoot`/`forFeature` scenario, first direct export wins matches intent: explicit feature imports are registered before globals from `bindGlobalScope()`.

### Edge case

Dropping the `!forwardRef` check means the loop always stops at the first direct export, even when that wrapper is a `forwardRef` alias. The old code could fall through to a later import in that rare case.

## Tests

- Added regression unit tests in `packages/core/test/injector/injector.spec.ts`:
  - first import wins when it is already resolved (controller case)
  - first import wins when only the second is resolved (service case)
- `npx mocha packages/core/test/injector/injector.spec.ts` — 56 passing
- Manual verification via patched repro app (`fork-verify/` in repro repo)

## Checklist

- [x] Bug fix with unit tests
- [x] Follows commit message conventions
- [x] Linked to issue #17136