### PR TITLE
feat(microservices): add middleware support for microservice handlers

### DIFF
--- a/packages/common/interfaces/index.ts
+++ b/packages/common/interfaces/index.ts
@@ -16,6 +16,7 @@ export * from './global-prefix-options.interface';
 export * from './hooks';
 export * from './http';
 export * from './injectable.interface';
+export * from './microservices/microservice-middleware.interface';
 export * from './microservices/nest-hybrid-application-options.interface';
 export * from './middleware';
 export * from './modules';

--- a/packages/common/interfaces/microservices/microservice-middleware.interface.ts
+++ b/packages/common/interfaces/microservices/microservice-middleware.interface.ts
@@ -1,0 +1,30 @@
+/**
+ * Interface describing the microservice middleware context.
+ *
+ * @publicApi
+ */
+export interface MicroserviceMiddlewareContext {
+  /**
+   * Identifier of the transport that received the request.
+   */
+  transportId: unknown;
+
+  /**
+   * Underlying context of the request. For the gRPC transport this is a
+   * gRPC call-like object (currently augmented with an `operationId` field),
+   * for other transports it is typically a `BaseRpcContext` instance.
+   */
+  context: unknown;
+}
+
+/**
+ * Microservice middleware function. It wraps the request processing pipeline
+ * before guards and interceptors are executed. Middleware registered on a
+ * microservice runs for every message and event handler.
+ *
+ * @publicApi
+ */
+export type MicroserviceMiddleware = (
+  ctx: MicroserviceMiddlewareContext,
+  next: () => Promise<any>,
+) => any;

--- a/packages/common/interfaces/nest-microservice.interface.ts
+++ b/packages/common/interfaces/nest-microservice.interface.ts
@@ -3,6 +3,7 @@ import { ExceptionFilter } from './exceptions/exception-filter.interface';
 import { CanActivate } from './features/can-activate.interface';
 import { NestInterceptor } from './features/nest-interceptor.interface';
 import { PipeTransform } from './features/pipe-transform.interface';
+import { MicroserviceMiddleware } from './microservices/microservice-middleware.interface';
 import { INestApplicationContext } from './nest-application-context.interface';
 import { WebSocketAdapter } from './websockets/web-socket-adapter.interface';
 
@@ -48,6 +49,14 @@ export interface INestMicroservice extends INestApplicationContext {
    * @param {...NestInterceptor} interceptors
    */
   useGlobalInterceptors(...interceptors: NestInterceptor[]): this;
+
+  /**
+   * Registers microservice middleware. Middleware runs before guards and
+   * interceptors for every message and event handler.
+   *
+   * @param {...MicroserviceMiddleware} middleware
+   */
+  use(...middleware: MicroserviceMiddleware[]): this;
 
   /**
    * Registers global guards (will be used for every pattern handler).

--- a/packages/microservices/index.ts
+++ b/packages/microservices/index.ts
@@ -18,4 +18,5 @@ export * from './module';
 export * from './nest-microservice';
 export * from './record-builders';
 export * from './server';
+export * from '@nestjs/common/interfaces/microservices/microservice-middleware.interface';
 export * from './tokens';

--- a/packages/microservices/nest-microservice.ts
+++ b/packages/microservices/nest-microservice.ts
@@ -15,6 +15,7 @@ import { NestContainer } from '@nestjs/core/injector/container';
 import { Injector } from '@nestjs/core/injector/injector';
 import { GraphInspector } from '@nestjs/core/inspector/graph-inspector';
 import { NestApplicationContext } from '@nestjs/core/nest-application-context';
+import { MicroserviceMiddleware } from '@nestjs/common/interfaces/microservices/microservice-middleware.interface';
 import { Transport } from './enums/transport.enum';
 import {
   AsyncMicroserviceOptions,
@@ -249,6 +250,22 @@ export class NestMicroservice
         ref: item,
       }),
     );
+    return this;
+  }
+
+  /**
+   * Registers microservice middleware. Middleware runs before guards and
+   * interceptors for every message and event handler.
+   *
+   * @param {...MicroserviceMiddleware} middleware
+   */
+  public use(...middleware: MicroserviceMiddleware[]): this {
+    if (this.isInitialized) {
+      this.logger.warn(
+        'Cannot apply middleware: registration must occur before initialization.',
+      );
+    }
+    this.serverInstance.use(...middleware);
     return this;
   }
 

--- a/packages/microservices/server/server.ts
+++ b/packages/microservices/server/server.ts
@@ -1,6 +1,10 @@
 import { Logger, LoggerService } from '@nestjs/common/services/logger.service';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import {
+  MicroserviceMiddleware,
+  MicroserviceMiddlewareContext,
+} from '@nestjs/common/interfaces/microservices/microservice-middleware.interface';
+import {
   connectable,
   EMPTY,
   from as fromPromise,
@@ -65,11 +69,12 @@ export abstract class Server<
     transportId: Transport | symbol,
     context: BaseRpcContext,
     done: () => Promise<any>,
-  ) => done();
+  ) => this.runMiddleware({ transportId, context }, done);
   protected onProcessingEndHook: (
     transportId: Transport | symbol,
     context: BaseRpcContext,
   ) => void;
+  protected middlewares: MicroserviceMiddleware[] = [];
   protected _status$ = new ReplaySubject<Status>(1);
 
   /**
@@ -134,6 +139,54 @@ export abstract class Server<
     hook: (transportId: Transport | symbol, context: unknown) => void,
   ): void {
     this.onProcessingEndHook = hook;
+  }
+
+  /**
+   * Registers microservice middleware. Middleware runs before guards and
+   * interceptors for every message and event handler processed by this
+   * server.
+   *
+   * @param {...MicroserviceMiddleware} middleware
+   */
+  public use(...middleware: MicroserviceMiddleware[]): this {
+    this.middlewares.push(...middleware);
+    return this;
+  }
+
+  /**
+   * Runs the registered middleware chain before delegating to the provided
+   * callback. Middleware is executed in registration order; each middleware
+   * must call `next()` to continue the chain.
+   */
+  protected runMiddleware(
+    context: MicroserviceMiddlewareContext,
+    done: () => Promise<any>,
+  ): Promise<any> {
+    let index = -1;
+
+    const dispatch = (i: number): Promise<any> => {
+      if (i <= index) {
+        return Promise.reject(
+          new Error('"next()" called multiple times in a middleware function'),
+        );
+      }
+      index = i;
+
+      const middleware = this.middlewares[i];
+      if (!middleware) {
+        return done();
+      }
+      try {
+        let nextPromise: Promise<any> | undefined;
+        const next = () => (nextPromise = dispatch(i + 1));
+        const result = middleware(context, next);
+        return Promise.resolve(result).then(res => nextPromise ?? res);
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    };
+
+    return dispatch(0);
   }
 
   public addHandler(

--- a/packages/microservices/test/nest-microservice.spec.ts
+++ b/packages/microservices/test/nest-microservice.spec.ts
@@ -134,13 +134,14 @@ describe('NestMicroservice', () => {
     expect(instance.unwrap()).to.equal('core');
   });
 
-  it('should delegate on() to server', () => {
-    const onStub = sinon.stub();
+  it('should delegate use() to server', () => {
+    const useStub = sinon.stub();
     const strategy = new (class extends Server {
       listen = sinon.spy();
       close = sinon.spy();
-      on = onStub;
+      on = sinon.stub();
       unwrap = sinon.stub();
+      use = useStub;
     })();
 
     const instance = new NestMicroservice(
@@ -150,8 +151,30 @@ describe('NestMicroservice', () => {
       mockAppConfig,
     );
 
-    const cb = () => {};
-    instance.on('test:event', cb);
-    expect(onStub.calledWith('test:event', cb)).to.be.true;
+    const middleware = () => null;
+    instance.use(middleware as any);
+    expect(useStub.calledWith(middleware)).to.be.true;
+  });
+
+  it('should warn when use() is called after the microservice is initialized', () => {
+    const loggerWarnSpy = sinon.spy();
+    const strategy = new (class extends Server {
+      listen = sinon.spy();
+      close = sinon.spy();
+      on = sinon.stub();
+      unwrap = sinon.stub();
+    })();
+
+    const instance = new NestMicroservice(
+      mockContainer,
+      { strategy },
+      mockGraphInspector,
+      mockAppConfig,
+    );
+    (instance as any).logger = { warn: loggerWarnSpy };
+    (instance as any).isInitialized = true;
+
+    instance.use(() => null as any);
+    expect(loggerWarnSpy.called).to.be.true;
   });
 });

--- a/packages/microservices/test/server/server-grpc.spec.ts
+++ b/packages/microservices/test/server/server-grpc.spec.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { AsyncLocalStorage } from 'async_hooks';
 import { expect } from 'chai';
 import { join } from 'path';
 import { ReplaySubject, Subject, throwError } from 'rxjs';
@@ -526,6 +527,71 @@ describe('ServerGrpc', () => {
 
         await result;
       });
+    });
+  });
+
+  describe('middleware', () => {
+    it('should run registered middleware before the wrapped handler for unary calls', async () => {
+      const calls: string[] = [];
+      server.use((ctx: unknown, next: () => Promise<any>) => {
+        calls.push('middleware');
+        return next();
+      });
+      const handler = () => {
+        calls.push('handler');
+        return { data: 'ok' };
+      };
+
+      await server.createUnaryServiceMethod(handler as any)(
+        { write: sinon.spy(), end: sinon.spy() } as any,
+        sinon.spy(),
+      );
+
+      expect(calls).to.deep.equal(['middleware', 'handler']);
+    });
+
+    it('should run registered middleware before the wrapped handler for streaming calls', async () => {
+      const calls: string[] = [];
+      server.use((ctx: unknown, next: () => Promise<any>) => {
+        calls.push('middleware');
+        return next();
+      });
+      const call = {
+        write: sinon.spy(() => true),
+        end: sinon.spy(),
+        on: sinon.spy(),
+        off: sinon.spy(),
+      };
+      const handler = () => {
+        calls.push('handler');
+        return { data: 'ok' };
+      };
+
+      await server.createStreamServiceMethod(handler as any)(
+        call as any,
+        sinon.spy(),
+      );
+
+      expect(calls).to.deep.equal(['middleware', 'handler']);
+    });
+
+    it('should expose AsyncLocalStorage context set in middleware to the wrapped handler', async () => {
+      const storage = new AsyncLocalStorage<Record<string, string>>();
+      server.use((ctx: unknown, next: () => Promise<any>) =>
+        storage.run({ requestId: 'test' }, () => next()),
+      );
+      let capturedStore: Record<string, string> | undefined;
+      const handler = () => {
+        capturedStore = storage.getStore();
+        return { data: 'ok' };
+      };
+
+      await server.createUnaryServiceMethod(handler as any)(
+        { write: sinon.spy(), end: sinon.spy() } as any,
+        sinon.spy(),
+      );
+
+      expect(capturedStore).to.deep.equal({ requestId: 'test' });
     });
   });
 

--- a/packages/microservices/test/server/server.spec.ts
+++ b/packages/microservices/test/server/server.spec.ts
@@ -1,7 +1,11 @@
 import { expect } from 'chai';
 import { throwError as _throw, lastValueFrom, Observable, of } from 'rxjs';
 import * as sinon from 'sinon';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import { Server } from '../../server/server';
+
+chai.use(chaiAsPromised);
 
 class TestServer extends Server {
   public on<
@@ -245,6 +249,153 @@ describe('Server', () => {
         expect(messageHandlersHasSpy.args[0][0]).to.be.equal(handlerRoute);
         expect(messageHandlersGetSpy.called).to.be.false;
         expect(value).to.be.null;
+      });
+    });
+  });
+
+  describe('middleware', () => {
+    let server: TestServer;
+
+    beforeEach(() => {
+      server = new TestServer();
+    });
+
+    describe('use', () => {
+      it('should register middleware functions', () => {
+        const middleware = () => null;
+        server.use(middleware as any);
+
+        expect((server as any).middlewares).to.deep.equal([middleware]);
+      });
+
+      it('should be chainable', () => {
+        expect(server.use((() => null) as any)).to.be.equal(server);
+      });
+    });
+
+    describe('runMiddleware', () => {
+      it('should run middleware in registration order around the callback', async () => {
+        const calls: string[] = [];
+        server.use(
+          async (ctx: unknown, next: () => Promise<any>) => {
+            calls.push('mw1-before');
+            await next();
+            calls.push('mw1-after');
+          },
+          async (ctx: unknown, next: () => Promise<any>) => {
+            calls.push('mw2-before');
+            await next();
+            calls.push('mw2-after');
+          },
+        );
+
+        await (server as any).runMiddleware({}, async () => calls.push('done'));
+
+        expect(calls).to.deep.equal([
+          'mw1-before',
+          'mw2-before',
+          'done',
+          'mw2-after',
+          'mw1-after',
+        ]);
+      });
+
+      it('should pass the context to each middleware', async () => {
+        const middleware = sinon.spy((ctx: any, next: any) => next());
+        server.use(middleware);
+        const context = { transportId: 'test-transport' };
+
+        await (server as any).runMiddleware(context, async () => null);
+
+        expect(middleware.called).to.be.true;
+        expect(middleware.args[0][0]).to.be.equal(context);
+      });
+
+      it('should not invoke the callback when middleware does not call next', async () => {
+        server.use(() => null as any);
+        const callback = sinon.spy();
+
+        await (server as any).runMiddleware({}, callback);
+
+        expect(callback.called).to.be.false;
+      });
+
+      it('should reject when next is called more than once', async () => {
+        server.use((ctx: any, next: any) => {
+          next();
+          return next();
+        });
+
+        await expect(
+          (server as any).runMiddleware({}, async () => null),
+        ).to.be.rejectedWith(Error);
+      });
+
+      it('should propagate synchronous middleware errors', async () => {
+        const error = new Error('test-error');
+        server.use(() => {
+          throw error;
+        });
+
+        await expect(
+          (server as any).runMiddleware({}, async () => null),
+        ).to.be.rejectedWith(error);
+      });
+
+      it('should propagate asynchronous middleware errors', async () => {
+        const error = new Error('test-error');
+        server.use(() => Promise.reject(error));
+
+        await expect(
+          (server as any).runMiddleware({}, async () => null),
+        ).to.be.rejectedWith(error);
+      });
+
+      it('should run the callback even when middleware does not return next()', async () => {
+        const calls: string[] = [];
+        server.use((ctx: unknown, next: () => Promise<any>) => {
+          calls.push('middleware');
+          void next();
+        });
+        const callback = sinon.spy(async () => calls.push('done'));
+
+        await (server as any).runMiddleware({}, callback);
+
+        expect(calls).to.deep.equal(['middleware', 'done']);
+      });
+
+      it('should propagate downstream errors even when middleware does not return next()', async () => {
+        const error = new Error('test-error');
+        server.use((ctx: unknown, next: () => Promise<any>) => {
+          void next();
+          return undefined as any;
+        });
+        server.use(() => Promise.reject(error));
+
+        await expect(
+          (server as any).runMiddleware({}, async () => null),
+        ).to.be.rejectedWith(error);
+      });
+    });
+
+    describe('default onProcessingStartHook', () => {
+      it('should run registered middleware before the event handler', async () => {
+        const calls: string[] = [];
+        server.use((ctx: unknown, next: () => Promise<any>) => {
+          calls.push('middleware');
+          return next();
+        });
+        const handler = sinon.spy(async () => 'test');
+        server.addHandler('test-pattern', handler as any, true);
+
+        await server.handleEvent(
+          'test-pattern',
+          { data: 'hello' } as any,
+          {} as any,
+        );
+
+        expect(calls).to.deep.equal(['middleware']);
+        expect(handler.called).to.be.true;
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) — see note below

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
NestJS microservices (gRPC, TCP, MQTT, Redis, Kafka, NATS, RabbitMQ, and event handlers) have no way to run shared logic (auth, request-context via `AsyncLocalStorage`, tracing, etc.) before handler code executes. HTTP applications have `app.use()` middleware; microservices do not.

Closes #17402

## What is the new behavior?
Adds `use(...middleware)` support to microservices, mirroring the HTTP middleware API. Middleware runs before guards and interceptors for every message and event handler.

Example:

```typescript
const app = await NestFactory.createMicroservice<MicroserviceOptions>(
  AppModule,
  { transport: Transport.GRPC, options: {...} },
);

const requestContext = new AsyncLocalStorage<{ requestId: string }>();

app.use((ctx, next) =>
  requestContext.run({ requestId: uuid() }, () => next()),
);
```

Middleware receives a `MicroserviceMiddlewareContext` (`{ transportId, context }`) and must call `next()` to continue the chain. The chain is executed in registration order; calling `next()` more than once throws, and errors thrown or rejected by a middleware propagate to the caller.

Implementation is transport-agnostic: the shared `Server` base class exposes `use()` and runs the chain through the existing `onProcessingStartHook`, which all four gRPC call types (unary, server-streaming, client-streaming, bidi) and `handleEvent` already invoke. Custom `Server` implementations that override `onProcessingStartHook` opt out by design.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
- New public API surface: `MicroserviceMiddleware`, `MicroserviceMiddlewareContext`, `INestMicroservice#use`, `Server#use`.
- Tests added for: chain ordering, double-`next()` rejection, error propagation (sync/async), context passing, hook integration for events, unary + streaming gRPC calls, and AsyncLocalStorage propagation from middleware into handlers.
- Docs: will be added to https://github.com/nestjs/docs in a follow-up PR (referencing this feature under the microservices section).
- Note: CLA signature may be required before this can be merged (happy to sign).
