### PR TITLE
feat(common,core,fastify): add http query method decorator

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -7,7 +7,7 @@ import {
   NestMiddleware,
   NestModule,
   Param,
-  Query,
+  QueryString,
   Req,
   RequestMethod,
 } from '@nestjs/common';
@@ -217,7 +217,7 @@ describe('Middleware (FastifyAdapter)', () => {
     @Controller(QUERY_VALUE)
     class TestQueryController {
       @Get()
-      [QUERY_VALUE](@Query('test') test: string) {
+      [QUERY_VALUE](@QueryString('test') test: string) {
         return test;
       }
     }

--- a/integration/microservices/src/app.controller.ts
+++ b/integration/microservices/src/app.controller.ts
@@ -4,7 +4,7 @@ import {
   HttpCode,
   Inject,
   Post,
-  Query,
+  QueryString,
 } from '@nestjs/common';
 import {
   Client,
@@ -31,14 +31,17 @@ export class AppController {
 
   @Post()
   @HttpCode(200)
-  call(@Query('command') cmd, @Body() data: number[]): Observable<number> {
+  call(
+    @QueryString('command') cmd,
+    @Body() data: number[],
+  ): Observable<number> {
     return this.client.send<number>({ cmd }, data);
   }
 
   @Post('useFactory')
   @HttpCode(200)
   callWithClientUseFactory(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Observable<number> {
     return this.useFactoryClient.send<number>({ cmd }, data);
@@ -47,7 +50,7 @@ export class AppController {
   @Post('useClass')
   @HttpCode(200)
   callWithClientUseClass(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Observable<number> {
     return this.useClassClient.send<number>({ cmd }, data);
@@ -80,7 +83,7 @@ export class AppController {
   @Post('error')
   @HttpCode(200)
   serializeError(
-    @Query('client') query: 'custom' | 'standard' = 'standard',
+    @QueryString('client') query: 'custom' | 'standard' = 'standard',
     @Body() body: Record<string, any>,
   ): Observable<boolean> {
     const client = query === 'custom' ? this.customClient : this.client;

--- a/integration/microservices/src/grpc/grpc.controller.ts
+++ b/integration/microservices/src/grpc/grpc.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, Query } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, QueryString } from '@nestjs/common';
 import {
   Client,
   ClientGrpc,
@@ -163,7 +163,7 @@ export class GrpcController {
   @Post('error')
   @HttpCode(200)
   serializeError(
-    @Query('client') query: 'custom' | 'standard' = 'standard',
+    @QueryString('client') query: 'custom' | 'standard' = 'standard',
     @Body() body: Record<string, any>,
   ): Observable<boolean> {
     const client = query === 'custom' ? this.customClient : this.client;

--- a/integration/microservices/src/mqtt/mqtt.controller.ts
+++ b/integration/microservices/src/mqtt/mqtt.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, Query } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, QueryString } from '@nestjs/common';
 import {
   Client,
   ClientProxy,
@@ -27,7 +27,7 @@ export class MqttController {
   @Post()
   @HttpCode(200)
   async call(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Promise<Observable<number>> {
     await this.client.connect();

--- a/integration/microservices/src/nats/nats.controller.ts
+++ b/integration/microservices/src/nats/nats.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, HttpCode, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Post,
+  QueryString,
+} from '@nestjs/common';
 import {
   ClientProxy,
   ClientProxyFactory,
@@ -33,7 +40,7 @@ export class NatsController {
   @Post()
   @HttpCode(200)
   async call(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Promise<Observable<number>> {
     await this.client.connect();

--- a/integration/microservices/src/redis/redis.controller.ts
+++ b/integration/microservices/src/redis/redis.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, Query } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, QueryString } from '@nestjs/common';
 import {
   Client,
   ClientProxy,
@@ -18,7 +18,10 @@ export class RedisController {
 
   @Post()
   @HttpCode(200)
-  call(@Query('command') cmd, @Body() data: number[]): Observable<number> {
+  call(
+    @QueryString('command') cmd,
+    @Body() data: number[],
+  ): Observable<number> {
     return this.client.send<number>({ cmd }, data);
   }
 

--- a/integration/microservices/src/rmq/rmq.controller.ts
+++ b/integration/microservices/src/rmq/rmq.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, HttpCode, Post, Query } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post, QueryString } from '@nestjs/common';
 import {
   ClientProxy,
   ClientProxyFactory,
@@ -33,7 +33,7 @@ export class RMQController {
 
   @Post()
   @HttpCode(200)
-  call(@Query('command') cmd, @Body() data: number[]) {
+  call(@QueryString('command') cmd, @Body() data: number[]) {
     return this.client.send<number>({ cmd }, data);
   }
 

--- a/integration/microservices/src/tcp-tls/app.controller.ts
+++ b/integration/microservices/src/tcp-tls/app.controller.ts
@@ -4,7 +4,7 @@ import {
   HttpCode,
   Inject,
   Post,
-  Query,
+  QueryString,
 } from '@nestjs/common';
 import {
   Client,
@@ -44,14 +44,17 @@ export class AppController {
 
   @Post()
   @HttpCode(200)
-  call(@Query('command') cmd, @Body() data: number[]): Observable<number> {
+  call(
+    @QueryString('command') cmd,
+    @Body() data: number[],
+  ): Observable<number> {
     return this.client.send<number>({ cmd }, data);
   }
 
   @Post('useFactory')
   @HttpCode(200)
   callWithClientUseFactory(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Observable<number> {
     return this.useFactoryClient.send<number>({ cmd }, data);
@@ -60,7 +63,7 @@ export class AppController {
   @Post('useClass')
   @HttpCode(200)
   callWithClientUseClass(
-    @Query('command') cmd,
+    @QueryString('command') cmd,
     @Body() data: number[],
   ): Observable<number> {
     return this.useClassClient.send<number>({ cmd }, data);
@@ -93,7 +96,7 @@ export class AppController {
   @Post('error')
   @HttpCode(200)
   serializeError(
-    @Query('client') query: 'custom' | 'standard' = 'standard',
+    @QueryString('client') query: 'custom' | 'standard' = 'standard',
     @Body() body: Record<string, any>,
   ): Observable<boolean> {
     const client = query === 'custom' ? this.customClient : this.client;

--- a/integration/nest-application/sse/src/app.controller.ts
+++ b/integration/nest-application/sse/src/app.controller.ts
@@ -8,7 +8,7 @@ import {
   MessageEvent,
   NestInterceptor,
   Post,
-  Query,
+  QueryString,
   Req,
   RequestMethod,
   Sse,
@@ -56,14 +56,16 @@ export class AppController {
   }
 
   @Sse('sse/validated')
-  sseWithValidatedQuery(@Query() query: SseQueryDto): Observable<MessageEvent> {
+  sseWithValidatedQuery(
+    @QueryString() query: SseQueryDto,
+  ): Observable<MessageEvent> {
     return of({ data: { limit: query.limit } });
   }
 
   @Sse('sse/burst')
   sseBurst(
-    @Query('n') n = '20',
-    @Query('size') size = '65536',
+    @QueryString('n') n = '20',
+    @QueryString('size') size = '65536',
   ): Observable<MessageEvent> {
     const count = parseInt(n, 10);
     const payload = 'X'.repeat(parseInt(size, 10));

--- a/packages/common/decorators/http/request-mapping.decorator.ts
+++ b/packages/common/decorators/http/request-mapping.decorator.ts
@@ -120,6 +120,19 @@ export const All = createMappingDecorator(RequestMethod.ALL);
 export const Search = createMappingDecorator(RequestMethod.SEARCH);
 
 /**
+ * Route handler (method) Decorator. Routes HTTP QUERY requests to the specified path.
+ *
+ * Unlike the former `@Query()` parameter decorator (now `@QueryString()`), this
+ * registers an HTTP QUERY route. QUERY requests carry a body; use `@Body()` to
+ * read the payload.
+ *
+ * @see [Routing](https://docs.nestjs.com/controllers#routing)
+ *
+ * @publicApi
+ */
+export const Query = createMappingDecorator(RequestMethod.QUERY);
+
+/**
  * Route handler (method) Decorator. Routes Webdav PROPFIND requests to the specified path.
  *
  * @see [Routing](https://docs.nestjs.com/controllers#routing)

--- a/packages/common/decorators/http/route-params.decorator.ts
+++ b/packages/common/decorators/http/route-params.decorator.ts
@@ -327,13 +327,16 @@ export const Headers: (property?: string) => ParameterDecorator =
 
 /**
  * Route handler parameter decorator. Extracts the `query`
- * property from the `req` object and populates the decorated
- * parameter with the value of `query`. May also apply pipes to the bound
- * query parameter.
+ * property from the `req` object (URL query string) and populates the
+ * decorated parameter with the value of `query`. May also apply pipes to the
+ * bound query parameter.
+ *
+ * Formerly named `@Query()`. That name is now reserved for the HTTP QUERY
+ * method decorator; migrate parameter bindings to `@QueryString()`.
  *
  * For example:
  * ```typescript
- * async find(@Query('user') user: string)
+ * async find(@QueryString('user') user: string)
  * ```
  *
  * @param property name of single property to extract from the `query` object
@@ -343,16 +346,19 @@ export const Headers: (property?: string) => ParameterDecorator =
  *
  * @publicApi
  */
-export function Query(): ParameterDecorator;
+export function QueryString(): ParameterDecorator;
 /**
  * Route handler parameter decorator. Extracts the `query`
- * property from the `req` object and populates the decorated
- * parameter with the value of `query`. May also apply pipes to the bound
- * query parameter.
+ * property from the `req` object (URL query string) and populates the
+ * decorated parameter with the value of `query`. May also apply pipes to the
+ * bound query parameter.
+ *
+ * Formerly named `@Query()`. That name is now reserved for the HTTP QUERY
+ * method decorator; migrate parameter bindings to `@QueryString()`.
  *
  * For example:
  * ```typescript
- * async find(@Query('user') user: string)
+ * async find(@QueryString('user') user: string)
  * ```
  *
  * @param property name of single property to extract from the `query` object
@@ -362,18 +368,21 @@ export function Query(): ParameterDecorator;
  *
  * @publicApi
  */
-export function Query(
+export function QueryString(
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator;
 /**
  * Route handler parameter decorator. Extracts the `query`
- * property from the `req` object and populates the decorated
- * parameter with the value of `query`. May also apply pipes to the bound
- * query parameter.
+ * property from the `req` object (URL query string) and populates the
+ * decorated parameter with the value of `query`. May also apply pipes to the
+ * bound query parameter.
+ *
+ * Formerly named `@Query()`. That name is now reserved for the HTTP QUERY
+ * method decorator; migrate parameter bindings to `@QueryString()`.
  *
  * For example:
  * ```typescript
- * async find(@Query('user') user: string)
+ * async find(@QueryString('user') user: string)
  * ```
  *
  * @param property name of single property to extract from the `query` object
@@ -383,19 +392,22 @@ export function Query(
  *
  * @publicApi
  */
-export function Query(
+export function QueryString(
   property: string,
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator;
 /**
  * Route handler parameter decorator. Extracts the `query`
- * property from the `req` object and populates the decorated
- * parameter with the value of `query`. May also apply pipes to the bound
- * query parameter.
+ * property from the `req` object (URL query string) and populates the
+ * decorated parameter with the value of `query`. May also apply pipes to the
+ * bound query parameter.
+ *
+ * Formerly named `@Query()`. That name is now reserved for the HTTP QUERY
+ * method decorator; migrate parameter bindings to `@QueryString()`.
  *
  * For example:
  * ```typescript
- * async find(@Query('user') user: string)
+ * async find(@QueryString('user') user: string)
  * ```
  *
  * @param property name of single property to extract from the `query` object
@@ -405,7 +417,7 @@ export function Query(
  *
  * @publicApi
  */
-export function Query(
+export function QueryString(
   property?: string | (Type<PipeTransform> | PipeTransform),
   ...pipes: (Type<PipeTransform> | PipeTransform)[]
 ): ParameterDecorator {

--- a/packages/common/enums/request-method.enum.ts
+++ b/packages/common/enums/request-method.enum.ts
@@ -15,4 +15,5 @@ export enum RequestMethod {
   MOVE,
   LOCK,
   UNLOCK,
+  QUERY,
 }

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -63,6 +63,8 @@ export interface HttpServer<
   options(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   search?(handler: RequestHandler<TRequest, TResponse>): any;
   search?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  query?(handler: RequestHandler<TRequest, TResponse>): any;
+  query?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   listen(port: number | string, callback?: () => void): any;
   listen(port: number | string, hostname: string, callback?: () => void): any;
   reply(response: any, body: any, statusCode?: number): any;

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Body, HostParam, Param, Query, Search } from '../../decorators';
+import { Body, HostParam, Param, QueryString, Search } from '../../decorators';
 import { RequestMethod } from '../../enums/request-method.enum';
 import {
   All,
@@ -16,6 +16,7 @@ import {
   Copy,
   Lock,
   Unlock,
+  Query,
 } from '../../index';
 import { ROUTE_ARGS_METADATA } from '../../constants';
 import { RouteParamtypes } from '../../enums/route-paramtypes.enum';
@@ -117,14 +118,14 @@ describe('@Post', () => {
     class Test {
       @Post()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Post([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -375,14 +376,71 @@ describe('@Search', () => {
     class Test {
       @Search()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Search([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    expect(path).to.be.eql('/');
+    expect(pathUsingArray).to.be.eql('/');
+  });
+});
+
+describe('@Query', () => {
+  const requestPath = 'test';
+  const requestProps = {
+    path: requestPath,
+    method: RequestMethod.QUERY,
+  };
+
+  const requestPathUsingArray = ['foo', 'bar'];
+  const requestPropsUsingArray = {
+    path: requestPathUsingArray,
+    method: RequestMethod.QUERY,
+  };
+
+  it('should enhance class with expected request metadata', () => {
+    class Test {
+      @Query(requestPath)
+      public static test() {}
+
+      @Query(requestPathUsingArray)
+      public static testUsingArray() {}
+    }
+
+    const path = Reflect.getMetadata('path', Test.test);
+    const method = Reflect.getMetadata('method', Test.test);
+    const pathUsingArray = Reflect.getMetadata('path', Test.testUsingArray);
+    const methodUsingArray = Reflect.getMetadata('method', Test.testUsingArray);
+
+    expect(path).to.be.eql(requestPath);
+    expect(method).to.be.eql(requestProps.method);
+    expect(pathUsingArray).to.be.eql(requestPathUsingArray);
+    expect(methodUsingArray).to.be.eql(requestPropsUsingArray.method);
+  });
+
+  it('should set path on "/" by default', () => {
+    class Test {
+      @Query()
+      public static test(
+        @Body() body,
+        @Param() params,
+        @HostParam() hostParams,
+      ) {}
+
+      @Query([])
+      public static testUsingArray(
+        @Body() body,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -468,14 +526,14 @@ describe('@PropFind', () => {
     class Test {
       @Propfind()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Propfind([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -526,14 +584,14 @@ describe('@PropPatch', () => {
     class Test {
       @Proppatch()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Proppatch([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -584,14 +642,14 @@ describe('@MkCol', () => {
     class Test {
       @Mkcol()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Mkcol([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -642,14 +700,14 @@ describe('@Copy', () => {
     class Test {
       @Copy()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Copy([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -700,14 +758,14 @@ describe('@Move', () => {
     class Test {
       @Move()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Move([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -758,14 +816,14 @@ describe('@Lock', () => {
     class Test {
       @Lock()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Lock([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
@@ -816,14 +874,14 @@ describe('@Unlock', () => {
     class Test {
       @Unlock()
       public static test(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}
 
       @Unlock([])
       public static testUsingArray(
-        @Query() query,
+        @QueryString() query,
         @Param() params,
         @HostParam() hostParams,
       ) {}

--- a/packages/core/helpers/router-method-factory.ts
+++ b/packages/core/helpers/router-method-factory.ts
@@ -18,6 +18,7 @@ export const REQUEST_METHOD_MAP = {
   [RequestMethod.MOVE]: 'move',
   [RequestMethod.LOCK]: 'lock',
   [RequestMethod.UNLOCK]: 'unlock',
+  [RequestMethod.QUERY]: 'query',
 } as const satisfies Record<RequestMethod, keyof HttpServer>;
 
 export class RouterMethodFactory {

--- a/packages/core/test/helpers/router-method-factory.spec.ts
+++ b/packages/core/test/helpers/router-method-factory.spec.ts
@@ -21,6 +21,7 @@ describe('RouterMethodFactory', () => {
     move: () => {},
     lock: () => {},
     unlock: () => {},
+    query: () => {},
     all: () => {},
   };
   beforeEach(() => {
@@ -47,6 +48,7 @@ describe('RouterMethodFactory', () => {
     expect(factory.get(target, RequestMethod.MOVE)).to.equal(target.move);
     expect(factory.get(target, RequestMethod.LOCK)).to.equal(target.lock);
     expect(factory.get(target, RequestMethod.UNLOCK)).to.equal(target.unlock);
+    expect(factory.get(target, RequestMethod.QUERY)).to.equal(target.query);
     expect(factory.get(target, -1 as any)).to.equal(target.use);
   });
 });

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -381,6 +381,10 @@ export class FastifyAdapter<
     return this.injectRouteOptions('SEARCH', ...args);
   }
 
+  public query(...args: any[]) {
+    return this.injectRouteOptions('QUERY', ...args);
+  }
+
   public propfind(...args: any[]) {
     return this.injectRouteOptions('PROPFIND', ...args);
   }


### PR DESCRIPTION
Rename the query-string parameter decorator from @Query to @QueryString and introduce @Query as the HTTP QUERY route decorator. BREAKING CHANGE: @Query() no longer extracts URL query parameters. Use @QueryString() instead. @Query() now registers HTTP QUERY routes; read the request body with @Body().

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information