### PR TITLE
fix(common): match string file types containing regex metacharacters

### DIFF
--- a/packages/common/pipes/file/file-type.validator.ts
+++ b/packages/common/pipes/file/file-type.validator.ts
@@ -132,16 +132,14 @@ export class FileTypeValidator extends FileValidator<
 
     // Skip magic number validation if set
     if (this.validationOptions.skipMagicNumbersValidation) {
-      return (
-        isFileValid && !!file.mimetype.match(this.validationOptions.fileType)
-      );
+      return isFileValid && this.matchesFileType(file.mimetype);
     }
 
     if (!isFileValid) return false;
 
     if (!file.buffer) {
       if (this.validationOptions.fallbackToMimetype) {
-        return !!file.mimetype.match(this.validationOptions.fileType);
+        return this.matchesFileType(file.mimetype);
       }
       return false;
     }
@@ -163,7 +161,7 @@ export class FileTypeValidator extends FileValidator<
           file.mimetype = fileType.mime;
         }
         // Match detected mime type against allowed type
-        return !!fileType.mime.match(this.validationOptions.fileType);
+        return this.matchesFileType(fileType.mime);
       }
 
       /**
@@ -172,7 +170,7 @@ export class FileTypeValidator extends FileValidator<
        * This is useful for plain text, CSVs, or files without recognizable signatures.
        */
       if (this.validationOptions.fallbackToMimetype) {
-        return !!file.mimetype.match(this.validationOptions.fileType);
+        return this.matchesFileType(file.mimetype);
       }
       return false;
     } catch (error) {
@@ -194,9 +192,19 @@ export class FileTypeValidator extends FileValidator<
 
       // Fallback to mimetype if enabled
       if (this.validationOptions.fallbackToMimetype) {
-        return !!file.mimetype.match(this.validationOptions.fileType);
+        return this.matchesFileType(file.mimetype);
       }
       return false;
     }
+  }
+
+  private matchesFileType(mimetype: string): boolean {
+    const { fileType } = this.validationOptions;
+    // A string is coerced into a RegExp by `String#match`, so MIME types holding
+    // regex metacharacters (the `+` in `image/svg+xml`) never match themselves.
+    if (typeof fileType === 'string' && mimetype === fileType) {
+      return true;
+    }
+    return !!mimetype.match(fileType);
   }
 }

--- a/packages/common/test/pipes/file/file-type.validator.spec.ts
+++ b/packages/common/test/pipes/file/file-type.validator.spec.ts
@@ -178,6 +178,46 @@ describe('FileTypeValidator', () => {
       expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
     });
 
+    it('should return true when the mimetype contains regex metacharacters and matches the expected type', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'image/svg+xml',
+        skipMagicNumbersValidation: true,
+      });
+
+      const requestFile = {
+        mimetype: 'image/svg+xml',
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
+    });
+
+    it('should return false when the mimetype contains regex metacharacters and does not match the expected type', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'image/svg+xml',
+        skipMagicNumbersValidation: true,
+      });
+
+      const requestFile = {
+        mimetype: 'image/png',
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(false);
+    });
+
+    it('should return true when fallbackToMimetype is enabled and the mimetype contains regex metacharacters', async () => {
+      const fileTypeValidator = new FileTypeValidator({
+        fileType: 'application/ld+json',
+        fallbackToMimetype: true,
+      });
+
+      const requestFile = {
+        mimetype: 'application/ld+json',
+        buffer: Buffer.from('{}'),
+      } as IFile;
+
+      expect(await fileTypeValidator.isValid(requestFile)).to.equal(true);
+    });
+
     it('should return false when the file buffer does not match any known type', async () => {
       const fileTypeValidator = new FileTypeValidator({
         fileType: 'unknown/type',


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no public API change, the documented behaviour is what starts working

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

`FileTypeValidator` matches the MIME type with `mimetype.match(this.validationOptions.fileType)`. When `fileType` is a string, `String.prototype.match` coerces it into a `RegExp`, so any MIME type that contains a regex metacharacter is compiled into a pattern that cannot match the string it was written as. `+` is the common case:

```js
'image/svg+xml'.match('image/svg+xml')     // null  -> /image\/svg+xml/ means "sv", one-or-more "g", "xml"
'application/ld+json'.match('application/ld+json') // null
```

So a validator configured for the exact type the client actually sent rejects the upload, and the resulting error message names the same type twice:

```ts
new ParseFilePipe({
  validators: [
    new FileTypeValidator({ fileType: 'image/svg+xml', skipMagicNumbersValidation: true }),
  ],
});
```

```
400 Validation failed (current file type is image/svg+xml, expected type is image/svg+xml)
400 Validation failed (current file type is application/ld+json, expected type is application/ld+json) - magic number detection failed, used mimetype fallback
```

This hits the two paths that exist for exactly these types. `image/svg+xml`, `application/ld+json`, `application/manifest+json` and the other structured-suffix types have no magic number, so they are validated either with `skipMagicNumbersValidation: true` or through the `fallbackToMimetype` branch — both of which compare against the client mimetype and therefore both fail.

## What is the new behavior?

A string `fileType` is compared literally first; if it is not an exact match, the existing regex coercion still runs. Partial values such as `fileType: 'jpeg'` matching `image/jpeg`, and `RegExp` file types, are unaffected — the change only adds the exact-string case, so nothing that validated before stops validating now.

The five comparison sites in `isValid` (skip-magic-numbers, no-buffer fallback, detected mime, undetected-mime fallback, and the error fallback) now go through one private helper, so they cannot drift apart.

Verified against the repo's own commands on `master` + this branch:

- `npm run test` — 2135 passing, exit 0
- `npm run build` — exit 0
- `npm run lint:ci` — exit 0 (2 pre-existing warnings, in `internal-core-module-factory.ts` and `client-kafka.spec.ts`)

The three added specs fail on `master` (2 of them) and pass with the fix; the third is the negative guard that `image/png` is still rejected by a `fileType: 'image/svg+xml'` validator.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The literal comparison is deliberately case-sensitive to match the current behaviour of the regex path; normalising MIME type casing would be a separate, wider change.
