### PR TITLE
fix(common): serialize error code into built-in exception bodies

### DIFF
--- a/packages/common/exceptions/bad-gateway.exception.ts
+++ b/packages/common/exceptions/bad-gateway.exception.ts
@@ -45,6 +45,7 @@ export class BadGatewayException extends HttpException {
         objectOrError,
         description,
         HttpStatus.BAD_GATEWAY,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.BAD_GATEWAY,
       httpExceptionOptions,

--- a/packages/common/exceptions/bad-request.exception.ts
+++ b/packages/common/exceptions/bad-request.exception.ts
@@ -45,6 +45,7 @@ export class BadRequestException extends HttpException {
         objectOrError,
         description,
         HttpStatus.BAD_REQUEST,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.BAD_REQUEST,
       httpExceptionOptions,

--- a/packages/common/exceptions/conflict.exception.ts
+++ b/packages/common/exceptions/conflict.exception.ts
@@ -41,7 +41,12 @@ export class ConflictException extends HttpException {
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
-      HttpException.createBody(objectOrError, description, HttpStatus.CONFLICT),
+      HttpException.createBody(
+        objectOrError,
+        description,
+        HttpStatus.CONFLICT,
+        httpExceptionOptions?.errorCode,
+      ),
       HttpStatus.CONFLICT,
       httpExceptionOptions,
     );

--- a/packages/common/exceptions/forbidden.exception.ts
+++ b/packages/common/exceptions/forbidden.exception.ts
@@ -45,6 +45,7 @@ export class ForbiddenException extends HttpException {
         objectOrError,
         description,
         HttpStatus.FORBIDDEN,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.FORBIDDEN,
       httpExceptionOptions,

--- a/packages/common/exceptions/gateway-timeout.exception.ts
+++ b/packages/common/exceptions/gateway-timeout.exception.ts
@@ -45,6 +45,7 @@ export class GatewayTimeoutException extends HttpException {
         objectOrError,
         description,
         HttpStatus.GATEWAY_TIMEOUT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.GATEWAY_TIMEOUT,
       httpExceptionOptions,

--- a/packages/common/exceptions/gone.exception.ts
+++ b/packages/common/exceptions/gone.exception.ts
@@ -41,7 +41,12 @@ export class GoneException extends HttpException {
       HttpException.extractDescriptionAndOptionsFrom(descriptionOrOptions);
 
     super(
-      HttpException.createBody(objectOrError, description, HttpStatus.GONE),
+      HttpException.createBody(
+        objectOrError,
+        description,
+        HttpStatus.GONE,
+        httpExceptionOptions?.errorCode,
+      ),
       HttpStatus.GONE,
       httpExceptionOptions,
     );

--- a/packages/common/exceptions/http-version-not-supported.exception.ts
+++ b/packages/common/exceptions/http-version-not-supported.exception.ts
@@ -47,6 +47,7 @@ export class HttpVersionNotSupportedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.HTTP_VERSION_NOT_SUPPORTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/im-a-teapot.exception.ts
+++ b/packages/common/exceptions/im-a-teapot.exception.ts
@@ -48,6 +48,7 @@ export class ImATeapotException extends HttpException {
         objectOrError,
         description,
         HttpStatus.I_AM_A_TEAPOT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.I_AM_A_TEAPOT,
       httpExceptionOptions,

--- a/packages/common/exceptions/internal-server-error.exception.ts
+++ b/packages/common/exceptions/internal-server-error.exception.ts
@@ -47,6 +47,7 @@ export class InternalServerErrorException extends HttpException {
         objectOrError,
         description,
         HttpStatus.INTERNAL_SERVER_ERROR,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.INTERNAL_SERVER_ERROR,
       httpExceptionOptions,

--- a/packages/common/exceptions/method-not-allowed.exception.ts
+++ b/packages/common/exceptions/method-not-allowed.exception.ts
@@ -45,6 +45,7 @@ export class MethodNotAllowedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.METHOD_NOT_ALLOWED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.METHOD_NOT_ALLOWED,
       httpExceptionOptions,

--- a/packages/common/exceptions/misdirected.exception.ts
+++ b/packages/common/exceptions/misdirected.exception.ts
@@ -45,6 +45,7 @@ export class MisdirectedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.MISDIRECTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.MISDIRECTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-acceptable.exception.ts
+++ b/packages/common/exceptions/not-acceptable.exception.ts
@@ -45,6 +45,7 @@ export class NotAcceptableException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_ACCEPTABLE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_ACCEPTABLE,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-found.exception.ts
+++ b/packages/common/exceptions/not-found.exception.ts
@@ -45,6 +45,7 @@ export class NotFoundException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_FOUND,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_FOUND,
       httpExceptionOptions,

--- a/packages/common/exceptions/not-implemented.exception.ts
+++ b/packages/common/exceptions/not-implemented.exception.ts
@@ -45,6 +45,7 @@ export class NotImplementedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.NOT_IMPLEMENTED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.NOT_IMPLEMENTED,
       httpExceptionOptions,

--- a/packages/common/exceptions/payload-too-large.exception.ts
+++ b/packages/common/exceptions/payload-too-large.exception.ts
@@ -45,6 +45,7 @@ export class PayloadTooLargeException extends HttpException {
         objectOrError,
         description,
         HttpStatus.PAYLOAD_TOO_LARGE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.PAYLOAD_TOO_LARGE,
       httpExceptionOptions,

--- a/packages/common/exceptions/precondition-failed.exception.ts
+++ b/packages/common/exceptions/precondition-failed.exception.ts
@@ -45,6 +45,7 @@ export class PreconditionFailedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.PRECONDITION_FAILED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.PRECONDITION_FAILED,
       httpExceptionOptions,

--- a/packages/common/exceptions/request-timeout.exception.ts
+++ b/packages/common/exceptions/request-timeout.exception.ts
@@ -45,6 +45,7 @@ export class RequestTimeoutException extends HttpException {
         objectOrError,
         description,
         HttpStatus.REQUEST_TIMEOUT,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.REQUEST_TIMEOUT,
       httpExceptionOptions,

--- a/packages/common/exceptions/service-unavailable.exception.ts
+++ b/packages/common/exceptions/service-unavailable.exception.ts
@@ -45,6 +45,7 @@ export class ServiceUnavailableException extends HttpException {
         objectOrError,
         description,
         HttpStatus.SERVICE_UNAVAILABLE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.SERVICE_UNAVAILABLE,
       httpExceptionOptions,

--- a/packages/common/exceptions/unauthorized.exception.ts
+++ b/packages/common/exceptions/unauthorized.exception.ts
@@ -45,6 +45,7 @@ export class UnauthorizedException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNAUTHORIZED,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNAUTHORIZED,
       httpExceptionOptions,

--- a/packages/common/exceptions/unprocessable-entity.exception.ts
+++ b/packages/common/exceptions/unprocessable-entity.exception.ts
@@ -47,6 +47,7 @@ export class UnprocessableEntityException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNPROCESSABLE_ENTITY,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNPROCESSABLE_ENTITY,
       httpExceptionOptions,

--- a/packages/common/exceptions/unsupported-media-type.exception.ts
+++ b/packages/common/exceptions/unsupported-media-type.exception.ts
@@ -47,6 +47,7 @@ export class UnsupportedMediaTypeException extends HttpException {
         objectOrError,
         description,
         HttpStatus.UNSUPPORTED_MEDIA_TYPE,
+        httpExceptionOptions?.errorCode,
       ),
       HttpStatus.UNSUPPORTED_MEDIA_TYPE,
       httpExceptionOptions,

--- a/packages/common/test/exceptions/error-code.exception.spec.ts
+++ b/packages/common/test/exceptions/error-code.exception.spec.ts
@@ -1,0 +1,135 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  GoneException,
+  HttpException,
+  InternalServerErrorException,
+  NotFoundException,
+  UnauthorizedException,
+  UnprocessableEntityException,
+} from '../../exceptions/index.js';
+
+describe('errorCode in built-in exception response bodies', () => {
+  it('should include errorCode in the body of the documented example', () => {
+    // https://docs.nestjs.com/exception-filters#machine-readable-error-codes
+    const exception = new BadRequestException('Password is too weak', {
+      errorCode: 'WEAK_PASSWORD',
+    });
+
+    expect(exception.getResponse()).toEqual({
+      statusCode: 400,
+      message: 'Password is too weak',
+      error: 'Bad Request',
+      errorCode: 'WEAK_PASSWORD',
+    });
+  });
+
+  it.each([
+    [BadRequestException, 400, 'Bad Request'],
+    [UnauthorizedException, 401, 'Unauthorized'],
+    [ForbiddenException, 403, 'Forbidden'],
+    [NotFoundException, 404, 'Not Found'],
+    [ConflictException, 409, 'Conflict'],
+    [GoneException, 410, 'Gone'],
+    [UnprocessableEntityException, 422, 'Unprocessable Entity'],
+    [InternalServerErrorException, 500, 'Internal Server Error'],
+  ] as const)(
+    '$1 should expose errorCode alongside a string message',
+    (ExceptionClass, statusCode, error) => {
+      const exception = new ExceptionClass('a message', {
+        errorCode: 'SOME_CODE',
+      });
+
+      expect(exception.getResponse()).toEqual({
+        statusCode,
+        message: 'a message',
+        error,
+        errorCode: 'SOME_CODE',
+      });
+      expect(exception.errorCode).toBe('SOME_CODE');
+    },
+  );
+
+  it('should expose errorCode when no message is supplied', () => {
+    const exception = new NotFoundException(undefined, {
+      errorCode: 'MISSING',
+    });
+
+    expect(exception.getResponse()).toEqual({
+      statusCode: 404,
+      message: 'Not Found',
+      errorCode: 'MISSING',
+    });
+  });
+
+  it('should expose errorCode alongside an array message', () => {
+    const exception = new BadRequestException(['first', 'second'], {
+      errorCode: 'VALIDATION_FAILED',
+    });
+
+    expect(exception.getResponse()).toEqual({
+      statusCode: 400,
+      message: ['first', 'second'],
+      error: 'Bad Request',
+      errorCode: 'VALIDATION_FAILED',
+    });
+  });
+
+  it('should keep both the cause and the errorCode', () => {
+    const cause = new Error('root cause');
+    const exception = new BadRequestException('a message', {
+      cause,
+      errorCode: 'WITH_CAUSE',
+    });
+
+    expect(exception.cause).toBe(cause);
+    expect(exception.errorCode).toBe('WITH_CAUSE');
+    expect(exception.getResponse()).toHaveProperty('errorCode', 'WITH_CAUSE');
+  });
+
+  it('should omit errorCode when none is provided', () => {
+    const exception = new BadRequestException('a message');
+
+    expect(exception.getResponse()).not.toHaveProperty('errorCode');
+    expect(exception.errorCode).toBeUndefined();
+  });
+
+  it('should omit errorCode when a plain description string is used', () => {
+    const exception = new BadRequestException('a message', 'A description');
+
+    expect(exception.getResponse()).toEqual({
+      statusCode: 400,
+      message: 'a message',
+      error: 'A description',
+    });
+  });
+
+  it('should leave a caller-supplied response object untouched', () => {
+    const customBody = { foo: 'bar' };
+    const exception = new BadRequestException(customBody, {
+      errorCode: 'IGNORED_IN_BODY',
+    });
+
+    // A custom object fully overrides the response body, so errorCode is not
+    // injected into it; it remains reachable via the `errorCode` property.
+    expect(exception.getResponse()).toEqual({ foo: 'bar' });
+    expect(customBody).toEqual({ foo: 'bar' });
+    expect(exception.errorCode).toBe('IGNORED_IN_BODY');
+  });
+
+  it('should not mutate the caller-supplied options object', () => {
+    const options = { errorCode: 'FROZEN' };
+    Object.freeze(options);
+
+    expect(() => new BadRequestException('a message', options)).not.toThrow();
+  });
+
+  it('should still expose errorCode on a direct HttpException', () => {
+    const exception = new HttpException('a message', 418, {
+      errorCode: 'DIRECT',
+    });
+
+    expect(exception.errorCode).toBe('DIRECT');
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

The docs already describe this behaviour; this makes the code match them.

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17614

The [docs](https://docs.nestjs.com/exception-filters#machine-readable-error-codes) describe passing an `errorCode` so it is serialized into the response body:

```ts
throw new BadRequestException('Password is too weak', { errorCode: 'WEAK_PASSWORD' });
```

The body comes back without it:

```json
{ "message": "Password is too weak", "error": "Bad Request", "statusCode": 400 }
```

`HttpException.createBody` already takes `errorCode` as a fourth argument and merges it into the body, and the constructor already assigns `this.errorCode`. But every built-in subclass calls `createBody` with three arguments:

```ts
super(
  HttpException.createBody(objectOrError, description, HttpStatus.BAD_REQUEST),
  HttpStatus.BAD_REQUEST,
  httpExceptionOptions,
);
```

So the option reaches `exception.errorCode` but never the serialized body, which is what `BaseExceptionFilter` sends.

## What is the new behavior?

Each subclass forwards `httpExceptionOptions?.errorCode` to `createBody`, activating the overload that exists for it:

```json
{ "message": "Password is too weak", "error": "Bad Request", "statusCode": 400, "errorCode": "WEAK_PASSWORD" }
```

A custom object response is unchanged. `createBody` returns such an object verbatim, and the JSDoc describes it as overriding "the entire JSON response body", so `errorCode` is not injected into it — it stays reachable on `exception.errorCode`. There is a test covering that.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Nothing changes for exceptions created without `errorCode`: the option is `undefined`, and `createBody` already guards on it.

## Other information

**Scope.** 21 built-in subclasses, one added argument each. `errorCode` was introduced in #15525, which added the option, the instance property and the `createBody` overload, but no call site.

**Tests.** `packages/common/test/exceptions/error-code.exception.spec.ts` covers the documented example, eight subclasses across the status range, the no-message and array-message shapes, `cause` alongside `errorCode`, and the cases that should stay unchanged (no `errorCode`, plain description string, custom object body). 12 of them fail on master.

**Two cases this does not cover**, if they'd be worth a follow-up:

- `new HttpException('msg', 400, { errorCode })` used directly, rather than through a subclass.
- Subclasses defined outside this repo, which would need to pass the argument themselves.

Both would need the body to be composed in the `HttpException` constructor instead. That is not a drop-in change: once inside the constructor, a body built by `createBody` and a custom object a caller passed are indistinguishable — a caller can pass exactly `{ message, error, statusCode }` themselves — so the constructor cannot tell which one it may enrich without marking the body somehow. Happy to look at that separately if you think it is worth doing.
