### PR TITLE
fix(core): share existing singleton providers with lazily loaded modules

### DIFF
--- a/packages/common/test/utils/http-error-by-code.util.spec.ts
+++ b/packages/common/test/utils/http-error-by-code.util.spec.ts
@@ -57,9 +57,9 @@ describe('HttpErrorByCode', () => {
   });
 
   it('should set the correct default message for HttpVersionNotSupportedException', () => {
-    const instance = new (
-      HttpErrorByCode[HttpStatus.HTTP_VERSION_NOT_SUPPORTED] as any
-    )();
+    const instance = new (HttpErrorByCode[
+      HttpStatus.HTTP_VERSION_NOT_SUPPORTED
+    ] as any)();
     expect(instance.message).to.equal('HTTP Version Not Supported');
   });
 });

--- a/packages/common/test/utils/http-error-by-code.util.spec.ts
+++ b/packages/common/test/utils/http-error-by-code.util.spec.ts
@@ -57,9 +57,9 @@ describe('HttpErrorByCode', () => {
   });
 
   it('should set the correct default message for HttpVersionNotSupportedException', () => {
-    const instance = new (HttpErrorByCode[
-      HttpStatus.HTTP_VERSION_NOT_SUPPORTED
-    ] as any)();
+    const instance = new (
+      HttpErrorByCode[HttpStatus.HTTP_VERSION_NOT_SUPPORTED] as any
+    )();
     expect(instance.message).to.equal('HTTP Version Not Supported');
   });
 });

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -42,9 +42,11 @@ export class NestContainer {
 
   constructor(
     private readonly _applicationConfig:
-      ApplicationConfig | undefined = undefined,
+      | ApplicationConfig
+      | undefined = undefined,
     private readonly _contextOptions:
-      NestApplicationContextOptions | undefined = undefined,
+      | NestApplicationContextOptions
+      | undefined = undefined,
   ) {
     const moduleOpaqueKeyFactory =
       this._contextOptions?.moduleIdGeneratorAlgorithm === 'deep-hash'

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -42,11 +42,9 @@ export class NestContainer {
 
   constructor(
     private readonly _applicationConfig:
-      | ApplicationConfig
-      | undefined = undefined,
+      ApplicationConfig | undefined = undefined,
     private readonly _contextOptions:
-      | NestApplicationContextOptions
-      | undefined = undefined,
+      NestApplicationContextOptions | undefined = undefined,
   ) {
     const moduleOpaqueKeyFactory =
       this._contextOptions?.moduleIdGeneratorAlgorithm === 'deep-hash'
@@ -109,7 +107,7 @@ export class NestContainer {
     if (this.modules.has(token)) {
       return {
         moduleRef: this.modules.get(token)!,
-        inserted: true,
+        inserted: false,
       };
     }
 

--- a/packages/core/injector/container.ts
+++ b/packages/core/injector/container.ts
@@ -154,7 +154,7 @@ export class NestContainer {
         },
         scope,
       ),
-      inserted: false,
+      inserted: true,
     };
   }
 

--- a/packages/core/injector/internal-core-module/internal-core-module-factory.ts
+++ b/packages/core/injector/internal-core-module/internal-core-module-factory.ts
@@ -28,7 +28,7 @@ export class InternalCoreModuleFactory {
         timestamp: false,
       });
       const injector = new Injector({
-        preview: container.contextOptions?.preview!,
+        preview: container.contextOptions?.preview ?? false,
         instanceDecorator:
           container.contextOptions?.instrument?.instanceDecorator,
       });

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -114,6 +114,10 @@ export class DependenciesScanner {
       (await this.insertOrOverrideModule(moduleDefinition, overrides, scope)) ??
       {};
 
+    if (lazy && !moduleInserted) {
+      return [];
+    }
+
     moduleDefinition =
       this.getOverrideModuleByModule(moduleDefinition, overrides)?.newModule ??
       moduleDefinition;
@@ -443,10 +447,7 @@ export class DependenciesScanner {
   public isCustomProvider(
     provider: Provider,
   ): provider is
-    | ClassProvider
-    | ValueProvider
-    | FactoryProvider
-    | ExistingProvider {
+    ClassProvider | ValueProvider | FactoryProvider | ExistingProvider {
     return provider && !isNil((provider as any).provide);
   }
 
@@ -491,8 +492,7 @@ export class DependenciesScanner {
           | typeof APP_INTERCEPTOR
       ];
     const factoryOrClassProvider = newProvider as
-      | FactoryProvider
-      | ClassProvider;
+      FactoryProvider | ClassProvider;
     if (this.isRequestOrTransient(factoryOrClassProvider.scope!)) {
       return this.container.addInjectable(newProvider, token, enhancerSubtype);
     }

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -447,7 +447,10 @@ export class DependenciesScanner {
   public isCustomProvider(
     provider: Provider,
   ): provider is
-    ClassProvider | ValueProvider | FactoryProvider | ExistingProvider {
+    | ClassProvider
+    | ValueProvider
+    | FactoryProvider
+    | ExistingProvider {
     return provider && !isNil((provider as any).provide);
   }
 
@@ -492,7 +495,8 @@ export class DependenciesScanner {
           | typeof APP_INTERCEPTOR
       ];
     const factoryOrClassProvider = newProvider as
-      FactoryProvider | ClassProvider;
+      | FactoryProvider
+      | ClassProvider;
     if (this.isRequestOrTransient(factoryOrClassProvider.scope!)) {
       return this.container.addInjectable(newProvider, token, enhancerSubtype);
     }

--- a/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
+++ b/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Global, Injectable, Module } from '@nestjs/common';
 import { expect } from 'chai';
 import {
   LazyModuleLoader,
@@ -74,6 +74,113 @@ describe('LazyModuleLoader', () => {
         const moduleRef = await lazyModuleLoader.load(() => ModuleC);
         const moduleRef2 = await lazyModuleLoader.load(() => ModuleC);
         expect(moduleRef).to.equal(moduleRef2);
+      });
+    });
+
+    describe('singleton sharing and repeated loading (#17428)', () => {
+      let constructionsCount = 0;
+      let globalConstructionsCount = 0;
+
+      @Injectable()
+      class SharedService {
+        constructor() {
+          constructionsCount++;
+        }
+      }
+
+      @Module({
+        providers: [SharedService],
+        exports: [SharedService],
+      })
+      class SharedModule {}
+
+      @Global()
+      @Module({
+        providers: [
+          {
+            provide: 'GlobalService',
+            useFactory: () => {
+              globalConstructionsCount++;
+              return 'global';
+            },
+          },
+        ],
+        exports: ['GlobalService'],
+      })
+      class GlobalSharedModule {}
+
+      @Injectable()
+      class Consumer {
+        constructor(readonly shared: SharedService) {}
+      }
+
+      @Module({
+        imports: [SharedModule],
+        providers: [Consumer],
+      })
+      class LazyModule {}
+
+      @Module({
+        providers: [
+          {
+            provide: 'GlobalConsumer',
+            useFactory: (globalService: any) => globalService,
+            inject: ['GlobalService'],
+          },
+        ],
+      })
+      class LazyGlobalModule {}
+
+      @Module({
+        imports: [SharedModule, GlobalSharedModule],
+      })
+      class EagerModule {}
+
+      let eagerSharedService: SharedService;
+
+      beforeEach(async () => {
+        constructionsCount = 0;
+        globalConstructionsCount = 0;
+
+        // Boot the eager graph
+        await dependenciesScanner.scan(EagerModule);
+        await instanceLoader.createInstancesOfDependencies();
+
+        const { token: sharedModuleToken } = await (
+          lazyModuleLoader as any
+        ).moduleCompiler.compile(SharedModule);
+        const sharedModuleInstance = modulesContainer.get(sharedModuleToken)!;
+        eagerSharedService =
+          sharedModuleInstance.getProviderByKey(SharedService).instance;
+      });
+
+      it('should share already-initialized singleton providers with lazily-loaded consumer', async () => {
+        const lazyModuleRef = await lazyModuleLoader.load(() => LazyModule);
+        const lazyConsumer = lazyModuleRef.get(Consumer);
+        expect(lazyConsumer.shared).to.equal(eagerSharedService);
+        expect(constructionsCount).to.equal(1);
+      });
+
+      it('should not construct the provider again on repeated load() calls', async () => {
+        await lazyModuleLoader.load(() => LazyModule);
+        expect(constructionsCount).to.equal(1);
+
+        await lazyModuleLoader.load(() => LazyModule);
+        expect(constructionsCount).to.equal(1);
+      });
+
+      it('should correctly support global modules without duplicating constructor calls', async () => {
+        const lazyGlobalRef = await lazyModuleLoader.load(
+          () => LazyGlobalModule,
+        );
+        const globalConsumer = lazyGlobalRef.get('GlobalConsumer', {
+          strict: false,
+        });
+        expect(globalConsumer).to.equal('global');
+        expect(globalConstructionsCount).to.equal(1);
+
+        await lazyModuleLoader.load(() => LazyGlobalModule);
+        expect(globalConstructionsCount).to.equal(1);
       });
     });
   });

--- a/packages/microservices/microservices-module.ts
+++ b/packages/microservices/microservices-module.ts
@@ -51,7 +51,7 @@ export class MicroservicesModule<
     );
 
     const injector = new Injector({
-      preview: container.contextOptions?.preview!,
+      preview: container.contextOptions?.preview ?? false,
       instanceDecorator:
         container.contextOptions?.instrument?.instanceDecorator,
     });

--- a/packages/microservices/test/client/client-kafka.spec.ts
+++ b/packages/microservices/test/client/client-kafka.spec.ts
@@ -905,8 +905,7 @@ describe('ClientKafka', () => {
       });
 
       it('should call callback', async () => {
-        /* eslint-disable-next-line no-async-promise-executor */
-        return new Promise(async resolve => {
+        return new Promise(resolve => {
           return client['publish'](readPacket, ({ err }) => resolve(err));
         }).then(err => {
           expect(err).to.be.instanceof(Error);


### PR DESCRIPTION
Fixes #17428

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17428

When a module is lazily loaded via `LazyModuleLoader.load()` and it imports a module that is already initialized in the eager graph, the imported module's providers are constructed again instead of being reused. The lazy consumer receives a fresh instance while the root graph keeps the original. Every subsequent `load()` of the same module also re-runs the constructors, discarding the results — meaning any resource-holding provider (SDK client, DB connection, etc.) leaks on every call, since lazy modules never receive lifecycle hooks to clean them up.

## What is the new behavior?

- `NestContainer.addModule()` now correctly returns `{ inserted: false }` when the module is already registered in the container (previously it incorrectly returned `inserted: true` even for existing modules).
- `DependenciesScanner.scanForModules()` now short-circuits during a lazy load when the module was already inserted (`lazy && !moduleInserted`), returning `[]` immediately instead of re-scanning and re-registering the module's provider subgraph. This prevents `InstanceLoader` from overwriting existing `InstanceWrapper` instances and re-running constructors.
- Added regression tests in `lazy-module-loader.spec.ts` covering:
  - Already-initialized eager singleton providers are correctly shared with lazily-loaded consumers (same instance reference).
  - Repeated `load()` calls for the same module do not re-run constructors.
  - `@Global()` module providers continue to resolve correctly without duplicate construction (existing correct behavior preserved).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Verified locally with the reproduction script referenced in #17428 — all previously failing assertions (`shared=false`, unnecessary re-construction on cached reload) now pass as `shared=true` / zero additional constructions.

Ran the relevant test suite (`lazy-module-loader.spec.ts` and full `packages/core` injector specs) locally with no regressions.