### PR TITLE
refactor(websockets): drop the redundant pattern append in the ws context creator

### DIFF
--- a/packages/websockets/context/ws-context-creator.ts
+++ b/packages/websockets/context/ws-context-creator.ts
@@ -121,8 +121,8 @@ export class WsContextCreator {
     const targetPattern = this.reflectCallbackPattern(callback);
     return this.wsProxy.create(
       async (...args: unknown[]) => {
-        args.push(targetPattern);
-
+        // The pattern is already appended by `WsProxy` before this callback runs,
+        // so it is the last element of `args` at this point.
         const initialArgs = this.contextUtils.createNullArray(argsLength);
         fnCanActivate && (await fnCanActivate(args));
 

--- a/packages/websockets/test/context/ws-context-creator.spec.ts
+++ b/packages/websockets/test/context/ws-context-creator.spec.ts
@@ -10,6 +10,7 @@ import { InterceptorsConsumer } from '../../../core/interceptors/interceptors-co
 import { InterceptorsContextCreator } from '../../../core/interceptors/interceptors-context-creator.js';
 import { PipesConsumer } from '../../../core/pipes/pipes-consumer.js';
 import { PipesContextCreator } from '../../../core/pipes/pipes-context-creator.js';
+import { MESSAGE_METADATA } from '../../constants.js';
 import { ExceptionFiltersContext } from '../../context/exception-filters-context.js';
 import { WsContextCreator } from '../../context/ws-context-creator.js';
 import { WsProxy } from '../../context/ws-proxy.js';
@@ -236,5 +237,68 @@ describe('WsContextCreator', () => {
         expect(pipesFn).toBeTypeOf('function');
       });
     });
+  });
+});
+
+describe('WsContextCreator (pattern forwarding)', () => {
+  @Injectable()
+  class PatternTest {
+    handle(client: unknown, data: unknown) {
+      return of(true);
+    }
+  }
+
+  let creator: WsContextCreator;
+  let recordedArgs: unknown[];
+
+  beforeEach(() => {
+    recordedArgs = [];
+
+    const guardsConsumer = new GuardsConsumer();
+    vi.spyOn(guardsConsumer, 'tryActivate').mockImplementation(
+      async (_guards, args: any[]) => {
+        recordedArgs = [...args];
+        return true;
+      },
+    );
+
+    const guardsContextCreator = new GuardsContextCreator(new NestContainer());
+    vi.spyOn(guardsContextCreator, 'create').mockImplementation(
+      () => [{ canActivate: () => true }] as any,
+    );
+
+    creator = new WsContextCreator(
+      // the real proxy, so the pattern it appends is part of the result
+      new WsProxy(),
+      new ExceptionFiltersContext(new NestContainer() as any),
+      new PipesContextCreator(new NestContainer() as any) as any,
+      new PipesConsumer() as any,
+      guardsContextCreator as any,
+      guardsConsumer as any,
+      new InterceptorsContextCreator(new NestContainer()) as any,
+      new InterceptorsConsumer() as any,
+    );
+  });
+
+  it('appends the message pattern to the arguments exactly once', async () => {
+    const instance = new PatternTest();
+    Reflect.defineMetadata(MESSAGE_METADATA, 'myEvent', instance.handle);
+
+    const proxy = creator.create(instance, instance.handle, 'test', 'handle');
+    await proxy('client', { some: 'payload' });
+
+    expect(recordedArgs.filter(arg => arg === 'myEvent')).toHaveLength(1);
+    expect(recordedArgs[recordedArgs.length - 1]).toEqual('myEvent');
+  });
+
+  it('keeps the pattern reachable through getPattern()', async () => {
+    const instance = new PatternTest();
+    Reflect.defineMetadata(MESSAGE_METADATA, 'myEvent', instance.handle);
+
+    const proxy = creator.create(instance, instance.handle, 'test', 'handle');
+    await proxy('client', { some: 'payload' });
+
+    const host = new ExecutionContextHost(recordedArgs);
+    expect(host.switchToWs().getPattern()).toEqual('myEvent');
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

Issue Number: N/A

The message pattern is appended to the handler arguments twice on every dispatch.

`packages/websockets/context/ws-proxy.ts:13`, in the wrapper `WsProxy.create` returns:

```ts
args = [...args, targetPattern ?? 'unknown'];
```

`packages/websockets/context/ws-context-creator.ts:124`, inside the callback that wrapper invokes:

```ts
args.push(targetPattern);
```

So guards, interceptors and pipes receive an array ending with the pattern twice:

```
guard getArgs():       [client, data, 'raw-event-name', 'myEvent', 'myEvent']
interceptor getArgs(): [client, data, 'raw-event-name', 'myEvent', 'myEvent']
```

### Why this is safe to remove

The two appends are not the same mechanism, so it is worth being explicit about why only one is needed.

`WsProxy` does `args = [...args, pattern]` and then calls `targetCallback(...args)`. Spreading into a rest parameter always produces a **distinct array**, so the array `WsProxy` closes over and the array the callback sees were never the same object. That is exactly why #12382 added the `WsProxy` level append in the first place: the original `args.push()` inside the callback never propagated back out, so exception filters could not see the pattern. Once that append existed, the inner one became redundant for the consumers that do see it, and it was left in place.

Every consumer was checked:

- `switchToWs().getClient()` reads index 0, `getData()` reads index 1
- `switchToWs().getPattern()` reads the last element, and both duplicate entries hold the same value
- the `ACK` branch of `WsParamsFactory.exchangeKeyForValue` uses `args.find(isFunction)`; the pattern is a string
- `GuardsConsumer` and `InterceptorsConsumer` forward the array without inspecting it
- the pipes path spreads `args` into `params` and only reads `params[0]`, `params[1]` and `.find(isFunction)`
- `argsLength` comes from decorator metadata, not from `args.length`, so `createNullArray` is unaffected
- `WsProxy.handleError` builds the filter context from its own array, which only ever had one append

Both adapter call shapes were checked, `(client, data, event)` for platform-ws and `(client, data)` or an ack for platform-socket.io.

## What is the new behavior?

The redundant `args.push(targetPattern)` is gone. `getPattern()`, `getClient()`, `getData()` and ack detection are unchanged.

Two tests are added. The first asserts the pattern appears exactly once and fails on master:

```
AssertionError: expected [ 'myEvent', 'myEvent' ] to have a length of 1 but got 2
```

The second checks `getPattern()` still resolves. It passes either way by design, since `getPattern()` reads the last element; it is there as a sanity check that the accessor keeps working, not as a regression guard.

Both use a real `WsProxy`. The existing describe block in that file mocks `wsProxy.create` as identity, which is why the current suite never saw the duplicate.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

A custom guard that indexes `getArgs()` from the end, for example `args[args.length - 2]` expecting the ack, would see a different value. Nothing in the public API documents index based access to the raw ws argument array, and the three accessors are unaffected.

## Other information

Full unit suite passes, 277 files and 2774 tests. `oxlint` and `prettier --check` are clean on both changed files. `integration/websockets` passes as well, 6 files and 22 tests, no Docker needed.

The duplicate dates back to 6f43a8b26 (#12382, September 2023) and neither line has been touched since.
