### PR TITLE
fix(core): load deferred forward-ref providers from their host module

### DIFF
--- a/integration/scopes/e2e/durable-cross-module-forward-ref.spec.ts
+++ b/integration/scopes/e2e/durable-cross-module-forward-ref.spec.ts
@@ -1,0 +1,49 @@
+import { INestApplication } from '@nestjs/common';
+import { ContextIdFactory } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { DurableContextIdStrategy } from '../src/durable/durable-context-id.strategy.js';
+import { DurableModule } from '../src/durable/durable.module.js';
+
+describe('Durable providers in a forwardRef cycle spanning modules (issue #17562 follow-up)', () => {
+  let server: any;
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [DurableModule],
+    }).compile();
+
+    app = moduleRef.createNestApplication();
+    server = app.getHttpServer();
+    await app.init();
+
+    ContextIdFactory.apply(new DurableContextIdStrategy());
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const call = (tenantId: number) =>
+    request(server)
+      .get('/durable/cross-module-forward-ref')
+      .set({ 'x-tenant-id': String(tenantId) });
+
+  it('should construct every provider of the cycle for every tenant', async () => {
+    for (const tenantId of [43, 44]) {
+      const response = await call(tenantId);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual({
+        constructorCalled: true,
+        tenantId: String(tenantId),
+        elephant: `trumpet from ${tenantId}, lion says roar from ${tenantId}`,
+      });
+    }
+
+    // durable sub-tree caches the instances; repeat requests must keep working
+    const repeated = await call(44);
+    expect(repeated.status).toEqual(200);
+    expect(repeated.body.constructorCalled).toEqual(true);
+  });
+});

--- a/integration/scopes/src/durable/durable-cross-module.modules.ts
+++ b/integration/scopes/src/durable/durable-cross-module.modules.ts
@@ -1,0 +1,26 @@
+import { forwardRef, Module } from '@nestjs/common';
+import { DurableElephantsService } from './durable-elephants.service.js';
+import { DurableLionsService } from './durable-lions.service.js';
+import { tenantConnectionProvider } from './durable-tenant-connection.provider.js';
+import { DurableZooService } from './durable-zoo.service.js';
+
+@Module({
+  imports: [forwardRef(() => DurableLionsModule)],
+  providers: [tenantConnectionProvider, DurableElephantsService],
+  exports: [DurableElephantsService],
+})
+export class DurableElephantsModule {}
+
+@Module({
+  imports: [forwardRef(() => DurableElephantsModule)],
+  providers: [tenantConnectionProvider, DurableLionsService],
+  exports: [DurableLionsService],
+})
+export class DurableLionsModule {}
+
+@Module({
+  imports: [DurableElephantsModule],
+  providers: [tenantConnectionProvider, DurableZooService],
+  exports: [DurableZooService],
+})
+export class DurableZooModule {}

--- a/integration/scopes/src/durable/durable-elephants.service.ts
+++ b/integration/scopes/src/durable/durable-elephants.service.ts
@@ -1,0 +1,30 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { DurableLionsService } from './durable-lions.service.js';
+import {
+  TENANT_CONNECTION,
+  TenantConnection,
+} from './durable-tenant-connection.provider.js';
+
+/**
+ * One half of a forwardRef cycle that spans two modules:
+ * `DurableElephantsService` (DurableElephantsModule) <->
+ * `DurableLionsService` (DurableLionsModule).
+ *
+ * Deliberately default-scoped: the tree becomes durable transitively via
+ * TENANT_CONNECTION. Regression fixture for the deferred forwardRef load
+ * resolving the provider against the consumer's module instead of the
+ * provider's host module (follow-up to issue #17562).
+ */
+@Injectable()
+export class DurableElephantsService {
+  constructor(
+    @Inject(TENANT_CONNECTION)
+    private readonly connection: TenantConnection,
+    @Inject(forwardRef(() => DurableLionsService))
+    private readonly lionsService: DurableLionsService,
+  ) {}
+
+  trumpet() {
+    return `trumpet from ${this.connection.tenantId}, lion says ${this.lionsService.roar()}`;
+  }
+}

--- a/integration/scopes/src/durable/durable-lions.service.ts
+++ b/integration/scopes/src/durable/durable-lions.service.ts
@@ -1,0 +1,20 @@
+import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import { DurableElephantsService } from './durable-elephants.service.js';
+import {
+  TENANT_CONNECTION,
+  TenantConnection,
+} from './durable-tenant-connection.provider.js';
+
+@Injectable()
+export class DurableLionsService {
+  constructor(
+    @Inject(TENANT_CONNECTION)
+    private readonly connection: TenantConnection,
+    @Inject(forwardRef(() => DurableElephantsService))
+    private readonly elephantsService: DurableElephantsService,
+  ) {}
+
+  roar() {
+    return `roar from ${this.connection.tenantId}`;
+  }
+}

--- a/integration/scopes/src/durable/durable-tenant-connection.provider.ts
+++ b/integration/scopes/src/durable/durable-tenant-connection.provider.ts
@@ -1,0 +1,25 @@
+import { Provider, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { TenantContext } from './durable-context-id.strategy.js';
+
+export const TENANT_CONNECTION = 'TENANT_CONNECTION';
+
+export interface TenantConnection {
+  tenantId: string;
+}
+
+/**
+ * Request-scoped durable factory (a per-tenant "connection"). The services
+ * consuming it stay default-scoped and become durable only transitively —
+ * which means they DO get loaded during static bootstrap, so their static
+ * instance host carries a settled `donePromise` that durable clones inherit.
+ */
+export const tenantConnectionProvider: Provider = {
+  provide: TENANT_CONNECTION,
+  scope: Scope.REQUEST,
+  durable: true,
+  useFactory: (payload: TenantContext): TenantConnection => ({
+    tenantId: payload.tenantId,
+  }),
+  inject: [REQUEST],
+};

--- a/integration/scopes/src/durable/durable-zoo.service.ts
+++ b/integration/scopes/src/durable/durable-zoo.service.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { DurableElephantsService } from './durable-elephants.service.js';
+import {
+  TENANT_CONNECTION,
+  TenantConnection,
+} from './durable-tenant-connection.provider.js';
+
+/**
+ * Plain consumer of the cross-module cycle, hosted in a third module
+ * (DurableZooModule). The absent optional dependency keeps the ctor
+ * metadata sparse, so every request resolves through the slow path that
+ * forwards the consumer's moduleRef to `resolveComponentHost`.
+ */
+@Injectable()
+export class DurableZooService {
+  constructor(
+    @Inject(TENANT_CONNECTION)
+    private readonly connection: TenantConnection,
+    private readonly elephantsService: DurableElephantsService,
+    @Optional()
+    @Inject('ZOO_KEEPER')
+    private readonly zooKeeper?: unknown,
+  ) {}
+
+  visit() {
+    return {
+      constructorCalled: !!this.connection,
+      tenantId: this.connection?.tenantId,
+      elephant: this.elephantsService.trumpet(),
+    };
+  }
+}

--- a/integration/scopes/src/durable/durable.controller.ts
+++ b/integration/scopes/src/durable/durable.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
+import { DurableZooService } from './durable-zoo.service.js';
 import { DurableCatsService } from './durable-forward-ref.services.js';
 import { DurableService } from './durable.service.js';
 import { NonDurableService } from './non-durable.service.js';
@@ -9,11 +10,17 @@ export class DurableController {
     private readonly durableService: DurableService,
     private readonly nonDurableService: NonDurableService,
     private readonly durableCatsService: DurableCatsService,
+    private readonly durableZooService: DurableZooService,
   ) {}
 
   @Get('forward-ref')
   forwardRef() {
     return this.durableCatsService.meow();
+  }
+
+  @Get('cross-module-forward-ref')
+  crossModuleForwardRef() {
+    return this.durableZooService.visit();
   }
 
   @Get()

--- a/integration/scopes/src/durable/durable.module.ts
+++ b/integration/scopes/src/durable/durable.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
+import { DurableZooModule } from './durable-cross-module.modules.js';
 import { DurableController } from './durable.controller.js';
 import {
   DurableCatsService,
@@ -10,6 +11,7 @@ import { DurableService } from './durable.service.js';
 import { NonDurableService } from './non-durable.service.js';
 
 @Module({
+  imports: [DurableZooModule],
   controllers: [DurableController],
   providers: [
     DurableService,

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -584,7 +584,11 @@ export class Injector {
       if (instanceHost.donePromise) {
         void instanceHost.donePromise
           .then(() =>
-            this.loadProvider(instanceWrapper, moduleRef, resolutionContext),
+            this.loadProvider(
+              instanceWrapper,
+              instanceWrapper.host ?? moduleRef,
+              resolutionContext,
+            ),
           )
           .catch(err => {
             instanceWrapper.settlementSignal?.error(err);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17562 (follow-up — #17563 fixed one of the two branches)

#17563 fixed the durable forwardRef regression for instance hosts **without** an inherited `donePromise` (the `else` branch, which correctly loads from `instanceWrapper.host ?? moduleRef`). The sibling `if (instanceHost.donePromise)` branch still defers the load with the **consumer's** `moduleRef`:

```ts
void instanceHost.donePromise
  .then(() => this.loadProvider(instanceWrapper, moduleRef, resolutionContext))
```

Since `cloneStaticInstance` spreads the static host (`{...staticInstance}`), a fresh durable/request host usually **inherits the settled bootstrap `donePromise`** — so this is the branch that actually runs in real apps. When the forwardRef'd provider is hosted in a **different module** than its consumer, `loadInstance` misses the token in the wrong module's provider collection and throws a message-less `RuntimeException` **before** its `try/catch`. The deferred `.catch` swallows it, the host stays pending forever, and every consumer for that durable context receives the never-constructed `Object.create` placeholder — until the process restarts. First property access throws `Cannot read properties of undefined`.

Hit in production on 11.2.3 with a multi-tenant durable setup: a `TaskGenerationService → ResourcesService → TaskDefinitionsService → TaskGenerationService` forwardRef cycle spanning three modules; every write endpoint touching the cycle returned 500 per tenant. Instrumented trace:

```
DEFER-load SWALLOWED ERROR for TaskGenerationService
  module used: TaskDefinitionsModule   host module: TasksModule   err: RuntimeException
```

## What is the new behavior?

The deferred load resolves the provider against `instanceWrapper.host ?? moduleRef` — the same correction the other two call sites (including the one added by #17563) already use.

Regression test added: a forwardRef cycle spanning two modules, made durable **transitively** through a request-scoped durable factory provider (so the services are default-scoped and get a static-bootstrap load whose settled `donePromise` the durable clones inherit), consumed from a third module through the sparse ctor-metadata path (an absent `@Optional()` dependency keeps the metadata sparse; the dense path is unaffected since `loadCtorMetadata` already resolves via `item.host`). The test fails with 500 before the fix and passes after.

Verified: new spec red→green, `integration/scopes` suite 55/55, `packages/core` unit tests 1073/1073. The same one-line fix applies cleanly to the 11.x line (verified on the `11.2.3` branch: scopes suite 55 passing, 860 core unit tests) — a backport to an 11.2.x patch release would be much appreciated, as production apps on v11 hit this; we currently carry it as a pnpm patch.

Worth noting separately: the `collection.get(token)`/`RuntimeException` throw in `loadInstance` sits before the `try/catch`, so any error there skips `removeInstanceByContextId` and is silently swallowed by the deferred `.catch` — which is what made this failure mode invisible. Happy to harden that in a follow-up if wanted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No