### PR TITLE
feat(core): support sse comments

### DIFF
--- a/packages/common/interfaces/http/message-event.interface.ts
+++ b/packages/common/interfaces/http/message-event.interface.ts
@@ -1,6 +1,7 @@
 export interface MessageEvent {
-  data: string | object;
+  data?: string | object;
   id?: string;
   type?: string;
   retry?: number;
+  comment?: string;
 }

--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -1,17 +1,38 @@
 import { MessageEvent } from '@nestjs/common/interfaces';
-import { isObject } from '@nestjs/common/utils/shared.utils';
+import {
+  isNil,
+  isObject,
+  isUndefined,
+} from '@nestjs/common/utils/shared.utils';
 import { IncomingMessage, OutgoingHttpHeaders } from 'http';
 import { Transform } from 'stream';
+
+function serializeSseLines(value: string, prefix: string): string {
+  return value
+    .split(/\r\n|\r|\n/)
+    .map(line => `${prefix}${line}\n`)
+    .join('');
+}
 
 function toDataString(data: string | object): string {
   if (isObject(data)) {
     return toDataString(JSON.stringify(data));
   }
 
-  return data
-    .split(/\r\n|\r|\n/)
-    .map(line => `data: ${line}\n`)
-    .join('');
+  return serializeSseLines(data, 'data: ');
+}
+
+function toCommentString(comment: string): string {
+  return serializeSseLines(comment, ': ');
+}
+
+function isCommentOnly(message: MessageEvent): boolean {
+  return (
+    !isNil(message.comment) &&
+    isUndefined(message.data) &&
+    isUndefined(message.type) &&
+    isUndefined(message.retry)
+  );
 }
 
 export type AdditionalHeaders = Record<
@@ -46,6 +67,7 @@ export type HeaderStream = WritableHeaderStream & ReadHeaders;
  * - type
  * - id
  * - retry
+ * - comment
  *
  * If constructed with a HTTP Request, it will optimise the socket for streaming.
  * If this stream is piped to an HTTP Response, it will set appropriate headers.
@@ -130,12 +152,10 @@ export class SseStream extends Transform {
       String(val).replace(/[\r\n]/g, '');
 
     let data = message.type ? `event: ${sanitize(message.type)}\n` : '';
-    data +=
-      message.id !== undefined && message.id !== null
-        ? `id: ${sanitize(message.id)}\n`
-        : '';
+    data += !isNil(message.id) ? `id: ${sanitize(message.id)}\n` : '';
     data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
-    data += message.data ? toDataString(message.data) : '';
+    data += !isNil(message.comment) ? toCommentString(message.comment) : '';
+    data += !isNil(message.data) ? toDataString(message.data) : '';
     data += '\n';
     this.push(data);
     callback();
@@ -148,7 +168,7 @@ export class SseStream extends Transform {
     message: MessageEvent,
     cb: (error: Error | null | undefined) => void,
   ) {
-    if (message.id === undefined || message.id === null) {
+    if (isNil(message.id) && !isCommentOnly(message)) {
       this.lastEventId!++;
       message.id = this.lastEventId!.toString();
     }

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -124,6 +124,76 @@ data: hello
     );
   });
 
+  it('only skips generated ids for comment-only messages', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage({ comment: 'comment-only' }, noop);
+    sse.writeMessage({ comment: 'with-type', type: 'notice' }, noop);
+    sse.writeMessage({ comment: 'with-retry', retry: 1000 }, noop);
+    sse.writeMessage({ comment: 'with-data', data: 'hello' }, noop);
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      `
+: comment-only
+
+event: notice
+id: 1
+: with-type
+
+id: 2
+retry: 1000
+: with-retry
+
+id: 3
+: with-data
+data: hello
+
+`,
+    );
+  });
+
+  it('writes empty and multiline comments', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage({ comment: '' }, noop);
+    sse.writeMessage({ comment: 'first\r\nsecond\rthird\n\nfourth' }, noop);
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      [
+        '',
+        ': ',
+        '',
+        ': first',
+        ': second',
+        ': third',
+        ': ',
+        ': fourth',
+        '',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  it('serializes empty data strings', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage({ data: '' }, noop);
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(['', 'id: 1', 'data: ', '', ''].join('\n'));
+  });
+
   it('does not write headers eagerly in pipe()', () => {
     const sse = new SseStream();
     let writeHeadCalled = false;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`SseStream` can serialize `data`, `event`, `id`, and `retry`, but not SSE
comment lines.

Issue Number: #17274

## What is the new behavior?

`MessageEvent` accepts an optional `comment` field, and `data` is optional so
comment-only frames can be represented.

For example:

```ts
{ comment: 'keep-alive' }
```

is serialized as:

```text
: keep-alive

```

Multiline comments are serialized line by line using the same line-ending
handling as `data`. Comment-only frames do not consume generated event IDs,
while messages containing other event fields keep the existing ID behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`MessageEvent.data` becomes optional to represent comment-only frames. Existing
`MessageEvent` values remain valid.

## Other information

This implementation preserves the existing `event`, `id`, `retry`, `data`
field order and shares multiline serialization between data and comments.
Tests cover empty comments, mixed line endings, comment-plus-data frames, and
event ID sequencing.

Local checks:

- Targeted `SseStream` tests: 15 passing
- Targeted NYC coverage: all added executable lines and new branches covered
- ESLint on changed files
- `npm run build`
- `git diff --check`
