### PR TITLE
fix(websockets): correct type guard to check value not key

### DIFF
--- a/packages/websockets/gateway-metadata-explorer.ts
+++ b/packages/websockets/gateway-metadata-explorer.ts
@@ -80,7 +80,7 @@ export class GatewayMetadataExplorer {
 
   public *scanForServerHooks(instance: NestGateway): IterableIterator<string> {
     for (const propertyKey in instance) {
-      if (isFunction(propertyKey)) {
+      if (isFunction(instance[propertyKey])) {
         continue;
       }
       const property = String(propertyKey);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
In GatewayMetadataExplorer.scanForServerHooks, the isFunction guard 
checks `propertyKey` (always a string from `for...in`) instead of 
`instance[propertyKey]` (the actual property value). The guard never 
fires — all enumerable properties, including methods, are unnecessarily 
checked for GATEWAY_SERVER_METADATA metadata.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Guard now checks `instance[propertyKey]`, correctly skipping 
function-valued properties. Redundant metadata lookups on methods 
are avoided.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information