### PR TITLE
fix(core): convert every legacy wildcard in a route, not just one

### DIFF
--- a/packages/core/router/legacy-route-converter.ts
+++ b/packages/core/router/legacy-route-converter.ts
@@ -31,46 +31,49 @@ export class LegacyRouteConverter {
       ? this.printWarning.bind(this)
       : () => {};
 
-    if (normalizedRoute.endsWith('/(.*)/')) {
-      const convertedRoute = route.replace('(.*)', '{*path}');
-      // Skip printing warning for the "all" wildcard.
-      if (normalizedRoute !== '/(.*)/') {
-        printWarning(route, convertedRoute);
+    // A route may carry more than one legacy wildcard, so walk its segments and
+    // convert every one of them. Converting a single occurrence left the others
+    // untouched, and path-to-regexp still rejects a route that holds one.
+    const segments = route.split('/');
+    const lastSegmentIndex =
+      segments[segments.length - 1] === ''
+        ? segments.length - 2
+        : segments.length - 1;
+
+    let converted = false;
+    let segmentStart = 0;
+    const convertedSegments = segments.map((segment, index) => {
+      // Offset of the "/" that opens this segment. Mid-path wildcards were
+      // already named after it, so reuse it and leave the parameter names of
+      // the routes that used to convert untouched.
+      const slashOffset = Math.max(segmentStart - 1, 0);
+      segmentStart += segment.length + 1;
+
+      if (segment !== '*' && segment !== '(.*)' && segment !== '+') {
+        return segment;
       }
-      return convertedRoute;
-    }
+      converted = true;
 
-    if (normalizedRoute.endsWith('/*/')) {
-      const convertedRoute = route.replace('*', '{*path}');
-      // Skip printing warning for the "all" wildcard.
-      if (normalizedRoute !== '/*/') {
-        printWarning(route, convertedRoute);
+      if (index !== lastSegmentIndex) {
+        // A wildcard in the middle matches at least one segment, and each one
+        // needs a name of its own so that two of them never collide.
+        return `*path${slashOffset}`;
       }
-      return convertedRoute;
+      // A trailing "*" or "(.*)" also matches the path without it, which the
+      // optional form "{*path}" preserves. A trailing "+" does not.
+      return segment === '+' ? '*path' : '{*path}';
+    });
+
+    if (!converted) {
+      return route;
     }
 
-    if (normalizedRoute.endsWith('/+/')) {
-      const convertedRoute = route.replace('/+', '/*path');
+    const convertedRoute = convertedSegments.join('/');
+    // Skip printing warning for the "all" wildcard.
+    if (normalizedRoute !== '/*/' && normalizedRoute !== '/(.*)/') {
       printWarning(route, convertedRoute);
-      return convertedRoute;
     }
-
-    // When route includes any wildcard segments in the middle.
-    if (normalizedRoute.includes('/*/')) {
-      // Replace each "*" segment with a named parameter, using a different name
-      // for each. Match "/*" with a lookahead for the following "/" so the
-      // trailing slash is not consumed. Consuming it made two adjacent "/*/*/"
-      // segments share a slash, so only the first one got converted and the
-      // second was left as an unnamed "*" that path-to-regexp still rejects.
-      const convertedRoute = route.replaceAll(
-        /\/\*(?=\/)/g,
-        (match, offset) => `/*path${offset}`,
-      );
-      printWarning(route, convertedRoute);
-      return convertedRoute;
-    }
-
-    return route;
+    return convertedRoute;
   }
 
   static printError(route: string): void {

--- a/packages/core/test/router/legacy-route-converter.spec.ts
+++ b/packages/core/test/router/legacy-route-converter.spec.ts
@@ -1,3 +1,4 @@
+import { pathToRegexp } from 'path-to-regexp';
 import { LegacyRouteConverter } from '../../router/legacy-route-converter.js';
 
 describe('LegacyRouteConverter', () => {
@@ -83,6 +84,39 @@ describe('LegacyRouteConverter', () => {
       it('should print warning for mid-path wildcards', () => {
         LegacyRouteConverter.tryConvert('/a/*/b', { logs: true });
         expect(warnSpy).toHaveBeenCalled();
+      });
+    });
+
+    describe('routes with more than one wildcard', () => {
+      it('should convert both the mid-path and the trailing wildcard', () => {
+        expect(LegacyRouteConverter.tryConvert('/a/*/b/*')).toBe(
+          '/a/*path2/b/{*path}',
+        );
+        expect(LegacyRouteConverter.tryConvert('/a/(.*)/b/(.*)')).toBe(
+          '/a/*path2/b/{*path}',
+        );
+      });
+
+      it('should convert a mid-path (.*) segment', () => {
+        expect(LegacyRouteConverter.tryConvert('/a/(.*)/b')).toBe(
+          '/a/*path2/b',
+        );
+      });
+
+      it('should return routes that path-to-regexp accepts', () => {
+        const routes = [
+          '/a/*/b/*',
+          '/a/*/b/*/c/*',
+          '/a/(.*)/b/(.*)',
+          '/a/*/b/(.*)',
+          '/a/(.*)/b/*',
+          '/a/+/b/+',
+        ];
+
+        for (const route of routes) {
+          const convertedRoute = LegacyRouteConverter.tryConvert(route);
+          expect(() => pathToRegexp(convertedRoute)).not.toThrow();
+        }
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

`LegacyRouteConverter.tryConvert()` converts one wildcard per route. Each of the three tail branches calls `String.prototype.replace()` with a string pattern, which rewrites the **first** match in the route, and the first match is not always the wildcard the branch is looking at. A route that carries two of them comes out half converted, and `path-to-regexp` still rejects the result:

| route | converted to | `pathToRegexp()` |
| --- | --- | --- |
| `/a/*/b/*` | `/a/{*path}/b/*` | `Missing parameter name at index 14` |
| `/a/(.*)/b/(.*)` | `/a/{*path}/b/(.*)` | `Unexpected ( at index 13` |
| `/a/*/b/(.*)` | `/a/*/b/{*path}` | `Missing parameter name at index 4` |
| `/a/(.*)/b/*` | `/a/(.{*path})/b/*` | `Unexpected ( at index 3` |
| `/a/+/b/+` | `/a/*path/b/+` | `Unexpected + at index 11` |

The fourth row is the worst of them: `replace('*', ...)` finds the `*` inside `(.*)` and rewrites the group into `(.{*path})`.

A `(.*)` or a `+` segment in the middle of the path is not converted either, since only `/*/` is looked for there.

Since `ExpressAdapter.normalizePath()` and `mapToExcludeRoute()` both call `tryConvert()` and rethrow the `TypeError`, the application fails to boot with `Unsupported route path`, which is the message the converter exists to avoid.

## What is the new behavior?

`tryConvert()` walks the segments of the route and converts every legacy wildcard it finds, rather than a single occurrence. The trailing one still becomes the optional `{*path}` (or `*path` for a `+`), the ones in the middle keep getting a name of their own.

| route | converted to | `pathToRegexp()` |
| --- | --- | --- |
| `/a/*/b/*` | `/a/*path2/b/{*path}` | ok |
| `/a/(.*)/b/(.*)` | `/a/*path2/b/{*path}` | ok |
| `/a/*/b/(.*)` | `/a/*path2/b/{*path}` | ok |
| `/a/(.*)/b/*` | `/a/*path2/b/{*path}` | ok |
| `/a/+/b/+` | `/a/*path2/b/*path` | ok |
| `/a/(.*)/b` | `/a/*path2/b` | ok |

Parameter names are unchanged for the routes that already converted. Mid-path wildcards are still named after the offset of the `/` that opens the segment, so `/a/*/b` stays `/a/*path2/b` and `/a/*/*/b` stays `/a/*path2/*path4/b`.

I ran both versions over 259 routes built from combinations of `*`, `(.*)` and `+` in every position: 171 of them changed from rejected to accepted by `path-to-regexp`, none changed output while keeping the same verdict, and none regressed.

Three tests were added to `legacy-route-converter.spec.ts`. They fail on master and pass here. The 18 tests already in the file pass unchanged, as do the 225 tests under `packages/core/test/router`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

`vitest run` on this branch: 275 test files pass out of 276, 2716 tests pass. The one file that does not finish is `packages/testing/test/testing-module-builder.spec.ts`, which behaves the same way on master on this machine and passes when run on its own.
