### PR TITLE
fix(microservices): nullify grpcclient on close when tryshutdown fails

### DIFF
--- a/packages/microservices/server/server-grpc.ts
+++ b/packages/microservices/server/server-grpc.ts
@@ -548,18 +548,21 @@ export class ServerGrpc extends Server<never, never> {
   public async close(): Promise<void> {
     if (this.grpcClient) {
       const graceful = this.getOptionsProp(this.options, 'gracefulShutdown');
-      if (graceful) {
-        await new Promise<void>((resolve, reject) => {
-          this.grpcClient.tryShutdown((error: Error) => {
-            if (error) reject(error);
-            else resolve();
+      try {
+        if (graceful) {
+          await new Promise<void>((resolve, reject) => {
+            this.grpcClient.tryShutdown((error: Error) => {
+              if (error) reject(error);
+              else resolve();
+            });
           });
-        });
-      } else {
-        this.grpcClient.forceShutdown();
+        } else {
+          this.grpcClient.forceShutdown();
+        }
+      } finally {
+        this.grpcClient = null;
       }
     }
-    this.grpcClient = null;
   }
 
   public deserialize(obj: any): any {

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -901,6 +901,19 @@ describe('ServerGrpc', () => {
       expect(grpcClient.forceShutdown.called).to.be.false;
       expect(grpcClient.tryShutdown.called).to.be.true;
     });
+
+    it('should nullify grpcClient even if tryShutdown fails', async () => {
+      const grpcClient = {
+        forceShutdown: sinon.spy(),
+        tryShutdown: sinon.stub().yields(new Error('shutdown failed')),
+      };
+      untypedServer.grpcClient = grpcClient;
+      untypedServer.options.gracefulShutdown = true;
+
+      await server.close().catch(() => {});
+
+      expect(untypedServer.grpcClient).to.be.null;
+    });
   });
 
   describe('deserialize', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When `close()` is called with graceful shutdown enabled and `tryShutdown()` invokes its callback with an error, the promise rejects before the client reference is cleared.

Current flow:

```ts
await tryShutdown();

this.grpcClient = null; // Never reached if tryShutdown() rejects
```

This leaves `this.grpcClient` pointing to a client that has already been closed.

Issue Number: N/A

## What is the new behavior?

The shutdown logic is wrapped in a `try...finally` block so the client reference is always cleared, regardless of whether `tryShutdown()` succeeds or fails.

```ts
try {
  await tryShutdown();
} finally {
  this.grpcClient = null;
}
```

This guarantees the internal state is cleaned up even when graceful shutdown reports an error.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information