### PR TITLE
fix(common): flatten grouped validation errors in parse array pipe

### DIFF
--- a/packages/common/pipes/parse-array.pipe.ts
+++ b/packages/common/pipes/parse-array.pipe.ts
@@ -7,7 +7,12 @@ import {
   PipeTransform,
 } from '../interfaces/features/pipe-transform.interface.js';
 import { HttpErrorByCode } from '../utils/http-error-by-code.util.js';
-import { isNil, isString, isUndefined } from '../utils/shared.utils.js';
+import {
+  isNil,
+  isObject,
+  isString,
+  isUndefined,
+} from '../utils/shared.utils.js';
 import { ValidationPipe, ValidationPipeOptions } from './validation.pipe.js';
 
 const VALIDATION_ERROR_MESSAGE = 'Validation failed (parsable array expected)';
@@ -137,6 +142,12 @@ export class ParseArrayPipe implements PipeTransform {
               if (Array.isArray(response.message)) {
                 message = response.message.map(
                   (item: string) => `[${i}] ${item}`,
+                );
+              } else if (isObject(response.message)) {
+                message = Object.entries(
+                  response.message as Record<string, string[]>,
+                ).flatMap(([path, messages]) =>
+                  messages.map(item => `[${i}] ${path}: ${item}`),
                 );
               } else {
                 message = `[${i}] ${response.message}`;

--- a/packages/common/test/pipes/parse-array.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-array.pipe.spec.ts
@@ -215,6 +215,64 @@ describe('ParseArrayPipe', () => {
           }
         });
 
+        it('should validate each item and concat grouped errors', async () => {
+          class ArrItemWithProp {
+            @IsNumber()
+            number: number;
+          }
+          const pipe = new ParseArrayPipe({
+            items: ArrItemWithProp,
+            stopAtFirstError: false,
+            errorFormat: 'grouped',
+          });
+          try {
+            await pipe.transform(
+              [
+                { number: '1' },
+                { number: 1 },
+                { number: '3' },
+              ] as ArrItemWithProp[],
+              {} as ArgumentMetadata,
+            );
+            throw null;
+          } catch (err) {
+            expect(err).toBeInstanceOf(BadRequestException);
+            expect(err.getResponse().message).toEqual([
+              '[0] number: number must be a number conforming to the specified constraints',
+              '[2] number: number must be a number conforming to the specified constraints',
+            ]);
+          }
+        });
+
+        it('should validate each nested object and concat grouped errors', async () => {
+          class RandomObject {
+            @IsString({ message: 'Title is required' })
+            title: string;
+          }
+          class ArrItemObject {
+            @Type(() => RandomObject)
+            @ValidateNested()
+            random: RandomObject;
+          }
+          const pipe = new ParseArrayPipe({
+            items: ArrItemObject,
+            stopAtFirstError: false,
+            errorFormat: 'grouped',
+          });
+          try {
+            await pipe.transform(
+              [{ random: {} }] as any[],
+              {} as ArgumentMetadata,
+            );
+            throw null;
+          } catch (err) {
+            expect(err).toBeInstanceOf(BadRequestException);
+            expect(err.getResponse().message).toEqual([
+              '[0] random.title: Title is required',
+            ]);
+          }
+        });
+
         it('should validate each nested object and concat errors', async () => {
           class RandomObject {
             @IsDefined()


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With `stopAtFirstError: false`, `ParseArrayPipe` concatenates the errors of every item into one flat list. It only handles `response.message` being an array, so with `errorFormat: 'grouped'` the message is a `Record<string, string[]>` and gets interpolated into the string as `[0] [object Object]`.

Issue Number: #17572


## What is the new behavior?

A grouped message is expanded into one entry per constraint, keeping the property path: `[0] name: name should not be empty`.

The result stays a flat `string[]` rather than a grouped record, since that branch aggregates the errors of every item into a single list and the pipe's default `exceptionFactory` would return an object body verbatim, without the `statusCode`/`error` envelope `ValidationPipe` assembles for the grouped format.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #17572
