### PR TITLE
 feat: narrow body parser options to the selected parser for Express

### DIFF
--- a/integration/nest-application/use-body-parser/e2e/express.spec.ts
+++ b/integration/nest-application/use-body-parser/e2e/express.spec.ts
@@ -1,6 +1,5 @@
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { Test } from '@nestjs/testing';
-import { OptionsUrlencoded } from 'body-parser';
 import request from 'supertest';
 import { AppModule } from '../src/app.module.js';
 
@@ -64,7 +63,7 @@ describe('Body Parser (Express Application)', () => {
           rawBody: true,
           logger: false,
         })
-        .useBodyParser<OptionsUrlencoded>('urlencoded', {
+        .useBodyParser('urlencoded', {
           limit: Buffer.from(stringLimit).byteLength,
           extended: true,
         });

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -16,8 +16,10 @@ import * as http from 'http';
 import * as https from 'https';
 import { pathToRegexp } from 'path-to-regexp';
 import { Duplex, Writable } from 'stream';
-import { NestExpressBodyParserOptions } from '../interfaces/nest-express-body-parser-options.interface.js';
-import { NestExpressBodyParserType } from '../interfaces/nest-express-body-parser.interface.js';
+import {
+  NestExpressBodyParserOptionsFor,
+  NestExpressBodyParserType,
+} from '../interfaces/nest-express-body-parser.interface.js';
 import { ServeStaticOptions } from '../interfaces/serve-static-options.interface.js';
 import { getBodyParserOptions } from './utils/get-body-parser-options.util.js';
 import {
@@ -333,10 +335,11 @@ export class ExpressAdapter extends AbstractHttpAdapter<
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
-    const bodyParserJsonOptions = getBodyParserOptions(rawBody!);
-    const bodyParserUrlencodedOptions = getBodyParserOptions(rawBody!, {
-      extended: true,
-    });
+    const bodyParserJsonOptions = getBodyParserOptions<'json'>(rawBody!);
+    const bodyParserUrlencodedOptions = getBodyParserOptions<'urlencoded'>(
+      rawBody!,
+      { extended: true },
+    );
 
     const parserMiddleware = {
       jsonParser: express.json(bodyParserJsonOptions),
@@ -347,14 +350,12 @@ export class ExpressAdapter extends AbstractHttpAdapter<
       .forEach(parserKey => this.use(parserMiddleware[parserKey]));
   }
 
-  public useBodyParser<
-    Options extends NestExpressBodyParserOptions = NestExpressBodyParserOptions,
-  >(
-    type: NestExpressBodyParserType,
+  public useBodyParser<ParserType extends NestExpressBodyParserType>(
+    type: ParserType,
     rawBody: boolean,
-    options?: Omit<Options, 'verify'>,
+    options?: NestExpressBodyParserOptionsFor<ParserType>,
   ): this {
-    const parserOptions = getBodyParserOptions<Options>(rawBody, options);
+    const parserOptions = getBodyParserOptions<ParserType>(rawBody, options);
     const parser = express[type](parserOptions);
 
     this.use(parser);

--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -335,8 +335,9 @@ export class ExpressAdapter extends AbstractHttpAdapter<
   }
 
   public registerParserMiddleware(prefix?: string, rawBody?: boolean) {
-    const bodyParserJsonOptions = getBodyParserOptions<'json'>(rawBody!);
-    const bodyParserUrlencodedOptions = getBodyParserOptions<'urlencoded'>(
+    const bodyParserJsonOptions = getBodyParserOptions('json', rawBody!);
+    const bodyParserUrlencodedOptions = getBodyParserOptions(
+      'urlencoded',
       rawBody!,
       { extended: true },
     );
@@ -355,7 +356,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
     rawBody: boolean,
     options?: NestExpressBodyParserOptionsFor<ParserType>,
   ): this {
-    const parserOptions = getBodyParserOptions<ParserType>(rawBody, options);
+    const parserOptions = getBodyParserOptions(type, rawBody, options);
     const parser = express[type](parserOptions);
 
     this.use(parser);

--- a/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
+++ b/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
@@ -20,6 +20,7 @@ const rawBodyParser = (
 export function getBodyParserOptions<
   ParserType extends NestExpressBodyParserType,
 >(
+  parser: ParserType,
   rawBody: boolean,
   options?: NestExpressBodyParserOptionsFor<ParserType>,
 ): NestExpressBodyParserOptionsMap[ParserType] {

--- a/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
+++ b/packages/platform-express/adapters/utils/get-body-parser-options.util.ts
@@ -1,6 +1,10 @@
 import type { RawBodyRequest } from '@nestjs/common';
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { NestExpressBodyParserOptions } from '../../interfaces/index.js';
+import type {
+  NestExpressBodyParserOptionsFor,
+  NestExpressBodyParserOptionsMap,
+  NestExpressBodyParserType,
+} from '../../interfaces/index.js';
 
 const rawBodyParser = (
   req: RawBodyRequest<IncomingMessage>,
@@ -13,18 +17,18 @@ const rawBodyParser = (
   return true;
 };
 
-export function getBodyParserOptions<Options = NestExpressBodyParserOptions>(
+export function getBodyParserOptions<
+  ParserType extends NestExpressBodyParserType,
+>(
   rawBody: boolean,
-  options?: Omit<Options, 'verify'>,
-): Options {
-  let parserOptions: Options = (options || {}) as Options;
-
+  options?: NestExpressBodyParserOptionsFor<ParserType>,
+): NestExpressBodyParserOptionsMap[ParserType] {
   if (rawBody === true) {
-    parserOptions = {
-      ...parserOptions,
+    return {
+      ...options,
       verify: rawBodyParser,
     };
   }
 
-  return parserOptions;
+  return options || {};
 }

--- a/packages/platform-express/interfaces/nest-express-application.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-application.interface.ts
@@ -2,8 +2,10 @@ import type { HttpServer, INestApplication } from '@nestjs/common';
 import type { Express } from 'express';
 import type { Server as CoreHttpServer } from 'http';
 import type { Server as CoreHttpsServer } from 'https';
-import { NestExpressBodyParserOptions } from './nest-express-body-parser-options.interface.js';
-import { NestExpressBodyParserType } from './nest-express-body-parser.interface.js';
+import {
+  NestExpressBodyParserOptionsFor,
+  NestExpressBodyParserType,
+} from './nest-express-body-parser.interface.js';
 import { ServeStaticOptions } from './serve-static-options.interface.js';
 import type { CorsOptions, CorsOptionsDelegate } from '@nestjs/common/internal';
 
@@ -100,11 +102,16 @@ export interface NestExpressApplication<
    * );
    * app.useBodyParser('json', { limit: '50mb' });
    *
+   * The accepted options are narrowed by the `parser` argument, so
+   * `useBodyParser('json', ...)` only accepts `express.json` options,
+   * `useBodyParser('urlencoded', ...)` only accepts `express.urlencoded`
+   * options, and so on.
+   *
    * @returns {this}
    */
-  useBodyParser<Options = NestExpressBodyParserOptions>(
-    parser: NestExpressBodyParserType,
-    options?: Omit<Options, 'verify'>,
+  useBodyParser<ParserType extends NestExpressBodyParserType>(
+    parser: ParserType,
+    options?: NestExpressBodyParserOptionsFor<ParserType>,
   ): this;
 
   /**

--- a/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser-options.interface.ts
@@ -3,6 +3,12 @@ import type { IncomingMessage } from 'http';
 /**
  * Type alias to keep compatibility with @types/body-parser
  * @see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dcd1673c4fa18a15ea8cd8ff8af7d563bb6dc8e6/types/body-parser/index.d.ts#L48-L66#L48-L66
+ *
+ * @deprecated Prefer {@link NestExpressBodyParserOptionsFor}, which resolves the
+ * exact options type for a given parser. The catch-all index signature below
+ * makes `keyof` resolve to `string | number`, which disables excess-property
+ * checking and makes `Omit<_, 'verify'>` a no-op.
+ *
  * @publicApi
  */
 export interface NestExpressBodyParserOptions {

--- a/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
@@ -1,4 +1,34 @@
+import express from 'express';
+
+/**
+ * Maps each body parser to the options object accepted by its Express factory.
+ *
+ * Derived from `express` itself so the two can never drift: `useBodyParser`
+ * ultimately calls `express[parser](options)`.
+ *
+ * @publicApi
+ */
+export interface NestExpressBodyParserOptionsMap {
+  json: NonNullable<Parameters<typeof express.json>[0]>;
+  urlencoded: NonNullable<Parameters<typeof express.urlencoded>[0]>;
+  text: NonNullable<Parameters<typeof express.text>[0]>;
+  raw: NonNullable<Parameters<typeof express.raw>[0]>;
+}
+
 /**
  * Interface defining possible body parser types, to be used with `NestExpressApplication.useBodyParser()`.
  */
-export type NestExpressBodyParserType = 'json' | 'urlencoded' | 'text' | 'raw';
+export type NestExpressBodyParserType = keyof NestExpressBodyParserOptionsMap;
+
+/**
+ * Options accepted by a given body parser.
+ *
+ * `verify` is excluded because it is reserved: Nest sets it internally to
+ * capture the raw request body when the application is created with
+ * `{ rawBody: true }`.
+ *
+ * @publicApi
+ */
+export type NestExpressBodyParserOptionsFor<
+  ParserType extends NestExpressBodyParserType,
+> = Omit<NestExpressBodyParserOptionsMap[ParserType], 'verify'>;

--- a/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
+++ b/packages/platform-express/interfaces/nest-express-body-parser.interface.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+type Express = typeof import('express');
 
 /**
  * Maps each body parser to the options object accepted by its Express factory.
@@ -9,10 +9,10 @@ import express from 'express';
  * @publicApi
  */
 export interface NestExpressBodyParserOptionsMap {
-  json: NonNullable<Parameters<typeof express.json>[0]>;
-  urlencoded: NonNullable<Parameters<typeof express.urlencoded>[0]>;
-  text: NonNullable<Parameters<typeof express.text>[0]>;
-  raw: NonNullable<Parameters<typeof express.raw>[0]>;
+  json: NonNullable<Parameters<Express['json']>[0]>;
+  urlencoded: NonNullable<Parameters<Express['urlencoded']>[0]>;
+  text: NonNullable<Parameters<Express['text']>[0]>;
+  raw: NonNullable<Parameters<Express['raw']>[0]>;
 }
 
 /**

--- a/packages/platform-express/test/adapters/utils/get-body-parser-options.util.spec.ts
+++ b/packages/platform-express/test/adapters/utils/get-body-parser-options.util.spec.ts
@@ -3,39 +3,39 @@ import { getBodyParserOptions } from '../../../adapters/utils/get-body-parser-op
 describe('getBodyParserOptions', () => {
   describe('when rawBody is false', () => {
     it('should return empty options when no options provided', () => {
-      const result = getBodyParserOptions(false);
+      const result = getBodyParserOptions('json', false);
       expect(result).toEqual({});
     });
 
     it('should return provided options unchanged', () => {
       const options = { limit: '10mb', inflate: true };
-      const result = getBodyParserOptions(false, options);
+      const result = getBodyParserOptions('json', false, options);
       expect(result).toEqual(options);
     });
 
     it('should not include verify function', () => {
-      const result = getBodyParserOptions(false);
+      const result = getBodyParserOptions('json', false);
       expect(result).not.toHaveProperty('verify');
     });
   });
 
   describe('when rawBody is true', () => {
     it('should include verify function in options', () => {
-      const result = getBodyParserOptions<any>(true);
+      const result = getBodyParserOptions('json', true);
       expect(result).toHaveProperty('verify');
       expect(result.verify).toBeTypeOf('function');
     });
 
     it('should merge verify with existing options', () => {
       const options = { limit: '10mb' };
-      const result = getBodyParserOptions<any>(true, options);
+      const result = getBodyParserOptions('json', true, options);
       expect(result.limit).toBe('10mb');
       expect(result.verify).toBeTypeOf('function');
     });
 
     describe('verify function (rawBodyParser)', () => {
       it('should assign buffer to req.rawBody when buffer is a Buffer', () => {
-        const result = getBodyParserOptions<any>(true);
+        const result = getBodyParserOptions('json', true);
         const req: any = {};
         const res: any = {};
         const buffer = Buffer.from('test data');
@@ -47,7 +47,7 @@ describe('getBodyParserOptions', () => {
       });
 
       it('should not assign rawBody when buffer is not a Buffer', () => {
-        const result = getBodyParserOptions<any>(true);
+        const result = getBodyParserOptions('json', true);
         const req: any = {};
         const res: any = {};
         const notBuffer = 'not a buffer';
@@ -59,7 +59,7 @@ describe('getBodyParserOptions', () => {
       });
 
       it('should always return true', () => {
-        const result = getBodyParserOptions<any>(true);
+        const result = getBodyParserOptions('json', true);
         const req: any = {};
         const res: any = {};
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

<img width="1090" height="250" alt="image" src="https://github.com/user-attachments/assets/1c0fcc0d-bc96-490d-8d39-c00f98e4abad" />

the method `#useBodyParser` never checked its options argument. Their type `Options` occurs only inside `Omit<Options, 'verify'>`, a non-inferrable position, so it always fell back to its default, and that default carries a `[key: string]: unknown` index signature. `keyof` on it is `string | number`, `Exclude<string | number, 'verify'>` removes nothing, and the resulting `Pick<T, string | number>` collapses to bare index signatures.

Every call therefore accepted any key, any value type, and even `verify` the single option the signature claims to remove, and the one Nest reserves to capture `rawBody`.

And so we can supply anything as a option + we did not have the autocompletion.

## What is the new behavior?

<img width="1364" height="702" alt="image" src="https://github.com/user-attachments/assets/6eb4b27c-5a12-4634-a922-efcce92750f5" />

`#useBodyParser` now takes the parser type as its first type argument.

Calls that pass an explicit options type, such as `app.useBodyParser<OptionsUrlencoded>('urlencoded', {...})` no longer compile.
Drop the type argument and let it be inferred from the parser argument.

## Does this PR introduce a breaking change?
- [x] Yes - which is why I'm proposing this to v12; this was not planned on v11 tho
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
