### PR TITLE
fix(core): scan pre-registered dynamic imports of lazily loaded modules

### DIFF
--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -115,7 +115,13 @@ export class DependenciesScanner {
       {};
 
     if (lazy && !moduleInserted) {
-      return [];
+      // A dynamic module's imports are registered before being scanned, so skip only instantiated modules.
+      const moduleAsProvider = moduleInstance?.getProviderByKey(
+        moduleInstance.metatype,
+      );
+      if (!moduleAsProvider || !isNil(moduleAsProvider.instance)) {
+        return [];
+      }
     }
 
     moduleDefinition =
@@ -177,7 +183,7 @@ export class DependenciesScanner {
       return registeredModuleRefs;
     }
 
-    if (lazy && moduleInserted) {
+    if (lazy) {
       this.container.bindGlobalsToImports(moduleInstance);
     }
     return [moduleInstance].concat(registeredModuleRefs);

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -119,7 +119,7 @@ export class DependenciesScanner {
       const moduleAsProvider = moduleInstance?.getProviderByKey(
         moduleInstance.metatype,
       );
-      if (!moduleAsProvider || !isNil(moduleAsProvider.instance)) {
+      if (moduleAsProvider && !isNil(moduleAsProvider.instance)) {
         return [];
       }
     }

--- a/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
+++ b/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
@@ -183,5 +183,87 @@ describe('LazyModuleLoader', () => {
         expect(globalConstructionsCount).to.equal(1);
       });
     });
+
+    describe('dynamic module imports (#17462)', () => {
+      const itemsProvider = { provide: 'ITEMS', useValue: ['a', 'b'] };
+
+      @Module({
+        providers: [itemsProvider],
+        exports: [itemsProvider],
+      })
+      class ChildProviderModule {}
+
+      @Module({})
+      class ParentRootModule {}
+
+      const parentRootModuleDefinition = {
+        module: ParentRootModule,
+        imports: [{ module: ChildProviderModule }],
+        providers: [
+          {
+            provide: 'PARENT_ITEMS',
+            useFactory: (items: string[]) => items,
+            inject: ['ITEMS'],
+          },
+        ],
+      };
+
+      it('should resolve providers exported by a dynamic import of a lazily loaded dynamic module', async () => {
+        const moduleRef = await lazyModuleLoader.load(
+          () => parentRootModuleDefinition,
+        );
+        expect(moduleRef.get('PARENT_ITEMS')).to.equal(itemsProvider.useValue);
+      });
+
+      it('should return an existing module reference on repeated load() calls', async () => {
+        const moduleRef = await lazyModuleLoader.load(
+          () => parentRootModuleDefinition,
+        );
+        const moduleRef2 = await lazyModuleLoader.load(
+          () => parentRootModuleDefinition,
+        );
+        expect(moduleRef).to.equal(moduleRef2);
+      });
+
+      it('should resolve global providers from a dynamic import of a lazily loaded dynamic module', async () => {
+        const globalProvider = { provide: 'GLOBAL_ITEMS', useValue: ['c'] };
+
+        @Global()
+        @Module({
+          providers: [globalProvider],
+          exports: [globalProvider],
+        })
+        class GlobalItemsModule {}
+
+        @Module({ imports: [GlobalItemsModule] })
+        class RootModule {}
+
+        @Module({
+          providers: [
+            {
+              provide: 'CHILD_GLOBAL_ITEMS',
+              useFactory: (items: string[]) => items,
+              inject: ['GLOBAL_ITEMS'],
+            },
+          ],
+          exports: ['CHILD_GLOBAL_ITEMS'],
+        })
+        class GlobalConsumerChildModule {}
+
+        @Module({})
+        class GlobalConsumerParentModule {}
+
+        await dependenciesScanner.scan(RootModule);
+        await instanceLoader.createInstancesOfDependencies();
+
+        const moduleRef = await lazyModuleLoader.load(() => ({
+          module: GlobalConsumerParentModule,
+          imports: [{ module: GlobalConsumerChildModule }],
+        }));
+        expect(moduleRef.get('CHILD_GLOBAL_ITEMS', { strict: false })).to.equal(
+          globalProvider.useValue,
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #17462

## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #17462

A lazily loaded dynamic module whose metadata carries `imports` no longer resolves:

```ts
const moduleRef = await lazyModuleLoader.load(() => ({
  module: ParentRootModule,
  imports: [{ module: ChildProviderModule }],
}));
// Nest can't resolve dependencies of the ParentService (?) ...
```

`NestContainer.setModule` registers a dynamic module's own `imports` up front, through `addDynamicMetadata` -> `addDynamicModules` -> `addModule`, before the scanner walks them. Since #17430 the scanner treats "already registered" as "already handled" and returns early, so those imports stay registered but never get scanned or instantiated. The first `load()` fails dependency injection and every later one hands back the same half-built module.

The same early return also skips `bindGlobalsToImports`, which only ran for freshly inserted modules, so `@Global` tokens are unresolvable from a pre-registered import as well.

## What is the new behavior?

The lazy skip now applies only to modules that were actually instantiated, which is the case #17430 cares about. A module that was registered but never scanned still gets scanned, and globals are bound for everything a lazy pass walks.

Three specs in `lazy-module-loader.spec.ts` cover it: the exported provider of a dynamic import, repeated `load()` calls returning the cached reference, and a `@Global` token resolved from a dynamic import. All three fail on master and the #17428 tests keep passing.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
