### PR TITLE
fix(fastify): run middleware on routes excluded from global prefix

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -763,6 +763,60 @@ describe('Middleware (FastifyAdapter)', () => {
     });
   });
 
+  describe('should run middleware on routes excluded from the global prefix', () => {
+    @Controller()
+    class ExcludedRouteController {
+      @Get('graphql')
+      graphql(@Req() req: FastifyRequest['raw']) {
+        return { success: true, pong: req?.['raw']?.headers?.ping };
+      }
+
+      @Get('data')
+      data(@Req() req: FastifyRequest['raw']) {
+        return { success: true, pong: req?.['raw']?.headers?.ping };
+      }
+    }
+
+    @Module({
+      controllers: [ExcludedRouteController],
+    })
+    class ExcludedRouteModule implements NestModule {
+      configure(consumer: MiddlewareConsumer) {
+        consumer
+          .apply((req, res, next) => {
+            req.headers['ping'] = 'pong';
+            next();
+          })
+          .forRoutes('/{*path}');
+      }
+    }
+
+    beforeEach(async () => {
+      app = (
+        await Test.createTestingModule({
+          imports: [ExcludedRouteModule],
+        }).compile()
+      ).createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+    });
+
+    it(`GET forRoutes('/{*path}') with global prefix and excluded route`, async () => {
+      app.setGlobalPrefix('/api', { exclude: ['/graphql'] });
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+
+      await request(app.getHttpServer())
+        .get('/graphql')
+        .expect(200, { success: true, pong: 'pong' });
+      await request(app.getHttpServer())
+        .get('/api/data')
+        .expect(200, { success: true, pong: 'pong' });
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+  });
+
   describe('should respect fastify routing options', () => {
     const MIDDLEWARE_RETURN_VALUE = 'middleware_return';
 

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -685,7 +685,11 @@ export class FastifyAdapter<
       normalizedPath = normalizedPath === '/*path' ? '*path' : normalizedPath;
 
       // Normalize the path to support the prefix if it set in application
-      if (this._pathPrefix && !normalizedPath.startsWith(this._pathPrefix)) {
+      if (
+        this._pathPrefix &&
+        !normalizedPath.startsWith(this._pathPrefix) &&
+        (normalizedPath === '/' || normalizedPath === '')
+      ) {
         normalizedPath = `${this._pathPrefix}${normalizedPath}`;
         if (normalizedPath.endsWith('/')) {
           normalizedPath = `${normalizedPath}{*path}`;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When `setGlobalPrefix(prefix, { exclude })` excludes a concrete route (e.g. `/graphql`) and
route-scoped middleware is applied with `forRoutes('/{*path}')`, the fastify adapter's
`createMiddlewareFactory` re-prefixes every non-prefixed middleware path — rewriting the
excluded route to `${prefix}/<route>`. The middleware is then registered on the prefixed
path and never runs on the excluded route (no logging, serializers, or trace context applied).

Related: #14894, partially fixed by #14895.

Minimal reproduction: https://github.com/Arun445/nest-bug-reproduce

Issue Number: N/A

## What is the new behavior?

The re-prefix now only fires when the middleware path collapsed to the application root
(`/` or `''`), so concrete excluded routes stay unprefixed and their route-scoped middleware
runs as expected. The `exclude: ['/']` root-collapse behavior from #13401 is preserved, and a
regression test covering `forRoutes('/{*path}')` with an excluded route has been added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Follow-up to #14895 / #14894.

Minimal reproduction: https://github.com/Arun445/nest-bug-reproduce

Steps to reproduce:

1. Run the application and call both the REST and the GraphQL endpoints.
2. The GraphQL endpoint has no middleware or logger serializer applied, while the REST endpoint does.
3. Comment out or remove `setGlobalPrefix`.
4. Call both endpoints again — they now behave the same (middleware applied to both).
