### PR TITLE
fix(core): avoid legacy warning for generated wildcard paths

### DIFF
--- a/packages/core/middleware/route-info-path-extractor.ts
+++ b/packages/core/middleware/route-info-path-extractor.ts
@@ -33,16 +33,17 @@ export class RouteInfoPathExtractor {
     const versionPaths = this.extractVersionPathFrom(version);
 
     if (this.isAWildcard(path)) {
+      const wildcardPath = this.getNamedWildcardPath(path);
       const entries =
         versionPaths.length > 0
           ? versionPaths
               .map(versionPath => [
                 this.prefixPath + versionPath + '$',
-                this.prefixPath + versionPath + addLeadingSlash(path),
+                this.prefixPath + versionPath + wildcardPath,
               ])
               .flat()
           : this.prefixPath
-            ? [this.prefixPath + '$', this.prefixPath + addLeadingSlash(path)]
+            ? [this.prefixPath + '$', this.prefixPath + wildcardPath]
             : [addLeadingSlash(path)];
 
       return Array.isArray(this.excludedGlobalPrefixRoutes)
@@ -78,6 +79,14 @@ export class RouteInfoPathExtractor {
 
     const wildcardRegexp = /^\/\{.*\}.*|^\/\*.*$/;
     return wildcardRegexp.test(path);
+  }
+
+  private getNamedWildcardPath(path: string): string {
+    if (['*', '/*', '/*/', '(.*)', '/(.*)'].includes(path)) {
+      return '/{*path}';
+    }
+
+    return addLeadingSlash(path);
   }
 
   private extractNonWildcardPathsFrom({

--- a/packages/core/test/middleware/route-info-path-extractor.spec.ts
+++ b/packages/core/test/middleware/route-info-path-extractor.spec.ts
@@ -31,7 +31,7 @@ describe('RouteInfoPathExtractor', () => {
           method: RequestMethod.ALL,
           version: '1',
         }),
-      ).to.eql(['/v1$', '/v1/*']);
+      ).to.eql(['/v1$', '/v1/{*path}']);
     });
 
     it(`should return correct paths when set global prefix`, () => {
@@ -42,7 +42,14 @@ describe('RouteInfoPathExtractor', () => {
           path: '*',
           method: RequestMethod.ALL,
         }),
-      ).to.eql(['/api$', '/api/*']);
+      ).to.eql(['/api$', '/api/{*path}']);
+
+      expect(
+        routeInfoPathExtractor.extractPathsFrom({
+          path: '/{*splat}',
+          method: RequestMethod.ALL,
+        }),
+      ).to.eql(['/api$', '/api/{*splat}']);
 
       expect(
         routeInfoPathExtractor.extractPathsFrom({
@@ -50,7 +57,7 @@ describe('RouteInfoPathExtractor', () => {
           method: RequestMethod.ALL,
           version: '1',
         }),
-      ).to.eql(['/api/v1$', '/api/v1/*']);
+      ).to.eql(['/api/v1$', '/api/v1/{*path}']);
     });
 
     it(`should return correct paths when set global prefix and global prefix options`, () => {
@@ -66,7 +73,7 @@ describe('RouteInfoPathExtractor', () => {
           path: '*',
           method: RequestMethod.ALL,
         }),
-      ).to.eql(['/api$', '/api/*', '/foo']);
+      ).to.eql(['/api$', '/api/{*path}', '/foo']);
 
       expect(
         routeInfoPathExtractor.extractPathsFrom({
@@ -74,7 +81,7 @@ describe('RouteInfoPathExtractor', () => {
           method: RequestMethod.ALL,
           version: '1',
         }),
-      ).to.eql(['/api/v1$', '/api/v1/*', '/v1/foo']);
+      ).to.eql(['/api/v1$', '/api/v1/{*path}', '/v1/foo']);
 
       expect(
         routeInfoPathExtractor.extractPathsFrom({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

`forRoutes('*')` is expanded with global prefixes and URI versions before middleware registration. That can generate paths like `/api/*` or `/v1/*`, which then flow through the legacy route converter and produce a migration warning for a path the user did not write.

Issue Number: #17231

## What is the new behavior?

When a simple wildcard middleware route is expanded with a prefix or URI version, the generated wildcard segment now uses the named wildcard syntax directly (`/{*path}`). User-authored legacy wildcard paths such as `legacy/*` still go through the existing converter and warning path.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation run locally:

- `npx prettier --ignore-path ./.prettierignore --write packages/core/middleware/route-info-path-extractor.ts packages/core/test/middleware/route-info-path-extractor.spec.ts`
- `./node_modules/.bin/eslint.cmd packages/core/middleware/route-info-path-extractor.ts packages/core/test/middleware/route-info-path-extractor.spec.ts`
- `npx tsc -b packages/core --pretty false`
- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js packages/core/test/middleware/*.spec.ts`
- `node --loader ts-node/esm ./node_modules/mocha/bin/mocha.js integration/hello-world/e2e/middleware.spec.ts integration/hello-world/e2e/middleware-fastify.spec.ts`
- `git diff --check`

I also tried `npm run test`; it exited with code 1 in this Windows/Node 24 environment without a Mocha failure summary in the captured output, so I relied on the focused core middleware and e2e slices above for this change.