### PR TITLE
fix(common): reject null file input in ParseFilePipe

### DIFF
--- a/packages/common/pipes/file/parse-file.pipe.ts
+++ b/packages/common/pipes/file/parse-file.pipe.ts
@@ -2,11 +2,7 @@ import { Injectable, Optional } from '../../decorators/core/index.js';
 import { HttpStatus } from '../../enums/index.js';
 import { PipeTransform } from '../../interfaces/features/pipe-transform.interface.js';
 import { HttpErrorByCode } from '../../utils/http-error-by-code.util.js';
-import {
-  isEmptyArray,
-  isObject,
-  isUndefined,
-} from '../../utils/shared.utils.js';
+import { isEmptyArray, isNil, isObject } from '../../utils/shared.utils.js';
 import { FileValidator } from './file-validator.interface.js';
 import { ParseFileOptions } from './parse-file-options.interface.js';
 
@@ -65,7 +61,7 @@ export class ParseFilePipe implements PipeTransform {
 
   private thereAreNoFilesIn(value: unknown): boolean {
     const isEmptyObject = isObject(value) && isEmptyArray(Object.keys(value));
-    return isUndefined(value) || isEmptyArray(value) || isEmptyObject;
+    return isNil(value) || isEmptyArray(value) || isEmptyObject;
   }
 
   protected async validate(file: unknown): Promise<any> {

--- a/packages/common/test/pipes/file/parse-file.pipe.spec.ts
+++ b/packages/common/test/pipes/file/parse-file.pipe.spec.ts
@@ -25,6 +25,18 @@ class AlwaysInvalidValidator extends FileValidator {
   }
 }
 
+// Mirrors the real behavior of built-in validators (e.g. MaxFileSizeValidator,
+// FileTypeValidator), which treat a missing file as trivially valid and skip
+// their own check rather than failing.
+class SkipsValidationWhenNoFileValidator extends FileValidator {
+  isValid(file?: unknown): boolean {
+    return !file;
+  }
+  buildErrorMessage(): string {
+    return customErrorMessage;
+  }
+}
+
 describe('ParseFilePipe', () => {
   let parseFilePipe: ParseFilePipe;
   describe('transform', () => {
@@ -152,6 +164,14 @@ describe('ParseFilePipe', () => {
         );
       });
 
+      it('should throw an error if the file is null', async () => {
+        const requestFile = null;
+
+        await expect(parseFilePipe.transform(requestFile)).rejects.toThrow(
+          BadRequestException,
+        );
+      });
+
       it('should pass validation if a file is provided', async () => {
         const requestFile = {
           path: 'some-path',
@@ -159,6 +179,22 @@ describe('ParseFilePipe', () => {
 
         await expect(parseFilePipe.transform(requestFile)).resolves.toEqual(
           requestFile,
+        );
+      });
+    });
+
+    describe('when the file is null and a validator that skips missing files is registered', () => {
+      beforeEach(() => {
+        parseFilePipe = new ParseFilePipe({
+          validators: [new SkipsValidationWhenNoFileValidator({})],
+        });
+      });
+
+      it('should throw a "File is required" error instead of letting the validator silently pass', async () => {
+        const requestFile = null;
+
+        await expect(parseFilePipe.transform(requestFile)).rejects.toThrow(
+          BadRequestException,
         );
       });
     });


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## What is the current behavior?

`ParseFilePipe.thereAreNoFilesIn()` only checks for `undefined` via `isUndefined()`. When the value is `null` instead, it's treated as if a file were present:

- The `fileIsRequired` check is skipped, even though `fileIsRequired` defaults to `true`.
- Any registered validator that already treats a falsy file as trivially valid (e.g. `MaxFileSizeValidator.isValid()` returns `true` when `!file`) also silently passes.

As a result, `new ParseFilePipe().transform(null)` resolves to `null` instead of throwing, and the failure only surfaces later as a `TypeError` when the handler dereferences the file.

## What is the new behavior?

`thereAreNoFilesIn()` now uses `isNil()` instead of `isUndefined()`, so `null` and `undefined` are handled identically — both correctly trigger the "File is required" exception (or the registered validators, if `fileIsRequired` is `false`).

Two regression tests were added:
- `null` with `fileIsRequired: true` now throws `BadRequestException`.
- `null` with a validator that mimics the built-in "skip validation when no file" behavior (like `MaxFileSizeValidator`) now still throws, instead of silently passing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

`null` was never valid/expected input for a required file parameter; this only makes the pipe reject it explicitly instead of silently letting it through.