### PR TITLE
feat(core): include auto-converted route in legacy route path warning

### DIFF
--- a/packages/core/router/legacy-route-converter.ts
+++ b/packages/core/router/legacy-route-converter.ts
@@ -32,33 +32,37 @@ export class LegacyRouteConverter {
       : () => {};
 
     if (normalizedRoute.endsWith('/(.*)/')) {
+      const convertedRoute = route.replace('(.*)', '{*path}');
       // Skip printing warning for the "all" wildcard.
       if (normalizedRoute !== '/(.*)/') {
-        printWarning(route);
+        printWarning(route, convertedRoute);
       }
-      return route.replace('(.*)', '{*path}');
+      return convertedRoute;
     }
 
     if (normalizedRoute.endsWith('/*/')) {
+      const convertedRoute = route.replace('*', '{*path}');
       // Skip printing warning for the "all" wildcard.
       if (normalizedRoute !== '/*/') {
-        printWarning(route);
+        printWarning(route, convertedRoute);
       }
-      return route.replace('*', '{*path}');
+      return convertedRoute;
     }
 
     if (normalizedRoute.endsWith('/+/')) {
-      printWarning(route);
-      return route.replace('/+', '/*path');
+      const convertedRoute = route.replace('/+', '/*path');
+      printWarning(route, convertedRoute);
+      return convertedRoute;
     }
 
     // When route includes any wildcard segments in the middle.
     if (normalizedRoute.includes('/*/')) {
-      printWarning(route);
       // Replace each /*/ segment with a named parameter using different name for each segment.
-      return route.replaceAll('/*/', (match, offset) => {
+      const convertedRoute = route.replaceAll('/*/', (match, offset) => {
         return `/*path${offset}/`;
       });
+      printWarning(route, convertedRoute);
+      return convertedRoute;
     }
 
     return route;
@@ -68,9 +72,12 @@ export class LegacyRouteConverter {
     this.logger.error(UNSUPPORTED_PATH_MESSAGE`${route}`);
   }
 
-  static printWarning(route: string): void {
-    this.logger.warn(
-      UNSUPPORTED_PATH_MESSAGE`${route}` + ' Attempting to auto-convert...',
-    );
+  static printWarning(route: string, convertedRoute?: string): void {
+    // Surface the auto-converted result so users can map the flagged path to a
+    // concrete fix, instead of only seeing the (often prefixed) offending path.
+    const autoConvertMessage = convertedRoute
+      ? ` Attempting to auto-convert to "${convertedRoute}"...`
+      : ' Attempting to auto-convert...';
+    this.logger.warn(UNSUPPORTED_PATH_MESSAGE`${route}` + autoConvertMessage);
   }
 }

--- a/packages/core/test/router/legacy-route-converter.spec.ts
+++ b/packages/core/test/router/legacy-route-converter.spec.ts
@@ -1,0 +1,83 @@
+import { Logger } from '@nestjs/common';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { LegacyRouteConverter } from '../../router/legacy-route-converter';
+
+describe('LegacyRouteConverter', () => {
+  describe('tryConvert', () => {
+    let warnStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      warnStub = sinon.stub(Logger.prototype, 'warn');
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should convert a trailing "*" wildcard to a named parameter', () => {
+      expect(LegacyRouteConverter.tryConvert('/v1/*')).to.equal('/v1/{*path}');
+    });
+
+    it('should convert a trailing "(.*)" wildcard to a named parameter', () => {
+      expect(LegacyRouteConverter.tryConvert('/v1/(.*)')).to.equal(
+        '/v1/{*path}',
+      );
+    });
+
+    it('should convert a trailing "+" wildcard to a named parameter', () => {
+      expect(LegacyRouteConverter.tryConvert('/v1/+')).to.equal('/v1/*path');
+    });
+
+    it('should convert wildcard segments in the middle of the path', () => {
+      expect(LegacyRouteConverter.tryConvert('/v1/*/users')).to.equal(
+        '/v1/*path3/users',
+      );
+    });
+
+    it('should leave routes without legacy wildcards untouched', () => {
+      expect(LegacyRouteConverter.tryConvert('/v1/users')).to.equal(
+        '/v1/users',
+      );
+    });
+
+    it('should not warn for the bare "all" wildcard', () => {
+      LegacyRouteConverter.tryConvert('*');
+      expect(warnStub.called).to.be.false;
+    });
+
+    it('should include the auto-converted route in the warning message', () => {
+      LegacyRouteConverter.tryConvert('/v1/*');
+      expect(warnStub.calledOnce).to.be.true;
+      expect(warnStub.firstCall.firstArg).to.contain(
+        'Attempting to auto-convert to "/v1/{*path}"...',
+      );
+      expect(warnStub.firstCall.firstArg).to.contain(
+        'Unsupported route path: "/v1/*"',
+      );
+    });
+
+    it('should not log when logging is disabled', () => {
+      LegacyRouteConverter.tryConvert('/v1/*', { logs: false });
+      expect(warnStub.called).to.be.false;
+    });
+  });
+
+  describe('printWarning', () => {
+    let warnStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      warnStub = sinon.stub(Logger.prototype, 'warn');
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should fall back to the generic message when no converted route is given', () => {
+      LegacyRouteConverter.printWarning('/v1/*');
+      expect(warnStub.firstCall.firstArg).to.contain(
+        'Attempting to auto-convert...',
+      );
+      expect(warnStub.firstCall.firstArg).to.not.contain('auto-convert to');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [ ] Docs have been added / updated (not applicable — warning message only)

## PR Type

- [x] Bugfix / DX improvement

## What is the current behavior?

The `LegacyRouteConverter` warning prints only the offending — and often global-prefixed — path, e.g.:

```
Unsupported route path: "/v1/*". ... Attempting to auto-convert...
```

But nobody ever wrote `/v1/*`. What's actually in the code is a wildcard matcher such as `forRoutes('*')`, and the prefix (`v1`) is prepended by Nest. So when a user greps their codebase for `/v1/*` to locate the offending call, they find nothing. Worse, the matcher frequently lives inside a third-party module under `node_modules`, so the developer owns neither the wildcard nor has any lead pointing at which dependency applied it.

Issue: #17231 (where @kamilmysliwiec confirmed the idea is fair and welcomed a PR).

## What is the new behavior?

The warning now appends the auto-converted result, pointing the user straight at the concrete fix:

```
Unsupported route path: "/v1/*". ... Attempting to auto-convert to "/v1/{*path}"...
```

- `tryConvert` now computes the converted route first and passes it to `printWarning`.
- The new `convertedRoute` parameter on `printWarning` is **optional**, so the existing signature and behavior are preserved (it falls back to the original generic message when omitted).
- Zero behavior change — only the warning text is enriched.
- Adds `legacy-route-converter.spec.ts` (there was no spec for this file before), covering each wildcard form, the prefixed case, the "all" wildcard skip, disabled logging, and the message content.

## Does this PR introduce a breaking change?

- [x] No
