### PR TITLE
fix(core): omit connection header on http2 sse responses

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -74,9 +74,11 @@ export class SseStream extends Transform {
   private _destination: WritableHeaderStream | null = null;
   private _statusCode = 200;
   private _additionalHeaders: AdditionalHeaders | undefined;
+  private readonly _isHttp2: boolean;
 
   constructor(req?: IncomingMessage) {
     super({ objectMode: true });
+    this._isHttp2 = (req?.httpVersionMajor ?? 1) > 1;
     if (req && req.socket) {
       req.socket.setKeepAlive(true);
       req.socket.setNoDelay(true);
@@ -123,7 +125,9 @@ export class SseStream extends Transform {
         ...additionalHeaders,
         // See https://github.com/dunglas/mercure/blob/main/subscribe.go#L347-L362
         'Content-Type': 'text/event-stream',
-        Connection: 'keep-alive',
+        // Hop-by-hop header, forbidden in HTTP/2
+        // https://www.rfc-editor.org/rfc/rfc9113#section-8.2.2
+        ...(!this._isHttp2 && { Connection: 'keep-alive' }),
         // Disable cache, even for old browsers and proxies
         'Cache-Control':
           'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -1,5 +1,5 @@
 import { EventSource } from 'eventsource';
-import { createServer, OutgoingHttpHeaders } from 'http';
+import { createServer, IncomingMessage, OutgoingHttpHeaders } from 'http';
 import { AddressInfo } from 'net';
 import { Writable } from 'stream';
 import { HeaderStream, SseStream } from '../../router/sse-stream.js';
@@ -238,6 +238,29 @@ data: hello
           expect(headers).toEqual({
             'Content-Type': 'text/event-stream',
             Connection: 'keep-alive',
+            'Cache-Control':
+              'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
+            Pragma: 'no-cache',
+            Expire: '0',
+            'X-Accel-Buffering': 'no',
+          });
+          callback();
+          return sink;
+        },
+      );
+      sse.pipe(sink);
+      sse.writeMessage({ data: 'trigger' }, noop);
+    }));
+
+  it('omits the Connection header when the request is served over HTTP/2', () =>
+    new Promise<void>(callback => {
+      const sse = new SseStream({
+        httpVersionMajor: 2,
+      } as unknown as IncomingMessage);
+      const sink = new Sink(
+        (status: number, headers: string | OutgoingHttpHeaders) => {
+          expect(headers).toEqual({
+            'Content-Type': 'text/event-stream',
             'Cache-Control':
               'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
             Pragma: 'no-cache',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`SseStream.commitHeaders()` writes `Connection: keep-alive` on every SSE response. `Connection` is a hop-by-hop header that carries no meaning in HTTP/2, and RFC 9113 section 8.2.2 forbids it there. When the app itself serves HTTP/2 (the Fastify adapter with `http2: true`, for instance), that header reaches `Http2ServerResponse.writeHead`, which drops it and prints `UnsupportedWarning: The provided connection header is not valid` once per process.

Issue Number: #17588


## What is the new behavior?

`SseStream` records the request's HTTP version in its constructor and sends `Connection: keep-alive` only when the request is HTTP/1.x. Responses over HTTP/1.1 keep exactly the headers they had before.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Scope, so this isn't oversold. Node strips the header before it goes on the wire, so HTTP/2 clients never saw it and nothing about the response bytes changes here. What the patch removes is a spurious Node warning and a header Nest should not be generating in the first place.

That also means I can't tie it to the `ERR_HTTP2_PROTOCOL_ERROR` reported in #17588. That setup terminates HTTP/2 at a proxy, and whether the proxy forwards HTTP/1.1 or h2c to the container, Nest is not putting `Connection` on an HTTP/2 message either way. The reported symptom looks like it has a different cause, so I'd leave the issue open rather than close it on this.
