### PR TITLE
fix(core): treat null as invalid in isCustomClass, isCustomFactory, isCustomUseExisting

### DIFF
--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -323,7 +323,7 @@ export class Module {
   }
 
   public isCustomClass(provider: any): provider is ClassProvider {
-    return !isUndefined((provider as ClassProvider).useClass);
+    return !isNil((provider as ClassProvider).useClass);
   }
 
   public isCustomValue(provider: any): provider is ValueProvider {
@@ -334,11 +334,11 @@ export class Module {
   }
 
   public isCustomFactory(provider: any): provider is FactoryProvider {
-    return !isUndefined((provider as FactoryProvider).useFactory);
+    return !isNil((provider as FactoryProvider).useFactory);
   }
 
   public isCustomUseExisting(provider: any): provider is ExistingProvider {
-    return !isUndefined((provider as ExistingProvider).useExisting);
+    return !isNil((provider as ExistingProvider).useExisting);
   }
 
   public isDynamicModule(exported: any): exported is DynamicModule {

--- a/packages/core/test/injector/module.spec.ts
+++ b/packages/core/test/injector/module.spec.ts
@@ -311,6 +311,44 @@ describe('Module', () => {
     });
   });
 
+  describe('isCustomClass', () => {
+    it('should return true when useClass is defined', () => {
+      expect(moduleRef.isCustomClass({ useClass: TestProvider })).toBe(true);
+    });
+    it('should return false when useClass is null', () => {
+      expect(moduleRef.isCustomClass({ useClass: null })).toBe(false);
+    });
+    it('should return false when useClass is undefined', () => {
+      expect(moduleRef.isCustomClass({})).toBe(false);
+    });
+  });
+
+  describe('isCustomFactory', () => {
+    it('should return true when useFactory is defined', () => {
+      expect(moduleRef.isCustomFactory({ useFactory: () => ({}) })).toBe(true);
+    });
+    it('should return false when useFactory is null', () => {
+      expect(moduleRef.isCustomFactory({ useFactory: null })).toBe(false);
+    });
+    it('should return false when useFactory is undefined', () => {
+      expect(moduleRef.isCustomFactory({})).toBe(false);
+    });
+  });
+
+  describe('isCustomUseExisting', () => {
+    it('should return true when useExisting is defined', () => {
+      expect(moduleRef.isCustomUseExisting({ useExisting: TestProvider })).toBe(
+        true,
+      );
+    });
+    it('should return false when useExisting is null', () => {
+      expect(moduleRef.isCustomUseExisting({ useExisting: null })).toBe(false);
+    });
+    it('should return false when useExisting is undefined', () => {
+      expect(moduleRef.isCustomUseExisting({})).toBe(false);
+    });
+  });
+
   describe('when get instance', () => {
     describe('when metatype does not exists in providers collection', () => {
       beforeEach(() => {


### PR DESCRIPTION
Closes #17599

`isCustomClass`, `isCustomFactory`, and `isCustomUseExisting` in
`packages/core/injector/module.ts` used `isUndefined()` to detect
missing provider values. This means `{ useClass: null }`,
`{ useFactory: null }`, and `{ useExisting: null }` are all
misclassified as valid providers, leading to confusing runtime
crashes instead of a clear rejection.

Fix: replace `isUndefined` with `isNil` at all three call sites.

Note: if this behavior turns out to be intentional for any of the
three cases, happy to revert or adjust accordingly.