### PR TITLE
fix(fastify): append headers instead of overwriting

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -609,7 +609,17 @@ export class FastifyAdapter<
   }
 
   public appendHeader(response: any, name: string, value: string) {
-    response.header(name, value);
+    const current = response.getHeader(name);
+    if (current === undefined) {
+      return response.header(name, value);
+    }
+    // Fastify Reply.header() already concatenates set-cookie.
+    // Re-passing the accumulated list would duplicate previous cookies.
+    if (String(name).toLowerCase() === 'set-cookie') {
+      return response.header(name, value);
+    }
+    const values = Array.isArray(current) ? current : [current];
+    return response.header(name, values.concat(value));
   }
 
   public getRequestHostname(request: TRequest): string {

--- a/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
+++ b/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
@@ -85,4 +85,110 @@ describe('FastifyAdapter', () => {
       expect(result).toBe(error);
     });
   });
+
+  describe('appendHeader', () => {
+    it('should append to an existing header instead of overwriting it', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append after setHeader', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.setHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append when header names differ only by case', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'X-A', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'X-A'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append more than two values', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.appendHeader(reply, 'x-a', '3');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2', '3']);
+      await fastifyAdapter.close();
+    });
+
+    it('should still append set-cookie values', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'a=1');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'b=2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'set-cookie'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['a=1', 'b=2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should not duplicate set-cookie when appending a third value', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'a=1');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'b=2');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'c=3');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'set-cookie'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['a=1', 'b=2', 'c=3']);
+      await fastifyAdapter.close();
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`AbstractHttpAdapter.appendHeader` / `ExpressAdapter.appendHeader` append a header value (`response.append`). `FastifyAdapter.appendHeader` calls Fastify `reply.header()`, which **replaces** any existing value except for `set-cookie`.

Calling `appendHeader` twice with the same name (for example `x-a: 1` then `x-a: 2`) therefore keeps only the last value on Fastify, while Express keeps both.

This dates back to the original adapter methods in https://github.com/nestjs/nest/pull/12955.

Issue Number: N/A

## What is the new behavior?

`FastifyAdapter.appendHeader` concatenates onto the current header when one is already set, matching Express.

`set-cookie` still goes through Fastify `reply.header()` only. Fastify already concatenates that name; passing the accumulated list back into `header()` would duplicate previous cookies.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Call sites that used `appendHeader` as a second `setHeader` on Fastify would start seeing multiple values. That matches the method name and `ExpressAdapter`.

## Other information

Repro: Fastify adapter, `appendHeader(res, 'x-a', '1')` then `appendHeader(res, 'x-a', '2')`, then `getHeader(res, 'x-a')`. Before: `'2'`. After: `['1', '2']`.

Tests: `packages/platform-fastify/test/adapters/fastify-adapter.spec.ts` (append twice, `setHeader` then append, header name case, three values, `set-cookie` without duplicates).

```bash
npx vitest run packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
```
