### PR TITLE
test(core): add unit tests for module-ref

### DIFF
--- a/packages/core/test/injector/module-ref.spec.ts
+++ b/packages/core/test/injector/module-ref.spec.ts
@@ -1,0 +1,250 @@
+import { Injectable, Scope, Type } from '@nestjs/common';
+import { RuntimeException } from '../../errors/exceptions';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { NestContainer } from '../../injector/container';
+import { ModuleRef } from '../../injector/module-ref';
+import { Module } from '../../injector/module';
+import { ContextId } from '../../injector/instance-wrapper';
+import { STATIC_CONTEXT } from '../../injector/constants';
+import { InstanceLoader } from '../../injector/instance-loader';
+import { Injector } from '../../injector/injector';
+import { GraphInspector } from '../../inspector/graph-inspector';
+import { InstanceWrapper } from '../../injector/instance-wrapper';
+
+class ConcreteModuleRef extends ModuleRef {
+  get<TInput = any, TResult = TInput>(
+    typeOrToken: any,
+    options?: any,
+  ): TResult | Array<TResult> {
+    return this.find(typeOrToken, {
+      moduleId: options?.strict
+        ? (this.container.getModules().values().next().value?.id ?? undefined)
+        : undefined,
+      each: options?.each,
+    });
+  }
+
+  resolve<TInput = any, TResult = TInput>(
+    typeOrToken: any,
+    contextId?: { id: number },
+    options?: any,
+  ): Promise<TResult | Array<TResult>> {
+    const contextModule = this.container.getModules().values().next().value!;
+    return this.resolvePerContext(
+      typeOrToken,
+      contextModule,
+      contextId ?? STATIC_CONTEXT,
+      options,
+    );
+  }
+
+  create<T = any>(type: Type<T>, contextId?: ContextId): Promise<T> {
+    const contextModule = this.container.getModules().values().next().value!;
+    return this.instantiateClass(type, contextModule, contextId);
+  }
+}
+
+describe('ModuleRef', () => {
+  let container: NestContainer;
+  let moduleRef: ConcreteModuleRef;
+  let module: Module;
+
+  beforeEach(async () => {
+    container = new NestContainer();
+    const { moduleRef: mod } = (await container.addModule(
+      class TestModule {},
+      [],
+    ))!;
+    module = mod;
+    moduleRef = new ConcreteModuleRef(container);
+  });
+
+  describe('introspect', () => {
+    it('should return Scope.DEFAULT for a static provider', () => {
+      class StaticService {}
+      container.addProvider(StaticService, module.token);
+      const result = moduleRef.introspect(StaticService);
+      expect(result.scope).to.equal(Scope.DEFAULT);
+    });
+
+    it('should return Scope.REQUEST for a request-scoped provider', () => {
+      @Injectable({ scope: Scope.REQUEST })
+      class ReqScopedService {}
+      container.addProvider(ReqScopedService, module.token);
+      const result = moduleRef.introspect(ReqScopedService);
+      expect(result.scope).to.equal(Scope.REQUEST);
+    });
+
+    it('should return Scope.TRANSIENT for a transient provider', () => {
+      @Injectable({ scope: Scope.TRANSIENT })
+      class TransientService {}
+      container.addProvider(TransientService, module.token);
+      const result = moduleRef.introspect(TransientService);
+      expect(result.scope).to.equal(Scope.TRANSIENT);
+    });
+  });
+
+  describe('registerRequestByContextId', () => {
+    it('should delegate to container.registerRequestProvider', () => {
+      const stub = sinon.stub(container, 'registerRequestProvider');
+      const request = { foo: 'bar' };
+      const contextId = { id: 42 };
+      moduleRef.registerRequestByContextId(request, contextId);
+      expect(stub.calledOnceWith(request, contextId)).to.be.true;
+      stub.restore();
+    });
+  });
+
+  describe('instantiateClass', () => {
+    it('should create an instance with resolved dependencies', async () => {
+      @Injectable()
+      class A {}
+      @Injectable()
+      class B {}
+      container.addProvider(A, module.token);
+      container.addProvider(B, module.token);
+
+      @Injectable()
+      class Foo {
+        constructor(
+          public a: A,
+          public b: B,
+        ) {}
+      }
+
+      const instance = await moduleRef.create(Foo);
+      expect(instance).to.be.instanceOf(Foo);
+      expect(instance.a).to.be.instanceOf(A);
+      expect(instance.b).to.be.instanceOf(B);
+    });
+
+    it('should propagate errors from dependency resolution', async () => {
+      class UnregisteredDep {}
+
+      @Injectable()
+      class MissingDep {
+        constructor(_x: UnregisteredDep) {}
+      }
+
+      try {
+        await moduleRef.create(MissingDep);
+        expect.fail('should have thrown');
+      } catch (err) {
+        expect(err).to.be.instanceOf(RuntimeException);
+      }
+    });
+  });
+
+  describe('find', () => {
+    let instanceLoader: InstanceLoader;
+
+    beforeEach(async () => {
+      const injector = new Injector();
+      instanceLoader = new InstanceLoader(
+        container,
+        injector,
+        new GraphInspector(container),
+      );
+    });
+
+    it('should retrieve a static provider instance', async () => {
+      @Injectable()
+      class MyService {}
+      container.addProvider(MyService, module.token);
+      await instanceLoader.createInstancesOfDependencies(
+        container.getModules(),
+      );
+      const instance = moduleRef.get(MyService);
+      expect(instance).to.be.instanceOf(MyService);
+    });
+
+    it('should throw InvalidClassScopeException for request-scoped provider', () => {
+      @Injectable({ scope: Scope.REQUEST })
+      class ReqService {}
+      container.addProvider(ReqService, module.token);
+      expect(() => moduleRef.get(ReqService)).to.throw();
+    });
+
+    it('should return all instances when each: true', async () => {
+      @Injectable()
+      class ServiceA {}
+      @Injectable()
+      class ServiceB {}
+      @Injectable()
+      class ServiceC {}
+      const TOKEN = 'MULTI';
+      const { moduleRef: modA } = (await container.addModule(
+        class ModA {},
+        [],
+      ))!;
+      const { moduleRef: modB } = (await container.addModule(
+        class ModB {},
+        [],
+      ))!;
+      container.addProvider({ provide: TOKEN, useClass: ServiceA }, modA.token);
+      container.addProvider({ provide: TOKEN, useClass: ServiceB }, modB.token);
+      container.addProvider(
+        { provide: TOKEN, useClass: ServiceC },
+        module.token,
+      );
+      await instanceLoader.createInstancesOfDependencies(
+        container.getModules(),
+      );
+      const instances = moduleRef.get(TOKEN, { each: true });
+      expect(instances).to.have.length(3);
+    });
+  });
+
+  describe('resolve', () => {
+    let instanceLoader: InstanceLoader;
+
+    beforeEach(async () => {
+      const injector = new Injector();
+      instanceLoader = new InstanceLoader(
+        container,
+        injector,
+        new GraphInspector(container),
+      );
+    });
+
+    it('should resolve a static dependency', async () => {
+      @Injectable()
+      class MyService {}
+      container.addProvider(MyService, module.token);
+      await instanceLoader.createInstancesOfDependencies(
+        container.getModules(),
+      );
+      const instance = await moduleRef.resolve(MyService);
+      expect(instance).to.be.instanceOf(MyService);
+    });
+
+    it('should resolve a transient dependency, returning new instances each time', async () => {
+      @Injectable({ scope: Scope.TRANSIENT })
+      class TransientService {}
+
+      container.addProvider(TransientService, module.token);
+      await instanceLoader.createInstancesOfDependencies(
+        container.getModules(),
+      );
+      const a = await moduleRef.resolve(TransientService, { id: 1 });
+      const b = await moduleRef.resolve(TransientService, { id: 2 });
+      expect(a).to.be.instanceOf(TransientService);
+      expect(b).to.be.instanceOf(TransientService);
+      expect(a).not.to.equal(b);
+    });
+
+    it('should resolve a request-scoped dependency', async () => {
+      @Injectable({ scope: Scope.REQUEST })
+      class ReqService {}
+
+      container.addProvider(ReqService, module.token);
+      await instanceLoader.createInstancesOfDependencies(
+        container.getModules(),
+      );
+      const contextId = { id: 99 };
+      const instance = await moduleRef.resolve(ReqService, contextId);
+      expect(instance).to.be.instanceOf(ReqService);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Tests

## What is the current behavior?
`ModuleRef` (in `packages/core/injector/module-ref.ts`) has zero dedicated unit tests. Its methods (`introspect`, `registerRequestByContextId`, `instantiateClass`, `find`, `resolve`) are only covered indirectly through `NestApplicationContext` integration tests.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds `packages/core/test/injector/module-ref.spec.ts` with 12 tests covering:

- `introspect()` — returns correct scope for DEFAULT, REQUEST, and TRANSIENT providers
- `registerRequestByContextId()` — delegates to container
- `instantiateClass()` — resolves dependencies and propagates errors
- `find()` — single lookup, request-scoped rejection, multi-instance with `each: true`
- `resolve()` — static, transient (unique per context), and request-scoped resolution

All existing tests continue to pass.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information