### PR TITLE
fix(microservices): serialize grpc exceptions by default

### DIFF
--- a/packages/microservices/exceptions/base-rpc-exception-filter.ts
+++ b/packages/microservices/exceptions/base-rpc-exception-filter.ts
@@ -5,6 +5,7 @@ import {
   type RpcExceptionFilter,
 } from '@nestjs/common';
 import { Observable, throwError as _throw } from 'rxjs';
+import { GrpcException } from './grpc-exception.js';
 import { RpcException } from './rpc-exception.js';
 import { isObject } from '@nestjs/common/internal';
 import { MESSAGES } from '@nestjs/core/internal';
@@ -20,6 +21,9 @@ export class BaseRpcExceptionFilter<
 
   public catch(exception: T, host: ArgumentsHost): Observable<R> {
     const status = 'error';
+    if (exception instanceof GrpcException) {
+      return _throw(() => exception.getError());
+    }
     if (!(exception instanceof RpcException)) {
       return this.handleUnknownError(exception, status);
     }

--- a/packages/microservices/test/exceptions/rpc-exceptions-handler.spec.ts
+++ b/packages/microservices/test/exceptions/rpc-exceptions-handler.spec.ts
@@ -1,5 +1,7 @@
 import { EMPTY, of } from 'rxjs';
 import { catchError } from 'rxjs/operators';
+import { GrpcStatus } from '../../enums/grpc-status.enum.js';
+import { GrpcNotFoundException } from '../../exceptions/grpc-exception.js';
 import { RpcException } from '../../exceptions/rpc-exception.js';
 import { RpcExceptionsHandler } from '../../exceptions/rpc-exceptions-handler.js';
 
@@ -53,6 +55,27 @@ describe('RpcExceptionsHandler', () => {
             .pipe(
               catchError((err: any) => {
                 expect(err).toEqual({ message, status: 'error' });
+                done();
+                return EMPTY;
+              }),
+            )
+            .subscribe(() => ({}));
+        }));
+    });
+    describe('when exception is instance of GrpcException', () => {
+      it('should emit the gRPC error code and message', () =>
+        new Promise<void>(done => {
+          const stream$ = handler.handle(
+            new GrpcNotFoundException('User not found'),
+            null!,
+          );
+          stream$
+            .pipe(
+              catchError((err: any) => {
+                expect(err).toEqual({
+                  code: GrpcStatus.NOT_FOUND,
+                  message: 'User not found',
+                });
                 done();
                 return EMPTY;
               }),


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
`GrpcException` and its 15 named subclasses (`GrpcNotFoundException`, `GrpcInvalidArgumentException`, etc.) are only serialized to proper gRPC status codes when the user explicitly registers `GrpcExceptionFilter` via `app.useGlobalFilters(new GrpcExceptionFilter())`.

By default, a handler throwing any of these hits `BaseRpcExceptionFilter.catch`, which has no `GrpcException` branch — so the exception falls through to `handleUnknownError` and produces `{ status: 'error', message: 'Internal server error' }` with no numeric gRPC code. grpc-js then maps every reply to `UNKNOWN` (13), so the entire exception layer silently degrades.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
`BaseRpcExceptionFilter` recognizes `GrpcException` and emits its gRPC error body (`{ code, message }`, from `GrpcException.getError()`), so the exceptions work out of the box through the default pipeline — no filter registration required.

```ts
if (exception instanceof GrpcException) {
  return _throw(() => exception.getError());
}
```

Test added in `rpc-exceptions-handler.spec.ts` asserting `handler.handle(new GrpcNotFoundException('User not found'))` emits `{ code: GrpcStatus.NOT_FOUND, message: 'User not found' }`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information