### PR TITLE
docs(changelog): point sample commit scope at sample/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ The following is the list of supported scopes:
 
 - **common**: for changes made on `packages/common` directory
 - **core**: for changes made on `packages/core` directory
-- **sample**: for changes made on `packages/sample` directory
+- **sample**: for changes made on `sample` directory
 - **microservices**: for changes made on `packages/microservices` directory
 - **express**: for changes made on `packages/platform-express` directory
 - **fastify**: for changes made on `packages/platform-fastify` directory

--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -121,7 +121,7 @@ export class SseStream extends Transform {
     if (this._destination.writeHead) {
       this._destination.writeHead(statusCode, {
         ...additionalHeaders,
-        // See https://github.com/dunglas/mercure/blob/master/hub/subscribe.go#L124-L130
+        // See https://github.com/dunglas/mercure/blob/main/subscribe.go#L347-L362
         'Content-Type': 'text/event-stream',
         Connection: 'keep-alive',
         // Disable cache, even for old browsers and proxies


### PR DESCRIPTION
## Problem
Two stale documentation paths:

1. `CONTRIBUTING.md` documents the `sample` commit scope as applying to `packages/sample`. That directory does not exist. Sample apps live in the top-level `sample/` directory (also referenced later in the same file as `sample/#`).
2. `packages/core/router/sse-stream.ts` cites `https://github.com/dunglas/mercure/blob/master/hub/subscribe.go#L124-L130` as the source of the SSE headers. That path 404s after the default-branch move (`master` -> `main`) and the file move. The same header-send logic is now in `subscribe.go` (`sendHeaders`).

## Solution
- Point the `sample` scope at `sample` instead of `packages/sample`.
- Update the comment to `https://github.com/dunglas/mercure/blob/main/subscribe.go#L347-L362`.
- No runtime behavior change.

## Verification
- `packages/sample` is absent; `sample/` exists.
- Old Mercure URL: GET 404 (redirects to `main/hub/subscribe.go`, still missing).
- New Mercure URL: GET 200. `sendHeaders` is at lines 347-362.
