### PR TITLE
fix(core): throw UndefinedDependencyException for null/undefined in factory provider inject array

### DIFF
--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -465,7 +465,8 @@ export class Injector {
       if (isNil(token)) {
         throw new UndefinedDependencyException(wrapper.name, {
           index,
-          dependencies: wrapper.inject,
+          dependencies: (wrapper.inject ?? undefined) as
+            InjectorDependency[] | undefined,
         });
       }
       if (typeof item !== 'object') {

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -442,8 +442,11 @@ export class Injector {
     function isOptionalFactoryDependency(
       value: InjectionToken | OptionalFactoryDependency,
     ): value is OptionalFactoryDependency {
+      const token = (value as OptionalFactoryDependency)?.token;
+      if (isNil(token)) {
+        return false;
+      }
       return (
-        !isUndefined((value as OptionalFactoryDependency).token) &&
         !isUndefined((value as OptionalFactoryDependency).optional) &&
         !(value as any).prototype
       );
@@ -453,6 +456,18 @@ export class Injector {
       item: InjectionToken | OptionalFactoryDependency,
       index: number,
     ): InjectionToken => {
+      const isWrappedDependency =
+        !isNil(item) && typeof item === 'object' && 'token' in item;
+      const token = isWrappedDependency
+        ? (item as OptionalFactoryDependency).token
+        : item;
+
+      if (isNil(token)) {
+        throw new UndefinedDependencyException(wrapper.name, {
+          index,
+          dependencies: wrapper.inject,
+        });
+      }
       if (typeof item !== 'object') {
         return item;
       }

--- a/packages/core/test/injector/injector.spec.ts
+++ b/packages/core/test/injector/injector.spec.ts
@@ -2,6 +2,7 @@ import { Optional, Scope } from '@nestjs/common';
 import { PARAMTYPES_METADATA } from '@nestjs/common/constants.js';
 import { Inject } from '../../../common/decorators/core/inject.decorator.js';
 import { Injectable } from '../../../common/decorators/core/injectable.decorator.js';
+import { UndefinedDependencyException } from '../../errors/exceptions/undefined-dependency.exception.js';
 import { STATIC_CONTEXT } from '../../injector/constants.js';
 import { NestContainer } from '../../injector/container.js';
 import { Injector, PropertyDependency } from '../../injector/injector.js';
@@ -992,6 +993,39 @@ describe('Injector', () => {
 
       expect(dependencies).toEqual([FixtureDep1, FixtureDep2, FixtureDep2, {}]);
       expect(optionalDependenciesIds).toEqual([1]);
+    });
+
+    it('should throw "UndefinedDependencyException" instead of a raw TypeError when an inject entry is null', () => {
+      const wrapper = new InstanceWrapper({
+        name: 'TOKEN',
+        inject: [null as any],
+      });
+
+      expect(() => injector.getFactoryProviderDependencies(wrapper)).toThrow(
+        UndefinedDependencyException,
+      );
+    });
+
+    it('should throw "UndefinedDependencyException" instead of a raw TypeError when an inject entry is undefined', () => {
+      const wrapper = new InstanceWrapper({
+        name: 'TOKEN',
+        inject: [undefined as any],
+      });
+
+      expect(() => injector.getFactoryProviderDependencies(wrapper)).toThrow(
+        UndefinedDependencyException,
+      );
+    });
+
+    it('should throw "UndefinedDependencyException" when an inject entry is an object with a null token', () => {
+      const wrapper = new InstanceWrapper({
+        name: 'TOKEN',
+        inject: [{ token: null } as any],
+      });
+
+      expect(() => injector.getFactoryProviderDependencies(wrapper)).toThrow(
+        UndefinedDependencyException,
+      );
     });
   });
 


### PR DESCRIPTION
Related to #17607 (identified by @micalevisk)

Factory providers with `inject: [null]` or `inject: [undefined]` 
currently throw a raw `TypeError` deep in 
`isOptionalFactoryDependency()` / `mapFactoryProviderInjectArray()` 
because neither function guards against null/undefined before 
dereferencing `.token` or using the `in` operator.

Fix: add `isNil()` guards at both call sites so null/undefined 
entries in the inject array produce a proper 
`UndefinedDependencyException` with a clear message instead of 
a raw TypeError.