### PR TITLE
fix(core): scan pre-registered dynamic imports of lazy modules

### DIFF
--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -146,6 +146,15 @@ export class Module {
     return moduleRef!.instance as NestModule;
   }
 
+  /**
+   * Modules are registered in the container before they are scanned (dynamic
+   * `imports` are pre-registered by `NestContainer#addDynamicMetadata`), so
+   * registration alone does not imply the module was ever instantiated.
+   */
+  get isInstantiated(): boolean {
+    return !isNil(this._providers.get(this._metatype)?.instance);
+  }
+
   get metatype(): Type<any> {
     return this._metatype;
   }

--- a/packages/core/scanner.ts
+++ b/packages/core/scanner.ts
@@ -114,7 +114,7 @@ export class DependenciesScanner {
       (await this.insertOrOverrideModule(moduleDefinition, overrides, scope)) ??
       {};
 
-    if (lazy && !moduleInserted) {
+    if (lazy && !moduleInserted && moduleInstance?.isInstantiated) {
       return [];
     }
 
@@ -177,7 +177,7 @@ export class DependenciesScanner {
       return registeredModuleRefs;
     }
 
-    if (lazy && moduleInserted) {
+    if (lazy) {
       this.container.bindGlobalsToImports(moduleInstance);
     }
     return [moduleInstance].concat(registeredModuleRefs);

--- a/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
+++ b/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
@@ -1,4 +1,10 @@
-import { Global, Injectable, Module } from '@nestjs/common';
+import {
+  DynamicModule,
+  Global,
+  Inject,
+  Injectable,
+  Module,
+} from '@nestjs/common';
 import { expect } from 'chai';
 import {
   LazyModuleLoader,
@@ -181,6 +187,119 @@ describe('LazyModuleLoader', () => {
 
         await lazyModuleLoader.load(() => LazyGlobalModule);
         expect(globalConstructionsCount).to.equal(1);
+      });
+    });
+
+    describe('dynamic modules with pre-registered dynamic imports (#17462)', () => {
+      // The import must itself be a `DynamicModule` object: those are
+      // pre-registered by `NestContainer#addDynamicMetadata` before the lazy
+      // scan reaches them, so they look "already registered" to the scanner.
+      @Module({
+        providers: [{ provide: 'ITEMS', useValue: ['itemA', 'itemB'] }],
+        exports: ['ITEMS'],
+      })
+      class ChildProviderModule {}
+
+      @Injectable()
+      class ParentService {
+        constructor(@Inject('ITEMS') readonly items: string[]) {}
+      }
+
+      @Module({ providers: [ParentService], exports: [ParentService] })
+      class ParentRootModule {}
+
+      @Module({
+        providers: [{ provide: 'GLOBAL_DEP', useValue: 'globalDep' }],
+        exports: ['GLOBAL_DEP'],
+      })
+      @Global()
+      class GlobalDepModule {}
+
+      @Module({
+        providers: [
+          {
+            provide: 'CHILD_OUT',
+            useFactory: (dep: string) => `child(${dep})`,
+            inject: ['GLOBAL_DEP'],
+          },
+        ],
+        exports: ['CHILD_OUT'],
+      })
+      class ChildNeedsGlobalModule {}
+
+      @Injectable()
+      class GlobalHuskConsumer {
+        constructor(@Inject('CHILD_OUT') readonly childOut: string) {}
+      }
+
+      @Module({
+        providers: [GlobalHuskConsumer],
+        exports: [GlobalHuskConsumer],
+      })
+      class GlobalHuskRootModule {}
+
+      @Module({ imports: [GlobalDepModule] })
+      class AppModule {}
+
+      beforeEach(async () => {
+        await dependenciesScanner.scan(AppModule);
+        await instanceLoader.createInstancesOfDependencies();
+      });
+
+      it('should scan dynamic imports declared in the dynamic metadata', async () => {
+        // Arrange
+        const child: DynamicModule = { module: ChildProviderModule };
+        const definition: DynamicModule = {
+          module: ParentRootModule,
+          imports: [child],
+          exports: [child],
+        };
+
+        // Act
+        const moduleRef = await lazyModuleLoader.load(() => definition);
+
+        // Assert
+        expect(moduleRef.get(ParentService).items).to.deep.equal([
+          'itemA',
+          'itemB',
+        ]);
+      });
+
+      it('should keep the module resolvable on repeated load() calls', async () => {
+        // Arrange
+        const child: DynamicModule = { module: ChildProviderModule };
+        const definition: DynamicModule = {
+          module: ParentRootModule,
+          imports: [child],
+          exports: [child],
+        };
+
+        // Act
+        const first = await lazyModuleLoader.load(() => definition);
+        const second = await lazyModuleLoader.load(() => definition);
+
+        // Assert
+        expect(first).to.equal(second);
+        expect(second.get(ParentService).items).to.deep.equal([
+          'itemA',
+          'itemB',
+        ]);
+      });
+
+      it('should bind global providers into a rescanned dynamic import', async () => {
+        // Arrange
+        const definition: DynamicModule = {
+          module: GlobalHuskRootModule,
+          imports: [{ module: ChildNeedsGlobalModule }],
+        };
+
+        // Act
+        const moduleRef = await lazyModuleLoader.load(() => definition);
+
+        // Assert
+        expect(moduleRef.get(GlobalHuskConsumer).childOut).to.equal(
+          'child(globalDep)',
+        );
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Docs are not affected: this restores documented behavior rather than changing the public API.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17462

A lazily loaded `DynamicModule` whose dynamic metadata carries `imports` never has those imports scanned, so their providers are never registered and injection fails:

```
Nest can't resolve dependencies of the ParentService (?).
Please make sure that the argument "ITEMS" at index [0] is available
in the ParentRootModule module.
```

Every subsequent `load()` returns the cached, half-built module, so the failure is permanent for the lifetime of the process.

`NestContainer#setModule` pre-registers a dynamic module's `imports` (`addDynamicMetadata` -> `addDynamicModules` -> `addModule`) **before** the scanner recurses into them. Those modules therefore report `inserted: false`, and the lazy skip condition treats them as already loaded: they stay registered but are never scanned or instantiated.

The exact trigger is that the inner import must itself be a `DynamicModule` object (`imports: [{ module: Child }]`), not a class reference. With a class reference the parent's import edge still pulls the module in via `insertImport`, so the failure is not observable.

A second, related case: a rescanned module reports `inserted: false`, so `lazy && moduleInserted` also skipped binding `@Global` providers into it, breaking providers that resolve a token available only through a global module.

## What is the new behavior?

Skip only modules that were actually instantiated, distinguishing "registered" from "registered and instantiated":

```ts
if (lazy && !moduleInserted && moduleInstance?.isInstantiated) {
  return [];
}
```

and bind global providers on every lazy pass, so rescanned modules still receive `@Global` providers.

The "was this instantiated" state lives in `Module.isInstantiated` rather than having the scanner inspect the module's internal provider map.

Verified against the reproduction from the issue ([RaviAjaibSingh/nestjs-dependency-injection-experiments](https://github.com/RaviAjaibSingh/nestjs-dependency-injection-experiments)) — all three scenarios go from `BUG` to `OK`, including the #17428 case, which stays fixed:

```
testing: lazy consumer shares boot singleton      ... OK
testing: lazy dynamic module with dynamic imports ... OK
testing: rescanned husk resolves @Global token    ... OK
```

| | passing | failing |
|---|---|---|
| `master` + the new specs | 833 | 3 |
| `master` + this fix | 836 | 0 |

The three new specs fail without the fix and pass with it. `tsc -b packages` and `eslint` are clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The skip condition was introduced in #17430 (fixing #17428). That fix is preserved — this PR only narrows the condition so pre-registered, never-instantiated modules are still scanned.
