### PR TITLE
fix(core): resolve barrier immediately when target count is zero

### DIFF
--- a/packages/core/helpers/barrier.ts
+++ b/packages/core/helpers/barrier.ts
@@ -14,6 +14,10 @@ export class Barrier {
     this.promise = new Promise<void>(resolve => {
       this.resolve = resolve;
     });
+
+    if (targetCount === 0) {
+      this.resolve();
+    }
   }
 
   /**
@@ -23,7 +27,7 @@ export class Barrier {
    */
   public signal(): void {
     this.currentCount += 1;
-    if (this.currentCount === this.targetCount) {
+    if (this.currentCount >= this.targetCount) {
       this.resolve();
     }
   }

--- a/packages/core/test/helpers/barrier.spec.ts
+++ b/packages/core/test/helpers/barrier.spec.ts
@@ -21,7 +21,24 @@ describe('Barrier', () => {
     (<any>barrier).resolve();
   });
 
+  describe('constructor', () => {
+    it('should resolve immediately when target count is zero', async () => {
+      const zeroBarrier = new Barrier(0);
+
+      await expect(zeroBarrier.wait()).to.be.fulfilled;
+    });
+  });
+
   describe('signal', () => {
+    it('should keep the barrier resolved when signaled more times than the target count', async () => {
+      for (let i = 0; i < targetCount + 1; i++) {
+        barrier.signal();
+      }
+
+      expect(barrierResolveSpy.called).to.be.true;
+      await expect(barrier.wait()).to.be.fulfilled;
+    });
+
     it('should resolve the barrier when target count is reached', async () => {
       for (let i = 0; i < targetCount; i++) {
         barrier.signal();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #17392

A `Barrier` only resolves its promise inside `signal()`, when `currentCount === targetCount`. The injector creates a barrier per class, sized to its dependency count (`resolveConstructorParams`) or `@Inject()` property count (`resolveProperties`). For a class with zero dependencies, `targetCount` is `0`, `signal()` is never called, and the barrier's promise never settles — one forever-pending `Promise` per zero-dependency class per module compilation. Vitest's `detectAsyncLeaks: true` flags this on every test file that compiles a testing module (reproduction: https://gist.github.com/ikrbasak/0eaf002bfe176918aafbce3307b7bf54).

## What is the new behavior?

- `Barrier` resolves eagerly in the constructor when `targetCount === 0`, so a barrier with no participants settles immediately. This fixes both injector call sites at once.
- `signal()` now checks `currentCount >= targetCount` instead of `===`, making it idempotent past the threshold. The injector deliberately calls `signal()` in catch blocks to unblock waiting dependencies, which can over-signal past `targetCount`; with `===`, a barrier over-signaled past its exact count would also never resolve.

Unit tests added for both behaviors in `barrier.spec.ts`. With the fix, the reproduction above reports zero async leaks.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

No caller awaits a zero-count barrier today (the awaits live inside per-dependency callbacks that do not exist when the count is 0), so behavior is unchanged; the fix only ensures the promise settles.

## Other information

Related but distinct prior work on this code: #15405, #15504 (race conditions in class dependency resolution), #16683 (injector hang when `design:paramtypes` is missing).
