### PR TITLE
test(microservices): remove debug console.log in server-kafka spec

### DIFF
--- a/packages/microservices/test/server/server-kafka.spec.ts
+++ b/packages/microservices/test/server/server-kafka.spec.ts
@@ -161,7 +161,7 @@ describe('ServerKafka', () => {
         .stub(server, 'bindEvents')
         .callsFake(() => ({}) as any);
 
-      await server.listen(err => console.log(err));
+      await server.listen(() => {});
       expect(bindEventsStub.called).to.be.true;
     });
     it('should call callback', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`console.log(err)` is used as the callback in a `server.listen()` test at `server-kafka.spec.ts:164`. This prints to stdout if an error occurs during test setup, polluting test output. The test asserts that bindEvents was called - the listen callback is irrelevant to the assertion.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Replaced with `() => {}` - a no-op callback. Test output is clean. Same pattern as the 3 already-merged console.log removal PRs (`clients.module.spec.ts`, `server-grpc.spec.ts`, `ws-exceptions-handler.spec.ts`).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information