### PR TITLE
fix(core): convert adjacent wildcard segments in legacy route converter

### DIFF
--- a/packages/core/router/legacy-route-converter.ts
+++ b/packages/core/router/legacy-route-converter.ts
@@ -57,10 +57,15 @@ export class LegacyRouteConverter {
 
     // When route includes any wildcard segments in the middle.
     if (normalizedRoute.includes('/*/')) {
-      // Replace each /*/ segment with a named parameter using different name for each segment.
-      const convertedRoute = route.replaceAll('/*/', (match, offset) => {
-        return `/*path${offset}/`;
-      });
+      // Replace each "*" segment with a named parameter, using a different name
+      // for each. Match "/*" with a lookahead for the following "/" so the
+      // trailing slash is not consumed. Consuming it made two adjacent "/*/*/"
+      // segments share a slash, so only the first one got converted and the
+      // second was left as an unnamed "*" that path-to-regexp still rejects.
+      const convertedRoute = route.replaceAll(
+        /\/\*(?=\/)/g,
+        (match, offset) => `/*path${offset}`,
+      );
       printWarning(route, convertedRoute);
       return convertedRoute;
     }

--- a/packages/core/test/router/legacy-route-converter.spec.ts
+++ b/packages/core/test/router/legacy-route-converter.spec.ts
@@ -34,6 +34,12 @@ describe('LegacyRouteConverter', () => {
       );
     });
 
+    it('should convert adjacent wildcard segments in the middle of the path', () => {
+      expect(LegacyRouteConverter.tryConvert('/a/*/*/b')).to.equal(
+        '/a/*path2/*path4/b',
+      );
+    });
+
     it('should leave routes without legacy wildcards untouched', () => {
       expect(LegacyRouteConverter.tryConvert('/v1/users')).to.equal(
         '/v1/users',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`LegacyRouteConverter.tryConvert` rewrites legacy wildcard routes into the named syntax that path-to-regexp v8 (Express 5) requires. The middle-wildcard branch uses `route.replaceAll('/*/', ...)`, which consumes the slash that two adjacent `/*/*/` segments share, so only the first segment gets converted:

```
tryConvert('/a/*/*/b')  // => '/a/*path2/*/b'
```

The leftover unnamed `*` is still rejected by path-to-regexp, so the app fails to start with the same "Unsupported route path" error the converter is meant to prevent.

## What is the new behavior?

The branch now matches `/*` with a lookahead for the following slash, so the slash is not consumed and every wildcard segment gets converted:

```
tryConvert('/a/*/*/b')  // => '/a/*path2/*path4/b'
```

Output for a single middle wildcard is unchanged, so `/v1/*/users` still becomes `/v1/*path3/users`. Added a regression test for the adjacent case.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I could not run the full suite locally, so I verified the conversion logic directly and added a unit test that follows the existing naming scheme.

Sorry if this is on the small side, adjacent `/*/*/` segments are an edge case. Happy to close it if it is not worth the churn, or to broaden it to the other legacy-syntax gaps if that is more useful.
