### PR TITLE
feat(core,common,platform-fastify): add query http method support

### DIFF
--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -120,6 +120,18 @@ export const All = createMappingDecorator(RequestMethod.ALL);
 export const Search = createMappingDecorator(RequestMethod.SEARCH);
 
 /**
+ * Route handler (method) Decorator. Routes HTTP QUERY requests to the specified path.
+ *
+ * **Note**: this is named `QueryMethod` (rather than `Query`) to avoid a name clash
+ * with the `@Query()` parameter decorator used to extract query-string params.
+ *
+ * @see [Routing](https://docs.nestjs.com/controllers#routing)
+ *
+ * @publicApi
+ */
+export const QueryMethod = createMappingDecorator(RequestMethod.QUERY);
+
+/**
  * Route handler (method) Decorator. Routes Webdav PROPFIND requests to the specified path.
  *
  * @see [Routing](https://docs.nestjs.com/controllers#routing)

--- a/packages/common/enums/request-method.enum.ts
+++ b/packages/common/enums/request-method.enum.ts
@@ -15,4 +15,5 @@ export enum RequestMethod {
   MOVE,
   LOCK,
   UNLOCK,
+  QUERY,
 }

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -63,6 +63,8 @@ export interface HttpServer<
   options(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   search?(handler: RequestHandler<TRequest, TResponse>): any;
   search?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  query?(handler: RequestHandler<TRequest, TResponse>): any;
+  query?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   listen(port: number | string, callback?: () => void): any;
   listen(port: number | string, hostname: string, callback?: () => void): any;
   reply(response: any, body: any, statusCode?: number): any;

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -16,6 +16,7 @@ import {
   Copy,
   Lock,
   Unlock,
+  QueryMethod,
 } from '../../index';
 import { ROUTE_ARGS_METADATA } from '../../constants';
 import { RouteParamtypes } from '../../enums/route-paramtypes.enum';
@@ -381,6 +382,63 @@ describe('@Search', () => {
       ) {}
 
       @Search([])
+      public static testUsingArray(
+        @Query() query,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
+  });
+});
+
+describe('@QueryMethod', () => {
+  const requestPath = 'test';
+  const requestProps = {
+    path: requestPath,
+    method: RequestMethod.QUERY,
+  };
+
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.QUERY,
+  };
+
+  it('should enhance class with expected request metadata', () => {
+    class Test {
+      @QueryMethod(requestPath)
+      public static test() {}
+
+      @QueryMethod(requestPathUsingArray)
+      public static testUsingArray() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
+
+    expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
+  });
+
+  it('should set path on "/" by default', () => {
+    class Test {
+      @QueryMethod()
+      public static test(
+        @Query() query,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
+
+      @QueryMethod([])
       public static testUsingArray(
         @Query() query,
         @Param() params,

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -113,6 +113,12 @@ export abstract class AbstractHttpAdapter<
     return this.instance.search(...args);
   }
 
+  public query(handler: RequestHandler);
+  public query(path: any, handler: RequestHandler);
+  public query(...args: any[]) {
+    return this.instance.query(...args);
+  }
+
   public options(handler: RequestHandler);
   public options(path: any, handler: RequestHandler);
   public options(...args: any[]) {

--- a/packages/core/helpers/router-method-factory.ts
+++ b/packages/core/helpers/router-method-factory.ts
@@ -18,6 +18,7 @@ export const REQUEST_METHOD_MAP = {
   [RequestMethod.MOVE]: 'move',
   [RequestMethod.LOCK]: 'lock',
   [RequestMethod.UNLOCK]: 'unlock',
+  [RequestMethod.QUERY]: 'query',
 } as const satisfies Record<RequestMethod, keyof HttpServer>;
 
 export class RouterMethodFactory {

--- a/packages/core/test/helpers/router-method-factory.spec.ts
+++ b/packages/core/test/helpers/router-method-factory.spec.ts
@@ -21,6 +21,7 @@ describe('RouterMethodFactory', () => {
     move: () => {},
     lock: () => {},
     unlock: () => {},
+    query: () => {},
     all: () => {},
   };
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('RouterMethodFactory', () => {
     expect(factory.get(target, RequestMethod.MOVE)).to.equal(target.move);
     expect(factory.get(target, RequestMethod.LOCK)).to.equal(target.lock);
     expect(factory.get(target, RequestMethod.UNLOCK)).to.equal(target.unlock);
+    expect(factory.get(target, RequestMethod.QUERY)).to.equal(target.query);
     expect(factory.get(target, -1 as any)).to.equal(target.use);
   });
 });

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -115,20 +115,25 @@ describe('RouterResponseController', () => {
   });
 
   describe('getStatusByMethod', () => {
-    describe('when RequestMethod is POST', () => {
-      it('should return 201', () => {
-        expect(
-          routerResponseController.getStatusByMethod(RequestMethod.POST),
-        ).to.be.eql(201);
-      });
+    it('should return 201 for POST', () => {
+      expect(
+        routerResponseController.getStatusByMethod(RequestMethod.POST),
+      ).to.be.eql(201);
     });
-    describe('when RequestMethod is not POST', () => {
-      it('should return 200', () => {
-        expect(
-          routerResponseController.getStatusByMethod(RequestMethod.GET),
-        ).to.be.eql(200);
+
+    const methods = (Object.values(RequestMethod) as unknown[]).filter(
+      (value): value is RequestMethod => typeof value === 'number',
+    );
+
+    methods
+      .filter(method => method !== RequestMethod.POST)
+      .forEach(method => {
+        it(`should return 200 for ${RequestMethod[method]}`, () => {
+          expect(routerResponseController.getStatusByMethod(method)).to.be.eql(
+            200,
+          );
+        });
       });
-    });
   });
 
   describe('render', () => {

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -381,6 +381,10 @@ export class FastifyAdapter<
     return this.injectRouteOptions('SEARCH', ...args);
   }
 
+  public query(...args: any[]) {
+    return this.injectRouteOptions('QUERY', ...args);
+  }
+
   public propfind(...args: any[]) {
     return this.injectRouteOptions('PROPFIND', ...args);
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The HTTP `QUERY` method is not explicitly supported.

Issue Number: #17161 


## What is the new behavior?
The HTTP `QUERY` method is now explicitly supported.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
I also updated the test that asserts that "all non-POST methods return 200". The test logic did not strictly match the title, it only tested that `GET` returned `200`.