### PR TITLE
fix(microservices): handle non-json mqtt response packets gracefully

### DIFF
--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -201,7 +201,15 @@ export class ClientMqtt extends ClientProxy<MqttEvents, MqttStatus> {
 
   public createResponseCallback(): (channel: string, buffer: Buffer) => any {
     return async (channel: string, buffer: Buffer) => {
-      const packet = JSON.parse(buffer.toString());
+      let packet: any;
+      try {
+        packet = JSON.parse(buffer.toString());
+      } catch (err) {
+        this.logger.debug(
+          'MQTT response packet is not in json format, bypassing...',
+        );
+        packet = buffer.toString();
+      }
       const { err, response, isDisposed, id } =
         await this.deserializer.deserialize(packet);
 

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -224,6 +224,27 @@ describe('ClientMqtt', () => {
         expect(callback).not.toHaveBeenCalled();
       });
     });
+    describe('message is not in json format', () => {
+      it('should not throw and pass the raw content to the deserializer', async () => {
+        callback = vi.fn();
+        const bufferMessage = Buffer.from(
+          `${responseMessage.id}|${responseMessage.response}`,
+        );
+        vi.spyOn(
+          Reflect.get(client, 'deserializer'),
+          'deserialize',
+        ).mockResolvedValue(responseMessage as any);
+        subscription = client.createResponseCallback();
+
+        client['routingMap'].set(responseMessage.id, callback);
+        await subscription('channel', bufferMessage);
+
+        expect(callback).toHaveBeenCalledWith({
+          err: undefined,
+          response: responseMessage.response,
+        });
+      });
+    });
   });
   describe('close', () => {
     let endSpy: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`ClientMqtt.createResponseCallback` parses every incoming reply with an unguarded `JSON.parse`:

```ts
return async (channel: string, buffer: Buffer) => {
  const packet = JSON.parse(buffer.toString());
```

A non-JSON payload arriving on a subscribed reply topic (a plain-text reply from a non-Nest service sharing the broker, a misconfigured publisher, a binary payload) makes the parse throw inside the async `'message'` listener. That becomes an unhandled promise rejection, which crashes the process under Node's default policy, and the pending request observable never settles.

ClientMqtt is the outlier here. Every sibling transport already guards this exact parse: `ClientRedis.createResponseCallback` wraps it in try/catch and falls back to the raw content with a debug log, and the MQTT, Redis and RMQ servers all parse incoming messages defensively.

Issue Number: N/A

## What is the new behavior?

The parse is guarded the same way `ClientRedis` does it: on failure, log at debug level and hand the raw content to the deserializer, so custom deserializers keep working with non-JSON formats and an unparseable stray message can no longer crash the client.

Added a spec mirroring the existing `createResponseCallback` cases: a non-JSON buffer must not throw and must reach the deserializer. Verification runs:

- with the fix: 36 passed (36)
- with the current master source and only the new spec added: 1 failed | 35 passed, the failing one being exactly the new case

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
