### PR TITLE
Fix/doc and pipe cleanup

### DIFF
--- a/packages/common/exceptions/misdirected.exception.ts
+++ b/packages/common/exceptions/misdirected.exception.ts
@@ -22,7 +22,7 @@ export class MisdirectedException extends HttpException {
    *
    * By default, the JSON response body contains two properties:
    * - `statusCode`: this will be the value 421.
-   * - `message`: the string `'Bad Gateway'` by default; override this by supplying
+   * - `message`: the string `'Misdirected'` by default; override this by supplying
    * a string in the `objectOrError` parameter.
    *
    * If the parameter `objectOrError` is a string, the response body will contain an

--- a/packages/common/exceptions/not-acceptable.exception.ts
+++ b/packages/common/exceptions/not-acceptable.exception.ts
@@ -22,8 +22,8 @@ export class NotAcceptableException extends HttpException {
    *
    * By default, the JSON response body contains two properties:
    * - `statusCode`: this will be the value 406.
-   * - `error`: the string `'Not Acceptable'` by default; override this by supplying
-   * a string in the `error` parameter.
+   * - `message`: the string `'Not Acceptable'` by default; override this by supplying
+   * a string in the `objectOrError` parameter.
    *
    * If the parameter `objectOrError` is a string, the response body will contain an
    * additional property, `error`, with a short description of the HTTP error. To override the

--- a/packages/common/pipes/parse-array.pipe.ts
+++ b/packages/common/pipes/parse-array.pipe.ts
@@ -16,7 +16,7 @@ const DEFAULT_ARRAY_SEPARATOR = ',';
 /**
  * @publicApi
  */
-export interface ParseArrayOptions extends Omit<
+export interface ParseArrayPipeOptions extends Omit<
   ValidationPipeOptions,
   'transform' | 'validateCustomDecorators' | 'exceptionFactory'
 > {
@@ -43,6 +43,9 @@ export interface ParseArrayOptions extends Omit<
   exceptionFactory?: (error: any) => any;
 }
 
+/** @deprecated Use `ParseArrayPipeOptions` instead. */
+export type ParseArrayOptions = ParseArrayPipeOptions;
+
 /**
  * Defines the built-in ParseArray Pipe
  *
@@ -55,7 +58,9 @@ export class ParseArrayPipe implements PipeTransform {
   protected readonly validationPipe: ValidationPipe;
   protected exceptionFactory: (error: string) => any;
 
-  constructor(@Optional() protected readonly options: ParseArrayOptions = {}) {
+  constructor(
+    @Optional() protected readonly options: ParseArrayPipeOptions = {},
+  ) {
     this.validationPipe = new ValidationPipe({
       transform: true,
       validateCustomDecorators: true,

--- a/packages/common/pipes/parse-date.pipe.ts
+++ b/packages/common/pipes/parse-date.pipe.ts
@@ -7,6 +7,9 @@ import {
 } from '../utils/http-error-by-code.util';
 import { isNil } from '../utils/shared.utils';
 
+/**
+ * @publicApi
+ */
 export interface ParseDatePipeOptions {
   /**
    * If true, the pipe will return null or undefined if the value is not provided
@@ -30,6 +33,9 @@ export interface ParseDatePipeOptions {
   exceptionFactory?: (error: string) => any;
 }
 
+/**
+ * @publicApi
+ */
 @Injectable()
 export class ParseDatePipe implements PipeTransform<
   string | number | undefined | null


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Two minor issues in `packages/common`:
1. `MisdirectedException` JSDoc says `'Bad Gateway'` instead of `'Misdirected'`
2. `NotAcceptableException` JSDoc says `error` param instead of `message`
3. `ParseDatePipe` and `ParseDatePipeOptions` are missing `@publicApi` annotation
4. `ParseArrayOptions` type name is inconsistent with other pipe options types (e.g. `ParseDatePipeOptions`, `ParseFloatPipeOptions`)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
1-2. JSDoc descriptions corrected
3. `@publicApi` added to both interface and class
4. Renamed to `ParseArrayPipeOptions`; deprecated type alias `ParseArrayOptions` left for backward compatibility

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information