### PR TITLE
fix(scripts): stop hiding build failures in the setup scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,18 +166,30 @@ You will need [Node.js](https://nodejs.org) version >= 20.
 $ npm ci --legacy-peer-deps # (or yarn install)
 ```
 
-2. In order to prepare your environment run `prepare.sh` shell script:
+2. To run the unit tests you are ready to go:
 
 ```bash
-$ sh scripts/prepare.sh
+$ npm run test
 ```
 
-That will compile fresh packages and afterward, move them all to `sample` directories.
+The unit tests run straight from the TypeScript sources, so no build step and no Docker
+are required.
+
+3. Only if you are going to run the **integration** tests, prepare that environment with
+   the `prepare.sh` shell script:
+
+```bash
+$ bash scripts/prepare.sh
+```
+
+That will compile fresh packages into the root `node_modules/@nestjs`, then start the
+Docker containers the integration tests need and wait for RabbitMQ to accept
+connections. Docker is required for this step.
 
 ### <a name="common-scripts"></a>Commonly used NPM scripts
 
 ```bash
-# build all packages and move to "sample" directories
+# build all packages into the root node_modules/@nestjs
 $ npm run build
 
 # run the full unit tests suite
@@ -185,7 +197,7 @@ $ npm run test
 
 # run integration tests
 # docker is required(!)
-$ sh scripts/run-integration.sh
+$ bash scripts/run-integration.sh
 
 # run linter
 $ npm run lint

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,5 +1,8 @@
+#!/usr/bin/env bash
+set -eu
+
 # 1. Build fresh packages and move them to sample and integration directories
-npm run build &>/dev/null
+npm run build
 
 # 2. Start docker containers to perform integration tests
 npm run test:docker:up

--- a/scripts/run-integration.sh
+++ b/scripts/run-integration.sh
@@ -1,5 +1,8 @@
-# 1. Build fresh packages and move them integration dit
-npm run build &>/dev/null
+#!/usr/bin/env bash
+set -eu
+
+# 1. Build fresh packages and move them to the integration directory
+npm run build
 
 # 2. Start docker containers to perform integration tests
 npm run test:docker:up


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

Issue Number: N/A

`scripts/prepare.sh` and `scripts/run-integration.sh` both start with:

```sh
npm run build &>/dev/null
```

Neither file has a shebang, `set -e`, or any check on the exit status. When the build fails the output is discarded, the script continues into the Docker steps, and it still exits 0.

Reproduced with a stand-in `npm` that prints a TypeScript error and exits 1:

```
$ sh prepare-sim.sh
docker containers started (simulated)
RabbitMQ is ready (simulated)
EXIT CODE: 0
```

The `&>` redirect is also not portable. With no shebang the interpreter is whatever the caller uses, and CONTRIBUTING.md says `sh scripts/prepare.sh`. Under dash, which is `/bin/sh` on most Debian and Ubuntu systems, `&>/dev/null` parses as "run in the background" plus a separate no-op redirect, so the build races the steps after it rather than being muted:

```
$ dash prepare-sim.sh
docker containers started (simulated)
error TS2322: Type 'string' is not assignable to type 'number'.
RabbitMQ is ready (simulated)
EXIT CODE: 0
```

## What is the new behavior?

Both scripts get `#!/usr/bin/env bash` and `set -eu`, and the redirect is removed. Verified with the same harness under bash, sh, dash and direct execution: exit 1 with the error visible when the build fails, exit 0 when it succeeds.

`pipefail` is deliberately left out. `dash -c "set -o pipefail"` fails with `Illegal option`, and neither script contains a pipeline or reads a shell variable, so `set -eu` is enough and keeps working if someone still invokes them with `sh`.

CONTRIBUTING.md is corrected in three places:

- `npm run build` runs `move:node_modules`, which copies compiled output into the root `node_modules/@nestjs`. `move:samples` is a separate task that only `build:samples` invokes. Two places said the build moves packages into the `sample` directories.
- `prepare.sh` also starts Docker containers and waits for RabbitMQ. Its description mentioned neither, while Docker was only noted further down next to `run-integration.sh`.
- `npm run test` needs no build and no Docker, since the vitest config resolves `@nestjs/*` straight to the TypeScript sources. It now comes before the integration setup, so contributors who only want unit tests are not sent through Docker.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

One thing worth a maintainer's eye. `.circleci/config.yml` runs `bash ./scripts/prepare.sh` in `integration_tests`, and that job already declares `requires: - build`, so a genuine compile failure fails the separate `build` job first and this script never runs in anger. The behavior change in CI is narrower: if `npm run test:docker:up` returns nonzero for a container the suite does not use, that previously fell through silently and now stops the job. `vitest.config.integration.mts` already excludes `integration/mongoose/**` and `integration/typeorm/**`, so the mysql and mongo services in the compose file are started but unused. I could not exercise a real Docker daemon to confirm compose's exit code on a partial start, so flagging it rather than claiming it is a non-issue.

PR #16825 touched docker-compose v1/v2 support through `package.json` and `scripts/docker-compose.js` and did not touch these two files, so there is no conflict.
