### PR TITLE
feat(common,core,platform-fastify): add HTTP QUERY method support (RFC 10008)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "markdown-table": "2.0.0",
         "mocha": "11.7.6",
         "mongoose": "9.7.4",
-        "mqtt": "5.15.1",
+        "mqtt": "5.15.2",
         "multer": "2.2.0",
         "mysql2": "3.22.6",
         "nats": "2.29.3",
@@ -3354,6 +3354,80 @@
           "optional": true
         },
         "@as-integrations/fastify": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/common": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.28.tgz",
+      "integrity": "sha512-bRImsxibie+AM7xjdwcrm/gr5YeacI65kSBNzTufa1Ib5iwziaY/lqMtRh9THq6pbV4e1HP9aI2ZxGUumnmaoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "file-type": "21.3.4",
+        "iterare": "1.2.1",
+        "load-esm": "1.0.3",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "class-transformer": ">=0.4.1",
+        "class-validator": ">=0.13.2",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/core": {
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.28.tgz",
+      "integrity": "sha512-06m63xIRj8+l8uOeh/8LnYupGubkyu4f+bPKIadaSui6vK9KpXgoz7HveT1yOVLcEt0M0oCOEW5EuEXZkEmBBQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-safe-stringify": "2.1.1",
+        "iterare": "1.2.1",
+        "path-to-regexp": "8.4.2",
+        "tslib": "2.8.1",
+        "uid": "2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
+        "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/microservices": {
+          "optional": true
+        },
+        "@nestjs/platform-express": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
           "optional": true
         }
       }
@@ -19758,9 +19832,9 @@
       }
     },
     "node_modules/mqtt": {
-      "version": "5.15.1",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.1.tgz",
-      "integrity": "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA==",
+      "version": "5.15.2",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.15.2.tgz",
+      "integrity": "sha512-VWZU2CSUY3U3oN0PSBRDE5SNsFi4zqqNeQ/uv3pZWqY3CrBXD/dhd0ZLjlsk5YnebGlrapi4lRVNJPUNQ5aZ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -120,6 +120,15 @@ export const All = createMappingDecorator(RequestMethod.ALL);
 export const Search = createMappingDecorator(RequestMethod.SEARCH);
 
 /**
+ * Route handler (method) Decorator. Routes HTTP QUERY requests to the specified path.
+ *
+ * @see [Routing](https://docs.nestjs.com/controllers#routing)
+ *
+ * @publicApi
+ */
+export const HttpQuery = createMappingDecorator(RequestMethod.QUERY);
+
+/**
  * Route handler (method) Decorator. Routes Webdav PROPFIND requests to the specified path.
  *
  * @see [Routing](https://docs.nestjs.com/controllers#routing)

--- a/packages/common/enums/request-method.enum.ts
+++ b/packages/common/enums/request-method.enum.ts
@@ -7,6 +7,7 @@ export enum RequestMethod {
   ALL,
   OPTIONS,
   HEAD,
+  QUERY,
   SEARCH,
   PROPFIND,
   PROPPATCH,

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -63,6 +63,8 @@ export interface HttpServer<
   options(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   search?(handler: RequestHandler<TRequest, TResponse>): any;
   search?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  query?(handler: RequestHandler<TRequest, TResponse>): any;
+  query?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   listen(port: number | string, callback?: () => void): any;
   listen(port: number | string, hostname: string, callback?: () => void): any;
   reply(response: any, body: any, statusCode?: number): any;

--- a/packages/common/test/decorators/request-mapping.decorator.spec.ts
+++ b/packages/common/test/decorators/request-mapping.decorator.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { RequestMapping } from '../../decorators/http/request-mapping.decorator';
+import {
+  HttpQuery,
+  RequestMapping,
+} from '../../decorators/http/request-mapping.decorator';
 import { RequestMethod } from '../../enums/request-method.enum';
 
 describe('@RequestMapping', () => {
@@ -58,5 +61,46 @@ describe('@RequestMapping', () => {
 
     expect(path).to.be.eql('/');
     expect(pathUsingArray).to.be.eql('/');
+  });
+});
+
+describe('@HttpQuery', () => {
+  it('should enhance method with QUERY method metadata', () => {
+    class Test {
+      @HttpQuery('test')
+      public static test() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+
+    expect(path).to.be.eql('test');
+    expect(method).to.be.eql(RequestMethod.QUERY);
+  });
+
+  it('should set path on "/" by default', () => {
+    class Test {
+      @HttpQuery()
+      public static test() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+
+    expect(path).to.be.eql('/');
+    expect(method).to.be.eql(RequestMethod.QUERY);
+  });
+
+  it('should accept a path array', () => {
+    class Test {
+      @HttpQuery(['foo', 'bar'])
+      public static test() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+
+    expect(path).to.be.eql(['foo', 'bar']);
+    expect(method).to.be.eql(RequestMethod.QUERY);
   });
 });

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -113,6 +113,12 @@ export abstract class AbstractHttpAdapter<
     return this.instance.search(...args);
   }
 
+  public query(handler: RequestHandler);
+  public query(path: any, handler: RequestHandler);
+  public query(...args: any[]) {
+    return this.instance.query(...args);
+  }
+
   public options(handler: RequestHandler);
   public options(path: any, handler: RequestHandler);
   public options(...args: any[]) {

--- a/packages/core/helpers/router-method-factory.ts
+++ b/packages/core/helpers/router-method-factory.ts
@@ -10,6 +10,7 @@ export const REQUEST_METHOD_MAP = {
   [RequestMethod.ALL]: 'all',
   [RequestMethod.OPTIONS]: 'options',
   [RequestMethod.HEAD]: 'head',
+  [RequestMethod.QUERY]: 'query',
   [RequestMethod.SEARCH]: 'search',
   [RequestMethod.PROPFIND]: 'propfind',
   [RequestMethod.PROPPATCH]: 'proppatch',

--- a/packages/core/test/helpers/router-method-factory.spec.ts
+++ b/packages/core/test/helpers/router-method-factory.spec.ts
@@ -14,6 +14,7 @@ describe('RouterMethodFactory', () => {
     patch: () => {},
     options: () => {},
     head: () => {},
+    query: () => {},
     propfind: () => {},
     proppatch: () => {},
     mkcol: () => {},
@@ -36,6 +37,7 @@ describe('RouterMethodFactory', () => {
     expect(factory.get(target, RequestMethod.PATCH)).to.equal(target.patch);
     expect(factory.get(target, RequestMethod.OPTIONS)).to.equal(target.options);
     expect(factory.get(target, RequestMethod.HEAD)).to.equal(target.head);
+    expect(factory.get(target, RequestMethod.QUERY)).to.equal(target.query);
     expect(factory.get(target, RequestMethod.PROPFIND)).to.equal(
       target.propfind,
     );

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -381,6 +381,10 @@ export class FastifyAdapter<
     return this.injectRouteOptions('SEARCH', ...args);
   }
 
+  public query(...args: any[]) {
+    return this.injectRouteOptions('QUERY', ...args);
+  }
+
   public propfind(...args: any[]) {
     return this.injectRouteOptions('PROPFIND', ...args);
   }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Feature
- [ ] Bugfix
- [ ] Code style update
- [ ] Refactoring
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Description

Add support for the HTTP QUERY method as defined in RFC 10008. The QUERY
method is a safe, idempotent, cacheable HTTP request with a body — filling
the gap between GET (URI-limited queries) and POST (non-idempotent).

### Changes

| File | Change |
|---|---|
| `packages/common/enums/request-method.enum.ts` | Add `QUERY` to enum |
| `packages/common/interfaces/http/http-server.interface.ts` | Add optional `query?()` |
| `packages/common/decorators/http/request-mapping.decorator.ts` | Add `@HttpQuery()` decorator |
| `packages/core/helpers/router-method-factory.ts` | Add to `REQUEST_METHOD_MAP` |
| `packages/core/adapters/http-adapter.ts` | Add `query()` delegation |
| `packages/platform-fastify/adapters/fastify-adapter.ts` | Add `query()` via `injectRouteOptions` |
| Tests | Update decorator and factory tests |

### Naming

The decorator is named `@HttpQuery()` (not `@Query()`) to avoid collision with
the existing `@Query()` parameter decorator. This follows the precedent set by
FastEndpoints (.NET) which ships `[HttpQuery(...)]` for the same purpose.

## Closing Issues

- Discussion: #17287

## What is the current behavior?

NestJS does not support the HTTP QUERY method.

## What is the new behavior?

- `RequestMethod.QUERY` is available in the enum
- `@HttpQuery()` decorator for routing QUERY requests
- QUERY routes work on both Express and Fastify adapters

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The ecosystem is actively adopting QUERY:
- Node.js: `http.METHODS` includes `QUERY` since v21.7.2
- FastEndpoints (.NET): already shipped `[HttpQuery(...)]`
- Fastify: PR #6832 adding `fastify.query()`
- Express: PR #7366 adding QUERY freshness validation
