### PR TITLE
feat(common): add override mimetype option to file type validator

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -56,6 +56,14 @@ export type FileTypeValidatorOptions = {
    * @default false
    */
   fallbackToMimetype?: boolean;
+
+  /**
+   * If `true`, replaces the client-provided mimetype with the mimetype
+   * detected from the file content using magic number validation.
+   *
+   * @default false
+   */
+  overrideMimeType?: boolean;
 };
 
 /**
@@ -151,6 +159,9 @@ export class FileTypeValidator extends FileValidator<
       const fileType = await fileTypeFromBuffer(file.buffer);
 
       if (fileType) {
+        if (this.validationOptions.overrideMimeType) {
+          file.mimetype = fileType.mime;
+        }
         // Match detected mime type against allowed type
         return !!fileType.mime.match(this.validationOptions.fileType);
       }

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -388,4 +388,22 @@ describe('FileTypeValidator', () => {
       );
     });
   });
+  describe('overrideMimeType', () => {
+    it('should override mimetype when overrideMimeType is enabled', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: /^image\/png$/,
+        overrideMimeType: true,
+      });
+
+      const requestFile: IFile = {
+        mimetype: 'image/jpeg',
+        buffer: pngBuffer,
+        size: pngBuffer.length,
+      };
+
+      await fileTypeValidator.isValid(requestFile);
+
+      expect(requestFile.mimetype).to.equal('image/png');
+    });
+  });
 });

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -401,9 +401,23 @@ describe('FileTypeValidator', () => {
         size: pngBuffer.length,
       };
 
-      await fileTypeValidator.isValid(requestFile);
-
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
       expect(requestFile.mimetype).to.equal('image/png');
+    });
+
+    it('should not override mimetype when overrideMimeType is disabled', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: /^image\/png$/,
+      });
+
+      const requestFile: IFile = {
+        mimetype: 'image/jpeg',
+        buffer: pngBuffer,
+        size: pngBuffer.length,
+      };
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
+      expect(requestFile.mimetype).to.equal('image/jpeg');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`FileTypeValidator` uses magic number detection to validate the actual file type based on its content. However, the detected MIME type is only used internally during validation.

After successful validation, the original `file.mimetype` value provided by the client remains unchanged. This value can be incorrect or spoofed because it is based only on the request metadata.

For example, if an MP4 file is renamed to `.png` and uploaded, the validator correctly detects the actual file type, but the `file.mimetype` property still contains the client-provided value:

```
{
  "mimetype": "image/png"
}
```


Issue Number: N/A


## What is the new behavior?
Adds a new optional `overrideMimeType` option to `FileTypeValidator`.

When `overrideMimeType` is set to `true`, the validator overwrites `file.mimetype` with the MIME type detected from the file content using magic number validation.

This allows users to rely on the validated MIME type after the validation step without needing to run additional file type detection logic.


## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information