### PR TITLE
fix(microservices): skip function-valued members in scanForClientHooks (match #17188)

### DIFF
--- a/packages/microservices/listener-metadata-explorer.ts
+++ b/packages/microservices/listener-metadata-explorer.ts
@@ -84,7 +84,7 @@ export class ListenerMetadataExplorer {
     instance: Controller,
   ): IterableIterator<ClientProperties> {
     for (const propertyKey in instance) {
-      if (isFunction(propertyKey)) {
+      if (isFunction(instance[propertyKey])) {
         continue;
       }
       const property = String(propertyKey);

--- a/packages/microservices/test/listeners-metadata-explorer.spec.ts
+++ b/packages/microservices/test/listeners-metadata-explorer.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { MetadataScanner } from '../../core/metadata-scanner';
+import {
+  CLIENT_CONFIGURATION_METADATA,
+  CLIENT_METADATA,
+} from '../constants';
 import { Client } from '../decorators/client.decorator';
 import { EventPattern } from '../decorators/event-pattern.decorator';
 import { MessagePattern } from '../decorators/message-pattern.decorator';
@@ -168,6 +172,32 @@ describe('ListenerMetadataExplorer', () => {
         property: 'redisClient',
         metadata: clientSecMetadata,
       });
+    });
+    it(`should skip function-valued members even if they carry client metadata`, () => {
+      class WithFnMember {
+        @Client(clientMetadata as any)
+        public client;
+      }
+      const obj = new WithFnMember();
+
+      // An enumerable, own, function-valued member (e.g. an arrow-function class
+      // field). The `isFunction` guard exists to short-circuit such members
+      // before client metadata is consulted.
+      (obj as any).fnHook = () => null;
+      Reflect.defineMetadata(CLIENT_METADATA, true, obj, 'fnHook');
+      Reflect.defineMetadata(
+        CLIENT_CONFIGURATION_METADATA,
+        clientMetadata,
+        obj,
+        'fnHook',
+      );
+
+      const properties = [...instance.scanForClientHooks(obj)].map(
+        hook => hook.property,
+      );
+
+      expect(properties).to.not.include('fnHook');
+      expect(properties).to.include('client');
     });
   });
 });

--- a/packages/microservices/test/listeners-metadata-explorer.spec.ts
+++ b/packages/microservices/test/listeners-metadata-explorer.spec.ts
@@ -1,10 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { MetadataScanner } from '../../core/metadata-scanner';
-import {
-  CLIENT_CONFIGURATION_METADATA,
-  CLIENT_METADATA,
-} from '../constants';
+import { CLIENT_CONFIGURATION_METADATA, CLIENT_METADATA } from '../constants';
 import { Client } from '../decorators/client.decorator';
 import { EventPattern } from '../decorators/event-pattern.decorator';
 import { MessagePattern } from '../decorators/message-pattern.decorator';


### PR DESCRIPTION
`scanForClientHooks` in `packages/microservices/listener-metadata-explorer.ts` guards method members with `if (isFunction(propertyKey))`, but `propertyKey` comes from `for...in` and is always a string, so the guard is dead code — function-valued members are never skipped before client metadata is read.

This is the microservices twin of #17188 ("fix(websockets): correct type guard to check value not key"), which applied the identical `isFunction(propertyKey)` → `isFunction(instance[propertyKey])` fix to the websockets `scanForServerHooks`. The microservices explorer was left untouched.

Verified both ways: a regression test fails on the old guard (a function-valued member surfaces as a client hook) and passes after the fix; existing `listeners-*` tests stay green (21 passing), `tsc -b packages/microservices` exits 0.