### PR TITLE
fix(core): trigger teardown of SSE producer Observable on client disconnect with interceptor

### DIFF
--- a/integration/nest-application/sse/e2e/express.spec.ts
+++ b/integration/nest-application/sse/e2e/express.spec.ts
@@ -5,8 +5,13 @@ import { expect } from 'chai';
 import { EventSource } from 'eventsource';
 import { AppModule } from '../src/app.module';
 import {
+  fetchInterceptorDelayedSseStats,
   fetchPromiseDelayedSseStats,
+  releaseInterceptorDelayedSse,
   releasePromiseDelayedSse,
+  waitForInterceptorDelayedSseClose,
+  waitForInterceptorDelayedSseRequestStart,
+  waitForInterceptorDelayedSseTeardown,
   waitForPromiseDelayedSseClose,
   waitForPromiseDelayedSseRequestStart,
   waitForPromiseDelayedSseTeardown,
@@ -260,6 +265,92 @@ describe('Sse (Express Application)', () => {
       await waitForPromiseDelayedSseTeardown(url);
 
       const stats = await fetchPromiseDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.runningStreams).to.equal(0);
+      expect(stats.subscriptionsStarted).to.equal(1);
+      expect(stats.teardownsObserved).to.equal(1);
+    });
+  });
+
+  describe('Promise<Observable> disconnect handling with interceptor', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestExpressApplication>({
+        forceCloseConnections: true,
+      });
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should subscribe and tear down if the GET SSE client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(`${url}/sse/interceptor/promise-delayed`, {
+        headers: {
+          accept: 'text/event-stream',
+        },
+        signal: abortController.signal,
+      });
+
+      await waitForInterceptorDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForInterceptorDelayedSseClose(url);
+
+      expect(await releaseInterceptorDelayedSse(url)).to.equal(1);
+
+      await waitForInterceptorDelayedSseTeardown(url);
+
+      const stats = await fetchInterceptorDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.runningStreams).to.equal(0);
+      expect(stats.subscriptionsStarted).to.equal(1);
+      expect(stats.teardownsObserved).to.equal(1);
+    });
+
+    it('should subscribe and tear down if the POST SSE client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(
+        `${url}/sse/post/interceptor/promise-delayed`,
+        {
+          method: 'POST',
+          headers: {
+            accept: 'text/event-stream',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ content: 'chunk-0' }),
+          signal: abortController.signal,
+        },
+      );
+
+      await waitForInterceptorDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForInterceptorDelayedSseClose(url);
+
+      expect(await releaseInterceptorDelayedSse(url)).to.equal(1);
+
+      await waitForInterceptorDelayedSseTeardown(url);
+
+      const stats = await fetchInterceptorDelayedSseStats(url);
       expect(stats.closeEventsObserved).to.equal(1);
       expect(stats.requestsStarted).to.equal(1);
       expect(stats.runningStreams).to.equal(0);

--- a/integration/nest-application/sse/e2e/fastify.spec.ts
+++ b/integration/nest-application/sse/e2e/fastify.spec.ts
@@ -8,8 +8,13 @@ import { expect } from 'chai';
 import { EventSource } from 'eventsource';
 import { AppModule } from '../src/app.module';
 import {
+  fetchInterceptorDelayedSseStats,
   fetchPromiseDelayedSseStats,
+  releaseInterceptorDelayedSse,
   releasePromiseDelayedSse,
+  waitForInterceptorDelayedSseClose,
+  waitForInterceptorDelayedSseRequestStart,
+  waitForInterceptorDelayedSseTeardown,
   waitForPromiseDelayedSseClose,
   waitForPromiseDelayedSseRequestStart,
   waitForPromiseDelayedSseTeardown,
@@ -271,6 +276,94 @@ describe('Sse (Fastify Application)', () => {
       await waitForPromiseDelayedSseTeardown(url);
 
       const stats = await fetchPromiseDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.runningStreams).to.equal(0);
+      expect(stats.subscriptionsStarted).to.equal(1);
+      expect(stats.teardownsObserved).to.equal(1);
+    });
+  });
+
+  describe('Promise<Observable> disconnect handling with interceptor', () => {
+    beforeEach(async () => {
+      const moduleFixture = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      app = moduleFixture.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter({
+          forceCloseConnections: true,
+        }),
+      );
+
+      await app.listen(0);
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should subscribe and tear down if the GET SSE client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(`${url}/sse/interceptor/promise-delayed`, {
+        headers: {
+          accept: 'text/event-stream',
+        },
+        signal: abortController.signal,
+      });
+
+      await waitForInterceptorDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForInterceptorDelayedSseClose(url);
+
+      expect(await releaseInterceptorDelayedSse(url)).to.equal(1);
+
+      await waitForInterceptorDelayedSseTeardown(url);
+
+      const stats = await fetchInterceptorDelayedSseStats(url);
+      expect(stats.closeEventsObserved).to.equal(1);
+      expect(stats.requestsStarted).to.equal(1);
+      expect(stats.runningStreams).to.equal(0);
+      expect(stats.subscriptionsStarted).to.equal(1);
+      expect(stats.teardownsObserved).to.equal(1);
+    });
+
+    it('should subscribe and tear down if the POST SSE client disconnects before the promise resolves', async () => {
+      const url = await app.getUrl();
+      const abortController = new AbortController();
+      const responsePromise = fetch(
+        `${url}/sse/post/interceptor/promise-delayed`,
+        {
+          method: 'POST',
+          headers: {
+            accept: 'text/event-stream',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ content: 'chunk-0' }),
+          signal: abortController.signal,
+        },
+      );
+
+      await waitForInterceptorDelayedSseRequestStart(url);
+      abortController.abort();
+
+      await responsePromise.catch(error => {
+        expect(error.name).to.equal('AbortError');
+      });
+
+      await waitForInterceptorDelayedSseClose(url);
+
+      expect(await releaseInterceptorDelayedSse(url)).to.equal(1);
+
+      await waitForInterceptorDelayedSseTeardown(url);
+
+      const stats = await fetchInterceptorDelayedSseStats(url);
       expect(stats.closeEventsObserved).to.equal(1);
       expect(stats.requestsStarted).to.equal(1);
       expect(stats.runningStreams).to.equal(0);

--- a/integration/nest-application/sse/e2e/utils.ts
+++ b/integration/nest-application/sse/e2e/utils.ts
@@ -68,3 +68,76 @@ export const waitForPromiseDelayedSseTeardown = async (appUrl: string) => {
     'Timed out waiting for the delayed SSE teardown to run.',
   );
 };
+
+export interface InterceptorDelayedSseStats {
+  closeEventsObserved: number;
+  requestsStarted: number;
+  runningStreams: number;
+  subscriptionsStarted: number;
+  teardownsObserved: number;
+}
+
+export const fetchInterceptorDelayedSseStats = async (
+  appUrl: string,
+): Promise<InterceptorDelayedSseStats> => {
+  const response = await fetch(
+    `${appUrl}/sse/interceptor/promise-delayed/stats`,
+  );
+  return response.json();
+};
+
+export const releaseInterceptorDelayedSse = async (appUrl: string) => {
+  const response = await fetch(
+    `${appUrl}/sse/interceptor/promise-delayed/release`,
+    { method: 'POST' },
+  );
+  const { released } = await response.json();
+
+  return released as number;
+};
+
+const waitForInterceptorDelayedSseStat = async (
+  appUrl: string,
+  predicate: (stats: InterceptorDelayedSseStats) => boolean,
+  timeoutErrorMessage: string,
+) => {
+  const deadline = Date.now() + 2_000;
+
+  while (Date.now() < deadline) {
+    const stats = await fetchInterceptorDelayedSseStats(appUrl);
+
+    if (predicate(stats)) {
+      return;
+    }
+
+    await sleep(20);
+  }
+
+  throw new Error(timeoutErrorMessage);
+};
+
+export const waitForInterceptorDelayedSseRequestStart = async (
+  appUrl: string,
+) => {
+  await waitForInterceptorDelayedSseStat(
+    appUrl,
+    stats => stats.requestsStarted > 0,
+    'Timed out waiting for the interceptor-delayed SSE request to start.',
+  );
+};
+
+export const waitForInterceptorDelayedSseClose = async (appUrl: string) => {
+  await waitForInterceptorDelayedSseStat(
+    appUrl,
+    stats => stats.closeEventsObserved > 0,
+    'Timed out waiting for the interceptor-delayed SSE request to close.',
+  );
+};
+
+export const waitForInterceptorDelayedSseTeardown = async (appUrl: string) => {
+  await waitForInterceptorDelayedSseStat(
+    appUrl,
+    stats => stats.teardownsObserved > 0,
+    'Timed out waiting for the interceptor-delayed SSE teardown to run.',
+  );
+};

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -1,13 +1,18 @@
 import {
   Body,
+  CallHandler,
   Controller,
+  ExecutionContext,
   Get,
+  Injectable,
   MessageEvent,
+  NestInterceptor,
   Post,
   Query,
   Req,
   RequestMethod,
   Sse,
+  UseInterceptors,
 } from '@nestjs/common';
 import { Type } from 'class-transformer';
 import { IsInt } from 'class-validator';
@@ -20,6 +25,13 @@ class SseQueryDto {
   limit!: number;
 }
 
+@Injectable()
+class PassthroughInterceptor implements NestInterceptor {
+  intercept(_context: ExecutionContext, next: CallHandler): Observable<any> {
+    return next.handle();
+  }
+}
+
 @Controller()
 export class AppController {
   private promiseDelayedRequestsStarted = 0;
@@ -28,6 +40,13 @@ export class AppController {
   private promiseDelayedTeardownsObserved = 0;
   private promiseDelayedRunningStreams = 0;
   private readonly promiseDelayedResolvers: Array<() => void> = [];
+
+  private interceptorDelayedRequestsStarted = 0;
+  private interceptorDelayedSubscriptionsStarted = 0;
+  private interceptorDelayedCloseEventsObserved = 0;
+  private interceptorDelayedTeardownsObserved = 0;
+  private interceptorDelayedRunningStreams = 0;
+  private readonly interceptorDelayedResolvers: Array<() => void> = [];
 
   @Sse('sse')
   sse(): Observable<MessageEvent> {
@@ -127,6 +146,76 @@ export class AppController {
       runningStreams: this.promiseDelayedRunningStreams,
       subscriptionsStarted: this.promiseDelayedSubscriptionsStarted,
       teardownsObserved: this.promiseDelayedTeardownsObserved,
+    };
+  }
+
+  @UseInterceptors(PassthroughInterceptor)
+  @Sse('sse/interceptor/promise-delayed')
+  sseInterceptorPromiseDelayed(
+    @Req() request: IncomingMessage & { raw?: IncomingMessage },
+  ): Promise<Observable<MessageEvent>> {
+    return this.createInterceptorDelayedSse(request);
+  }
+
+  @UseInterceptors(PassthroughInterceptor)
+  @Sse('sse/post/interceptor/promise-delayed', { method: RequestMethod.POST })
+  ssePostInterceptorPromiseDelayed(
+    @Req() request: IncomingMessage & { raw?: IncomingMessage },
+    @Body() _body: { content?: string },
+  ): Promise<Observable<MessageEvent>> {
+    return this.createInterceptorDelayedSse(request);
+  }
+
+  private createInterceptorDelayedSse(
+    request: IncomingMessage & { raw?: IncomingMessage },
+  ): Promise<Observable<MessageEvent>> {
+    this.interceptorDelayedRequestsStarted += 1;
+    this.interceptorDelayedRunningStreams += 1;
+    const rawRequest = request.socket ?? request;
+
+    rawRequest.once('close', () => {
+      this.interceptorDelayedCloseEventsObserved += 1;
+    });
+
+    return new Promise(resolve => {
+      this.interceptorDelayedResolvers.push(() =>
+        resolve(
+          new Observable<MessageEvent>(subscriber => {
+            this.interceptorDelayedSubscriptionsStarted += 1;
+
+            const intervalId = setInterval(() => {
+              subscriber.next({ data: { hello: 'world' } });
+            }, 50);
+
+            return () => {
+              clearInterval(intervalId);
+              this.interceptorDelayedTeardownsObserved += 1;
+              this.interceptorDelayedRunningStreams -= 1;
+            };
+          }),
+        ),
+      );
+    });
+  }
+
+  @Post('sse/interceptor/promise-delayed/release')
+  releaseInterceptorDelayedSse() {
+    const pendingResolvers = this.interceptorDelayedResolvers.splice(0);
+    pendingResolvers.forEach(resolve => resolve());
+
+    return {
+      released: pendingResolvers.length,
+    };
+  }
+
+  @Get('sse/interceptor/promise-delayed/stats')
+  getInterceptorDelayedSseStats() {
+    return {
+      closeEventsObserved: this.interceptorDelayedCloseEventsObserved,
+      requestsStarted: this.interceptorDelayedRequestsStarted,
+      runningStreams: this.interceptorDelayedRunningStreams,
+      subscriptionsStarted: this.interceptorDelayedSubscriptionsStarted,
+      teardownsObserved: this.interceptorDelayedTeardownsObserved,
     };
   }
 }

--- a/packages/core/interceptors/interceptors-consumer.ts
+++ b/packages/core/interceptors/interceptors-consumer.ts
@@ -6,8 +6,8 @@ import {
 } from '@nestjs/common/interfaces';
 import { isEmpty } from '@nestjs/common/utils/shared.utils';
 import { AsyncResource } from 'async_hooks';
-import { Observable, defer, from as fromPromise } from 'rxjs';
-import { mergeAll, switchMap } from 'rxjs/operators';
+import { Observable, defer, from } from 'rxjs';
+import { mergeAll } from 'rxjs/operators';
 import { ExecutionContextHost } from '../helpers/execution-context-host';
 
 export class InterceptorsConsumer {
@@ -51,11 +51,41 @@ export class InterceptorsConsumer {
   }
 
   public transformDeferred(next: () => Promise<any>): Observable<any> {
-    return fromPromise(next()).pipe(
-      switchMap(res => {
-        const isDeferred = res instanceof Promise || res instanceof Observable;
-        return isDeferred ? res : Promise.resolve(res);
-      }),
-    );
+    // Call next() eagerly here — this method is invoked inside
+    // defer(AsyncResource.bind(...)), so the async context (e.g. AsyncLocalStorage)
+    // is correctly inherited. Deferring next() into the subscriber function would
+    // lose that context because the subscriber is called outside the bound scope.
+    const nextPromise = next();
+    return new Observable(subscriber => {
+      let innerSub: { unsubscribe(): void } | undefined;
+
+      nextPromise
+        .then(res => {
+          if (subscriber.closed) {
+            // The outer subscription was torn down (e.g. an SSE client disconnect)
+            // before the async handler resolved. Subscribe-and-immediately-unsubscribe
+            // so the producer Observable's teardown/cleanup logic still runs.
+            if (res instanceof Observable) {
+              const sub = res.subscribe({ error: () => {} });
+              sub.unsubscribe();
+            }
+            return;
+          }
+          const isDeferred =
+            res instanceof Promise || res instanceof Observable;
+          innerSub = from(isDeferred ? res : Promise.resolve(res)).subscribe(
+            subscriber,
+          );
+        })
+        .catch(err => {
+          if (!subscriber.closed) {
+            subscriber.error(err);
+          }
+        });
+
+      return () => {
+        innerSub?.unsubscribe();
+      };
+    });
   }
 }

--- a/packages/core/test/interceptors/interceptors-consumer.spec.ts
+++ b/packages/core/test/interceptors/interceptors-consumer.spec.ts
@@ -178,6 +178,53 @@ describe('InterceptorsConsumer', () => {
         ).to.be.eql(val);
       });
     });
+    describe('when the subscriber is closed before the async handler resolves', () => {
+      it('should subscribe-and-immediately-unsubscribe the producer Observable so its teardown runs', async () => {
+        const teardown = sinon.spy();
+        const subscribed = sinon.spy();
+
+        const next = () =>
+          new Promise<Observable<never>>(resolve =>
+            setTimeout(
+              () =>
+                resolve(
+                  new Observable(() => {
+                    subscribed();
+                    return teardown;
+                  }),
+                ),
+              50,
+            ),
+          );
+
+        const obs$ = consumer.transformDeferred(next);
+        const sub = obs$.subscribe({ error: () => {} });
+
+        // Unsubscribe before the 50 ms delay resolves — simulates SSE client disconnect
+        sub.unsubscribe();
+
+        // Wait long enough for the async handler to resolve and the teardown path to run
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(subscribed.calledOnce).to.be.true;
+        expect(teardown.calledOnce).to.be.true;
+      });
+
+      it('should do nothing for non-Observable results (does not affect regular routes)', async () => {
+        const next = () =>
+          new Promise<string>(resolve =>
+            setTimeout(() => resolve('hello'), 50),
+          );
+
+        const obs$ = consumer.transformDeferred(next);
+        const sub = obs$.subscribe({ error: () => {} });
+        sub.unsubscribe();
+
+        // Wait for the async handler to resolve
+        await new Promise(resolve => setTimeout(resolve, 100));
+        // No assertion needed — this just verifies it doesn't throw
+      });
+    });
   });
   describe('deferred promise conversion', () => {
     it('should convert promise to observable deferred', async () => {

--- a/packages/core/test/router/router-response-controller.spec.ts
+++ b/packages/core/test/router/router-response-controller.spec.ts
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import { EventEmitter } from 'events';
 import { PassThrough, Writable } from 'stream';
 import { HttpStatus, RequestMethod } from '../../../common';
+import { InterceptorsConsumer } from '../../interceptors/interceptors-consumer';
 import { RouterResponseController } from '../../router/router-response-controller';
 import { SseStream } from '../../router/sse-stream';
 import { NoopHttpAdapter } from '../utils/noop-adapter.spec';
@@ -537,6 +538,77 @@ data: test
       expect(response.flushHeaders.called).to.equal(false);
       expect(response.content).to.equal('');
       expect(responseEndSpy.calledOnce).to.equal(true);
+    });
+
+    it('should trigger teardown of async SSE handler Observable when client disconnects mid-await (interceptor case, issue #17190)', async () => {
+      // Simulates: interceptor doing `return next.handle()`, async SSE handler
+      // that awaits 50ms before returning the producer Observable, client
+      // disconnect during the await.
+      const interceptorsConsumer = new InterceptorsConsumer();
+      const teardown = sinon.spy();
+      let subscribed = false;
+
+      const sseHandler = () =>
+        new Promise<Observable<never>>(resolve =>
+          setTimeout(
+            () =>
+              resolve(
+                new Observable(() => {
+                  subscribed = true;
+                  return teardown;
+                }),
+              ),
+            50,
+          ),
+        );
+
+      const passthroughInterceptors = [
+        { intercept: (_ctx: any, handler: any) => handler.handle() },
+      ];
+
+      // Run through the real interceptor chain — this is what the router does
+      // before handing `result` off to `sse()`.
+      const result = await interceptorsConsumer.intercept(
+        passthroughInterceptors,
+        [],
+        { constructor: null } as any,
+        sseHandler as any,
+        sseHandler,
+      );
+
+      const response = new Writable();
+      const responseEndSpy = sinon.spy();
+      response.end = responseEndSpy as any;
+      response._write = () => {};
+
+      const request = attachSocket(new PassThrough());
+
+      const ssePromise = routerResponseController.sse(
+        result as any,
+        response as unknown as ServerResponse,
+        request as unknown as IncomingMessage,
+      );
+
+      // Wait one macrotask so all pending microtasks flush: the Promise.resolve(result).then(…)
+      // callback runs, subscription is set, the interceptor chain's async nextFn() calls resolve,
+      // and sseHandler() is invoked (starting the 50ms timer) — but the timer has NOT fired yet.
+      // This puts us squarely in the "mid-await" window that issue #17190 describes.
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Disconnect while the async handler is still awaiting
+      request.socket.emit('close');
+
+      await ssePromise;
+      // Allow the async handler's setTimeout to fire and teardown path to run
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(subscribed).to.equal(true);
+      expect(teardown.calledOnce).to.equal(true);
+      // response.end() is called once explicitly in onClose, and once more by the
+      // pipe's auto-end when stream.end() fires — both are correct; we only care
+      // that it was called at least once.
+      expect(responseEndSpy.called).to.be.true;
+      expect(request.socket.listenerCount('close')).to.equal(0);
     });
 
     it('should close the request when observable completes', done => {


### PR DESCRIPTION
Fixes a lifecycle gap in `@Sse()` routes that use an interceptor with an async handler (#17190).

## Root cause

`InterceptorsConsumer.transformDeferred()` used `fromPromise(next()).pipe(switchMap(...))` to subscribe to the handler's result. When the client disconnects mid-await, `sse()` correctly calls `subscription.unsubscribe()`, which closes the RxJS subscriber. However, `switchMap` silently drops any emission that arrives on a closed subscriber — so when the async handler eventually resolves and returns the producer Observable, `switchMap` never subscribes to it. The producer Observable's teardown/unsubscribe logic therefore never runs.

## Fix

Replace `fromPromise + switchMap` in `transformDeferred` with a manual Observable that explicitly checks `subscriber.closed` when the handler's Promise resolves. If the subscriber is already closed and the result is an Observable, we subscribe-and-immediately-unsubscribe, which is the same pattern `sse()` already uses for the `Promise<Observable>` (no-interceptor) disconnect case introduced in #17128. `next()` is still called eagerly (not inside the subscriber function) to preserve `AsyncLocalStorage` context, which is inherited from the surrounding `AsyncResource.bind()` scope.

`router-response-controller.ts` is **not touched** — its `onClose` handler was already doing the right thing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- **Unit test** added to `interceptors-consumer.spec.ts`: subscriber closed before async handler resolves → producer Observable teardown fires.
- **Negative test** confirming non-Observable results (plain values, regular `@Get()`/`@Post()` routes) are unaffected.
- **Integration test** added to `router-response-controller.spec.ts` driving the full real stack: `InterceptorsConsumer.intercept()` with a passthrough interceptor, async SSE handler resolving after 50 ms, socket disconnect in the mid-await window. Asserts `subscribed === true`, `teardown.calledOnce === true`, `response.end()` called.
- Full `packages/core` test suite: **798 passing, 0 failing**.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation — **No**
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests passed

Closes #17190
