### PR TITLE
fix(common): serialize errorCode in built-in exception responses

### DIFF
--- a/packages/common/exceptions/bad-gateway.exception.ts
+++ b/packages/common/exceptions/bad-gateway.exception.ts
@@ -45,6 +45,7 @@ export class BadGatewayException extends HttpException {
         objectOrError,
         description,
         HttpStatus.BAD_GATEWAY,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.BAD_GATEWAY,
       httpExceptionOptions,

--- a/packages/common/exceptions/bad-request.exception.ts
+++ b/packages/common/exceptions/bad-request.exception.ts
@@ -45,6 +45,7 @@ export class BadRequestException extends HttpException {
         objectOrError,
         description,
         HttpStatus.BAD_REQUEST,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.BAD_REQUEST,
       httpExceptionOptions,

--- a/packages/common/exceptions/conflict.exception.ts
+++ b/packages/common/exceptions/conflict.exception.ts
@@ -41,7 +41,12 @@ export class ConflictException extends HttpException {
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
-      HttpException.createBody(objectOrError, description, HttpStatus.CONFLICT),
+      HttpException.createBody(
+        objectOrError,
+        description,
+        HttpStatus.CONFLICT,
+        httpExceptionOptions?.errorCode,
+      ),
       HttpStatus.CONFLICT,
       httpExceptionOptions,
     );

--- a/packages/common/exceptions/forbidden.exception.ts
+++ b/packages/common/exceptions/forbidden.exception.ts
@@ -45,6 +45,7 @@ export class ForbiddenException extends HttpException {
         objectOrError,
         description,
         HttpStatus.FORBIDDEN,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.FORBIDDEN,
       httpExceptionOptions,

--- a/packages/common/exceptions/gateway-timeout.exception.ts
+++ b/packages/common/exceptions/gateway-timeout.exception.ts
@@ -45,6 +45,7 @@ export class GatewayTimeoutException extends HttpException {
         objectOrError,
         description,
         HttpStatus.GATEWAY_TIMEOUT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.GATEWAY_TIMEOUT,
       httpExceptionOptions,

--- a/packages/common/exceptions/gone.exception.ts
+++ b/packages/common/exceptions/gone.exception.ts
@@ -41,7 +41,12 @@ export class GoneException extends HttpException {
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
-      HttpException.createBody(objectOrError, description, HttpStatus.GONE),
+      HttpException.createBody(
+        objectOrError,
+        description,
+        HttpStatus.GONE,
+        httpExceptionOptions?.errorCode,
+      ),
       HttpStatus.GONE,
       httpExceptionOptions,
     );

--- a/packages/common/exceptions/http-version-not-supported.exception.ts
+++ b/packages/common/exceptions/http-version-not-supported.exception.ts
@@ -47,6 +47,7 @@ export class HttpVersionNotSupportedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -48,6 +48,7 @@ export class ImATeapotException extends HttpException {
         objectOrError,
         description,
         HttpStatus.I_AM_A_TEAPOT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.I_AM_A_TEAPOT,
       httpExceptionOptions,

--- a/packages/common/exceptions/internal-server-error.exception.ts
+++ b/packages/common/exceptions/internal-server-error.exception.ts
@@ -47,6 +47,7 @@ export class InternalServerErrorException extends HttpException {
         objectOrError,
         description,
         HttpStatus.INTERNAL_SERVER_ERROR,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.INTERNAL_SERVER_ERROR,
       httpExceptionOptions,

--- a/packages/common/exceptions/method-not-allowed.exception.ts
+++ b/packages/common/exceptions/method-not-allowed.exception.ts
@@ -45,6 +45,7 @@ export class MethodNotAllowedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.METHOD_NOT_ALLOWED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.METHOD_NOT_ALLOWED,
       httpExceptionOptions,

--- a/packages/common/exceptions/misdirected.exception.ts
+++ b/packages/common/exceptions/misdirected.exception.ts
@@ -45,6 +45,7 @@ export class MisdirectedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.MISDIRECTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.MISDIRECTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-acceptable.exception.ts
+++ b/packages/common/exceptions/not-acceptable.exception.ts
@@ -45,6 +45,7 @@ export class NotAcceptableException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_ACCEPTABLE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_ACCEPTABLE,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-found.exception.ts
+++ b/packages/common/exceptions/not-found.exception.ts
@@ -45,6 +45,7 @@ export class NotFoundException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_FOUND,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_FOUND,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-implemented.exception.ts
+++ b/packages/common/exceptions/not-implemented.exception.ts
@@ -45,6 +45,7 @@ export class NotImplementedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_IMPLEMENTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_IMPLEMENTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/payload-too-large.exception.ts
+++ b/packages/common/exceptions/payload-too-large.exception.ts
@@ -45,6 +45,7 @@ export class PayloadTooLargeException extends HttpException {
         objectOrError,
         description,
         HttpStatus.PAYLOAD_TOO_LARGE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.PAYLOAD_TOO_LARGE,
       httpExceptionOptions,

--- a/packages/common/exceptions/precondition-failed.exception.ts
+++ b/packages/common/exceptions/precondition-failed.exception.ts
@@ -45,6 +45,7 @@ export class PreconditionFailedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.PRECONDITION_FAILED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.PRECONDITION_FAILED,
       httpExceptionOptions,

--- a/packages/common/exceptions/request-timeout.exception.ts
+++ b/packages/common/exceptions/request-timeout.exception.ts
@@ -45,6 +45,7 @@ export class RequestTimeoutException extends HttpException {
         objectOrError,
         description,
         HttpStatus.REQUEST_TIMEOUT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.REQUEST_TIMEOUT,
       httpExceptionOptions,

--- a/packages/common/exceptions/service-unavailable.exception.ts
+++ b/packages/common/exceptions/service-unavailable.exception.ts
@@ -45,6 +45,7 @@ export class ServiceUnavailableException extends HttpException {
         objectOrError,
         description,
         HttpStatus.SERVICE_UNAVAILABLE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.SERVICE_UNAVAILABLE,
       httpExceptionOptions,

--- a/packages/common/exceptions/unauthorized.exception.ts
+++ b/packages/common/exceptions/unauthorized.exception.ts
@@ -45,6 +45,7 @@ export class UnauthorizedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNAUTHORIZED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNAUTHORIZED,
       httpExceptionOptions,

--- a/packages/common/exceptions/unprocessable-entity.exception.ts
+++ b/packages/common/exceptions/unprocessable-entity.exception.ts
@@ -47,6 +47,7 @@ export class UnprocessableEntityException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNPROCESSABLE_ENTITY,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNPROCESSABLE_ENTITY,
       httpExceptionOptions,

--- a/packages/common/exceptions/unsupported-media-type.exception.ts
+++ b/packages/common/exceptions/unsupported-media-type.exception.ts
@@ -47,6 +47,7 @@ export class UnsupportedMediaTypeException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNSUPPORTED_MEDIA_TYPE,
       httpExceptionOptions,

--- a/packages/common/test/exceptions/http.exception.spec.ts
+++ b/packages/common/test/exceptions/http.exception.spec.ts
@@ -456,6 +456,66 @@ describe('HttpException', () => {
       );
       expect(body.errorCode).toBe('BAD_REQUEST_CODE');
     });
+
+    it('should be included in the response body of a built-in exception', () => {
+      const builtInErrorClasses = [
+        BadGatewayException,
+        BadRequestException,
+        ConflictException,
+        ForbiddenException,
+        GatewayTimeoutException,
+        GoneException,
+        HttpVersionNotSupportedException,
+        ImATeapotException,
+        InternalServerErrorException,
+        MethodNotAllowedException,
+        MisdirectedException,
+        NotAcceptableException,
+        NotFoundException,
+        NotImplementedException,
+        PayloadTooLargeException,
+        PreconditionFailedException,
+        RequestTimeoutException,
+        ServiceUnavailableException,
+        UnauthorizedException,
+        UnprocessableEntityException,
+        UnsupportedMediaTypeException,
+      ];
+
+      builtInErrorClasses.forEach(ExceptionClass => {
+        const error = new ExceptionClass('Custom message', {
+          errorCode: 'CUSTOM_ERROR_CODE',
+        });
+
+        const response = error.getResponse() as { errorCode: string };
+
+        expect(response.errorCode).toBe('CUSTOM_ERROR_CODE');
+      });
+    });
+
+    it('should be included in the response body when no message is given', () => {
+      const error = new BadRequestException(undefined, {
+        errorCode: 'WEAK_PASSWORD',
+      });
+
+      expect(error.getResponse()).toEqual({
+        message: 'Bad Request',
+        errorCode: 'WEAK_PASSWORD',
+        statusCode: 400,
+      });
+    });
+
+    it('should not add an errorCode when the options object has none', () => {
+      const error = new BadRequestException('Custom message', {
+        description: 'Some error description',
+      });
+
+      expect(error.getResponse()).toEqual({
+        message: 'Custom message',
+        error: 'Some error description',
+        statusCode: 400,
+      });
+    });
   });
 
   describe('when exception is thrown', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
#15525 added `errorCode` to `HttpExceptionOptions` and a fourth `createBody` parameter that merges it into the response body, but none of the built-in exceptions were updated to pass it. So `throw new BadRequestException('Password is too weak', { errorCode: 'WEAK_PASSWORD' })` sets `exception.errorCode` yet the serialized body still comes back as `{ message, error, statusCode }`, which is not what the docs describe.

Issue Number: #17614


## What is the new behavior?
Every built-in exception now forwards `httpExceptionOptions?.errorCode` to `HttpException.createBody`, so the code ends up in the response body:

```json
{
  "message": "Password is too weak",
  "error": "Bad Request",
  "errorCode": "WEAK_PASSWORD",
  "statusCode": 400
}
```

Nothing changes when no `errorCode` is given, and a custom object passed as `objectOrError` is still returned verbatim.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
A plain `new HttpException('Forbidden', 403, { errorCode })` is unchanged, since its response is a bare string and `BaseExceptionFilter` rebuilds the body itself. Covering that means touching `@nestjs/core`, so I left it out of a `common`-only fix, but I can add it here if you want it.

The docs example also omits the `error` field that the built-in exceptions always set, so it needs a small follow-up in nestjs/docs.nestjs.com.
