### PR TITLE
test: remove leftover debug console.log statements

### DIFF
--- a/packages/microservices/test/module/clients.module.spec.ts
+++ b/packages/microservices/test/module/clients.module.spec.ts
@@ -101,7 +101,7 @@ describe('ClientsModule', () => {
         try {
           await (dynamicModule.providers![0] as any).useFactory(optionsFactory);
         } catch (e) {
-          console.log(e);
+          void e;
         }
         expect(optionsFactory.createClientOptions.called).to.be.true;
       });

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -306,7 +306,6 @@ describe('ServerGrpc', () => {
         GrpcMethodStreamingType.NO_STREAMING,
       );
       const handlers = new Map([[testPattern, () => ({})]]);
-      console.log(handlers.entries());
       untypedServer.messageHandlers = handlers;
 
       expect(

--- a/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
+++ b/packages/websockets/test/exceptions/ws-exceptions-handler.spec.ts
@@ -54,7 +54,6 @@ describe('WsExceptionsHandler', () => {
           const message = 'Unauthorized';
 
           handler.handle(new WsException(message), executionContextHost);
-          console.log(emitStub.getCall(0).args);
           expect(
             emitStub.calledWith('exception', {
               message,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Cleanup of test files

## What is the current behavior?
3 debug console.log statements left in test files from development:
`ws-exceptions-handler.spec.ts`, `server-grpc.spec.ts`, `clients.module.spec.ts`.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
All debug console.log statements removed from test files. 
clients.module.spec.ts try/catch retained (needed for test flow),
only the console.log(e) inside it removed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information