### PR TITLE
chore: Add Cursor agent rules, skills, and enablement docs

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeReadFile": [
+      {
+        "command": ".cursor/hooks/guard-read.sh"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": ".cursor/hooks/format.sh",
+        "matcher": "Write"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/format.sh
+++ b/.cursor/hooks/format.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Auto-format edited files with prettier (matches lint-staged config).
+set -euo pipefail
+
+input=$(cat)
+path=$(echo "$input" | jq -r '.path // .file_path // .filePath // empty')
+
+if [[ -z "$path" || ! -f "$path" ]]; then
+  exit 0
+fi
+
+case "$path" in
+  *.ts|*.json)
+    if [[ -x "./node_modules/.bin/prettier" ]]; then
+      ./node_modules/.bin/prettier --ignore-path ./.prettierignore --write "$path" 2>/dev/null || true
+    fi
+    ;;
+esac
+
+exit 0

--- a/.cursor/hooks/guard-read.sh
+++ b/.cursor/hooks/guard-read.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Block reads of large generated/vendored paths to save context tokens.
+set -euo pipefail
+
+input=$(cat)
+path=$(echo "$input" | jq -r '.path // .file_path // .filePath // empty')
+
+if [[ -z "$path" ]]; then
+  echo '{ "permission": "allow" }'
+  exit 0
+fi
+
+# Normalize to forward slashes for matching
+path="${path//\\//}"
+
+is_blocked=false
+reason=""
+
+case "$path" in
+  *node_modules/*|*/node_modules/*)
+    is_blocked=true
+    reason="node_modules is vendored; read the TypeScript source under packages/ instead."
+    ;;
+  *.local-node/*|*/.local-node/*)
+    is_blocked=true
+    reason=".local-node is a local Node.js install; not part of the repo source."
+    ;;
+  *package-lock.json)
+    is_blocked=true
+    reason="package-lock.json is large; use package.json for dependency info."
+    ;;
+  */dist/*|*/dist)
+    is_blocked=true
+    reason="dist/ is build output; read the TypeScript source instead."
+    ;;
+  *.d.ts)
+    is_blocked=true
+    reason="*.d.ts is generated; read the corresponding .ts source under packages/."
+    ;;
+  */coverage/*|*/.nyc_output/*)
+    is_blocked=true
+    reason="coverage/ is test output; not source code."
+    ;;
+  packages/*/*.js)
+    is_blocked=true
+    reason="packages/**/*.js is compiled output; read the .ts source instead."
+    ;;
+esac
+
+if [[ "$is_blocked" == true ]]; then
+  jq -n \
+    --arg msg "$reason" \
+    '{ "permission": "deny", "user_message": $msg }'
+  exit 0
+fi
+
+echo '{ "permission": "allow" }'
+exit 0

--- a/.cursor/rules/00-index.mdc
+++ b/.cursor/rules/00-index.mdc
@@ -1,0 +1,16 @@
+---
+description: NestJS monorepo map and doc pointers
+alwaysApply: true
+---
+
+# NestJS Monorepo
+
+This is the **NestJS framework source** (`@nestjs/*` under `packages/`), not a single app.
+
+- **Build / test / samples**: [docs/DEVELOPER.md](../../docs/DEVELOPER.md)
+- **Change blast-radius before editing**: [ARCHITECTURE.md](../../ARCHITECTURE.md) cheat sheet
+- **Commits / PRs**: [CONTRIBUTING.md](../../CONTRIBUTING.md)
+
+**Do not read** (use TS source instead): `node_modules/`, `.local-node/`, `package-lock.json`, `dist/`, `packages/**/*.js`, `packages/**/*.d.ts`, `coverage/`, `.nyc_output/`.
+
+**Search before exploring**: grep or semantic search for a symbol; avoid broad directory reads.

--- a/.cursor/rules/decorators.mdc
+++ b/.cursor/rules/decorators.mdc
@@ -1,0 +1,32 @@
+---
+description: Decorator conventions for packages/common/decorators
+globs: packages/common/decorators/**/*.ts,packages/common/test/decorators/**/*.ts
+alwaysApply: false
+---
+
+# Decorators
+
+- Three folders, each a distinct concern: `decorators/core/` (DI + class decorators —
+  `@Injectable`, `@Controller`, `@Catch`, `@UseGuards`/`@UsePipes`/`@UseInterceptors`),
+  `decorators/http/` (route/param decorators — `@Header`, `@HttpCode`, `@Redirect`, route-param
+  factories), `decorators/modules/` (`@Module`, `@Global`).
+- Custom param decorators (the most common "single module change" here) go through
+  `createParamDecorator()` (`decorators/http/create-route-param-metadata.decorator.ts`), not a
+  hand-rolled `ParameterDecorator` — it registers `ROUTE_ARGS_METADATA` the same way built-ins
+  like `@Body()`/`@Param()` do, including pipe support via the `dataOrPipes` argument.
+- `@UseGuards`/`@UsePipes`/`@UseInterceptors`/`@Catch` (in `decorators/core/`) are pure metadata
+  attachers — they call `extendArrayMetadata` and don't execute anything themselves; the actual
+  `Guard`/`Pipe`/`Interceptor`/`ExceptionFilter` logic lives in `core/{guards,pipes,interceptors,exceptions}`
+  (see [`guards.mdc`](guards.mdc), [`interceptors.mdc`](interceptors.mdc),
+  [`exception-filters.mdc`](exception-filters.mdc)). Don't conflate "decorator behaves wrong"
+  with "consumer/engine behaves wrong" when triaging a bug report.
+- This is the most user-facing surface in `packages/common` (`ARCHITECTURE.md`: "VERY HIGH"
+  blast radius, 252 internal import sites) — a signature change here is breaking for the whole
+  ecosystem; adding a *new* decorator is additive/Easy.
+- Wire the barrel export into the matching **subfolder** index — `decorators/core/index.ts`,
+  `decorators/http/index.ts`, or `decorators/modules/index.ts` (the top `decorators/index.ts`
+  just re-exports those three, so don't add it there). Skip this and the decorator isn't
+  exported from `@nestjs/common`; `check-conformance` won't catch it (it exempts `index.ts`).
+- Tests mirror source under `packages/common/test/decorators/` (flat, one spec per decorator —
+  e.g. `use-pipes.decorator.spec.ts`). Most just assert the right metadata key/value was set via
+  `Reflect.getMetadata` on a decorated fixture class; no DI container or HTTP request involved.

--- a/.cursor/rules/exception-filters.mdc
+++ b/.cursor/rules/exception-filters.mdc
@@ -1,0 +1,44 @@
+---
+description: HttpException + ExceptionFilter conventions
+globs: packages/common/exceptions/**/*.ts,packages/common/test/exceptions/**/*.ts,packages/core/exceptions/**/*.ts,packages/core/test/exceptions/**/*.ts,packages/microservices/exceptions/**/*.ts,packages/microservices/test/exceptions/**/*.ts
+alwaysApply: false
+---
+
+# Exception Filters
+
+- Two layers: **HTTP exceptions** (`packages/common/exceptions/`, ~30 concrete classes extending
+  `HttpException`) that you *throw*, and **exception filters** (`packages/core/exceptions/`)
+  that *catch* them.
+- New HTTP exception: extend `HttpException`
+  ([`http.exception.ts`](../../packages/common/exceptions/http.exception.ts)), follow the
+  `BadRequestException` template — pass `(message, status)` to `super()`; the
+  `(objectOrError, descriptionOrOptions)` overloads are handled by `HttpException.createBody()`,
+  don't reimplement that logic in a subclass. Then export it — add
+  `export * from './<name>.exception';` to
+  [`packages/common/exceptions/index.ts`](../../packages/common/exceptions/index.ts)
+  (alphabetical order); this is the "+ index" step in `ARCHITECTURE.md`'s cheat sheet. Without
+  it the exception isn't part of the public API, and `check-conformance` won't flag the gap
+  (it exempts `index.ts`).
+- Custom filters implement `ExceptionFilter<T>`
+  ([`interfaces/exceptions/exception-filter.interface.ts`](../../packages/common/interfaces/exceptions/exception-filter.interface.ts)):
+  one method, `catch(exception: T, host: ArgumentsHost)`. The framework's catch-all is
+  `BaseExceptionFilter` (`packages/core/exceptions/base-exception-filter.ts`); request dispatch
+  goes through `ExceptionsHandler` (`exceptions-handler.ts`) →
+  `RouterExceptionFilters` (`packages/core/router/router-exception-filters.ts`).
+- Non-HTTP transports have their own variant — don't reuse `HttpException`/`ExceptionFilter` for
+  them: RPC uses `RpcException` + `BaseRpcExceptionFilter` (`packages/microservices/exceptions/`);
+  WS uses the `WsExceptionFilter` interface (`packages/common/interfaces/exceptions/`).
+- Tests mirror source: `packages/common/test/exceptions/`, `packages/core/test/exceptions/`,
+  `packages/microservices/test/exceptions/`. Exception subclass tests mostly assert
+  `getStatus()` / `getResponse()` / `message`; filter tests (e.g. `exceptions-handler.spec.ts`)
+  stub a fake `ArgumentsHost`/response object rather than booting a real app.
+- Difficulty (`ARCHITECTURE.md` §3): adding a new built-in HTTP exception is **Easy**
+  (additive); changing `HttpException`'s constructor or `createBody` is **Hard** — it's the
+  base of ~30 subclasses across `packages/common`. In practice even maintainer-authored
+  `createBody` changes have shipped without a dedicated spec (e.g. #12787) — CONTRIBUTING.md
+  still expects one for behavior changes, so add it rather than treat the historical gap as
+  precedent.
+- `BaseExceptionFilterContext` extends the shared `ContextCreator` base
+  (`packages/core/helpers/context-creator.ts`), also used by guards/interceptors/pipes
+  context-creators — see `guards.mdc`/`interceptors.mdc` if debugging filter *resolution*
+  (vs. the `catch()` call itself).

--- a/.cursor/rules/guards.mdc
+++ b/.cursor/rules/guards.mdc
@@ -1,0 +1,34 @@
+---
+description: Guards engine conventions (no concrete Guard ships in framework source)
+globs: packages/core/guards/**/*.ts,packages/core/test/guards/**/*.ts
+alwaysApply: false
+---
+
+# Guards
+
+- **No concrete `Guard` ships in framework source** — `packages/common` and `packages/core`
+  contain zero `*.guard.ts` files. Guards are a consumer-app concept; if you're asked to "add a
+  guard," it belongs in `sample/*` or an `integration/*` test fixture (e.g.
+  `integration/scopes/src/durable/durable.guard.ts`), not `packages/`.
+- What *does* live here is the **engine** that runs guards: implement against `CanActivate`
+  ([`interfaces/features/can-activate.interface.ts`](../../packages/common/interfaces/features/can-activate.interface.ts)) —
+  `canActivate(context: ExecutionContext): boolean | Promise<boolean> | Observable<boolean>` —
+  and the two files that execute them: `guards-context-creator.ts` (resolves which guards apply,
+  global → controller → route) and `guards-consumer.ts` (calls `canActivate`, short-circuits to
+  403 on `false`).
+- `GuardsContextCreator` extends the shared `ContextCreator` base
+  (`packages/core/helpers/context-creator.ts`), also extended by `InterceptorsContextCreator`,
+  `PipesContextCreator`, and `BaseExceptionFilterContext`. A bug in the shared base ripples
+  across all four checkpoints at once (e.g. #11305 fixed durable-scope resolution in all four
+  `*-context-creator.ts` files in a single PR) — check the base class, not just the guard-specific
+  file, when debugging context-creation issues.
+- This is **high blast-radius / Hard** territory (`ARCHITECTURE.md` §3-4) — changes affect every
+  request's authorization path. Run the full unit suite (`npm run test`), not just
+  `core/test/guards`.
+- Tests (`guards-consumer.spec.ts`, `guards-context-creator.spec.ts`): no real `Guard` class
+  needed — fakes are plain objects, e.g. `{ canActivate: () => true }`, passed wherever a
+  `CanActivate` is expected. Sinon isn't needed for the happy path; reach for it only when
+  asserting call order/arguments.
+- Lifecycle position: Middleware → **Guards** → Interceptors (before) → Pipes → Handler
+  (`ARCHITECTURE.md` §2a) — guards run before any pipe/interceptor, so they must never depend on
+  transformed or validated params.

--- a/.cursor/rules/interceptors.mdc
+++ b/.cursor/rules/interceptors.mdc
@@ -1,0 +1,31 @@
+---
+description: NestInterceptor conventions (engine + ClassSerializerInterceptor)
+globs: packages/core/interceptors/**/*.ts,packages/core/test/interceptors/**/*.ts,packages/common/serializer/**/*.ts,packages/common/test/serializer/**/*.ts
+alwaysApply: false
+---
+
+# Interceptors
+
+- Implement `NestInterceptor<T, R>`
+  ([`interfaces/features/nest-interceptor.interface.ts`](../../packages/common/interfaces/features/nest-interceptor.interface.ts)):
+  one method, `intercept(context: ExecutionContext, next: CallHandler): Observable<R> | Promise<Observable<R>>`.
+  Call `next.handle()` to continue the chain; `map`/`tap` the returned `Observable` for "after"
+  logic.
+- Unlike guards, there's one concrete framework-shipped example:
+  `ClassSerializerInterceptor` (`packages/common/serializer/class-serializer.interceptor.ts`) —
+  use it as the template for a real interceptor, not just the bare interface.
+- Engine: `interceptors-context-creator.ts` resolves applicable interceptors (global →
+  controller → route); `interceptors-consumer.ts` runs them around the handler call (both in
+  `packages/core/interceptors/`). `InterceptorsContextCreator` extends the shared `ContextCreator`
+  base (`packages/core/helpers/context-creator.ts`) — also extended by `GuardsContextCreator`,
+  `PipesContextCreator`, and `BaseExceptionFilterContext` — so a resolution bug there can affect
+  all four checkpoints at once, not just interceptors.
+- Tests mirror source under `packages/core/test/interceptors/` and
+  `packages/common/test/serializer/`. `class-serializer.interceptor.spec.ts` is the style
+  reference: a sinon **sandbox** (`sinon.createSandbox()`) to stub `Reflector`/the external
+  `class-transformer` package, restored in `afterEach`. Plain-object fakes (as with guards) are
+  enough when you aren't stubbing an external dependency.
+- Lifecycle position: Guards → **Interceptors (before)** → Pipes → Handler →
+  **Interceptors (after)** → Exception filters (`ARCHITECTURE.md` §2a) — interceptors are the
+  only checkpoint wrapping the handler on both sides, so response-shape changes (e.g.
+  serialization) belong here, not in a pipe.

--- a/.cursor/rules/lifecycle-trace.mdc
+++ b/.cursor/rules/lifecycle-trace.mdc
@@ -1,0 +1,36 @@
+---
+description: >-
+  Thread a Trace ID (this repo's GitHub issue number) through commits, PR
+  descriptions, and changelog mentions. Use when drafting a commit message,
+  a PR description, opening a discussion issue, or summarizing why a change
+  was made.
+alwaysApply: false
+---
+
+# Lifecycle Trace (Trace ID = GitHub issue number)
+
+This repo has no RFC/ADR numbering and no changelog-fragment system — don't invent one. It
+already has a lightweight join key; reuse it instead of adding new artifact types.
+
+- **Trace ID = the GitHub issue number.** It's already required in
+  `.github/PULL_REQUEST_TEMPLATE.md` (`Issue Number:` field) and in real commit history —
+  e.g. `bd36c2832 fix(common): resolve file-type path explicitly #15270`. Before drafting a
+  commit or PR for anything beyond a trivial fix, find the issue number or say plainly that none
+  exists yet — don't fabricate one and don't silently leave the template field at `N/A`.
+- **No issue yet for a major/breaking change?** Point at the `[discussion]`-prefixed issue
+  process (`CONTRIBUTING.md`) rather than skipping the link — that issue *is* this repo's Plan
+  stage.
+- **Commit format** stays the `commit-and-pr` skill's `<type>(<scope>): <subject>`; append
+  `#<issue>` when one exists (matches existing repo convention, not a new format).
+- **PR description as the missing Design record.** There's no ADR folder here, so for Hard /
+  high-blast-radius changes (`ARCHITECTURE.md` §4) the PR's "What is the new behavior?" section
+  is the only place the *why* will ever be captured — write it as a decision record, not just a
+  diff summary.
+- **Don't retrofit this repo's history.** This is forward-only discipline for new changes; it is
+  not a request to backfill issue links onto old commits or to add `proposals/`/`docs/adr/`
+  folders that nothing in this project's actual CI or review process reads.
+- **Triaging a fresh issue end-to-end?** Use the `triage-issue` skill — it produces the branch
+  name, the ticket (saved at `.cursor/triage/<issue>.md`), and the failing-test evidence this
+  rule assumes already exist before a commit/PR gets drafted. Its `verify-trace.sh`, wired in as
+  `.husky/pre-push`, is this repo's one *enforced* (not just agent-followed) checkpoint for that
+  ticket+evidence pairing — everything else in this file is agent-layer discipline only.

--- a/.cursor/rules/packages.mdc
+++ b/.cursor/rules/packages.mdc
@@ -1,0 +1,14 @@
+---
+description: Rules for editing @nestjs/* framework packages
+globs: packages/**/*.ts
+alwaysApply: false
+---
+
+# Framework Packages
+
+- Check blast-radius in [ARCHITECTURE.md](../../ARCHITECTURE.md) before editing `common`, `core/injector`, or `core/router`.
+- Add or update the mirrored `*.spec.ts` under `test/` for behavior changes (specs are never
+  colocated with source — see `tests.mdc`).
+- Run `npm run test` and `npm run lint` before finishing.
+- Commit scopes: `common`, `core`, `microservices`, `express`, `fastify`, `websockets`, `testing`, `ws`, `socket.io` (plus `sample` / `release` for those commit kinds; full enum in `.commitlintrc.json`, see [CONTRIBUTING.md](../../CONTRIBUTING.md)).
+- Avoid breaking public interfaces in `packages/common` without semver consideration.

--- a/.cursor/rules/pipes.mdc
+++ b/.cursor/rules/pipes.mdc
@@ -1,0 +1,27 @@
+---
+description: PipeTransform conventions for packages/common/pipes
+globs: packages/common/pipes/**/*.ts,packages/common/test/pipes/**/*.ts
+alwaysApply: false
+---
+
+# Pipes
+
+- Implement `PipeTransform<T, R>` ([`interfaces/features/pipe-transform.interface.ts`](../../packages/common/interfaces/features/pipe-transform.interface.ts)):
+  one method, `transform(value: T, metadata: ArgumentMetadata): R`.
+- Naming: `<name>.pipe.ts`, class suffixed `Pipe` (e.g. `ParseIntPipe`). On invalid input, throw
+  `BadRequestException` directly or via a constructor-supplied `exceptionFactory` — see
+  [`exception-filters.mdc`](exception-filters.mdc).
+- Minimal template: [`parse-int.pipe.ts`](../../packages/common/pipes/parse-int.pipe.ts).
+  Complex/configurable template: `validation.pipe.ts` (constructor options + `exceptionFactory`).
+- File-upload pipes (`pipes/file/`) implement `FileValidator`, not `PipeTransform`, directly —
+  see `pipes/file/file-validator.interface.ts`.
+- Wire the barrel export: add `export * from './<name>.pipe';` to
+  [`packages/common/pipes/index.ts`](../../packages/common/pipes/index.ts) in the existing
+  alphabetical order (as `parse-positive-int.pipe` is). `common/index.ts` re-exports `./pipes`,
+  so no second edit is needed. Without this the class compiles but isn't part of
+  `@nestjs/common`'s public API — and `check-conformance` won't flag it (it exempts `index.ts`).
+- Tests: `packages/common/test/pipes/<name>.pipe.spec.ts` (mirrors source; never colocated).
+  Style from `parse-int.pipe.spec.ts`: chai `expect`, no sinon — instantiate the pipe and call
+  `.transform(value, {} as ArgumentMetadata)` directly when metadata doesn't matter to the case.
+- Run `npm run test` + `npm run lint` before finishing; add or update the spec for any behavior
+  change (`CONTRIBUTING.md`).

--- a/.cursor/rules/samples.mdc
+++ b/.cursor/rules/samples.mdc
@@ -1,0 +1,13 @@
+---
+description: Sample app conventions (not framework source)
+globs: sample/**
+alwaysApply: false
+---
+
+# Sample Apps
+
+- Each `sample/*` directory is a **standalone app** with its own `package.json`.
+- Install with `npm install --legacy-peer-deps`.
+- After changing `packages/`, run `npm run build && npm run move:samples` from repo root.
+- Do not treat samples as framework source; keep changes minimal and scoped to the sample.
+- Commit scope: `sample/#` (e.g. `fix(sample/01): …`).

--- a/.cursor/rules/tests.mdc
+++ b/.cursor/rules/tests.mdc
@@ -1,0 +1,17 @@
+---
+description: Unit and integration test conventions
+globs: packages/**/test/**/*.spec.ts,integration/**/*.spec.ts
+alwaysApply: false
+---
+
+# Tests
+
+- Stack: **mocha** + **chai** + **sinon** (`hooks/mocha-init-hook.ts` in mocha config).
+- Unit tests: `npm run test` (watch: `npm run test:dev`).
+- Lint specs: `npm run lint:spec`.
+- Integration tests live under `integration/` — use Docker; see `run-integration-tests` skill.
+- Specs live in a **parallel `packages/<pkg>/test/` tree**, never colocated in the same folder
+  as the source — e.g. `pipes/parse-int.pipe.ts` → `test/pipes/parse-int.pipe.spec.ts`.
+  Mirror the source path exactly when adding a new spec.
+- See `pipes.mdc`, `exception-filters.mdc`, `guards.mdc`, `interceptors.mdc`, `decorators.mdc`
+  for per-concept conventions and concrete test-style examples.

--- a/.cursor/skills/build-and-verify/SKILL.md
+++ b/.cursor/skills/build-and-verify/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: build-and-verify
+description: >-
+  Build NestJS framework packages, link into samples, and run unit tests.
+  Use when changing packages/, verifying a fix, or preparing to test in a sample app.
+---
+
+# Build and Verify
+
+Full details: [docs/DEVELOPER.md](../../../docs/DEVELOPER.md)
+
+## Standard build
+
+```bash
+npm run build          # tsc -b packages/ + postbuild move:node_modules
+npm run move:samples   # copy @nestjs/* into sample/*/node_modules
+```
+
+## Verify changes
+
+```bash
+npm run test           # unit tests (packages/**/*.spec.ts)
+npm run lint           # eslint across packages + integration + specs
+```
+
+## Watch mode (active development)
+
+```bash
+npm run build:dev      # tsc --watch
+# Re-run move:samples after changes so samples see updates
+```
+
+## Test in a sample
+
+```bash
+npm run build && npm run move:samples
+cd sample/01-cats-app
+npm install --legacy-peer-deps
+npm run start:dev      # http://localhost:3000
+```
+
+## Production build
+
+```bash
+npm run build:prod     # clean + compile
+```
+
+## CI-style (slow)
+
+```bash
+npm run build:samples  # install all samples, build, test unit + e2e
+```

--- a/.cursor/skills/check-conformance/SKILL.md
+++ b/.cursor/skills/check-conformance/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: check-conformance
+description: >-
+  Check whether pipes/guards/interceptors/exceptions/decorators have test
+  coverage per repo convention, before opening a PR. Use after changing
+  packages/common/{pipes,exceptions,serializer,decorators}, packages/core/{guards,interceptors,exceptions},
+  or packages/microservices/exceptions, or when drafting a PR per lifecycle-trace.mdc.
+---
+
+# Check Conformance
+
+Executable version of the "specs mirror source, never colocated" convention from
+`tests.mdc` / `pipes.mdc` / `guards.mdc` / `interceptors.mdc` / `exception-filters.mdc` /
+`decorators.mdc`. Run it instead of eyeballing the diff for missing specs.
+
+```bash
+sh .cursor/skills/check-conformance/check.sh       # flags real gaps only
+sh .cursor/skills/check-conformance/check.sh -v    # also lists indirectly-covered files
+```
+
+## What it does
+
+For each source file under the 5 concept areas, it looks for a spec in two tiers:
+
+1. **Mirrored spec exists** (e.g. `packages/common/pipes/foo.pipe.ts` →
+   `packages/common/test/pipes/foo.pipe.spec.ts`) → pass, silent.
+2. **No mirrored spec** → falls back to grepping the file's exported class/function/const
+   name across the whole package's `test/` tree. If found, it's printed as `INDIRECT` (only
+   with `-v`) rather than `MISSING` — this is what legitimately happens for the ~21 built-in
+   HTTP exception subclasses (all asserted together in `http.exception.spec.ts`) and a couple
+   of support classes (`BaseExceptionFilterContext`, `ExternalExceptionFilter`) exercised only
+   through a consumer's spec.
+
+`index.ts`, `*.interface.ts` / `*.interfaces.ts`, and `constants.ts` / `*.constants.ts` files
+are exempt (no behavior to test).
+
+## Reading the output
+
+- `MISSING SPEC` — no mirrored spec and no reference anywhere in the package's `test/` tree.
+  Treat as a real gap; add a spec or confirm it's dead code.
+- `INDIRECT` (with `-v`) — covered, but only through another file's spec. Fine to leave, but
+  if you're touching that file's behavior, consider whether it now deserves its own spec.
+- Exit code is always `0` — this is a nudge for PR prep (see `lifecycle-trace.mdc`), not a CI
+  gate. Wire it into `lint-staged`/CI yourself if you want it to block.
+
+## Known limitation
+
+The symbol-name grep is best-effort (first `export class|function|const` in the file). A file
+with no top-level export, or one whose only export name collides with an unrelated identifier
+elsewhere in `test/`, can produce a wrong verdict — read the flagged file before trusting the
+output blindly.

--- a/.cursor/skills/check-conformance/check.sh
+++ b/.cursor/skills/check-conformance/check.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Conventions-as-code check for the 5 HTTP-lifecycle concept areas
+# (pipes, exception-filters, guards, interceptors, decorators).
+#
+# Flags source .ts files with no test coverage detected, per the convention in
+# tests.mdc / pipes.mdc / exception-filters.mdc / guards.mdc / interceptors.mdc /
+# decorators.mdc: specs normally live in a parallel packages/<pkg>/test/ tree
+# that mirrors the source path (never colocated). Some files are legitimately
+# covered only indirectly (e.g. ~22 built-in HTTP exception subclasses are all
+# exercised together in http.exception.spec.ts, not one spec each) - this script
+# checks for that via a symbol-name fallback before flagging anything.
+#
+# This is a NUDGE, not a gate: it never fails / exits non-zero. Run it before
+# opening a PR (see lifecycle-trace.mdc / commit-and-pr skill). Pass -v to also
+# print files that are only indirectly covered (no dedicated spec file).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+verbose=false
+[[ "${1:-}" == "-v" ]] && verbose=true
+
+is_exempt() {
+  local f="$1"
+  [[ "$(basename "$f")" == "index.ts" ]] && return 0
+  [[ "$(basename "$f")" == "constants.ts" || "$f" == *.constants.ts ]] && return 0
+  [[ "$f" == *.interface.ts || "$f" == *.interfaces.ts ]] && return 0
+  return 1
+}
+
+# Best-effort: first exported class/function/const name in the file.
+export_name() {
+  grep -oE 'export (default )?(abstract )?(class|function|const) [A-Za-z0-9_]+' "$1" \
+    | head -1 | awk '{print $NF}'
+}
+
+missing=0
+indirect=0
+total=0
+
+# $1 source dir, $2 mirrored test dir (subpath must match), $3 package test root
+# (searched as a fallback for indirect/aggregate coverage).
+check_mirrored() {
+  local src_dir="$1" test_dir="$2" pkg_test_root="$3"
+  while IFS= read -r -d '' f; do
+    [[ "$f" == *.d.ts || "$f" == *.spec.ts ]] && continue
+    is_exempt "$f" && continue
+    total=$((total + 1))
+    rel="${f#"$src_dir"/}"
+    expected="${test_dir}/${rel%.ts}.spec.ts"
+    if [[ -f "$expected" ]]; then
+      continue
+    fi
+    name=$(export_name "$f")
+    if [[ -n "$name" ]] && grep -rl "$name" "$pkg_test_root" >/dev/null 2>&1; then
+      indirect=$((indirect + 1))
+      $verbose && echo "INDIRECT (no dedicated spec, but '$name' referenced under $pkg_test_root): $f"
+      continue
+    fi
+    echo "MISSING SPEC: $f  (expected: $expected)"
+    missing=$((missing + 1))
+  done < <(find "$src_dir" -name '*.ts' -print0 2>/dev/null)
+}
+
+# Flat test dir, matched by basename only (decorators' test/ isn't subpath-mirrored).
+check_flat() {
+  local src_dir="$1" test_dir="$2" pkg_test_root="$3"
+  while IFS= read -r -d '' f; do
+    [[ "$f" == *.d.ts || "$f" == *.spec.ts ]] && continue
+    is_exempt "$f" && continue
+    total=$((total + 1))
+    base=$(basename "$f" .ts)
+    if find "$test_dir" -name "${base}.spec.ts" 2>/dev/null | grep -q .; then
+      continue
+    fi
+    name=$(export_name "$f")
+    if [[ -n "$name" ]] && grep -rl "$name" "$pkg_test_root" >/dev/null 2>&1; then
+      indirect=$((indirect + 1))
+      $verbose && echo "INDIRECT (no dedicated spec, but '$name' referenced under $pkg_test_root): $f"
+      continue
+    fi
+    echo "MISSING SPEC: $f  (expected basename: ${base}.spec.ts under $test_dir)"
+    missing=$((missing + 1))
+  done < <(find "$src_dir" -name '*.ts' -print0 2>/dev/null)
+}
+
+check_mirrored packages/common/pipes              packages/common/test/pipes              packages/common/test
+check_mirrored packages/common/exceptions         packages/common/test/exceptions         packages/common/test
+check_mirrored packages/core/exceptions           packages/core/test/exceptions           packages/core/test
+check_mirrored packages/microservices/exceptions  packages/microservices/test/exceptions  packages/microservices/test
+check_mirrored packages/core/guards               packages/core/test/guards               packages/core/test
+check_mirrored packages/core/interceptors         packages/core/test/interceptors         packages/core/test
+check_mirrored packages/common/serializer         packages/common/test/serializer         packages/common/test
+check_flat     packages/common/decorators         packages/common/test/decorators         packages/common/test
+
+echo "---"
+echo "$missing missing / $indirect indirect-only / $total total source files checked."
+$verbose || echo "(run with -v to also list indirect-only files)"
+exit 0

--- a/.cursor/skills/commit-and-pr/SKILL.md
+++ b/.cursor/skills/commit-and-pr/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: commit-and-pr
+description: >-
+  NestJS conventional commit format, scopes, pre-PR verification gates, and the
+  GitHub (gh) PR/issue workflow. Use when committing changes or preparing a pull request.
+---
+
+# Commit and PR
+
+Full details: [CONTRIBUTING.md](../../../CONTRIBUTING.md) and
+[docs/DEVELOPER.md](../../../docs/DEVELOPER.md#github-cli-and-contribution-workflow).
+
+## Pre-PR gates
+
+Run the gates via the `build-and-verify` skill (build + unit tests + lint) — that skill is the
+single source of truth for these commands, so they aren't restated here. For routing, adapter,
+or transport changes, also run the `run-integration-tests` skill (Docker).
+
+Implementing a triaged issue? The `implement-issue` skill runs all of these as its
+definition-of-done and renders the PR body before handing off here — this skill then owns only
+the conventional commit and the `gh` PR/issue mechanics.
+
+Triaging from a GitHub issue rather than a self-found fix? Use the `triage-issue` skill first —
+its ticket + failing-test evidence at `.cursor/triage/<issue>.md` are what `.husky/pre-push`
+(`verify-trace.sh`) actually checks before letting `git push` through on a matching branch name.
+
+## Commit format
+
+```
+<type>(<scope>): <subject>
+```
+
+Types (per `.commitlintrc.json` `type-enum`): `build`, `chore`, `ci`, `docs`, `feat`, `fix`,
+`perf`, `refactor`, `revert`, `style`, `test`, `sample`.
+
+Scopes (per `.commitlintrc.json` `scope-enum`): `common`, `core`, `sample`, `microservices`,
+`express`, `fastify`, `socket.io`, `ws`, `testing`, `websockets`, `release`. Multi-package:
+`common,core`. Samples: `sample/#`.
+
+Examples:
+
+```
+fix(core): resolve circular dependency in scoped provider
+test(common): add parse-positive-int pipe edge cases
+docs(sample/01): update cats app readme
+```
+
+- Imperative, present tense; no trailing period; max 100 chars per line. Subject case must be
+  one of commitlint's allowed cases (sentence / start / pascal / upper / lower) — a lower-case
+  imperative subject satisfies this.
+- Major features need a `[discussion]` issue first.
+- Format code: `npm run format` (or rely on afterFileEdit prettier hook).
+
+## Create PR / issues with `gh`
+
+Use the GitHub CLI (preferred over a GitHub MCP server in this repo). Pull/push is plain
+`git`; `gh` handles PRs, issues, and CI status. Push to a **fork** — direct pushes to
+`nestjs/nest` are not allowed.
+
+```bash
+gh repo fork nestjs/nest --remote    # one-time: add your fork as a remote
+git checkout -b fix/my-change master
+git push -u origin fix/my-change
+gh pr create --fill                  # PR against nestjs:master
+gh issue create                      # file a bug / feature request
+gh pr checks                         # CI status for the current branch
+```
+
+Install/auth: see [docs/DEVELOPER.md](../../../docs/DEVELOPER.md#github-cli-and-contribution-workflow)
+(`gh auth login` needs a browser; run it in your own terminal).

--- a/.cursor/skills/http-request-chain/SKILL.md
+++ b/.cursor/skills/http-request-chain/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: http-request-chain
+description: >-
+  Plan and implement cross-cutting HTTP request lifecycle changes (middleware,
+  guards, interceptors, pipes, filters). Use when modifying request ordering,
+  orchestration in core/router, or aligning HTTP with RPC/WebSocket context.
+---
+
+# HTTP Request Chain Changes
+
+**Difficulty:** Hard — see [ARCHITECTURE.md](../../../ARCHITECTURE.md) §2a (lifecycle diagram) and §4 (cheat sheet).
+
+Also read: [CONTRIBUTING.md](../../../CONTRIBUTING.md) for discussion issues and PR gates.
+
+## Before coding
+
+1. Open a `[discussion]` issue — request-chain changes are semver-sensitive.
+2. Define scope: ordering vs new stage vs shared context vs error propagation.
+3. Confirm what stays stable: public decorators, documented lifecycle order ([request-lifecycle FAQ](https://docs.nestjs.com/faq/request-lifecycle)).
+4. Decide whether RPC (`microservices`) and WebSocket gateways must match HTTP.
+
+Additive changes can ship incrementally. Reordering documented behavior needs a major release and migration notes.
+
+## Touch points (grep symbols; do not browse the whole repo)
+
+| Layer | Primary files |
+|-------|---------------|
+| Orchestration | `packages/core/router/router-execution-context.ts` |
+| Consumers | `packages/core/guards/guards-consumer.ts`, `interceptors/interceptors-consumer.ts`, pipes context creators |
+| Middleware | `packages/core/middleware/middleware-module.ts` |
+| Response / errors | `router-response-controller.ts`, `exceptions/exceptions-handler.ts`, `router-exception-filters.ts` |
+| Route registration | `router-explorer.ts`, `routes-resolver.ts` |
+| Non-HTTP parity | `packages/core/helpers/external-context-creator.ts` |
+| Contracts | `packages/common/interfaces/*`, `packages/common/decorators/` |
+| Adapters | `platform-express`, `platform-fastify` (entry/exit only) |
+
+Pipes run inside the handler passed to `InterceptorsConsumer.intercept()` — moving pipes before interceptors changes how the handler is nested, not a one-line tweak.
+
+## Package order of work
+
+```
+common (interfaces, decorators) → core (orchestration) → microservices / websockets → platform-* → testing
+```
+
+1. **common** — additive interfaces, metadata keys, optional decorator options only.
+2. **core** — orchestration in `RouterExecutionContext` + consumers; prefer flags or new code paths.
+3. **microservices / websockets** — align `ExternalContextCreator` if parity is required.
+4. **platform-*** — only if entry/response serialization changes; keep Express/Fastify parity.
+5. **testing** — update harness if global registration or lifecycle hooks change.
+
+Never import `core` from `common`.
+
+## Phased delivery
+
+| Phase | Goal |
+|-------|------|
+| A | Internal refactor, no behavior change — extract shared pipeline used by `RouterExecutionContext` and `ExternalContextCreator`; existing specs stay green |
+| B | Additive behavior — new stage/context/opt-in decorator; old path unchanged |
+| C | Behavior change — document breaking change, migration guide, major bump if needed |
+
+Avoid touching `common/interfaces` and `core/injector` in the same PR unless unavoidable.
+
+## Tests
+
+| Level | Where |
+|-------|-------|
+| Unit consumers | `packages/core/test/guards/guards-consumer.spec.ts`, `interceptors-consumer.spec.ts`, `router-execution-context.spec.ts`, `external-context-creator.spec.ts` |
+| Unit contracts | `packages/common/test/` (mirrors source tree; never colocated with the `.ts` it tests) |
+| Integration ordering | `integration/hello-world/e2e/guards.spec.ts`, `interceptors.spec.ts` |
+| Scopes / hooks | `integration/scopes/e2e/*`, `integration/hooks/e2e/lifecycle-hook-order.spec.ts` |
+
+When changing ordering, add **explicit ordering tests** (stage X before Y), not just outcome tests.
+
+Full gates: `npm run build`, `npm run test`, `npm run lint`, then `sh scripts/run-integration.sh` for routing changes.
+
+## PR hygiene
+
+- Split PRs when possible: `common` → `core` → integration → docs.
+- Commit scopes: `common,core` when both change.
+- Samples: only if demonstrating new API; do not refactor all samples.
+- Update public lifecycle docs if ordering changes.
+
+## Red flags (pause and redesign)
+
+- Reordering documented stages without a major release plan
+- Changing `ExecutionContext` shape used by user guards/interceptors
+- Diverging HTTP vs RPC vs WebSocket without explicit rationale
+- One PR touching `injector`, `router`, and `common/interfaces` together
+- Skipping integration tests for routing changes
+
+## Workflow
+
+```
+discussion issue → grep touch points → common (additive) → core refactor (no behavior)
+  → core feature (flagged) → ExternalContextCreator parity → unit + integration tests → split PRs
+```
+
+Use the `build-and-verify` and `run-integration-tests` skills for commands to run.

--- a/.cursor/skills/implement-issue/SKILL.md
+++ b/.cursor/skills/implement-issue/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: implement-issue
+description: >-
+  Take a triaged issue from failing test (red) to a verified, PR-ready change
+  (green): implement the minimal fix within scope, run the build/test/lint and
+  conformance gates, update the triage ticket with green evidence plus a
+  rollout/rollback note, and render the PR body for PM/QA/DevOps. Use after the
+  `triage-issue` skill has produced a red ticket, when implementing a scoped
+  fix/feature for a GitHub issue, or when asked to take an issue "to a PR".
+---
+
+# Implement Issue → Verified PR (red → green)
+
+Middle stage of this repo's three-skill pipeline:
+
+```
+triage-issue (plan → red)  →  implement-issue (red → green)  →  commit-and-pr (green → shipped)
+```
+
+It does **not** re-triage (that's `triage-issue`) and it does **not** run the git/`gh`
+mechanics (that's `commit-and-pr`). It owns only the red→green middle: implement, verify,
+and prepare the PR record.
+
+## When to use
+
+- A `triage-issue` ticket exists at `.cursor/triage/<issue>.md` with red (failing) evidence
+  and you're ready to write the fix.
+- Someone asks to "implement", "take to a PR", or "make the failing test pass" for a scoped
+  issue.
+
+If there's no triage ticket or branch yet, **stop and run `triage-issue` first** — don't
+improvise triage here.
+
+## Preconditions — run preflight first
+
+```bash
+bash .cursor/skills/implement-issue/scripts/preflight.sh
+```
+
+It confirms (advisory; it never edits anything):
+
+1. You're on a `<type>/<issue>-<slug>` branch (the convention from `triage-issue` /
+   `lifecycle-trace.mdc`).
+2. A filled triage ticket exists at `.cursor/triage/<issue>.md` with real red evidence
+   (not the placeholder).
+3. `.husky/pre-push` is installed — the one *enforced* gate (`verify-trace.sh`). If it's
+   missing, preflight prints the one-time install step and continues with a warning.
+
+Resolve any `STOP` line before writing code.
+
+## Steps
+
+1. **Re-read the ticket.** Implement the **minimal** change that turns the failing spec
+   green, against the exact surface the ticket identified — nothing more.
+   - **Additive contribution? Wire the barrel export.** A new pipe/exception/decorator isn't
+     part of `@nestjs/common`'s public API until it's re-exported. Add
+     `export * from './<file>'` to the relevant `index.ts` (e.g.
+     `packages/common/pipes/index.ts` or `exceptions/index.ts`; a new decorator goes in its
+     `decorators/core|http|modules/index.ts` subfolder barrel), keeping the file's existing
+     alphabetical order. `check-conformance` exempts `index.ts`, so it will **not** catch a
+     missing export — this step is on you. See the relevant concept rule (`pipes.mdc` etc.).
+2. **Respect scope + layering.** Touch only the target package directory, its existing
+   public exports, and the mirrored test path. Never introduce a `common → core` import
+   (ARCHITECTURE.md dependency rule). Do **not** touch `packages/common/interfaces|decorators`
+   or `core/injector|router` unless the ticket explicitly scopes you there — those are
+   Hard/breaking; flag and stop.
+3. **Update the spec.** Extend or adjust the mirrored `*.spec.ts` for the behavior change
+   (specs mirror source, never colocated — `tests.mdc`). Don't weaken the failing assertion
+   just to make it pass.
+4. **Run the gates** — use the existing skills, do not restate their commands:
+   - `build-and-verify` skill — build + unit tests + lint (canonical command list).
+   - `check-conformance` skill — must show **no new** `MISSING SPEC` for files this branch
+     touched.
+   - `run-integration-tests` skill (Docker) — **required** if the change touches routing,
+     adapters, or transports. If Docker isn't available, stop and say so; never claim
+     integration coverage you didn't run.
+5. **Prove green.** Capture the now-passing test output. If any gate fails, fix and re-run —
+   do not proceed to a PR with a red gate, and do not fabricate a pass.
+6. **Update the triage ticket in place.** Flip its Failing-Test Evidence from red to green,
+   list the files actually changed, and fill the rollout/rollback block (see
+   `references/devops-and-rollback.md`). The ticket stays the single source of truth.
+7. **Render the PR body** from the ticket using `assets/pr-body-template.md`. It reuses the
+   repo's `PULL_REQUEST_TEMPLATE.md` and fills `Issue Number` from the Trace ID. This is the
+   one-source / three-audience rendering: PM (current behavior, plain language), QA (the test
+   list + edge cases), DevOps (CI jobs touched, release tier, rollback).
+8. **Hand off to `commit-and-pr`** for the conventional commit and `gh pr create`. Do not
+   duplicate commit/PR mechanics here.
+
+## Definition of done
+
+- Target spec green; build/test/lint green (via `build-and-verify`); integration green or
+  explicitly N/A with a stated reason.
+- `check-conformance` shows no new gap for touched files.
+- Triage ticket updated: green evidence + files changed + rollout/rollback.
+- PR body rendered from the template; `commit-and-pr` invoked for the actual push/PR.
+- `.husky/pre-push` installed — or the warning surfaced to the user so it's a conscious skip.
+
+## Guardrails
+
+- **Minimal change only** — no opportunistic refactors outside the ticket's scope.
+- **Escalate, don't push through** Hard/breaking surfaces (`common` public API,
+  `injector`/`router`). This skill is for scoped, landable changes.
+- **Don't fabricate green.** If you can't make it pass, report why and stop.
+- **Single-source the shared knowledge:** commit format/scopes/`gh` flow live in
+  `commit-and-pr`; build/test/lint live in `build-and-verify`; Docker integration in
+  `run-integration-tests`. Reference them — never copy their commands into this file.

--- a/.cursor/skills/implement-issue/assets/pr-body-template.md
+++ b/.cursor/skills/implement-issue/assets/pr-body-template.md
@@ -1,0 +1,53 @@
+<!--
+  PR body skeleton for the implement-issue skill.
+  Render this FROM .cursor/triage/<issue>.md — don't recompute facts the ticket already holds.
+  It mirrors the repo's .github/PULL_REQUEST_TEMPLATE.md structure: fill the sections, don't
+  restructure them. The QA and DevOps sub-blocks are this repo's Goal-3 additions (one source,
+  three audiences) and sit inside the template's existing sections.
+-->
+
+## PR Checklist
+- [ ] The commit message follows our guidelines (see the `commit-and-pr` skill)
+- [ ] Tests for the changes have been added (for bug fixes / features)
+- [ ] Docs have been added / updated (for bug fixes / features)
+
+## PR Type
+<!-- check the one that applies -->
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Code style update (formatting, local variables)
+- [ ] Refactoring (no functional changes, no api changes)
+- [ ] Build related changes
+- [ ] CI related changes
+- [ ] Other... Please describe:
+
+## What is the current behavior?
+<!-- PM-readable: the problem in plain language, no code. From the ticket's "Problem" section. -->
+
+Issue Number: #<issue>
+<!-- Trace ID per lifecycle-trace.mdc. Never leave this at N/A when a real issue exists.
+     If no issue exists yet for a major/breaking change, link the [discussion] issue instead. -->
+
+## What is the new behavior?
+<!-- Decision record (lifecycle-trace.mdc): what changed and *why*, plus the files actually
+     touched. From the ticket's "Proposed Solution" + as-built file list. For Hard /
+     high-blast-radius changes this section is the only durable design record — write it as one. -->
+
+**QA — tests covering this change**
+<!-- From the ticket's Acceptance Criteria, now green. -->
+- `<spec path> :: "<it name>"` — Given … When … Then …
+- Edge cases covered: …
+- Edge cases not covered (and why it's acceptable): …
+
+## Does this PR introduce a breaking change?
+- [ ] Yes
+- [ ] No
+<!-- If it touches packages/common public API, add the semver note here. -->
+
+## Other information
+
+**DevOps / rollout** <!-- see references/devops-and-rollback.md for how to fill this -->
+- CI jobs this diff exercises: <Node-version unit matrix? Docker `integration_tests`? samples rebuild?>
+- Release tier: <patch | minor | major> (from the triage difficulty, ARCHITECTURE.md §3-4)
+- Rollback: `git revert <SHA>` + patch release / version pin — affected transports/adapters/consumers: <…>
+  <!-- nestjs/nest is a library: rollback = revert + release, not a runtime feature flag. -->

--- a/.cursor/skills/implement-issue/references/devops-and-rollback.md
+++ b/.cursor/skills/implement-issue/references/devops-and-rollback.md
@@ -1,0 +1,46 @@
+# DevOps / rollout block — how to fill it
+
+Loaded on demand by the `implement-issue` skill when rendering the PR body. The goal is to
+make a change legible to DevOps **without reading the diff**, reusing what the triage ticket
+already carries (blast radius, gates, release tier) — render, don't recompute.
+
+## CI jobs this diff exercises
+
+Map the touched paths to the CircleCI pipeline
+(`build` → Node-version test matrix → `lint:ci` → `integration_tests` → `samples`):
+
+- Any `packages/**` change → `build` + the Node-version **unit-test matrix** + lint.
+- Routing, adapters, or microservice transports → **also** the Docker-gated
+  `integration_tests` job. Run it locally first via the `run-integration-tests` skill.
+- Public API consumed by samples, or a `sample/*` change → the **samples** build/test job;
+  rebuild locally with `npm run build && npm run move:samples`.
+
+State only the jobs the diff actually reaches, so a reviewer knows where CI risk concentrates.
+
+## Release tier
+
+Pull straight from the triage difficulty (ARCHITECTURE.md §3-4) — don't re-score:
+
+- Trivial / Easy, additive in an isolated file → **patch**
+- New opt-in feature / additive interface → **minor**
+- Breaking change to `packages/common` public API, or request-lifecycle ordering → **major**
+
+Maintainers decide the actual tag; this is an estimate, matching the ticket's Release Estimate.
+
+## Rollback
+
+`nestjs/nest` is a **published library, not a deployed service**, so rollback is not a flag toggle:
+
+- Rollback = `git revert <SHA>` followed by a patch release (or consumers pin the previous
+  version). There is **no LaunchDarkly / runtime feature flag** in this repo.
+- Name the transports / adapters / consumers that regress if the change is reverted, so a
+  maintainer can see the blast radius of the revert itself.
+- The repo's *forward* safety mechanism is the additive / opt-in / phased-delivery pattern
+  (see the `http-request-chain` skill), not a runtime flag.
+
+## Reusing this skill in an application repo (future)
+
+If you point this same pipeline at one of your own **application** repos where rollout *is*
+flag-gated, the rollback line is the designed extension slot: add the flag name, its default
+state, and the kill-switch / runbook link. Keep the `nestjs/nest` version flag-free so the
+library PR body stays accurate — don't add a flag field that's always "N/A" here.

--- a/.cursor/skills/implement-issue/scripts/preflight.sh
+++ b/.cursor/skills/implement-issue/scripts/preflight.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Preflight for the implement-issue skill: confirms the red->green handoff
+# preconditions before any code is written. Advisory only — it never edits
+# anything. The real *enforced* gate is .husky/pre-push (verify-trace.sh from
+# the triage-issue skill); this is the agent-layer nudge that runs earlier.
+#
+# Output lines are prefixed OK / WARN / STOP so the agent can act on them:
+#   STOP  -> a precondition is missing; run triage-issue first, don't improvise.
+#   WARN  -> proceed, but a gate or evidence needs attention.
+#   OK    -> precondition satisfied.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel 2>/dev/null)" || { echo "STOP  not inside a git repo."; exit 0; }
+
+ok=true
+issue=""
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [[ "$branch" =~ ^[a-z]+/([0-9]+)-.+$ ]]; then
+  issue="${BASH_REMATCH[1]}"
+  echo "OK    branch '$branch' -> issue #$issue"
+else
+  echo "STOP  branch '$branch' isn't <type>/<issue>-<slug>. Run the triage-issue skill first."
+  ok=false
+fi
+
+if [[ -n "$issue" ]]; then
+  ticket=".cursor/triage/${issue}.md"
+  if [[ ! -f "$ticket" ]]; then
+    echo "STOP  no triage ticket at $ticket. Run the triage-issue skill first."
+    ok=false
+  elif grep -q '<paste of `npm run test`' "$ticket" 2>/dev/null; then
+    echo "WARN  $ticket still has placeholder Failing-Test Evidence."
+    echo "      Confirm the spec is actually red before implementing — don't write a fix against a green test."
+  else
+    echo "OK    triage ticket present with evidence: $ticket"
+  fi
+fi
+
+if [[ -f .husky/pre-push ]]; then
+  echo "OK    .husky/pre-push installed (verify-trace gate will run on push)."
+else
+  echo "WARN  .husky/pre-push not installed — the enforced triage gate won't run on push."
+  echo "      one-time fix:"
+  echo "        cp .cursor/skills/triage-issue/pre-push.sh .husky/pre-push && chmod +x .husky/pre-push"
+fi
+
+echo "---"
+if $ok; then
+  echo "preflight OK: clear to implement."
+else
+  echo "preflight blocked: resolve the STOP line(s) above first."
+fi
+exit 0

--- a/.cursor/skills/run-integration-tests/SKILL.md
+++ b/.cursor/skills/run-integration-tests/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: run-integration-tests
+description: >-
+  Run NestJS integration tests with Docker (Redis, NATS, RabbitMQ, etc.).
+  Use when changing microservice transports, HTTP adapters, or routing behavior.
+---
+
+# Run Integration Tests
+
+Full details: [docs/DEVELOPER.md](../../../docs/DEVELOPER.md) and [ARCHITECTURE.md](../../../ARCHITECTURE.md) section 5.
+
+**When required**: routing, adapters, microservice transports.
+
+## Full run (recommended)
+
+```bash
+sh scripts/run-integration.sh
+```
+
+Builds packages, starts Docker services, waits for RabbitMQ, runs tests.
+
+## Manual steps
+
+```bash
+npm run build
+npm run test:docker:up
+npm run test:docker:wait:rmq
+npm run test:integration
+npm run test:docker:down    # when finished
+```
+
+## Notes
+
+- Docker must be running (`integration/docker-compose.yml`).
+- `scripts/prepare.sh` only builds + starts Docker; it does **not** run tests or `move:samples`.

--- a/.cursor/skills/triage-issue/SKILL.md
+++ b/.cursor/skills/triage-issue/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: triage-issue
+description: >-
+  Paste a GitHub issue (or give an issue number) to get a structured ticket -
+  category, problem, solution, blast-radius/difficulty, workarounds, release
+  estimate, acceptance criteria - plus a branch off the issue number and
+  failing tests proving the gap before any fix is written. Use when triaging,
+  scoping, or planning a bug report, feature request, or regression.
+---
+
+# Triage Issue → Failing Tests
+
+Orchestrates existing conventions rather than inventing new ones:
+- Category taxonomy → `.github/ISSUE_TEMPLATE/` (Bug, Feature, Regression, Performance)
+- Blast radius / difficulty → `ARCHITECTURE.md` §3-4 (pull verbatim, don't re-score)
+- Trace ID = issue number, commit/PR conventions → `lifecycle-trace.mdc`, `commit-and-pr` skill
+- Spec location (mirror source, never colocated) → `tests.mdc` + concept rules
+- Coverage gaps → `check-conformance` skill
+- Build/lint/integration gates → `build-and-verify`, `run-integration-tests` skills
+- Push-time enforcement → `.husky/pre-push` runs `verify-trace.sh` (see Guardrails)
+
+## Input
+
+Paste the issue text directly, or give an issue number/URL — if you reference a
+number/URL, try `gh issue view <n>` first; if `gh` isn't installed or authenticated,
+ask for the text instead. Don't guess at issue content.
+
+## Steps
+
+1. **Classify** against the 4 real categories in `.github/ISSUE_TEMPLATE/`. If it
+   doesn't clearly fit one, ask rather than force it.
+2. **Locate the surface.** Grep the named symbol/behavior; find the matching row
+   in `ARCHITECTURE.md` §4's cheat sheet (or the closest analog).
+3. **Rate.** Copy Blast Radius and Difficulty straight from that table — don't
+   invent a new scale.
+4. **Write 3-7 acceptance criteria**, Given/When/Then, each naming the test that
+   will assert it.
+5. **Branch:** `git checkout -b <type>/<issue>-<slug> master` (`master` is this
+   repo's base branch per `CONTRIBUTING.md`; `<type>` matches `commit-and-pr`'s
+   conventional-commit types).
+6. **Scaffold the failing test(s)** at the mirrored `test/` path for the
+   identified surface, matching the sibling specs' mocha + chai style
+   (`describe`/`it`, `expect(...).to.equal(...)`). Routing/adapter/transport
+   issues need an `integration/` spec instead (Docker) — flag this, don't fake
+   a unit test for it.
+7. **Prove it's red.** Run `npm run test` (or the integration script) and paste
+   the failing output into the ticket. If it unexpectedly passes, stop and say
+   so — don't write a fix to force red, and don't claim a gap that isn't real.
+8. **Save the ticket.** Copy `ticket-template.md` to `.cursor/triage/<issue-number>.md`
+   and fill it in completely there (not just as chat output) — the pre-push gate
+   in Guardrails reads this exact path, so an unsaved ticket can't be verified.
+9. **Ownership gate:** non-tech-ownable only if Difficulty = Trivial AND
+   Blast Radius = none/low AND only `sample/*` or `*.md` is touched (this is
+   `ARCHITECTURE.md`'s own Trivial bar, not a new threshold). Anything else →
+   engineer required; a non-engineer can still own the ticket and run the gates.
+
+## Guardrails
+
+- This skill stops at red — it does not write the fix.
+- Never leave the PR template's `Issue Number:` field at `N/A` if a real issue
+  exists (see `lifecycle-trace.mdc`); if none exists yet, say so and point at
+  the `[discussion]`-issue process for major changes.
+- Don't touch `packages/common/interfaces|decorators` or `core/injector|router`
+  as part of triage scaffolding — flag Hard/breaking and stop there.
+- **Enforcement is real but local, not CI.** `verify-trace.sh` in this folder is meant to
+  run as `.husky/pre-push` so a missing/placeholder ticket blocks `git push` on a machine
+  that has it installed — see `pre-push.sh` in this folder for the one line to copy into
+  `.husky/pre-push` (file-tool writes to `.husky/` are blocked in this environment as a
+  safety measure, so that copy is a manual, one-time step on your own machine). This is
+  *not* equivalent to GitHub branch protection or required-status-checks on `nestjs/nest` —
+  it's bypassable with `--no-verify` or from any machine without the hook installed. Treat
+  it as a strong local nudge for this team's own workflow, not a substitute for real CI.

--- a/.cursor/skills/triage-issue/pre-push.sh
+++ b/.cursor/skills/triage-issue/pre-push.sh
@@ -1,0 +1,14 @@
+# Contents to copy into .husky/pre-push (one-time, manual — agent file-write tools
+# are blocked from touching .husky/ in this environment as a safety measure, since
+# git hooks auto-execute on every future `git push`). This repo already uses husky
+# for pre-commit/commit-msg; this just adds the matching pre-push file in the same
+# no-shebang, single-line style.
+#
+# From the repo root:
+#   cp .cursor/skills/triage-issue/pre-push.sh .husky/pre-push
+#   chmod +x .husky/pre-push
+#
+# (cp is fine — the comment lines above are valid no-ops in a shell script. If you'd
+# rather keep .husky/pre-push minimal, just paste the one real line below by hand.)
+
+bash .cursor/skills/triage-issue/verify-trace.sh

--- a/.cursor/skills/triage-issue/ticket-template.md
+++ b/.cursor/skills/triage-issue/ticket-template.md
@@ -1,0 +1,40 @@
+# [#<issue-number>] <title>
+
+**Category:** Bug | Regression | Feature | Performance/Enhancement
+**Trace ID:** #<issue-number>  **Branch:** `<type>/<issue-number>-<slug>`
+
+## Problem
+<1-3 sentences, in repo terms, linking the original issue.>
+
+## Acceptance Criteria
+- [ ] AC1 — Given … When … Then … → `packages/<pkg>/test/.../x.spec.ts :: "<it name>"`
+- [ ] AC2 — …
+
+## Proposed Solution
+<approach + exact files, from `ARCHITECTURE.md` §4>
+
+## Blast Radius & Difficulty  (source: `ARCHITECTURE.md` §3-4, not re-scored)
+| Surface | Blast radius | Difficulty |
+|---|---|---|
+| `packages/<pkg>/...` | none / low / medium / high / very high | Trivial → Hard |
+
+**Breaking change?** Yes/No — semver note if it touches `packages/common` public API.
+
+## Existing Workarounds (estimate — from the issue thread/docs only; "none found" if none)
+
+## Failing-Test Evidence (TDD red)
+```
+<paste of `npm run test` output showing the new spec failing, on this branch>
+```
+
+## Release Estimate (estimate, not a commitment)
+- Tier: <Difficulty> → likely **patch / minor / major**
+- Historical cadence on this repo: patch tags ~every 1-2 weeks, minor/major
+  ~every 4-8 months (from `git tag` history) — maintainers still decide.
+- Gates before merge: `npm run build`, `npm run test`, `npm run lint` (+
+  `sh scripts/run-integration.sh` if routing/adapter/transport).
+
+## Ownership Gate (advisory)
+Non-tech ownable only if Trivial + none/low blast radius + `sample/*`/`*.md`
+only. Otherwise engineer required.
+→ Verdict: <Non-tech ownable | Engineer required> — <one-line reason>.

--- a/.cursor/skills/triage-issue/verify-trace.sh
+++ b/.cursor/skills/triage-issue/verify-trace.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Pre-push gate, wired in via .husky/pre-push (this repo already uses husky for
+# pre-commit/commit-msg - this reuses that infra rather than adding a parallel one).
+#
+# Only fires on branches named <type>/<issue>-<slug> (e.g. fix/15270-resolve-x),
+# the convention introduced by the triage-issue skill / lifecycle-trace.mdc.
+# Any other branch name is left alone - this is not a generic gate.
+#
+# What it checks for a matching branch:
+#   1. A filled-in ticket at .cursor/triage/<issue>.md (produced by the
+#      triage-issue skill) - not just present, but with the placeholder
+#      Failing-Test-Evidence text actually replaced.
+#   2. No *new* missing-spec gaps (via check-conformance) among the files this
+#      branch actually touched relative to its merge base - pre-existing gaps
+#      elsewhere in the repo are not this branch's problem and won't block it.
+#
+# Fails OPEN (does not block) on infra problems it can't resolve (no base ref
+# to diff against, etc.) - it only fails CLOSED on a confirmed policy gap, never
+# on its own tooling errors. This only blocks `git push` from a machine that has
+# this husky hook installed; it is not a substitute for real CI / branch
+# protection on the actual GitHub remote.
+set -uo pipefail
+cd "$(git rev-parse --show-toplevel)" || exit 0
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+
+if [[ ! "$branch" =~ ^[a-z]+/([0-9]+)-.+$ ]]; then
+  echo "pre-push: '$branch' isn't <type>/<issue>-<slug> - triage gate not applicable, skipping."
+  exit 0
+fi
+issue="${BASH_REMATCH[1]}"
+ticket=".cursor/triage/${issue}.md"
+
+if [[ ! -f "$ticket" ]]; then
+  echo ""
+  echo "BLOCKED (pre-push): no triage ticket at $ticket for issue #$issue."
+  echo "Run the triage-issue skill and save its filled-out ticket there before pushing."
+  exit 1
+fi
+
+if grep -q '<paste of `npm run test`' "$ticket" 2>/dev/null; then
+  echo ""
+  echo "BLOCKED (pre-push): $ticket still has the placeholder Failing-Test Evidence."
+  echo "Paste the real (red) test output before pushing - don't fabricate a pass."
+  exit 1
+fi
+
+echo "pre-push: ticket for #$issue found with evidence filled in. Checking for new spec gaps..."
+
+base=""
+if git rev-parse --verify -q origin/master >/dev/null; then
+  base="origin/master"
+elif git rev-parse --verify -q master >/dev/null; then
+  base="master"
+else
+  echo "pre-push: no master/origin-master ref to diff against - skipping spec-gap check (fail-open)."
+  exit 0
+fi
+
+merge_base=$(git merge-base "$base" HEAD 2>/dev/null) || { echo "pre-push: couldn't compute merge-base - skipping spec-gap check (fail-open)."; exit 0; }
+
+changed_files=$(git diff --name-only "$merge_base" HEAD -- \
+  packages/common/pipes packages/common/exceptions packages/common/serializer \
+  packages/common/decorators packages/core/guards packages/core/interceptors \
+  packages/core/exceptions packages/microservices/exceptions 2>/dev/null)
+
+if [[ -z "$changed_files" ]]; then
+  echo "pre-push: no files in triage-gate scope changed by this branch. OK."
+  exit 0
+fi
+
+if [[ ! -f .cursor/skills/check-conformance/check.sh ]]; then
+  echo "pre-push: check-conformance script missing - skipping spec-gap check (fail-open)."
+  exit 0
+fi
+
+missing_now=$(bash .cursor/skills/check-conformance/check.sh 2>/dev/null | awk '/^MISSING SPEC:/ {print $3}')
+
+new_missing=""
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if printf '%s\n' "$missing_now" | grep -qxF "$f"; then
+    new_missing="${new_missing}${f}"$'\n'
+  fi
+done <<< "$changed_files"
+
+if [[ -n "$new_missing" ]]; then
+  echo ""
+  echo "BLOCKED (pre-push): this branch touches files with no detected test coverage:"
+  echo "$new_missing"
+  echo "Add the mirrored spec(s) (see tests.mdc) or run check-conformance -v to confirm indirect coverage."
+  exit 1
+fi
+
+echo "pre-push: no new spec gaps introduced by this branch. OK."
+exit 0

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,17 @@
+# Vendored / local tooling
+.local-node/
+**/node_modules/
+
+# Large lockfiles
+package-lock.json
+**/package-lock.json
+
+# Build output
+dist/
+**/dist/
+packages/**/*.js
+packages/**/*.d.ts
+
+# Test coverage
+coverage/
+.nyc_output/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ sample/**/package-lock.json
 
 # dependencies
 node_modules/
+.local-node/
 
 # IDE
 /.idea

--- a/AI-AGENT-SETUP-REVIEW.md
+++ b/AI-AGENT-SETUP-REVIEW.md
@@ -1,0 +1,182 @@
+# AI-Agent Enablement Review — `nestjs/nest`
+
+Review of the `.cursor/` rules, skills, hooks, and supporting docs (ARCHITECTURE.md,
+DESIGN.md, docs/DEVELOPER.md) added to make this repo AI-agent-friendly.
+
+---
+
+## 1. Overall assessment
+
+The setup is genuinely well-architected and unusually disciplined. The strongest design
+decision is that **rules and skills reference source-of-truth docs instead of copying
+them** ("pull verbatim from ARCHITECTURE.md §3-4, don't re-score"). That is exactly what
+keeps an agent context accurate over time and is the right call for your north star.
+
+Layering is sound:
+
+- **One** always-apply rule (`00-index.mdc`, 16 lines) — minimal always-on context.
+- **Per-package, glob-scoped** rules that only load when relevant files are touched.
+- **Agent-invoked skills** for workflows (triage, build, commit, conformance).
+- **A real enforced gate** (`verify-trace.sh` via husky pre-push) — not just advisory.
+- **Context-budget hygiene** via `.cursorignore` + the `guard-read.sh` read hook.
+
+The conformance script actually works and produces real signal — it flagged 4 genuinely
+missing specs (`intrinsic.exception.ts`, `base-rpc-exception-filter.ts`,
+`kafka-retriable-exception.ts`, `serialize-options.decorator.ts`). That alone proves the
+"bring CI knowledge earlier" thesis.
+
+The issues below are mostly drift, gaps against your stated goals, and a few duplication
+hotspots — not structural problems.
+
+---
+
+## 2. Highest-priority gaps
+
+### 2.1 `scaffold-contribution` still missing (design gap, not doc drift)
+
+DESIGN.md now describes the shipped skills-based system (`triage-issue` →
+`implement-issue` → `commit-and-pr` plus leaf skills). The remaining gap is procedural,
+not documentary: **`ParsePositiveIntPipe` is the reference onboarding exercise** (rules
+model it; it is not checked into `packages/` so agents can implement it fresh), but nothing
+yet automates "find sibling → write impl + mirrored spec + barrel export."
+
+**Recommendation:** build the `scaffold-contribution` skill (see 2.2) so Goal 2 is not
+assembled ad hoc from `pipes.mdc` et al.
+
+### 2.2 No "scaffold a first contribution" skill — Goal 2's core is missing
+
+You have skills for *triage* (plan), *build*, *commit*, *conformance*, and *integration
+tests*, plus an `http-request-chain` planning skill. The missing middle is the actual
+**"create the impl + mirrored spec + barrel export, modeled on the nearest sibling"**
+generator. Right now an agent assembles that ad hoc from `pipes.mdc` etc.
+
+**Recommendation:** add a `scaffold-contribution` skill that: picks the target package →
+finds the nearest sibling as a template → writes impl + mirrored spec + barrel export →
+runs `check-conformance` + lint/test. This is the single highest-leverage addition for
+Goal 2 and directly serves the "accuracy on every PR + reuse details" north star.
+
+### 2.3 Goal 3 (PM / QA / DevOps) is barely served
+
+Goal 3 and DESIGN.md requirement 5 ("multi-audience renderings of the same change") have
+**no dedicated mechanism**. The only artifact that comes close is `triage-issue`'s
+`ticket-template.md`, which happens to contain PM-ish (Problem), QA-ish (Acceptance
+Criteria), and DevOps-ish (Gates/Release estimate) sections — but it's a *triage* ticket,
+not a per-PR change summary, and it's not framed for those audiences.
+
+**Recommendation:** make the three-audience output a concrete step — either folded into the
+scaffold/commit-and-pr skill or a small `change-summary` skill that emits a PM summary
+(plain language, no code), a QA block (test list + edge cases covered/not), and a DevOps
+block (which CI jobs the diff touches: Node matrix? Docker integration job? samples
+rebuild?). You already enumerated exactly this in DESIGN.md §5 — it just needs to exist.
+
+### 2.4 Everything is Cursor-only — no Claude / Claude Code surface
+
+You said you're using "Cursor and Claude," and you're reviewing this *in Claude right now*,
+but the entire investment lives under `.cursor/` (`rules/*.mdc`, `skills/*/SKILL.md`,
+`hooks/`). Claude Code does **not** read `.cursor/rules` or auto-load `.cursor/skills`; it
+looks for `CLAUDE.md` / `AGENTS.md` and `.claude/`. So none of this guidance reaches Claude
+automatically today.
+
+Also worth verifying: `.cursor/skills/*/SKILL.md` uses the **Agent Skills** format
+(`name`/`description` frontmatter). Cursor's first-class primitive is `.cursor/commands/`;
+confirm Cursor actually auto-discovers `.cursor/skills/` in your version, otherwise these
+are effectively just markdown the agent reads only when pointed at them.
+
+**Recommendation:** add a thin `AGENTS.md` (or `CLAUDE.md`) at repo root that points to
+ARCHITECTURE.md / DEVELOPER.md / CONTRIBUTING.md and lists the skills — `AGENTS.md` is read
+by both Cursor and Claude Code, so it's the cheapest way to make the work portable. Keep
+the source-of-truth docs tool-agnostic (they already are) and let each tool's thin entry
+file point into them.
+
+---
+
+## 3. Duplication & context-overload analysis
+
+You asked specifically whether duplicated rules/skills could overload the agent context.
+**Short answer: the always-on footprint is small and safe; the duplication that exists is
+mostly mechanical (npm commands) and mostly harmless because of glob scoping.**
+
+What's actually always-on: only `00-index.mdc` (16 lines). Per-package rules and skills
+load on demand. This is the right design and is *not* an overload risk.
+
+Genuine duplication, ranked:
+
+1. **npm build/test/lint command blocks** are restated in ~5 places: `docs/DEVELOPER.md`,
+   `build-and-verify`, `commit-and-pr`, `run-integration-tests`, and `ARCHITECTURE.md §5`.
+   The skills do link to DEVELOPER.md but also re-list the commands. This is the worst
+   offender for drift (change a script name and you edit 5 files). *Recommendation:* let
+   `build-and-verify` own the command list; have the others link to it rather than restate.
+
+2. **Block/ignore lists in 3 mechanisms**: `.cursorignore`, `guard-read.sh`, and
+   `00-index.mdc`'s "Do not read" all enumerate `node_modules`, `dist`, `*.d.ts`, etc.
+   This is defense-in-depth (indexer vs runtime hook vs agent instruction) so it's
+   *defensible*, but the three lists can drift apart. *Recommendation:* keep all three but
+   add a one-line comment in each pointing to the others as the canonical trio.
+
+3. **The shared-`ContextCreator` paragraph** is repeated nearly verbatim in `guards.mdc`,
+   `interceptors.mdc`, `exception-filters.mdc`, and `decorators.mdc`. Because these are
+   glob-scoped, normally only one loads — so this is **not** a context-overload problem and
+   the repetition is arguably good (each rule is self-contained). Leave as-is.
+
+4. **Lifecycle ordering** appears in `ARCHITECTURE.md §2a` and is restated in `guards.mdc`,
+   `interceptors.mdc`, and the `http-request-chain` skill. Minor; acceptable since each
+   states only the one-line position relevant to its concept.
+
+Net: no rule/skill combination produces a dangerous context blow-up. The thing to fix is
+**single-sourcing the npm commands**, not the conceptual rules.
+
+---
+
+## 4. Smaller correctness / consistency issues
+
+- **Commit metadata is slightly out of sync with `commitlint`.** `commit-and-pr` and
+  `packages.mdc` list types missing `revert` and `sample` (both are in
+  `.commitlintrc.json` `type-enum`), and omit the `release` scope. `subject-case` in
+  commitlint allows sentence/start/pascal/upper/lower case — the skill says only
+  "imperative, present tense," which is fine but under-specifies. Align the skill's lists
+  with `.commitlintrc.json` so an agent doesn't author a commit the hook then rejects.
+
+- **`.cursor/.99999.md.discard`** is a stray file (looks like leftover failing-test
+  evidence). Remove it or move it into the triage flow; stray dotfiles in `.cursor/`
+  invite confusion.
+
+- **`.cursor/triage/` is empty** and only created at runtime. `verify-trace.sh` depends on
+  the exact path `.cursor/triage/<issue>.md`. Consider a `.gitkeep` + a one-line README so
+  the contract is discoverable without reading the script.
+
+- **`pre-push` is not installed** (`.husky/pre-push` is absent). This is intentional per the
+  skill (file-write to `.husky/` is blocked in this environment), but it means the "one
+  enforced gate" is currently *not active*. The README/onboarding should make the one-time
+  `cp .cursor/skills/triage-issue/pre-push.sh .husky/pre-push` step impossible to miss for a
+  new engineer, or it silently isn't enforced.
+
+---
+
+## 5. Recommendations, prioritized
+
+1. **Build the `scaffold-contribution` skill** (Goal 2 core; highest leverage). — *new*
+2. **Add a `change-summary` step/skill for PM/QA/DevOps output** (Goal 3). — *new*
+3. **Reconcile DESIGN.md with the shipped skills-based system** — *done in this commit*.
+4. **Add `AGENTS.md` at repo root** so the work reaches Claude/Claude Code, not just Cursor. — *new*
+5. **Single-source the npm command blocks** into `build-and-verify`; link from the rest. — *edit*
+6. **Align `commit-and-pr` / `packages.mdc` commit types & scopes with `.commitlintrc.json`.** — *edit*
+7. **Make the `pre-push` install step prominent** in onboarding (the only real gate). — *edit*
+8. **Housekeeping:** remove `.99999.md.discard`, `.gitkeep` for `.cursor/triage/`, confirm no
+   compiled `.js/.d.ts` are committed. — *edit*
+
+Items 1–4 advance your goals and north star directly; 5–8 are hygiene that reduces drift
+and keeps the agent's context accurate.
+
+---
+
+## 6. On the "future" north star (reduce PR time by moving CI knowledge earlier)
+
+You're already most of the way there conceptually: `check-conformance` mirrors the
+"specs mirror source" CI expectation, and `verify-trace.sh` gates on it pre-push. To
+actually shorten PR cycle time, the two missing links are (a) running the *real* gates
+(`build`/`test`/`lint`) automatically as part of the scaffold/triage flow rather than
+leaving them as a checklist, and (b) closing the Docker gap — every doc honestly notes
+integration tests haven't been run locally, which is the one class of failure most likely
+to surface only in CI. Wiring `run-integration-tests` into the definition of "done" for
+routing/adapter/transport changes (even if it just hard-stops with "Docker required") would
+catch the highest-latency CI failures before push.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,347 @@
+# NestJS Architecture & Change-Impact Guide
+
+> Audience: a developer (or an agent planning an edit) who needs to decide quickly
+> whether a proposed change is **Easy / Medium / Hard** before touching code.
+>
+> How to use this doc: find your change in the **Change Difficulty Cheat Sheet**,
+> or locate the package/folder in the **Package Reference** and read the
+> Blast Radius + Volatility ratings next to it.
+>
+> Ratings legend:
+> - **Blast Radius** = how many other things break if you change this (consumer count).
+> - **Volatility** = how often this area actually changes (2-yr git churn). High churn
+>   often means well-trodden + good test coverage, but also active/contended surface.
+> - **Difficulty** = realistic effort for a competent contributor to land a *correct* change.
+
+---
+
+## 1. Big Picture
+
+NestJS is a **monorepo** (Lerna + npm workspaces) of independent but layered packages.
+The core idea: a **platform-agnostic DI + metadata core** with **swappable HTTP/transport
+adapters** plugged in underneath.
+
+```
+                         ┌───────────────────────────┐
+                         │      @nestjs/common         │  ← decorators, interfaces,
+                         │  (decorators, pipes, DTO     │     pipes, exceptions, enums
+                         │   contracts, exceptions)     │     (the "vocabulary")
+                         └─────────────▲───────────────┘
+                                       │ (peer dep, 252 internal refs)
+        ┌──────────────────────────────┼──────────────────────────────┐
+        │                              │                                │
+┌───────┴────────┐          ┌──────────┴─────────┐          ┌───────────┴─────────┐
+│  @nestjs/core   │          │ @nestjs/microservices│         │ @nestjs/websockets   │
+│  DI container,  │          │  transport servers/  │         │  gateways, socket    │
+│  scanner,       │          │  clients (RMQ, Kafka,│         │  lifecycle           │
+│  router, request│          │  gRPC, NATS, MQTT…)  │         │                      │
+│  lifecycle      │          └──────────▲───────────┘         └──────────▲──────────┘
+└───────▲─────────┘                     │                                │
+        │ (HTTP adapter contract)       │                                │
+ ┌──────┴───────┬──────────────┐   (transport)                  ┌────────┴─────────┐
+ │ platform-    │ platform-     │                                │ platform-        │
+ │ express      │ fastify       │                                │ socket.io / ws   │
+ └──────────────┴──────────────┘                                └──────────────────┘
+
+  @nestjs/testing  ← wraps core + common + platform-express for unit/e2e harnesses
+```
+
+**Rendered version** (view in a mermaid-aware viewer, e.g. Cursor, GitHub, VS Code):
+
+```mermaid
+graph TD
+    common["common<br/>decorators, pipes, exceptions"]
+    core["core<br/>DI container, router, lifecycle"]
+    express["platform-express<br/>default HTTP adapter"]
+    fastify["platform-fastify<br/>alt HTTP adapter"]
+    transports["microservices / websockets<br/>RMQ, gRPC, NATS, WS gateways"]
+    testing["testing<br/>Test.createTestingModule()"]
+
+    express --> core
+    fastify --> core
+    transports --> core
+    core --> common
+    testing --> core
+    testing --> common
+    testing --> express
+```
+
+**Dependency rule of thumb (from each package's `peerDependencies`):**
+- `common` depends on nothing internal → it is the foundation (everything imports it).
+- `core` peer-depends on `common` (+ optionally microservices/websockets/platform-express).
+- `platform-*` peer-depend on `common` + `core`.
+- `microservices` / `websockets` peer-depend on `common` + `core`.
+- `testing` peer-depends on `common`, `core`, `microservices`, `platform-express`.
+
+> Source: each `packages/*/package.json` `peerDependencies`.
+
+---
+
+## 2. Sample Data Flow
+
+### 2a. HTTP request lifecycle (the most common path)
+
+A request to a controller route flows through these stages **in this order**
+(ordering per https://docs.nestjs.com/faq/request-lifecycle; implementation lives in
+`packages/core/router` + `packages/core/middleware`):
+
+```
+Incoming HTTP request
+        │
+        ▼
+[1] Platform adapter receives it
+     packages/platform-express/adapters/express-adapter.ts
+     (or platform-fastify/adapters/fastify-adapter.ts)
+        │
+        ▼
+[2] Middleware (global → module-bound)
+     packages/core/middleware/middleware-module.ts
+        │
+        ▼
+[3] Guards (global → controller → route)        ── can short-circuit (403)
+     packages/core/guards/guards-consumer.ts
+        │
+        ▼
+[4] Interceptors (pre-controller, "before")
+     packages/core/interceptors/interceptors-consumer.ts
+        │
+        ▼
+[5] Pipes (transform/validate params)
+     packages/common/pipes/validation.pipe.ts  + route-params-factory
+     packages/core/router/route-params-factory.ts
+        │
+        ▼
+[6] Route handler (your controller method)
+     dispatched via packages/core/router/router-execution-context.ts
+        │
+        ▼
+[7] Interceptors (post-controller, "after" / response mapping)
+        │
+        ▼
+[8] Exception filters (only if anything above threw)
+     packages/core/exceptions/exceptions-handler.ts
+     packages/core/router/router-exception-filters.ts
+        │
+        ▼
+[9] Response serialized & sent via the adapter
+     packages/core/router/router-response-controller.ts
+```
+
+**Rendered version:**
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Adapter as HTTP adapter
+    participant MW as Middleware
+    participant Guard as Guards
+    participant Interceptor
+    participant Pipe as Pipes
+    participant Controller
+    participant Service as Service / provider
+    participant Filter as Exception filter
+
+    Client->>Adapter: HTTP request
+    Adapter->>MW: forward
+    MW->>Guard: next()
+    Guard->>Guard: check authorization
+    alt unauthorized
+        Guard-->>Client: 403 Forbidden
+    else authorized
+        Guard->>Interceptor: continue (before)
+        Interceptor->>Pipe: continue
+        Pipe->>Pipe: validate / transform args
+        Pipe->>Controller: call handler
+        Controller->>Service: delegate business logic
+        Service-->>Controller: result
+        Controller-->>Interceptor: return value
+        Interceptor->>Interceptor: map response (after)
+        Interceptor-->>Adapter: response
+        Adapter-->>Client: HTTP response
+    end
+
+    opt exception thrown anywhere above
+        Note over Filter: ExceptionsHandler catches it
+        Filter-->>Adapter: error response
+        Adapter-->>Client: HTTP error
+    end
+```
+
+### 2b. Application bootstrap (startup) flow
+
+```
+NestFactory.create(AppModule)                      packages/core/nest-factory.ts
+        │
+        ▼
+DependenciesScanner.scan()                         packages/core/scanner.ts
+   walks module tree, reads @Module metadata
+        │
+        ▼
+InstanceLoader.createInstancesOfDependencies()     packages/core/injector/instance-loader.ts
+   uses Injector to resolve providers              packages/core/injector/injector.ts
+        │
+        ▼
+RoutesResolver registers controllers → routes      packages/core/router/routes-resolver.ts
+        │
+        ▼
+Lifecycle hooks fired (onModuleInit, etc.)         packages/core/hooks/
+        │
+        ▼
+app.listen() → adapter.listen()                    platform-express / platform-fastify
+```
+
+### 2c. Microservice message flow (alternate entrypoint)
+
+```
+Broker (RMQ/Kafka/NATS/MQTT/Redis/gRPC/TCP) message
+        │
+        ▼
+Transport Server receives                          packages/microservices/server/server-*.ts
+        │
+        ▼
+Deserializer → ListenersController dispatch         packages/microservices/listeners-controller.ts
+        │
+        ▼
+@MessagePattern / @EventPattern handler
+   (guards/pipes/interceptors/filters reused from core, RPC variants)
+        │
+        ▼
+Serializer → response published back                packages/microservices/serializers/
+```
+
+---
+
+## 3. Package Reference + Impact Analysis
+
+> Churn = number of non-test commits touching files in that area over the last 2 years
+> (`git log --since="2 years ago" --name-only`). Refs = internal import count (`rg`).
+
+### `packages/common` — the contract layer (HIGHEST BLAST RADIUS)
+- **Role:** Decorators, interfaces, enums, pipes, exceptions, DTO/validation contracts.
+  This is the "public vocabulary" every other package and every user app imports.
+- **Key files/folders:** `decorators/`, `pipes/`, `exceptions/`, `interfaces/`, `enums/`,
+  `serializer/`, `module-utils/`.
+- **Blast Radius:** **VERY HIGH** — 252 internal import sites reference `@nestjs/common`;
+  also the most-imported package in *user* code. Changing a public interface or decorator
+  signature is effectively a breaking change for the whole ecosystem.
+- **Volatility:** `common/pipes` (85 churn) and `common/exceptions` (49) are hot;
+  `file-type.validator.ts` (29) and `validation.pipe.ts` (13) are individual hotspots.
+- **Difficulty:**
+  - Adding a *new* exception/pipe/decorator → **Easy–Medium** (additive, isolated).
+  - Changing an *existing* interface, decorator signature, or pipe behavior → **HARD**
+    (semver-breaking, ripples into core + all platforms + user code).
+
+### `packages/core` — the engine (HIGH BLAST RADIUS, HIGH VOLATILITY)
+- **Role:** DI container, module scanner, instance resolution, router, request lifecycle,
+  guards/interceptors/pipes *consumers*, exception handling, lifecycle hooks, REPL.
+- **Key files/folders:**
+  - `injector/` (DI heart) — `injector.ts`, `module.ts`, `instance-wrapper.ts`, `container.ts`
+  - `router/` — `router-execution-context.ts`, `routes-resolver.ts`, `router-explorer.ts`
+  - `scanner.ts`, `nest-factory.ts`, `nest-application.ts`
+  - `middleware/`, `guards/`, `interceptors/`, `pipes/`, `exceptions/`, `hooks/`
+- **Blast Radius:** **HIGH** — `injector/injector` referenced 24×, `injector/module` 37×
+  internally; behavior changes here affect *every* app at runtime.
+- **Volatility:** `core/injector` (79 churn) and `core/router` (43) are among the busiest
+  areas in the repo. `injector.ts` alone: 19 changes; `scanner.ts`: 15.
+- **Difficulty:**
+  - Touching `injector/` or `scanner.ts` (DI resolution, scopes, circular deps) → **HARD**
+    (subtle ordering/scope bugs, large existing spec suite must stay green).
+  - Router param handling, lifecycle ordering → **HARD–Medium**.
+  - Adding a helper/util in `core/helpers` → **Medium**.
+
+### `packages/microservices` — transports (HIGHEST VOLATILITY, MEDIUM BLAST RADIUS)
+- **Role:** Transport servers + clients for RMQ, Kafka, gRPC, NATS, MQTT, Redis, TCP;
+  message (de)serialization; RPC-flavored guards/pipes/interceptors.
+- **Key files/folders:** `server/server-*.ts`, `client/client-*.ts`, `serializers/`,
+  `deserializers/`, `listeners-controller.ts`.
+- **Blast Radius:** **MEDIUM** — opt-in package; changes to *one* transport are isolated
+  to that transport's users. Shared base (`server/server.ts`, `nest-microservice.ts`)
+  is higher radius.
+- **Volatility:** **HIGHEST in repo** — `microservices/server` (98 churn),
+  `microservices/client` (62). Hotspots: `server-rmq.ts` (20), `server-grpc.ts` (18),
+  `client-rmq.ts` (14). These depend on external broker libs that change often.
+- **Difficulty:**
+  - Fix in a *single* transport (e.g. `server-rmq.ts`) → **Medium** (isolated, but needs
+    Docker + the broker running for integration tests).
+  - Change the shared transport base or interfaces → **HARD**.
+
+### `packages/platform-express` — default HTTP adapter (MEDIUM)
+- **Role:** Express implementation of core's `AbstractHttpAdapter` contract; multer uploads,
+  CORS, body parsing.
+- **Key files:** `adapters/express-adapter.ts` (12 churn), `multer/`.
+- **Blast Radius:** **MEDIUM** — default platform, so most apps use it, but it implements a
+  stable contract defined in core (`adapters/http-adapter.ts`).
+- **Volatility:** Moderate (`platform-express/adapters`: 13).
+- **Difficulty:** Adapter method tweak → **Medium**; new upload/CORS option → **Medium**.
+
+### `packages/platform-fastify` — alt HTTP adapter (MEDIUM, HIGH PER-FILE VOLATILITY)
+- **Role:** Fastify implementation of the same adapter contract.
+- **Key files:** `adapters/fastify-adapter.ts` — **the single most-changed file in the repo
+  (30 changes)**, due to Fastify's faster-moving API and routing quirks.
+- **Blast Radius:** **MEDIUM** (opt-in), but parity with Express is expected, so changes
+  often need a mirrored Express test.
+- **Difficulty:** **Medium**, occasionally **Hard** when Express/Fastify parity + routing
+  (`find-my-way`, `path-to-regexp`) interact.
+
+### `packages/websockets` + `platform-socket.io` / `platform-ws` (MEDIUM-LOW)
+- **Role:** Gateway abstraction (`@WebSocketGateway`), socket lifecycle; concrete adapters
+  for socket.io and ws.
+- **Key files:** `web-sockets-controller.ts`, `socket-module.ts`,
+  `exceptions/base-ws-exception-filter.ts` (10 churn).
+- **Blast Radius:** **LOW–MEDIUM** — opt-in, fewer consumers (websockets: 16 churn total).
+- **Difficulty:** Adapter/gateway fix → **Medium**; isolated and well-bounded.
+
+### `packages/testing` (LOW BLAST RADIUS)
+- **Role:** `Test.createTestingModule()` harness used by users and by Nest's own e2e suite.
+- **Blast Radius:** **LOW** (test-time only) but **wide reach** — a bug here breaks *everyone's*
+  test suites, so treat behavior changes carefully.
+- **Volatility:** Low (14 churn).
+- **Difficulty:** **Easy–Medium**.
+
+---
+
+## 4. Change Difficulty Cheat Sheet
+
+| I want to change… | Files to edit | Blast radius | Difficulty | Why |
+|---|---|---|---|---|
+| Fix a typo in a sample README | `sample/*/README.md` | none | **Trivial** | Docs only |
+| Add a new built-in HTTP exception | `packages/common/exceptions/` + index | high (additive) | **Easy** | Pattern is well-established |
+| Add a new `ValidationPipe` option | `packages/common/pipes/validation.pipe.ts` | high | **Medium** | Hot file (13 churn), many users, needs specs |
+| Fix one microservice transport bug | `packages/microservices/server/server-<x>.ts` | medium | **Medium** | Isolated, but needs Docker + broker for e2e |
+| Add option to Express adapter | `packages/platform-express/adapters/express-adapter.ts` | medium | **Medium** | Stable contract; mirror test likely needed |
+| Fix Fastify routing/response quirk | `packages/platform-fastify/adapters/fastify-adapter.ts` | medium | **Medium–Hard** | Most-changed file in repo; Express parity expected |
+| Change a public interface/decorator in `common` | `packages/common/interfaces/` or `decorators/` | **very high** | **Hard** | Breaking change across entire ecosystem |
+| Modify DI resolution / scopes / circular deps | `packages/core/injector/injector.ts`, `module.ts`, `instance-wrapper.ts` | **very high** | **Hard** | 79-churn area, subtle correctness, huge spec suite |
+| Change request lifecycle ordering | `packages/core/router/*`, `middleware/`, `guards/` | **very high** | **Hard** | Affects every request; semver-sensitive |
+| Add a `core/helpers` utility | `packages/core/helpers/` | low | **Medium** | Additive, internal |
+| Improve a testing-module feature | `packages/testing/` | low (wide) | **Easy–Medium** | Test-time only |
+
+**Quick heuristic for an agent/planner:**
+1. **Only `sample/` or `*.md` touched?** → Trivial.
+2. **Single file under `microservices/server|client`, `platform-*/adapters`, or `websockets`?**
+   → Medium (isolated, but check for Docker-based integration tests).
+3. **Any file under `packages/common/interfaces|decorators` or `packages/core/injector|router|scanner.ts`?**
+   → **Hard** by default — high blast radius and/or high volatility. Expect breaking-change
+   review, mandatory specs, and full unit + integration runs.
+
+---
+
+## 5. Mandatory Gates Before Any PR (from `CONTRIBUTING.md`)
+- `npm run build`
+- `npm run test` (357 unit specs)
+- `npm run lint`
+- Integration tests (`sh scripts/run-integration.sh`) — **Docker required** — when touching
+  routing, adapters, or microservice transports.
+- Conventional commits scoped to the package: `fix(core): …`, `fix(microservices): …`,
+  `test(common): …` (scopes enumerated in `CONTRIBUTING.md`).
+- Major features need a `[discussion]` issue first.
+
+---
+
+## 6. Where the numbers came from (so you can re-run them)
+- Inter-package deps: `packages/*/package.json` → `peerDependencies`.
+- Blast radius (import counts): `rg -l "@nestjs/common" packages` (252), `"@nestjs/core"` (54),
+  `"injector/injector"` (24), `"injector/module'"` (37).
+- Volatility (churn): `git log --since="2 years ago" --name-only --pretty=format: -- 'packages/**/*.ts'`
+  excluding `*.spec.ts`, aggregated by file and by area.
+- Request lifecycle ordering: https://docs.nestjs.com/faq/request-lifecycle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,37 +161,48 @@ from the main (upstream) repository:
 
 You will need [Node.js](https://nodejs.org) version >= 20.
 
-1. After cloning the repo, run:
+See the [developer guide][dev-doc] for full local setup: installing dependencies,
+building packages, linking them into samples, running example apps, and running tests.
+
+Quick start after cloning:
 
 ```bash
-$ npm ci --legacy-peer-deps # (or yarn install)
+$ npm ci --legacy-peer-deps
+$ npm run build
+$ npm run move:samples
 ```
 
-2. In order to prepare your environment run `prepare.sh` shell script:
+To run the simplest sample app:
 
 ```bash
-$ sh scripts/prepare.sh
+$ cd sample/01-cats-app
+$ npm install --legacy-peer-deps
+$ npm run start:dev
 ```
 
-That will compile fresh packages and afterward, move them all to `sample` directories.
+For integration tests (Docker required), use `sh scripts/run-integration.sh` or see
+the developer guide — `scripts/prepare.sh` only builds packages and starts Docker
+services; it does not move packages into samples.
 
 ### <a name="common-scripts"></a>Commonly used NPM scripts
 
 ```bash
-# build all packages and move to "sample" directories
+# build all packages (copies output to root node_modules/@nestjs)
 $ npm run build
+
+# copy built @nestjs packages into sample/*/node_modules
+$ npm run move:samples
 
 # run the full unit tests suite
 $ npm run test
 
-# run integration tests
-# docker is required(!)
+# run integration tests (docker is required)
 $ sh scripts/run-integration.sh
 
 # run linter
 $ npm run lint
 
-# build all packages and put them near to their source .ts files
+# clean production build (compiled output next to source in packages/)
 $ npm run build:prod
 ```
 
@@ -324,7 +335,7 @@ changes to be accepted, the CLA must be signed. It's a quick process, we promise
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 <!-- [individual-cla]: http://code.google.com/legal/individual-cla-v1.0.html -->
 <!-- [corporate-cla]: http://code.google.com/legal/corporate-cla-v1.0.html -->
-[dev-doc]: https://github.com/nestjs/nest/blob/master/docs/DEVELOPER.md
+[dev-doc]: docs/DEVELOPER.md
 [github]: https://github.com/nestjs/nest
 [stackoverflow]: https://stackoverflow.com/questions/tagged/nestjs
 [discord]: https://discordapp.com/invite/G7Qnnhy

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,143 @@
+# AI-Agent Enablement — Design Note
+
+Design rationale for the agent tooling layered onto the `nestjs/nest` monorepo: what was
+built to make this repo safely AI-developable, and why each piece exists. This describes the
+system **as shipped** — see each `SKILL.md` / `.mdc` for the operational detail.
+
+## Goals
+
+1. **Onboard a new engineer** without making them read every nuance of the codebase — the
+   agent supplies the context on demand.
+2. **Get to a correct first contribution** — blast-radius awareness, TDD, and repo
+   conventions (naming, spec placement, commit scopes) enforced, not memorized.
+3. **Let PM / QA / DevOps follow along** with the changes an engineer (or agent) makes.
+
+North star: **accuracy on every PR, and reuse details as much as possible** (one source of
+truth, referenced — never copied). Future direction: move CI knowledge (unit + e2e gates)
+earlier in the process so PR cycle time drops.
+
+## Target
+
+The NestJS framework monorepo itself, not a generated sample app. It's an unusually literal
+match for the scenario: decorator-driven, convention-heavy, with **real** CI/lint/commit
+gates and a real `CONTRIBUTING.md` to ground against instead of inventing process. Audience
+for the tooling: a new `nestjs/nest` contributor, plus the PM/QA/DevOps roles around them.
+
+## Primitives chosen, and why
+
+Verified against current Cursor docs, not recalled from memory.
+
+- **Project Rules** (`.cursor/rules/*.mdc`, version-controlled). Frontmatter:
+  `description` / `globs` / `alwaysApply`. Best practice from Cursor's docs: reference files
+  by `@`-path instead of copying their contents, keep rules small, split by concern.
+  → **One always-apply root rule** (`00-index.mdc`) for facts that hold repo-wide (test
+  stack is Mocha/Chai/Sinon not Jest; the do-not-read list; search-before-explore) and
+  **per-package, glob-scoped rules** for conventions that differ by package
+  (`pipes`, `guards`, `interceptors`, `decorators`, `exception-filters`, `tests`,
+  `packages`, `samples`, `lifecycle-trace`). They point at `ARCHITECTURE.md` /
+  `CONTRIBUTING.md` rather than restating them. Only `00-index` is always-on, so the
+  always-loaded context stays tiny.
+
+- **Agent Skills** (`.cursor/skills/<name>/SKILL.md`, the open Agent Skills standard Cursor
+  now discovers natively; also read by Claude Code / Codex). Frontmatter `name` /
+  `description`, with optional `scripts/`, `references/`, `assets/` loaded progressively.
+  → This is where multi-step **workflows** live. The centerpiece is a three-skill pipeline
+  (below); supporting skills (`build-and-verify`, `run-integration-tests`,
+  `check-conformance`, `http-request-chain`) are single-responsibility leaves the pipeline
+  composes, so command knowledge is defined once and referenced everywhere.
+  A pipeline of composable skills fits the "reuse details" north star better than one
+  monolithic command.
+
+- **Hooks** (`.cursor/hooks/`, `hooks.json`). `guard-read.sh` (a `beforeReadFile` hook)
+  blocks reads of vendored/generated paths to protect the context budget; `format.sh`
+  (`afterFileEdit`) runs prettier to match `lint-staged`. Defense-in-depth with
+  `.cursorignore` and `00-index`'s do-not-read list — three mechanisms, same intent.
+
+- **`@Docs`** — lower priority. Most of what a contributor needs is already in-repo; `@Docs`
+  earns its place only for `docs.nestjs.com` (the public API contract these packages
+  implement). Worth wiring, not worth over-indexing.
+
+## The contribution pipeline (Goals 1–3)
+
+Rather than one scaffold command, the workflow is a three-skill pipeline mapped to the change
+lifecycle, each stage handing a concrete artifact to the next:
+
+```
+triage-issue        →   implement-issue       →   commit-and-pr
+(plan → red)            (red → green)             (green → shipped)
+ticket + failing test   verified change +         conventional commit +
+at .cursor/triage/      updated ticket +          gh PR against a fork
+                        rendered PR body
+```
+
+- **`triage-issue`** — classify against the real `.github/ISSUE_TEMPLATE` categories, locate
+  the surface, pull blast-radius/difficulty **verbatim** from `ARCHITECTURE.md` §3-4 (never
+  re-scored), write Given/When/Then acceptance criteria, branch as `<type>/<issue>-<slug>`,
+  and scaffold the **failing** test that proves the gap. Stops at red — it never writes the
+  fix. Its `verify-trace.sh`, wired in as `.husky/pre-push`, is the one *enforced* gate.
+
+- **`implement-issue`** — the red→green middle. Preflight checks the handoff preconditions
+  (branch, filled ticket, pre-push installed), then the minimal in-scope fix is implemented,
+  the gates are run via the leaf skills, the triage ticket is updated to green with a
+  rollout/rollback note, and the PR body is rendered. Escalates and stops on Hard/breaking
+  surfaces (`common` public API, `injector`/`router`) rather than pushing through.
+
+- **`commit-and-pr`** — conventional commit (types/scopes kept in sync with
+  `.commitlintrc.json`) and the `gh` fork-PR flow. Kept separate so self-found fixes that
+  never went through triage still have a home, and so commit/`gh` knowledge is single-sourced.
+
+## Requirement-by-requirement mapping
+
+1. **First contribution, no full codebase read.** The per-concept rules (`pipes.mdc` et al.)
+   and the pipeline are modeled on a verified-correct reference contribution:
+   `ParsePositiveIntPipe` + mirrored spec + barrel export (same shape as `ParseIntPipe`).
+   That reference is the onboarding exercise — implement it fresh to prove the tooling.
+   A `scaffold-contribution` skill that generalizes the pattern is the next planned addition
+   (see below).
+2. **Catch mistakes early, strengthen tests.** TDD is structural: `triage-issue` requires a
+   red test before any fix, `implement-issue` won't proceed past a failing gate, and
+   `check-conformance` flags any source file missing its mirrored spec (it currently surfaces
+   4 real gaps). Deprecated-API awareness is grounded against the live repo
+   (`MetadataScanner.scanFromPrototype` → `getAllMethodNames`, Kafka's legacy partitioner →
+   `DefaultPartitioner`, the old `MaxFileSizeValidator` shape → `errorMessage`).
+3. **Fit the path to production; approved boundaries.** Scope is concrete: target package
+   dir + its public exports + the mirrored test path, honoring the `ARCHITECTURE.md`
+   dependency layering (`common` never imports `core`). Enforced two ways — statically via
+   rule `globs` so out-of-scope files don't enter context, and procedurally by reusing the
+   repo's *existing* guardrails (CircleCI matrix, husky pre-commit → lint-staged, commitlint
+   scope enum). Deliberately not a parallel CI system — the goal is to *fit* the team's CI.
+4. **Maintainable without the author.** Everything is plain version-controlled files
+   (`.cursor/rules`, `.cursor/skills`, `.cursor/hooks`, `ARCHITECTURE.md`, `docs/DEVELOPER.md`)
+   — no external service, no hidden state. Rules and skills reference source files instead of
+   duplicating them, so a convention change keeps working and an API rename breaks the
+   reference loudly rather than rotting silently.
+5. **Multi-audience (PM/QA/DevOps).** One source, three renderings: the triage ticket already
+   carries Problem (PM), Acceptance Criteria (QA), and Blast Radius + Gates + Release tier
+   (DevOps); `implement-issue` renders these into the PR body from the repo's actual PR
+   template — the PR being where these roles actually follow along. The DevOps block names the
+   CI jobs the diff touches, the semver tier, and a library-correct rollback (revert + release,
+   not a runtime flag), with a documented slot for flag-gated app repos later.
+
+## What's built vs. what's next
+
+Built: `ARCHITECTURE.md` (package map, blast-radius ratings, flow diagrams),
+`docs/DEVELOPER.md`, the rule set (1 always-apply + 9 scoped), the hooks, and the skill set —
+the `triage-issue` →
+`implement-issue` → `commit-and-pr` pipeline plus the `build-and-verify`,
+`run-integration-tests`, `check-conformance`, and `http-request-chain` leaves.
+
+Next: Establish a working pattern for the team. Make sure how it can accomplish org wide as well.
+How to go further with the Builder mentality?
+
+## Known limitations
+
+- **No Docker in the build environment**, so the Docker-gated integration job and samples
+  haven't been run against the new pipe — unit + lint have. `implement-issue` treats this
+  honestly: it requires a stated reason when integration coverage is skipped rather than
+  claiming it.
+- **The enforced gate is local, not CI.** `verify-trace.sh` blocks `git push` only on a
+  machine where `.husky/pre-push` is installed (a one-time manual `cp`, since file tools can't
+  write to `.husky/` here). It's a strong team-local nudge, not a substitute for branch
+  protection on `nestjs/nest`. Preflight surfaces a warning when it isn't installed.
+- **Cursor's runtime rule/skill firing** ("does this trigger on the right files") is grounded
+  in current docs but only fully verifiable inside Cursor live.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,366 @@
+# NestJS Developer Guide
+
+Local setup for working in the NestJS **framework monorepo** (the source of `@nestjs/*`
+packages). This is not a single deployable app — you build the packages, then run or
+test against the apps under `sample/` and `integration/`.
+
+For contribution workflow (PRs, commits, coding rules), see [CONTRIBUTING.md](../CONTRIBUTING.md).
+For package layout and change-impact guidance, see [ARCHITECTURE.md](../ARCHITECTURE.md).
+
+---
+
+## Prerequisites
+
+| Requirement | Notes |
+|-------------|-------|
+| **Node.js >= 20** | Required by root `package.json` `engines` |
+| **npm** | Repo uses `package-lock.json`; pass `--legacy-peer-deps` when installing |
+| **Docker** | Required for integration tests and some samples (MySQL, Mongo, Redis, etc.) |
+| **git** | Pull/push; remote is `github.com/nestjs/nest` (contribute via a fork) |
+| **GitHub CLI (`gh`)** | Optional but recommended for PRs, issues, and CI status — see [GitHub CLI and contribution workflow](#github-cli-and-contribution-workflow) |
+
+### Install Node.js with nvm
+
+If Node.js is not installed (or you need a supported version), use [nvm](https://github.com/nvm-sh/nvm). These steps work on macOS and Linux; agents can run them for a new developer:
+
+```bash
+# Download and install nvm:
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.5/install.sh | bash
+
+# in lieu of restarting the shell
+\. "$HOME/.nvm/nvm.sh"
+
+# Download and install Node.js:
+nvm install 24
+
+# Verify the Node.js version:
+node -v # Should print "v24.17.0".
+
+# Verify npm version:
+npm -v # Should print "11.13.0".
+```
+
+Node **24** satisfies the repo requirement (`>= 20`) and covers samples that need Node **>= 22** (e.g. `sample/35-use-esm-package-after-node22`). Patch versions may differ slightly from the examples above.
+
+---
+
+## GitHub CLI and contribution workflow
+
+Day-to-day git operations (`clone`, `pull`, `push`, branch, commit) only need **git** —
+the remote is already configured. The **GitHub CLI (`gh`)** is the recommended tool for
+everything that talks to the GitHub API: creating pull requests and issues, checking CI,
+and reviewing. It is preferred over a GitHub MCP server here because the Cursor agent
+workflows in this repo are built around `gh` shell commands.
+
+### Install `gh`
+
+Homebrew (if available):
+
+```bash
+brew install gh
+```
+
+No Homebrew? Install the official release binary into `~/.local/bin` (Apple Silicon):
+
+```bash
+GH_VERSION=2.95.0
+curl -fsSL -o /tmp/gh.zip \
+  "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_macOS_arm64.zip"
+unzip -oq /tmp/gh.zip -d /tmp
+mkdir -p "$HOME/.local/bin"
+cp "/tmp/gh_${GH_VERSION}_macOS_arm64/bin/gh" "$HOME/.local/bin/gh"
+chmod +x "$HOME/.local/bin/gh"
+```
+
+Ensure `~/.local/bin` is on your `PATH` (add to `~/.zshrc` if missing):
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+For Intel Macs use `macOS_amd64`; check the latest tag at
+<https://github.com/cli/cli/releases>.
+
+### Authenticate (one time)
+
+`gh auth login` opens a browser/device flow, so run it in your own terminal:
+
+```bash
+gh auth login      # GitHub.com -> HTTPS -> login with a browser
+gh auth status     # verify
+```
+
+### Fork-based contribution flow
+
+You cannot push directly to `nestjs/nest`. Fork once, then branch per change:
+
+```bash
+gh repo fork nestjs/nest --remote        # adds your fork as a remote
+git checkout -b fix/my-change master
+# ...edit, then build/test/lint (see Testing below)...
+git commit -m "fix(core): ..."           # follow CONTRIBUTING.md commit rules
+git push -u origin fix/my-change
+gh pr create --fill                       # opens a PR against nestjs:master
+```
+
+Common follow-ups:
+
+```bash
+gh issue create                           # file a bug / feature request
+gh pr status                              # state of your PRs
+gh pr checks                              # CI status for the current branch
+gh run watch                              # follow a running CI workflow
+```
+
+> Commit messages must follow the conventional-commit format enforced by commitlint +
+> husky — see [CONTRIBUTING.md](../CONTRIBUTING.md) and the `commit-and-pr` skill.
+
+---
+
+## Quick start
+
+From the repository root:
+
+```bash
+npm ci --legacy-peer-deps
+npm run build
+npm run move:samples
+
+cd sample/01-cats-app
+npm install --legacy-peer-deps
+npm run start:dev
+```
+
+The cats sample listens on **http://localhost:3000**.
+
+---
+
+## Install dependencies
+
+Install root dev dependencies once after cloning:
+
+```bash
+npm ci --legacy-peer-deps
+```
+
+`npm install --legacy-peer-deps` works as well. The flag matches what CI and gulp sample
+tasks use (`tools/gulp/tasks/samples.ts`).
+
+---
+
+## Build the framework packages
+
+### Standard build
+
+```bash
+npm run build
+```
+
+This runs `tsc -b` over `packages/` and triggers `postbuild`, which copies compiled
+output into `node_modules/@nestjs/` at the **repo root** via `gulp move:node_modules`.
+
+### Link built packages into samples
+
+`npm run build` does **not** copy into sample apps. After building (or when you change
+framework code and want samples to pick it up), run:
+
+```bash
+npm run move:samples
+```
+
+This copies compiled `@nestjs/*` packages into each sample's
+`node_modules/@nestjs/` directory.
+
+### Watch mode (active framework development)
+
+```bash
+npm run build:dev
+```
+
+Re-run `npm run move:samples` (or `npm run move:node_modules`) after changes so samples
+and tests see the updated build.
+
+### Production build
+
+```bash
+npm run build:prod
+```
+
+Runs a clean build (`npm run clean` first) and emits compiled `.js` / `.d.ts` next to
+source under `packages/`.
+
+---
+
+## Run a sample app
+
+Each numbered directory under `sample/` is a standalone Nest app with its own
+`package.json`.
+
+### Single sample (recommended for first run)
+
+```bash
+# From repo root — ensure local @nestjs packages are linked
+npm run build
+npm run move:samples
+
+cd sample/01-cats-app
+npm install --legacy-peer-deps
+npm run start:dev
+```
+
+Common scripts inside a sample:
+
+| Script | Purpose |
+|--------|---------|
+| `npm run start:dev` | Dev server with watch |
+| `npm run start:debug` | Debug + watch |
+| `npm run build` | Compile the sample |
+| `npm run start:prod` | Run compiled `dist/main.js` |
+| `npm run test` | Unit tests |
+| `npm run test:e2e` | End-to-end tests |
+
+### Install dependencies for all samples
+
+From the repo root:
+
+```bash
+npx gulp install:samples
+```
+
+This runs `npm install --legacy-peer-deps` in every sample directory (skipping samples
+that require a newer Node version than you have).
+
+---
+
+## Samples that need extra services
+
+Some samples require Docker or a local database before `npm run start:dev`:
+
+| Sample | Extra setup |
+|--------|-------------|
+| `05-sql-typeorm`, `07-sequelize` | `docker-compose up` in the sample directory (MySQL) |
+| `06-mongoose`, `13-mongo-typeorm`, `14-mongoose-base` | `docker-compose up` (MongoDB) |
+| `26-queues` | `docker-compose up` (Redis) |
+| `35-use-esm-package-after-node22` | Node.js **>= 22** |
+
+Check each sample's `README.md` for credentials and port details.
+
+---
+
+## Testing
+
+### Unit tests
+
+```bash
+npm run test
+```
+
+Watch mode:
+
+```bash
+npm run test:dev
+```
+
+### Lint
+
+```bash
+npm run lint
+npm run lint:fix   # auto-fix where possible
+```
+
+### Integration tests (Docker required)
+
+Integration tests use services defined in `integration/docker-compose.yml` (Redis,
+NATS, MQTT, MySQL, PostgreSQL, RabbitMQ, etc.).
+
+Full integration run:
+
+```bash
+sh scripts/run-integration.sh
+```
+
+That script builds packages, starts Docker services, waits for RabbitMQ, and runs
+`npm run test:integration`.
+
+Manual steps:
+
+```bash
+npm run build
+npm run test:docker:up
+npm run test:docker:wait:rmq
+npm run test:integration
+npm run test:docker:down    # when finished
+```
+
+`scripts/prepare.sh` only performs the build + Docker startup + RabbitMQ wait steps —
+it does **not** run integration tests and does **not** call `move:samples`.
+
+### Build and test all samples (CI-style, slow)
+
+```bash
+npm run build:samples
+```
+
+This installs all samples, builds the monorepo, moves packages into samples, builds
+every sample, and runs unit + e2e tests across them.
+
+---
+
+## Monorepo layout
+
+```
+packages/          @nestjs/* source (common, core, platform-*, microservices, …)
+sample/            Example Nest apps (01-cats-app, …)
+integration/       Integration test suites + docker-compose.yml
+tools/gulp/        Gulp tasks (move:samples, install:samples, …)
+scripts/           Shell helpers (prepare.sh, run-integration.sh, …)
+```
+
+Packages are managed with [Lerna](https://lerna.js.org/) (`lerna.json` lists
+`packages/*`). There is no root `npm start` — run individual samples or tests instead.
+
+---
+
+## Common workflows
+
+### I changed code under `packages/` and want to verify in a sample
+
+```bash
+npm run build
+npm run move:samples
+cd sample/01-cats-app && npm run start:dev
+```
+
+### I am fixing a bug with a unit test
+
+1. Add or update a `*.spec.ts` under the relevant `packages/` directory.
+2. `npm run test` (or `npm run test:dev` while iterating).
+3. `npm run lint` before opening a PR.
+
+### I am preparing a pull request
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md): run the full unit suite, integration tests
+if your change touches transports or adapters, and follow commit message conventions.
+
+---
+
+## Troubleshooting
+
+**Sample still uses old `@nestjs` behavior after my package change**
+
+Run `npm run build && npm run move:samples` again. Samples resolve `@nestjs/*` from
+their local `node_modules/@nestjs/`, not from the root install alone.
+
+**`npm install` peer dependency errors**
+
+Use `--legacy-peer-deps` at the root and in sample directories.
+
+**Integration tests fail to connect to RabbitMQ / Redis / etc.**
+
+Ensure Docker is running, then `npm run test:docker:up` and
+`npm run test:docker:wait:rmq` before `npm run test:integration`.
+
+**`prepare.sh` did not set up samples**
+
+Expected — `prepare.sh` builds packages and starts integration-test Docker services.
+For sample development use `npm run build` and `npm run move:samples` instead.


### PR DESCRIPTION
Adds version-controlled Cursor agent tooling and supporting docs so contributors (human or AI) can work safely in the Nest monorepo without reading the entire codebase first. **No runtime/framework API changes** — this is documentation, rules, skills, and local-dev onboarding only.

## Summary

- **`ARCHITECTURE.md`** — package map, dependency layering, blast-radius ratings, and request-flow diagrams for scoping changes before editing.
- **`docs/DEVELOPER.md`** — local setup guide (install, build, link samples, run tests, integration tests, GitHub CLI workflow).
- **`.cursor/rules/`** — 1 always-apply index rule + 9 glob-scoped rules (`pipes`, `guards`, `interceptors`, `decorators`, `exception-filters`, `tests`, `packages`, `samples`, `lifecycle-trace`). Rules reference source files instead of copying them.
- **`.cursor/skills/`** — composable workflow skills: `triage-issue` → `implement-issue` → `commit-and-pr`, plus leaves (`build-and-verify`, `check-conformance`, `run-integration-tests`, `http-request-chain`).
- **`.cursor/hooks/`** — `guard-read.sh` blocks reads of vendored/generated paths; `format.sh` runs prettier on edit (matches lint-staged).
- **`.cursorignore`** — keeps lockfiles, compiled output, and vendored paths out of agent context.
- **`DESIGN.md` / `AI-AGENT-SETUP-REVIEW.md`** — design rationale and self-review notes for the tooling layer.
- **`CONTRIBUTING.md`** — quick-start updated to point at `docs/DEVELOPER.md`; clarifies `build` vs `move:samples` vs `prepare.sh`.

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features) — N/A: no `packages/` runtime changes; shell helpers validated with `bash -n`; `check-conformance/check.sh` exercised locally (reports 4 pre-existing upstream spec gaps, none introduced here)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other — developer/AI-agent enablement (rules, skills, hooks, docs)

## What is the current behavior?

Contributors rely on tribal knowledge and scattered docs to navigate the monorepo. `CONTRIBUTING.md` quick-start references `scripts/prepare.sh` without a single local developer guide; there is no blast-radius map for scoping changes; and AI agents have no repo-specific conventions for pipes/guards/interceptors, test placement, or commit scopes — leading to context-heavy exploration and convention misses.

Issue Number: N/A (proposed tooling improvement; no linked issue)

## What is the new behavior?

Contributors and AI agents get a layered, version-controlled enablement stack:

| Layer | Purpose |
|-------|---------|
| `ARCHITECTURE.md` | Where to edit, dependency rules, blast-radius before touching code |
| `docs/DEVELOPER.md` | How to build, test, run samples, and use `gh` for PRs |
| `.cursor/rules/*.mdc` | Convention-on-demand (glob-scoped; only loads when relevant files are touched) |
| `.cursor/skills/` | Multi-step workflows (triage → implement → commit/PR) composing single-responsibility leaves |
| `.cursor/hooks/` | Context-budget hygiene + auto-format on edit |
| `check-conformance/check.sh` | Nudge script flagging source files missing mirrored specs |

**Optional one-time setup** (documented in `triage-issue` skill): copy `.cursor/skills/triage-issue/pre-push.sh` to `.husky/pre-push` to enforce triage-ticket + spec-gap checks on `<type>/<issue>-<slug>` branches.

**Onboarding exercise:** rules are modeled on a `ParsePositiveIntPipe` reference contribution (same shape as `ParseIntPipe`); implement it fresh to verify the pipeline end-to-end.

**QA — validation performed for this PR**

- All `.sh` scripts pass `bash -n`
- `check-conformance/check.sh` runs cleanly (4 missing specs are pre-existing upstream, not introduced by this diff)
- No changes under `packages/` except `.gitignore` (adds `.local-node/`)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

**DevOps / rollout**

- CI jobs this diff exercises: none directly (docs + `.cursor/` tooling only; no CircleCI config changes)
- Release tier: N/A — not a published package change
- Rollback: revert commit `bf2c0a8` if maintainers prefer not to carry agent tooling in-tree

**Maintainer notes**

- See `DESIGN.md` for goals, primitives chosen, and known limitations (Docker integration tests not run for this tooling-only change; `pre-push` gate is opt-in until manually installed).
- See `AI-AGENT-SETUP-REVIEW.md` for a candid self-review and prioritized follow-ups (`scaffold-contribution` skill, PM/QA/DevOps change-summary, `AGENTS.md` for non-Cursor agents).
