### PR TITLE
test(core): fix flaky promise assertions in scanner spec

### DIFF
--- a/packages/core/test/scanner.spec.ts
+++ b/packages/core/test/scanner.spec.ts
@@ -1,6 +1,10 @@
 import { Catch, Injectable } from '@nestjs/common';
+import * as chai from 'chai';
 import { expect } from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
+
+chai.use(chaiAsPromised);
 import { GUARDS_METADATA } from '../../common/constants';
 import { Controller } from '../../common/decorators/core/controller.decorator';
 import { UseGuards } from '../../common/decorators/core/use-guards.decorator';
@@ -406,21 +410,21 @@ describe('DependenciesScanner', () => {
     it('should throw "InvalidClassModuleException" exception when supplying a class annotated with `@Injectable()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      expect(scanner.insertModule(TestComponent, [])).to.be.rejectedWith(
+      return expect(scanner.insertModule(TestComponent, [])).to.be.rejectedWith(
         InvalidClassModuleException,
       );
     });
     it('should throw "InvalidClassModuleException" exception when supplying a class annotated with `@Controller()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      expect(scanner.insertModule(TestController, [])).to.be.rejectedWith(
-        InvalidClassModuleException,
-      );
+      return expect(
+        scanner.insertModule(TestController, []),
+      ).to.be.rejectedWith(InvalidClassModuleException);
     });
     it('should throw "InvalidClassModuleException" exception when supplying a class annotated with (only) `@Catch()` decorator', () => {
       sinon.stub(container, 'addModule').returns({} as any);
 
-      expect(
+      return expect(
         scanner.insertModule(TestExceptionFilterWithoutInjectable, []),
       ).to.be.rejectedWith(InvalidClassModuleException);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
3 tests in `DependenciesScanner.insertModule` suite (`scanner.spec.ts:409,416,424`) are broken `chai-as-promised` is not loaded so `.rejectedWith` throws `Invalid Chai property`. Even if loaded, the promise is not returned to Mocha, so assertions never actually run.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
`chai-as-promised` is imported and `chai.use()` called. The 3 assertion promises are returned to Mocha via `return`. Tests now correctly verify that `insertModule` rejects `@Injectable()`, `@Controller()`, and `@Catch()` only classes.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information