### PR TITLE
fix(express,fastify): apply falsy status codes in `reply()`

### DIFF
--- a/packages/platform-express/adapters/express-adapter.ts
+++ b/packages/platform-express/adapters/express-adapter.ts
@@ -106,7 +106,7 @@ export class ExpressAdapter extends AbstractHttpAdapter<
   }
 
   public reply(response: any, body: any, statusCode?: number) {
-    if (statusCode) {
+    if (!isNil(statusCode)) {
       response.status(statusCode);
     }
     if (isNil(body)) {

--- a/packages/platform-express/test/adapters/express-adapter.spec.ts
+++ b/packages/platform-express/test/adapters/express-adapter.spec.ts
@@ -48,6 +48,46 @@ describe('ExpressAdapter', () => {
     });
   });
 
+  describe('reply', () => {
+    const createResponse = () => ({
+      status: vi.fn(),
+      send: vi.fn(),
+      json: vi.fn(),
+      getHeader: vi.fn(),
+      setHeader: vi.fn(),
+    });
+
+    it('should apply the given status code', () => {
+      const response = createResponse();
+
+      expressAdapter.reply(response, { message: 'Oops' }, 404);
+
+      expect(response.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should not apply any status code when it is omitted', () => {
+      const response = createResponse();
+
+      expressAdapter.reply(response, { message: 'Hello' });
+
+      expect(response.status).not.toHaveBeenCalled();
+    });
+
+    it('should apply falsy status codes instead of dropping them', () => {
+      // "0" and "NaN" are falsy, but they were still passed in. Forwarding them
+      // lets express reject the value, whereas skipping the call leaves the
+      // status that was set before the handler ran (200/201), so an error would
+      // be sent with a successful status code.
+      for (const statusCode of [0, NaN]) {
+        const response = createResponse();
+
+        expressAdapter.reply(response, { message: 'Oops' }, statusCode);
+
+        expect(response.status).toHaveBeenCalledWith(statusCode);
+      }
+    });
+  });
+
   describe('mapException', () => {
     it('should map URIError with status code to BadRequestException', () => {
       const error = new URIError();

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -49,6 +49,7 @@ import { pathToRegexp } from 'path-to-regexp';
 import {
   type VersionValue,
   loadPackage,
+  isNil,
   isString,
   isUndefined,
 } from '@nestjs/common/internal';
@@ -455,7 +456,7 @@ export class FastifyAdapter<
         )
       : response;
 
-    if (statusCode) {
+    if (!isNil(statusCode)) {
       fastifyReply.status(statusCode);
     }
     if (body instanceof StreamableFile) {

--- a/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
+++ b/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
@@ -11,6 +11,45 @@ describe('FastifyAdapter', () => {
 
   afterEach(() => vi.restoreAllMocks());
 
+  describe('reply', () => {
+    const createReply = () => ({
+      status: vi.fn(),
+      send: vi.fn(),
+      getHeader: vi.fn(),
+      header: vi.fn(),
+    });
+
+    it('should apply the given status code', () => {
+      const reply = createReply();
+
+      fastifyAdapter.reply(reply as any, { message: 'Oops' }, 404);
+
+      expect(reply.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should not apply any status code when it is omitted', () => {
+      const reply = createReply();
+
+      fastifyAdapter.reply(reply as any, { message: 'Hello' });
+
+      expect(reply.status).not.toHaveBeenCalled();
+    });
+
+    it('should apply falsy status codes instead of dropping them', () => {
+      // "0" and "NaN" are falsy, but they were still passed in. Forwarding them
+      // lets fastify reject the value, whereas skipping the call leaves the
+      // status that was set before the handler ran (200/201), so an error would
+      // be sent with a successful status code.
+      for (const statusCode of [0, NaN]) {
+        const reply = createReply();
+
+        fastifyAdapter.reply(reply as any, { message: 'Oops' }, statusCode);
+
+        expect(reply.status).toHaveBeenCalledWith(statusCode);
+      }
+    });
+  });
+
   describe('mapException', () => {
     it('should map FastifyError with status code to HttpException', () => {
       const FastifyErrorCls = createError(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`reply()` sets the status only when it is truthy. A falsy code that was passed in gets skipped,
so the response keeps the status set before the handler ran (200, or 201 on POST), and the
exception goes out as a success.

```ts
@Get('code/:c')
code(@Param('c') c: string): void {
  throw new HttpException('Oops', Number(c)); // no custom exception filter
}
```

| thrown status | HTTP status | body |
| --- | --- | --- |
| `NaN` | **200** | `{"statusCode":null,"message":"Oops"}` |
| `0` | **200** | `{"statusCode":0,"message":"Oops"}` |
| `-1` | 500 | `{"statusCode":500,"message":"Internal server error"}` |
| `99` | 500 | `{"statusCode":500,"message":"Internal server error"}` |
| `404` | 404 | `{"statusCode":404,"message":"Oops"}` |

I ran into it with a `NaN` from an unchecked `Number()`. Express and fastify both do this.

`-1` and `99` are just as invalid and they already work fine: `response.status()` gets called,
the framework rejects the value, and the exception layer returns a 500. The only thing putting
`0` and `NaN` on a different path is that they're falsy.


## What is the new behavior?

```diff
- if (statusCode) {
+ if (!isNil(statusCode)) {
    response.status(statusCode);
  }
```

Leaving the status out still skips the call, so #1901 and interceptors calling `res.status()`
are unaffected. A status that was passed now reaches express/fastify, which validate it.

I didn't add any validation to `HttpException`. The adapters just need to stop throwing the value
away. `undefined` keeps its current meaning since there's no way to tell it apart from a missing
argument (#13404).


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Anything that reaches express/fastify today behaves the same. Invalid falsy codes go from a silent
200 to a 500.


## Other information

`isNil` is already used one line below for `body`, and in `sse-stream.ts` since #16782, which was
the same kind of falsy guard swallowing a valid `id: 0`.

Both new tests fail on master and pass with the change.

I found this while working on an RFC 9457 exception filter
(Fcmam5/nest-problem-details#55), but the bug isn't in the filter. The table above comes from an
app with no custom filter at all.
