### PR TITLE
fix(core): omit hop-by-hop Connection header for HTTP/2 SSE responses

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -74,9 +74,11 @@ export class SseStream extends Transform {
   private _destination: WritableHeaderStream | null = null;
   private _statusCode = 200;
   private _additionalHeaders: AdditionalHeaders | undefined;
+  private _request: IncomingMessage | undefined;
 
   constructor(req?: IncomingMessage) {
     super({ objectMode: true });
+    this._request = req;
     if (req && req.socket) {
       req.socket.setKeepAlive(true);
       req.socket.setNoDelay(true);
@@ -119,11 +121,18 @@ export class SseStream extends Transform {
     const statusCode = this._statusCode ?? 200;
     const additionalHeaders = this._additionalHeaders;
     if (this._destination.writeHead) {
+      // `Connection` is a hop-by-hop header defined for HTTP/1.1 connection
+      // management. It's meaningless once a connection is multiplexed over
+      // HTTP/2 and is explicitly forbidden by RFC 7540 8.1.2.2 - sending it
+      // anyway breaks SSE behind an HTTP/2-terminating proxy/edge that
+      // passes it through (net::ERR_HTTP2_PROTOCOL_ERROR in the browser).
+      // Only include it for HTTP/1.x requests.
+      const isHttp2 = this._request?.httpVersionMajor === 2;
       this._destination.writeHead(statusCode, {
         ...additionalHeaders,
         // See https://github.com/dunglas/mercure/blob/main/subscribe.go#L347-L362
         'Content-Type': 'text/event-stream',
-        Connection: 'keep-alive',
+        ...(isHttp2 ? {} : { Connection: 'keep-alive' }),
         // Disable cache, even for old browsers and proxies
         'Cache-Control':
           'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -252,6 +252,44 @@ data: hello
       sse.writeMessage({ data: 'trigger' }, noop);
     }));
 
+  it('omits the Connection header for HTTP/2 requests', () =>
+    new Promise<void>(callback => {
+      const req = { httpVersionMajor: 2 } as any;
+      const sse = new SseStream(req);
+      const sink = new Sink(
+        (status: number, headers: string | OutgoingHttpHeaders) => {
+          expect(headers).toEqual({
+            'Content-Type': 'text/event-stream',
+            'Cache-Control':
+              'private, no-cache, no-store, must-revalidate, max-age=0, no-transform',
+            Pragma: 'no-cache',
+            Expire: '0',
+            'X-Accel-Buffering': 'no',
+          });
+          expect(headers).not.toHaveProperty('Connection');
+          callback();
+          return sink;
+        },
+      );
+      sse.pipe(sink);
+      sse.writeMessage({ data: 'trigger' }, noop);
+    }));
+
+  it('keeps the Connection header for HTTP/1.x requests', () =>
+    new Promise<void>(callback => {
+      const req = { httpVersionMajor: 1 } as any;
+      const sse = new SseStream(req);
+      const sink = new Sink(
+        (status: number, headers: string | OutgoingHttpHeaders) => {
+          expect(headers).toHaveProperty('Connection', 'keep-alive');
+          callback();
+          return sink;
+        },
+      );
+      sse.pipe(sink);
+      sse.writeMessage({ data: 'trigger' }, noop);
+    }));
+
   it('sets additional headers when provided', () =>
     new Promise<void>(callback => {
       const sse = new SseStream();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`SseStream` (used by `@Sse()`) unconditionally writes a `Connection: keep-alive` header on every SSE response. `Connection` is a hop-by-hop header defined for HTTP/1.1 connection management and is explicitly forbidden on HTTP/2 by [RFC 7540 §8.1.2.2](https://httpwg.org/specs/rfc7540.html#rfc.section.8.1.2.2).

When a Nest app sits behind an edge/proxy that terminates TLS and speaks HTTP/2 to the browser (Azure Container Apps, Google Cloud Run, Vercel, Cloudflare, nginx with `http2 on`, etc.) and the header is passed through to the client, the browser tears the SSE connection down mid-stream with `net::ERR_HTTP2_PROTOCOL_ERROR` — even though the initial response already reported `200 OK`, so it presents as an intermittent failure.

Issue Number: #17588

## What is the new behavior?

`SseStream` now keeps a reference to the request it was constructed with and only includes the `Connection` header when the request is HTTP/1.x, using the standard `httpVersionMajor` property Node sets on both the classic `http` module and the `http2` compatibility API (`req.httpVersionMajor === 2`). No behavior changes for HTTP/1.1 clients.

Added two tests to `sse-stream.spec.ts` mirroring the existing header test: one asserting the `Connection` header is omitted (and every other header stays the same) when `httpVersionMajor: 2`, and one asserting it's still sent for `httpVersionMajor: 1`. Verified the new HTTP/2 test fails with the header present (temporarily reverted the fix, confirmed the assertion catches it) before restoring the fix.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

- Related prior fix in the same file/root-cause pattern: #6882 (`Transfer-Encoding: identity` breaking SSE behind Traefik).
- `npm run test` (vitest) passes for `packages/core/test/router/sse-stream.spec.ts` (18/18) and the related `router-response-controller.spec.ts` / `router-execution-context.spec.ts` (74/74).
- Full monorepo `tsc -b packages` builds clean; `oxlint` and `prettier --check` clean on the two changed files.
