### PR TITLE
feat(core): support comments in sse stream

### DIFF
--- a/packages/common/interfaces/http/message-event.interface.ts
+++ b/packages/common/interfaces/http/message-event.interface.ts
@@ -1,6 +1,7 @@
 export interface MessageEvent {
-  data: string | object;
+  data?: string | object;
   id?: string;
   type?: string;
   retry?: number;
+  comment?: string;
 }

--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -14,6 +14,13 @@ function toDataString(data: string | object): string {
     .join('');
 }
 
+function toCommentString(comment: string): string {
+  return comment
+    .split(/\r\n|\r|\n/)
+    .map(line => `: ${line}\n`)
+    .join('');
+}
+
 export type AdditionalHeaders = Record<
   string,
   string[] | string | number | undefined
@@ -46,6 +53,7 @@ export type HeaderStream = WritableHeaderStream & ReadHeaders;
  * - type
  * - id
  * - retry
+ * - comment
  *
  * If constructed with a HTTP Request, it will optimise the socket for streaming.
  * If this stream is piped to an HTTP Response, it will set appropriate headers.
@@ -129,13 +137,20 @@ export class SseStream extends Transform {
     const sanitize = (val: string | number) =>
       String(val).replace(/[\r\n]/g, '');
 
-    let data = message.type ? `event: ${sanitize(message.type)}\n` : '';
+    let data =
+      message.comment !== undefined && message.comment !== null
+        ? toCommentString(message.comment)
+        : '';
+    data += message.type ? `event: ${sanitize(message.type)}\n` : '';
     data +=
       message.id !== undefined && message.id !== null
         ? `id: ${sanitize(message.id)}\n`
         : '';
     data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
-    data += message.data ? toDataString(message.data) : '';
+    data +=
+      message.data !== undefined && message.data !== null
+        ? toDataString(message.data)
+        : '';
     data += '\n';
     this.push(data);
     callback();
@@ -148,7 +163,17 @@ export class SseStream extends Transform {
     message: MessageEvent,
     cb: (error: Error | null | undefined) => void,
   ) {
-    if (message.id === undefined || message.id === null) {
+    const isCommentOnlyMessage =
+      message.comment !== undefined &&
+      message.comment !== null &&
+      message.data === undefined &&
+      message.type === undefined &&
+      message.retry === undefined;
+
+    if (
+      !isCommentOnlyMessage &&
+      (message.id === undefined || message.id === null)
+    ) {
       this.lastEventId!++;
       message.id = this.lastEventId!.toString();
     }

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -124,6 +124,51 @@ data: hello
     );
   });
 
+  it('writes comment-only messages without an event id', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage(
+      {
+        comment: 'keep-alive',
+      },
+      noop,
+    );
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      `
+: keep-alive
+
+`,
+    );
+  });
+
+  it('writes multiline comments line by line', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage(
+      {
+        comment: 'line 1\nline 2',
+      },
+      noop,
+    );
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      `
+: line 1
+: line 2
+
+`,
+    );
+  });
+
   it('does not write headers eagerly in pipe()', () => {
     const sse = new SseStream();
     let writeHeadCalled = false;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`SseStream` serializes `data`, `type`, `id`, and `retry`, but it does not provide a way to serialize SSE comment lines.

Issue Number: #17274


## What is the new behavior?

`MessageEvent` now supports an optional `comment` field.

For example:

    { comment: 'keep-alive' }

is serialized as:

    : keep-alive

Multiline comments are serialized line by line:

    { comment: 'line 1\nline 2' }

as:

    : line 1
    : line 2

Comment-only frames are written without an auto-generated event id, matching the standard SSE comment frame shape.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

This is an additive change. Existing `data`, `type`, `id`, and `retry` serialization behavior is preserved.

Tests run:

- `npm run test`
- `npm run lint`
