### PR TITLE
refactor(core): remove async promise executor anti-patterns

### DIFF
--- a/packages/core/injector/module-ref.ts
+++ b/packages/core/injector/module-ref.ts
@@ -182,9 +182,9 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
       });
     }
 
-    return new Promise<T>(async (resolve, reject) => {
-      try {
-        const callback = async (instances: any[]) => {
+    return new Promise<T>((resolve, reject) => {
+      const callback = async (instances: any[]) => {
+        try {
           const properties = await this.injector.resolveProperties(
             wrapper,
             moduleRef,
@@ -197,20 +197,16 @@ export abstract class ModuleRef extends AbstractInstanceResolver {
           const instance = new type(...instances);
           this.injector.applyProperties(instance, properties);
           resolve(instance);
-        };
-        await this.injector.resolveConstructorParams<T>(
-          wrapper,
-          moduleRef,
-          undefined,
-          callback,
-          {
-            contextId: contextId ?? STATIC_CONTEXT,
-            inquirer: wrapper,
-          },
-        );
-      } catch (err) {
-        reject(err);
-      }
+        } catch (err) {
+          reject(err);
+        }
+      };
+      this.injector
+        .resolveConstructorParams<T>(wrapper, moduleRef, undefined, callback, {
+          contextId: contextId ?? STATIC_CONTEXT,
+          inquirer: wrapper,
+        })
+        .catch(reject);
     });
   }
 }

--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -254,16 +254,10 @@ export class NestApplicationContext<
     if (this.isInitialized) {
       return this;
     }
-    /* eslint-disable-next-line no-async-promise-executor */
-    this.initializationPromise = new Promise(async (resolve, reject) => {
-      try {
-        await this.callInitHook();
-        await this.callBootstrapHook();
-        resolve();
-      } catch (err) {
-        reject(err);
-      }
-    });
+    this.initializationPromise = (async () => {
+      await this.callInitHook();
+      await this.callBootstrapHook();
+    })();
     await this.initializationPromise;
 
     this.isInitialized = true;

--- a/packages/microservices/client/client-kafka.ts
+++ b/packages/microservices/client/client-kafka.ts
@@ -146,50 +146,43 @@ export class ClientKafka
     if (this.initialized) {
       return this.initialized.then(() => this._producer!);
     }
-    /* eslint-disable-next-line no-async-promise-executor */
-    this.initialized = new Promise(async (resolve, reject) => {
-      try {
-        this.client = this.createClient();
-        if (!this.producerOnlyMode) {
-          const partitionAssigners = [
-            (
-              config: ConstructorParameters<
-                typeof KafkaReplyPartitionAssigner
-              >[1],
-            ) => new KafkaReplyPartitionAssigner(this, config),
-          ];
+    this.initialized = (async () => {
+      this.client = this.createClient();
+      if (!this.producerOnlyMode) {
+        const partitionAssigners = [
+          (
+            config: ConstructorParameters<
+              typeof KafkaReplyPartitionAssigner
+            >[1],
+          ) => new KafkaReplyPartitionAssigner(this, config),
+        ];
 
-          const consumerOptions = Object.assign(
-            {
-              partitionAssigners,
-            },
-            this.options.consumer || {},
-            {
-              groupId: this.groupId,
-            },
-          );
+        const consumerOptions = Object.assign(
+          {
+            partitionAssigners,
+          },
+          this.options.consumer || {},
+          {
+            groupId: this.groupId,
+          },
+        );
 
-          this._consumer = this.client!.consumer(consumerOptions);
-          this.registerConsumerEventListeners();
+        this._consumer = this.client!.consumer(consumerOptions);
+        this.registerConsumerEventListeners();
 
-          // Set member assignments on join and rebalance
-          this._consumer.on(
-            this._consumer.events.GROUP_JOIN,
-            this.setConsumerAssignments.bind(this),
-          );
-          await this._consumer.connect();
-          await this.bindTopics();
-        }
-
-        this._producer = this.client!.producer(this.options.producer || {});
-        this.registerProducerEventListeners();
-        await this._producer.connect();
-
-        resolve();
-      } catch (err) {
-        reject(err);
+        // Set member assignments on join and rebalance
+        this._consumer.on(
+          this._consumer.events.GROUP_JOIN,
+          this.setConsumerAssignments.bind(this),
+        );
+        await this._consumer.connect();
+        await this.bindTopics();
       }
-    });
+
+      this._producer = this.client!.producer(this.options.producer || {});
+      this.registerProducerEventListeners();
+      await this._producer.connect();
+    })();
     return this.initialized.then(() => this._producer!);
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Three methods use `new Promise(async (resolve, reject) => { try { ... resolve() } catch(e) { reject(e) } })` - an async executor anti-pattern. The promise returned by the async function is silently swallowed, so any error thrown *before* the first `await` (synchronous errors) is never caught, and the outer try/catch just duplicates what the async function already does.

Files affected:

- `NestApplicationContext.init()` - `packages/core/nest-application-context.ts`
- `ClientKafka.connect()` - `packages/microservices/client/client-kafka.ts`
- `ModuleRef.instantiateClass()` - `packages/core/injector/module-ref.ts`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
All three are replaced with proper patterns:

- **init() / connect()** - async IIFE `(async () => { ... })()` since the body is entirely async and returns nothing
- **instantiateClass()** - standard `new Promise((resolve, reject) => { ... })` with `.catch(reject)` on the inner async call, since `resolve` is captured inside a callback

Behavior is identical. One less anti-pattern in the codebase.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
All existing tests pass. No new test added since this is a refactoring with no behavioral change — the logic before and after is identical, just removing the unnecessary async executor wrapper.