### PR TITLE
fix(core): serialize SSE retry field when value is zero

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -153,7 +153,7 @@ export class SseStream extends Transform {
 
     let data = message.type ? `event: ${sanitize(message.type)}\n` : '';
     data += !isNil(message.id) ? `id: ${sanitize(message.id)}\n` : '';
-    data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
+    data += !isNil(message.retry) ? `retry: ${sanitize(message.retry)}\n` : '';
     data += !isNil(message.comment) ? toCommentString(message.comment) : '';
     data += !isNil(message.data) ? toDataString(message.data) : '';
     data += '\n';

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -124,6 +124,32 @@ data: hello
     );
   });
 
+  it('writes retry even when the value is zero', async () => {
+    const sse = new SseStream();
+    const sink = new Sink();
+    sse.pipe(sink);
+
+    sse.writeMessage(
+      {
+        id: 'the-id',
+        retry: 0,
+        data: 'hello',
+      },
+      noop,
+    );
+    sse.end();
+    await written(sink);
+
+    expect(sink.content).to.equal(
+      `
+id: the-id
+retry: 0
+data: hello
+
+`,
+    );
+  });
+
   it('only skips generated ids for comment-only messages', async () => {
     const sse = new SseStream();
     const sink = new Sink();


### PR DESCRIPTION
Truthy checks omitted retry: 0, so clients never received an explicit zero reconnection delay. Use isNil like other MessageEvent fields.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In `SseStream._transform`, the `retry` field is serialized with a truthy check:

```ts
data += message.retry ? `retry: ${sanitize(message.retry)}\n` : '';
```

Because `0` is falsy in JavaScript, a `MessageEvent` with `retry: 0` is serialized **without** a `retry` field — as if `retry` was omitted.

Example wire output for `{ data: 'hello', retry: 0 }`:

```text
id: 1
data: hello
```

(`retry: 0` is missing)

Relevant code (current `master`):

https://github.com/nestjs/nest/blob/master/packages/core/router/sse-stream.ts

Issue Number: #17359


## What is the new behavior?

`retry` is serialized with `!isNil(...)`, consistent with other optional `MessageEvent` fields (`id`, `data`, `comment`):

```ts
data += !isNil(message.retry) ? `retry: ${sanitize(message.retry)}\n` : '';
```

`retry: 0` is now included in the SSE frame, e.g.:

```text
id: 1
retry: 0
data: hello
```

A unit test covers this case.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- Pre-existing issue (not introduced by #17327); after that PR, `data` / `id` / `comment` already use `isNil`, while `retry` still used a truthy check.
- Elsewhere in `SseStream`, `retry: 0` is already treated as “present” (e.g. `isCommentOnly` uses `isUndefined(message.retry)`); only the serializer treated `0` as missing.