### PR TITLE
fix(microservices): correct pub/sub client type in redis listeners

### DIFF
--- a/packages/microservices/server/server-redis.ts
+++ b/packages/microservices/server/server-redis.ts
@@ -58,7 +58,7 @@ export class ServerRedis extends Server<RedisEvents, RedisStatus> {
       this.pubClient = this.createRedisClient();
 
       [this.subClient, this.pubClient].forEach((client, index) => {
-        const type = index === 0 ? 'pub' : 'sub';
+        const type = index === 0 ? 'sub' : 'pub';
         this.registerErrorListener(client);
         this.registerReconnectListener(client);
         this.registerReadyListener(client);

--- a/packages/microservices/test/server/server-redis.spec.ts
+++ b/packages/microservices/test/server/server-redis.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
 import { NO_MESSAGE_HANDLER } from '../../constants';
 import { RedisContext } from '../../ctx-host';
@@ -51,6 +52,27 @@ describe('ServerRedis', () => {
         server.listen(callbackSpy);
         expect(callbackSpy.calledWith(error)).to.be.true;
       });
+    });
+  });
+  describe('event listeners registered before "listen"', () => {
+    it('should forward the matching client type ("sub"/"pub") to the listener', () => {
+      const subClient = new EventEmitter();
+      const pubClient = new EventEmitter();
+      const createClientStub = sinon.stub(server, 'createRedisClient');
+      createClientStub.onFirstCall().returns(subClient as any);
+      createClientStub.onSecondCall().returns(pubClient as any);
+      sinon.stub(server, 'start').callsFake((cb?: () => void) => cb?.());
+
+      const readySpy = sinon.spy();
+      server.on('ready', readySpy);
+
+      server.listen(() => {});
+
+      subClient.emit('ready');
+      pubClient.emit('ready');
+
+      expect(readySpy.firstCall.args[0]).to.be.equal('sub');
+      expect(readySpy.secondCall.args[0]).to.be.equal('pub');
     });
   });
   describe('close', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17330 


## What is the new behavior?

Index `0` is labeled `'sub'` and index `1` is labeled`'pub'`, matching `on()` and `ClientRedis`. Added a regression test that fails without the fix




## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information