### PR TITLE
fix(express): map missing multer field nesting error

### DIFF
--- a/packages/platform-express/multer/multer/multer.utils.ts
+++ b/packages/platform-express/multer/multer/multer.utils.ts
@@ -20,6 +20,7 @@ export function transformException(
     case multerExceptions.LIMIT_FIELD_KEY:
     case multerExceptions.LIMIT_FIELD_VALUE:
     case multerExceptions.LIMIT_FIELD_COUNT:
+    case multerExceptions.LIMIT_FIELD_NESTING:
     case multerExceptions.LIMIT_UNEXPECTED_FILE:
     case multerExceptions.LIMIT_PART_COUNT:
     case multerExceptions.MISSING_FIELD_NAME:

--- a/packages/platform-express/test/multer/multer/multer.utils.spec.ts
+++ b/packages/platform-express/test/multer/multer/multer.utils.spec.ts
@@ -39,6 +39,21 @@ describe('transformException', () => {
           BadRequestException,
         );
       });
+      it('should return "BadRequestException" for LIMIT_FIELD_NESTING', () => {
+        const err = { message: multerExceptions.LIMIT_FIELD_NESTING };
+        expect(transformException(err as any)).to.be.instanceof(
+          BadRequestException,
+        );
+      });
+      it('should append the field property to the message', () => {
+        const err = {
+          message: multerExceptions.LIMIT_FIELD_NESTING,
+          field: 'foo',
+        };
+        expect(transformException(err as any)!.message).to.equal(
+          `${multerExceptions.LIMIT_FIELD_NESTING} - foo`,
+        );
+      });
     });
     describe('and is busboy/multipart exception', () => {
       it('should return "BadRequestException"', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Multipart requests that exceed the configurable `limits.fieldNestingDepth` option get HTTP 500. Multer emits the `LIMIT_FIELD_NESTING` error code (`'Field name nesting too deep'`), but `transformException` in `packages/platform-express/multer/multer/multer.utils.ts` does not map it, so the raw `MulterError` falls through the switch and is returned as-is. Every other multer limit code is mapped to `BadRequestException`/`PayloadTooLargeException` (see commit `4c38a767b`).

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
`LIMIT_FIELD_NESTING` is mapped to `BadRequestException` (HTTP 400), consistent with the other field/file limit codes. When multer attaches a `field` name, it is appended to the message (e.g. `Field name nesting too deep - foo`).


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information