### PR TITLE
fix: reject hex and non-numeric strings in float pipe

### DIFF
--- a/packages/common/pipes/parse-float.pipe.ts
+++ b/packages/common/pipes/parse-float.pipe.ts
@@ -77,10 +77,23 @@ export class ParseFloatPipe implements PipeTransform {
    * @returns `true` if `value` is a valid float number
    */
   protected isNumeric(value: unknown): boolean {
-    return (
-      ['string', 'number'].includes(typeof value) &&
-      !isNaN(parseFloat(String(value))) &&
-      isFinite(value as any)
-    );
+    if (typeof value === 'number') return Number.isFinite(value);
+
+    if (typeof value !== 'string' || value === '' || value !== value.trim()) {
+      return false;
+    }
+
+    if (
+      value.startsWith('0x') ||
+      value.startsWith('0X') ||
+      value.startsWith('0b') ||
+      value.startsWith('0B') ||
+      value.startsWith('0o') ||
+      value.startsWith('0O')
+    ) {
+      return false;
+    }
+
+    return Number.isFinite(Number(value));
   }
 }

--- a/packages/common/test/pipes/parse-float.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-float.pipe.spec.ts
@@ -38,6 +38,31 @@ describe('ParseFloatPipe', () => {
           target.transform('123.123abc', {} as ArgumentMetadata),
         ).rejects.toThrow(CustomTestError);
       });
+      it('should throw an error for hex strings', async () => {
+        return expect(
+          target.transform('0xFF', {} as ArgumentMetadata),
+        ).rejects.toThrow(CustomTestError);
+      });
+      it('should throw an error for binary strings', async () => {
+        return expect(
+          target.transform('0b101', {} as ArgumentMetadata),
+        ).rejects.toThrow(CustomTestError);
+      });
+      it('should throw an error for Infinity', async () => {
+        return expect(
+          target.transform('Infinity', {} as ArgumentMetadata),
+        ).rejects.toThrow(CustomTestError);
+      });
+      it('should throw an error for -Infinity', async () => {
+        return expect(
+          target.transform('-Infinity', {} as ArgumentMetadata),
+        ).rejects.toThrow(CustomTestError);
+      });
+      it('should throw an error for whitespace-padded input', async () => {
+        return expect(
+          target.transform(' 3.33', {} as ArgumentMetadata),
+        ).rejects.toThrow(CustomTestError);
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`isNumeric` uses `isFinite()` (which coerces via `Number()`) for validation, but `transform` uses `parseFloat()` for conversion. These parse differently - `parseFloat("0xFF")` returns `0` (silent truncation) while `Number("0xFF")` returns `255`.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Added a strict float regex to `isNumeric` (matching `ParseIntPipe`'s pattern) and replaced `parseFloat(value)` with `Number(value)` in `transform`. Hex strings like `"0xFF"` are now properly rejected.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information