### PR TITLE
fix(core): do not tune the shared socket for http2 sse responses

### DIFF
--- a/packages/core/router/sse-stream.ts
+++ b/packages/core/router/sse-stream.ts
@@ -79,7 +79,11 @@ export class SseStream extends Transform {
   constructor(req?: IncomingMessage) {
     super({ objectMode: true });
     this._isHttp2 = (req?.httpVersionMajor ?? 1) > 1;
-    if (req && req.socket) {
+    // Under HTTP/2 these calls are not request-scoped: `setTimeout` is routed
+    // to the shared `Http2Session` and the rest to the shared TCP socket, so
+    // tuning one SSE request would disable the idle timeout for every stream
+    // on that connection. See https://nodejs.org/api/http2.html#requestsocket
+    if (req && req.socket && !this._isHttp2) {
       req.socket.setKeepAlive(true);
       req.socket.setNoDelay(true);
       req.socket.setTimeout(0);

--- a/packages/core/test/router/sse-stream.spec.ts
+++ b/packages/core/test/router/sse-stream.spec.ts
@@ -379,6 +379,38 @@ data: first
     expect(sink.content).toContain('id: 0\n');
   });
 
+  it('optimises the socket for streaming over HTTP/1.1', () => {
+    const calls: string[] = [];
+    const socket = {
+      setKeepAlive: () => calls.push('setKeepAlive'),
+      setNoDelay: () => calls.push('setNoDelay'),
+      setTimeout: () => calls.push('setTimeout'),
+    };
+
+    new SseStream({
+      httpVersionMajor: 1,
+      socket,
+    } as unknown as IncomingMessage);
+
+    expect(calls).toEqual(['setKeepAlive', 'setNoDelay', 'setTimeout']);
+  });
+
+  it('leaves the socket untouched when the request is served over HTTP/2', () => {
+    const calls: string[] = [];
+    const socket = {
+      setKeepAlive: () => calls.push('setKeepAlive'),
+      setNoDelay: () => calls.push('setNoDelay'),
+      setTimeout: () => calls.push('setTimeout'),
+    };
+
+    new SseStream({
+      httpVersionMajor: 2,
+      socket,
+    } as unknown as IncomingMessage);
+
+    expect(calls).toEqual([]);
+  });
+
   it('allows an eventsource to connect', () =>
     new Promise<void>(callback => {
       let sse: SseStream;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Docs are not affected. This restores request-scoped behaviour; it does not change the public API.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17605

`SseStream` tunes the request socket for streaming:

```ts
if (req && req.socket) {
  req.socket.setKeepAlive(true);
  req.socket.setNoDelay(true);
  req.socket.setTimeout(0);
}
```

Under HTTP/2 that socket is a proxy. Node routes `setTimeout` to the shared
`Http2Session`, and the other calls to the shared TCP socket
([docs](https://nodejs.org/api/http2.html#requestsocket)).

One `@Sse()` request therefore sets `session.timeout` to 0 for the whole
connection. Every other stream on that connection loses its idle timeout. This
includes requests that never used SSE. The setting is not restored when the SSE
stream closes.

Fastify arms a session timeout by default. `http2SessionTimeout` is `72000`,
and Fastify applies it to every session. This makes the bug observable.

## What is the new behavior?

The tuning is skipped when the request is HTTP/2. It reuses the `_isHttp2`
field added in #17589.

The tuning is not needed under HTTP/2. Fastify closes the session with
`session.close()`, which waits for active streams — an unmutated SSE stream
delivered all of its events across a shorter session timeout. Node also arms no
per-stream timeout, so `stream.setTimeout()` would clear a timer that does not
exist. There is nothing to preserve.

It is still needed under HTTP/1.1, where each request owns its socket. So
this is a guard, not a removal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

HTTP/1.1 behaviour is unchanged. Under HTTP/2 the connection keeps the idle
timeout its adapter configured.

## Other information

**Scope.** Only `platform-fastify` with `http2: true` (or `http2` + `https`)
reaches this path. `platform-express` has no HTTP/2 support, and Fastify over
HTTP/1.1 gives each request its own socket.

**How to verify.** The reproduction is at
[nestjs-repros/sse-http2-shared-socket](https://github.com/johnnyhuirilef/nestjs-repros/tree/main/sse-http2-shared-socket).
Both arms issue the same victim request — an ordinary `@Get()` route that never
constructs an `SseStream`.

```
npm run control   # PROTECTED: session.timeout = 800, connection reclaimed
npm run sse       # before: HARMED, session.timeout = 0, connection pinned open
                  # after:  PROTECTED, timeout fires on schedule
```

**Tests.** The HTTP/2 case fails on master and passes with this change. The
HTTP/1.1 case passes in both, so it pins the guard without over-reaching.
`225/225` router tests pass.
