### PR TITLE
fix(core): drop the g flag from middleware overlap regexes

### DIFF
--- a/packages/core/middleware/builder.ts
+++ b/packages/core/middleware/builder.ts
@@ -114,9 +114,12 @@ export class MiddlewareBuilder implements MiddlewareConsumer {
         .map(route => ({
           method: route.method,
           path: route.path,
+          // No `g` flag: each regex is reused across every route below, and a
+          // global regex advances `lastIndex` on a match, so the next `test()`
+          // would resume mid-string and fail the `^` anchor. The pattern is
+          // anchored and only used with `test()`, so `g` buys nothing anyway.
           regex: new RegExp(
             '^(' + route.path.replace(regexMatchParams, wildcard) + ')$',
-            'g',
           ),
         }));
 

--- a/packages/core/test/middleware/builder.spec.ts
+++ b/packages/core/test/middleware/builder.spec.ts
@@ -181,6 +181,30 @@ describe('MiddlewareBuilder', () => {
             },
           ]);
         });
+
+        it('should remove every route overlapping the same parameterized one', () => {
+          // The parameterized route's regex is reused for each candidate, so a
+          // stateful (global) regex would leave `lastIndex` past the end of the
+          // previous match and let every other concrete route through. #17334
+          configProxy.forRoutes(
+            { path: 'cats/:id', method: RequestMethod.GET },
+            { path: 'cats/1', method: RequestMethod.GET },
+            { path: 'cats/2', method: RequestMethod.GET },
+            { path: 'cats/3', method: RequestMethod.GET },
+          );
+
+          expect(builder.build()).to.deep.equal([
+            {
+              middleware: [],
+              forRoutes: [
+                {
+                  method: RequestMethod.GET,
+                  path: '/cats/:id',
+                },
+              ],
+            },
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (not applicable — internal behaviour, no public API change)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #17334

`removeOverlappedRoutes` builds one regex per parameterized route and reuses it while filtering every route. Those regexes were created with the `g` flag, and a global regex advances `lastIndex` on a successful `test()`, so the next call resumes mid-string and fails the `^` anchor.

Overlap detection therefore depended on iteration order. Reproducing the exact logic in isolation:

```
with    g: ["cats/:id","cats/2"]
without g: ["cats/:id"]
```

So with `cats/:id`, `cats/1`, `cats/2`, `cats/3`, the route `cats/2` survives deduplication and the middleware runs **twice** for `/cats/2` — exactly what the reporter observed. The alternation is the `lastIndex` tell:

```js
const re = new RegExp('^(cats/([^/]*))$', 'g');
re.test('cats/1'); // true,  lastIndex = 6
re.test('cats/2'); // false, lastIndex = 0   <-- resumed at offset 6
re.test('cats/3'); // true,  lastIndex = 6
```

## What is the new behavior?

The `g` flag is dropped. The pattern is anchored (`^...$`) and only ever used with `test()`, so the flag bought nothing but statefulness. Overlap detection no longer depends on iteration order or leftover regex state, and every concrete route overlapping `cats/:id` is deduplicated.

## Tests

Added `should remove every route overlapping the same parameterized one` to `builder.spec.ts`, using the issue's `cats/:id` + three concrete routes so more than one candidate has to match the same regex — a single concrete route can't catch this, which is why the existing overlap test passed throughout.

Reverting only `builder.ts` fails exactly that one test and nothing else.

## Verification

- `packages/core/test/middleware/*.spec.ts` → **35 passing**
- `packages/core/test/**/*.spec.ts` → **610 passing**

Note: `npm install` fails on `master` with an `ERESOLVE` peer conflict (`graphql@17` vs `@apollo/server@5`'s `^16`), so I installed with `--legacy-peer-deps` and deliberately kept the resulting `package-lock.json` churn out of this PR — the diff is only the two source files.

## Does this PR introduce a breaking change?

- [x] No

Behaviour only changes where deduplication was previously being skipped by accident.
