### PR TITLE
fix(fastify): append headers instead of overwriting

### DIFF
--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -609,7 +609,17 @@ export class FastifyAdapter<
   }
 
   public appendHeader(response: any, name: string, value: string) {
-    response.header(name, value);
+    const current = response.getHeader(name);
+    if (current === undefined) {
+      return response.header(name, value);
+    }
+    // Fastify Reply.header() already concatenates set-cookie.
+    // Re-passing the accumulated list would duplicate previous cookies.
+    if (String(name).toLowerCase() === 'set-cookie') {
+      return response.header(name, value);
+    }
+    const values = Array.isArray(current) ? current : [current];
+    return response.header(name, values.concat(value));
   }
 
   public getRequestHostname(request: TRequest): string {

--- a/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
+++ b/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
@@ -1,3 +1,18 @@
+/**
+ * @aci-keep
+ *
+ * ROLE(TEST): 本文件是可执行规格，生产代码是其约束对象。
+ * INPUT: 被测签名、状态、依赖、副作用与已知异常。
+ * OUTPUT: 可复现且证据闭合的断言结果。
+ * MUST: L0环境可逆、L1正向、L2边界、L3负向完备（详见脚手架命令）。
+ * MUST NOT: skip/todo、空断言、恒真断言、仅验证实现细节。
+ * ERROR: 失败必须暴露契约差异；不得捕获后忽略。
+ * TEST: 每个场景独立验证输入、状态、时间或外部契约中的至少一维。
+ * SCOPE(SPEC): BDD(Vitest)行为规格；围绕可观察行为组织场景。
+ * MUST: 使用given/when/then命名并闭合前置、动作、结果。
+ * MUST NOT: 整栈启动、真实DB、curl、跨模块实现细节。
+ */
+
 import { FastifyAdapter } from '../../adapters/fastify-adapter';
 import { createError } from '@fastify/error';
 import { HttpException } from '@nestjs/common';

--- a/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
+++ b/packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
@@ -85,4 +85,110 @@ describe('FastifyAdapter', () => {
       expect(result).toBe(error);
     });
   });
+
+  describe('appendHeader', () => {
+    it('should append to an existing header instead of overwriting it', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append after setHeader', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.setHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append when header names differ only by case', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'X-A', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'X-A'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should append more than two values', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'x-a', '1');
+        fastifyAdapter.appendHeader(reply, 'x-a', '2');
+        fastifyAdapter.appendHeader(reply, 'x-a', '3');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'x-a'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['1', '2', '3']);
+      await fastifyAdapter.close();
+    });
+
+    it('should still append set-cookie values', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'a=1');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'b=2');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'set-cookie'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['a=1', 'b=2']);
+      await fastifyAdapter.close();
+    });
+
+    it('should not duplicate set-cookie when appending a third value', async () => {
+      fastifyAdapter.initHttpServer();
+      fastifyAdapter.get('/p', (_req, reply) => {
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'a=1');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'b=2');
+        fastifyAdapter.appendHeader(reply, 'set-cookie', 'c=3');
+        fastifyAdapter.reply(reply, {
+          got: fastifyAdapter.getHeader(reply, 'set-cookie'),
+        });
+      });
+
+      await fastifyAdapter.getInstance().ready();
+      const res = await fastifyAdapter.inject({ method: 'GET', url: '/p' });
+
+      expect(JSON.parse(res.body).got).toEqual(['a=1', 'b=2', 'c=3']);
+      await fastifyAdapter.close();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- make FastifyAdapter.appendHeader append existing header values
- preserve set-cookie handling without duplication
- add regression coverage for repeated, mixed-case, and set-cookie headers

## Tests
- npm test -- --run packages/platform-fastify/test/adapters/fastify-adapter.spec.ts
- npx tsc --noEmit --pretty false -p packages/platform-fastify/tsconfig.json