### PR TITLE
fix(core): throw UndefinedDependencyException for null param in resolveSingleParam

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -496,7 +496,7 @@ export class Injector {
     resolutionContext: ResolutionContext = { contextId: STATIC_CONTEXT },
     keyOrIndex?: symbol | string | number,
   ) {
-    if (isUndefined(param)) {
+    if (isNil(param)) {
       this.logger.log(
         'Nest encountered an undefined dependency. This may be due to a circular import or a missing dependency declaration.',
       );

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -2,6 +2,7 @@ import { Optional, Scope } from '@nestjs/common';
 import { PARAMTYPES_METADATA } from '@nestjs/common/constants.js';
 import { Inject } from '../../../common/decorators/core/inject.decorator.js';
 import { Injectable } from '../../../common/decorators/core/injectable.decorator.js';
+import { UndefinedDependencyException } from '../../errors/exceptions/undefined-dependency.exception.js';
 import { STATIC_CONTEXT } from '../../injector/constants.js';
 import { NestContainer } from '../../injector/container.js';
 import { Injector, PropertyDependency } from '../../injector/injector.js';
@@ -202,6 +203,28 @@ describe('Injector', () => {
           null!,
         ),
       ).rejects.toBeDefined();
+    });
+
+    it('should throw "UndefinedDependencyException" when param is undefined', async () => {
+      await expect(
+        injector.resolveSingleParam(
+          new InstanceWrapper({ name: 'Test' }),
+          undefined!,
+          { index: 0, dependencies: [] },
+          null!,
+        ),
+      ).rejects.toBeInstanceOf(UndefinedDependencyException);
+    });
+
+    it('should throw "UndefinedDependencyException" when param is null', async () => {
+      await expect(
+        injector.resolveSingleParam(
+          new InstanceWrapper({ name: 'Test' }),
+          null!,
+          { index: 0, dependencies: [] },
+          null!,
+        ),
+      ).rejects.toBeInstanceOf(UndefinedDependencyException);
     });
   });
 


### PR DESCRIPTION
Closes #17607

`resolveSingleParam()` in `packages/core/injector/injector.ts` 
used `isUndefined()` to detect missing dependencies. When `param` 
is `null` (e.g. from `@Inject(null)` misuse or metadata edge cases), 
this check is skipped — the helpful `UndefinedDependencyException` 
diagnostic is never thrown, and a much more opaque error surfaces 
later in resolution logic.

Fix: replace `isUndefined` with `isNil` at this call site.