### PR TITLE
fix(common): Reject hex and trailing chars in ParseFloatPipe isNumeric

### DIFF
--- a/packages/common/pipes/parse-float.pipe.ts
+++ b/packages/common/pipes/parse-float.pipe.ts
@@ -76,7 +76,7 @@ export class ParseFloatPipe implements PipeTransform<string> {
   protected isNumeric(value: string): boolean {
     return (
       ['string', 'number'].includes(typeof value) &&
-      !isNaN(parseFloat(value)) &&
+      /^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(value) &&
       isFinite(value as any)
     );
   }

--- a/packages/common/test/pipes/parse-float.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-float.pipe.spec.ts
@@ -39,6 +39,26 @@ describe('ParseFloatPipe', () => {
           target.transform('123.123abc', {} as ArgumentMetadata),
         ).to.be.rejectedWith(CustomTestError);
       });
+      it('should throw an error for hex string', async () => {
+        return expect(
+          target.transform('0xFF', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+      it('should throw an error for binary string', async () => {
+        return expect(
+          target.transform('0b101', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+      it('should throw an error for Infinity', async () => {
+        return expect(
+          target.transform('Infinity', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
+      it('should throw an error for -Infinity', async () => {
+        return expect(
+          target.transform('-Infinity', {} as ArgumentMetadata),
+        ).to.be.rejectedWith(CustomTestError);
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`ParseFloatPipe.isNumeric()` currently uses `!isNaN(parseFloat(value))` to validate numeric input. Since `parseFloat()` accepts partially valid strings, invalid values can be silently truncated instead of rejected.

For example:

- `parseFloat("0xFF")` returns `0`
- `parseFloat("123abc")` returns `123`

As a result, these invalid inputs pass validation and are converted into incorrect numeric values instead of triggering a validation error.

Issue Number: N/A

## What is the new behavior?
`ParseFloatPipe` now validates input using the following regular expression:

```ts
/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/
```

This performs strict validation of decimal floating-point numbers before parsing, similar to how `ParseIntPipe` validates integers using `^-?\d+$`.

Using a regular expression instead of `Number()` ensures that only valid decimal floating-point syntax is accepted. JavaScript's `Number()` would also accept hexadecimal (`0xFF`) and binary (`0b101`) literals, which are outside the intended scope of `ParseFloatPipe`.

The pipe now correctly rejects invalid inputs such as:

- `0xFF`
- `0b101`
- `123abc`
- `3.14.15`

while continuing to accept valid decimal values and scientific notation.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information