### PR TITLE
chore(deps): regenerate package-lock.json to match package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,17 +47,17 @@
         "@grpc/grpc-js": "1.14.4",
         "@grpc/proto-loader": "0.8.1",
         "@nats-io/transport-node": "^3.0.2",
-        "@nestjs/apollo": "13.4.5",
-        "@nestjs/graphql": "13.4.5",
-        "@nestjs/mongoose": "11.0.4",
-        "@nestjs/typeorm": "11.0.3",
+        "@nestjs/apollo": "14.0.0",
+        "@nestjs/graphql": "14.0.0",
+        "@nestjs/mongoose": "12.0.0",
+        "@nestjs/typeorm": "12.0.1",
         "@standard-schema/spec": "1.1.0",
         "@types/amqplib": "0.10.8",
         "@types/cors": "2.8.19",
         "@types/express": "5.0.6",
         "@types/gulp": "4.0.18",
         "@types/http-errors": "2.0.5",
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
         "@types/supertest": "7.2.1",
         "@types/ws": "8.18.1",
         "@vitest/coverage-istanbul": "4.1.11",
@@ -89,7 +89,7 @@
         "lerna": "10.0.1",
         "lerna-changelog": "2.2.0",
         "light-my-request": "6.6.0",
-        "lint-staged": "17.3.0",
+        "lint-staged": "17.4.1",
         "markdown-table": "2.0.0",
         "mongoose": "9.9.4",
         "mqtt": "5.15.2",
@@ -207,23 +207,6 @@
       },
       "peerDependencies": {
         "graphql": "14.x || 15.x || 16.x"
-      }
-    },
-    "node_modules/@apollo/server-plugin-landing-page-graphql-playground": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/server-plugin-landing-page-graphql-playground/-/server-plugin-landing-page-graphql-playground-4.0.1.tgz",
-      "integrity": "sha512-tWhQzD7DtiTO/wfbGvasryz7eJSuEh9XJHgRTMZI7+Wu/omylG5gH6K6ksg1Vccg8/Xuglfi2f1M5Nm/IlBBGw==",
-      "deprecated": "The use of GraphQL Playground in Apollo Server was supported in previous versions, but this is no longer the case as of December 31, 2022. This package exists for v4 migration purposes only. We do not intend to resolve security issues or other bugs with this package if they arise, so please migrate away from this to [Apollo Server's default Explorer](https://www.apollographql.com/docs/apollo-server/api/plugin/landing-pages) as soon as possible.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@apollographql/graphql-playground-html": "1.6.29"
-      },
-      "engines": {
-        "node": ">=14.0"
-      },
-      "peerDependencies": {
-        "@apollo/server": "^4.0.0"
       }
     },
     "node_modules/@apollo/usage-reporting-protobuf": {
@@ -391,16 +374,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@apollographql/graphql-playground-html": {
-      "version": "1.6.29",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz",
-      "integrity": "sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xss": "^1.0.8"
       }
     },
     "node_modules/@as-integrations/express5": {
@@ -2892,13 +2865,12 @@
       }
     },
     "node_modules/@nestjs/apollo": {
-      "version": "13.4.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-13.4.5.tgz",
-      "integrity": "sha512-/7hYsCTZK7lYyde4xnvOl+WKDM81ju7JniMnDxIZAOKfVF/9wFRzCT8lJchGsJLSULTJq5mOgjYaXW5DjRGPJw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/apollo/-/apollo-14.0.0.tgz",
+      "integrity": "sha512-+zui1iiSozGJX1X2rMSS01H9v18nZh1fgFBIdV6pAIzz9iRJCCLshnEbcWTTePYBbKyDguMKjqykBW2HF0vrbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@apollo/server-plugin-landing-page-graphql-playground": "4.0.1",
         "iterall": "1.3.0",
         "lodash.omit": "4.18.0",
         "tslib": "2.8.1"
@@ -2908,9 +2880,9 @@
         "@apollo/server": "^5.0.0",
         "@apollo/subgraph": "^2.0.0",
         "@as-integrations/fastify": "^2.1.1 || ^3.0.0",
-        "@nestjs/common": "^11.0.1",
-        "@nestjs/core": "^11.0.1",
-        "@nestjs/graphql": "^13.0.0",
+        "@nestjs/common": "^12.0.0",
+        "@nestjs/core": "^12.0.0",
+        "@nestjs/graphql": "^14.0.0",
         "graphql": "^16.10.0 || ^17.0.0"
       },
       "peerDependenciesMeta": {
@@ -2937,30 +2909,29 @@
       "link": true
     },
     "node_modules/@nestjs/graphql": {
-      "version": "13.4.5",
-      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.4.5.tgz",
-      "integrity": "sha512-yfgH1ccLP6+PlnlJc+lq04VcAl7uHcocBOJCVrn95jARigxcWWYdyiGZckgt9jMqrFj3FQFnUMyzV7AvydmQtA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-14.0.0.tgz",
+      "integrity": "sha512-QLWXDxGRIjcZOoBLFa44LPC0wWJOYvmG0e85gMOaHmggnXpNqkoEtsbJ0NlShYqqGzzrprQWQw/PcCXTO6FjvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@graphql-tools/merge": "9.2.3",
         "@graphql-tools/schema": "10.1.0",
         "@graphql-tools/utils": "12.0.0",
-        "@nestjs/mapped-types": "2.1.1",
+        "@nestjs/mapped-types": "12.0.0",
         "chokidar": "4.0.3",
-        "graphql-tag": "2.12.6",
+        "es-toolkit": "1.51.0",
+        "graphql-tag": "2.12.7",
         "graphql-ws": "6.2.1",
-        "lodash": "4.18.1",
         "normalize-path": "3.0.0",
-        "subscriptions-transport-ws": "0.11.0",
         "tinyglobby": "0.2.17",
         "tslib": "2.8.1",
         "ws": "8.21.3"
       },
       "peerDependencies": {
         "@apollo/subgraph": "^2.9.3",
-        "@nestjs/common": "^11.0.1",
-        "@nestjs/core": "^11.0.1",
+        "@nestjs/common": "^12.0.0",
+        "@nestjs/core": "^12.0.0",
         "class-transformer": "*",
         "class-validator": "*",
         "graphql": "^16.11.0 || ^17.0.0",
@@ -2983,13 +2954,16 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
-      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-12.0.0.tgz",
+      "integrity": "sha512-aX7lxZcqXldtnSr0bgT2ZPQvpTpIwBMW1GMX29o4s3q02vmq6JoTYuPW0GwYXa8BiFMRX7WbGZVDA703pNqOMQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
       "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0 || ^12.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
         "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
@@ -3008,14 +2982,14 @@
       "link": true
     },
     "node_modules/@nestjs/mongoose": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/@nestjs/mongoose/-/mongoose-11.0.4.tgz",
-      "integrity": "sha512-LUOlUeSOfbjdIu22QwOmczv2CzJQr9LUBo2mOfbXrGCu2svpr5Hiu71zBFrb/9UC+H8BjGMKbBOq1nEbMF6ZJA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mongoose/-/mongoose-12.0.0.tgz",
+      "integrity": "sha512-Xjv1+9zeRyEh9UE9f7DSVOigEA5CF9kJis8uqfE3v/AB6QNxPC0gb+TcKEhAf9zkVQ3e3dM48QfI+tdP0jrJZA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/common": "^11.0.0 || ^12.0.0",
+        "@nestjs/core": "^11.0.0 || ^12.0.0",
         "mongoose": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "rxjs": "^7.0.0"
       }
@@ -3041,14 +3015,17 @@
       "link": true
     },
     "node_modules/@nestjs/typeorm": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.3.tgz",
-      "integrity": "sha512-zJ+E5l7auVVA7c0PsvcMdyvRPKTUqU5s2ToYmOA2QEsXQ42qbUGtK4+1HlRfpHqBkCSXP+phiH4luvf9DyJNog==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-12.0.1.tgz",
+      "integrity": "sha512-7dsdaD/PSiwCAAhv78+ScS3e6lW41BOMZ8LB7/v5p/hovSUc1wUH1DBXhLgqYx0ChXYLzDybBIADN6lvBhiM6w==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
       "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "@nestjs/core": "^10.0.0 || ^11.0.0",
+        "@nestjs/common": "^10.0.0 || ^11.0.0 || ^12.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0 || ^12.0.0",
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0 || ^1.0.0-dev"
@@ -5555,9 +5532,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -7005,13 +6982,6 @@
       "engines": {
         "node": ">= 10.13.0"
       }
-    },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -8591,13 +8561,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssfilter": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-      "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -9375,15 +9338,16 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.51.0.tgz",
+      "integrity": "sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
         "docs",
         "benchmarks",
-        "tests/types"
+        "tests/types",
+        "tests/browser-compat"
       ]
     },
     "node_modules/es5-ext": {
@@ -11088,9 +11052,9 @@
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.7.tgz",
+      "integrity": "sha512-xnE/NFzy+0eIesvAsREJZ284zTl/wYuBAvpsFSDhRGRdRHdnE90M21Q3xAWyYInb0J756c6x0pIQ62+vtvOs1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11100,7 +11064,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/graphql-ws": {
@@ -14911,15 +14875,15 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.3.0.tgz",
-      "integrity": "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.4.1.tgz",
+      "integrity": "sha512-FmJeudcalbSfg1du+JCfvi5vS6Qt08KgbfLWiHinbef+2JJwUZwAWVoaO1AcJVUTWPfk0t30PMQNwPAeCzYQ+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.5",
+        "picomatch": "^4.0.7",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
+        "tinyexec": "^1.3.0"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -14968,13 +14932,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash._basecopy": {
       "version": "3.0.1",
@@ -17841,9 +17798,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20225,53 +20182,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -20366,16 +20276,6 @@
       "optional": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/symbol-observable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/tar": {
@@ -22500,30 +22400,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/xss": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.15.tgz",
-      "integrity": "sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.20.3",
-        "cssfilter": "0.0.10"
-      },
-      "bin": {
-        "xss": "bin/xss"
-      },
-      "engines": {
-        "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/xss/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

Issue Number: N/A

`npm ci --legacy-peer-deps`, the command CONTRIBUTING.md gives for a fresh checkout, fails on master:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Invalid: lock file's @nestjs/apollo@13.4.5 does not satisfy @nestjs/apollo@14.0.0
npm error Invalid: lock file's @nestjs/graphql@13.4.5 does not satisfy @nestjs/graphql@14.0.0
npm error Invalid: lock file's @nestjs/mongoose@11.0.4 does not satisfy @nestjs/mongoose@12.0.0
npm error Invalid: lock file's @nestjs/typeorm@11.0.3 does not satisfy @nestjs/typeorm@12.0.1
npm error Invalid: lock file's @types/node@26.3.0 does not satisfy @types/node@26.4.0
npm error Invalid: lock file's lint-staged@17.3.0 does not satisfy lint-staged@17.4.1
```

Plus four transitive mismatches: `@nestjs/mapped-types`, `es-toolkit`, `graphql-tag`, `picomatch`.

The lockfile was in sync at `4c751c503`, the v12.0.1 release. Five dependency commits since then changed `package.json` only: `5c78b3c6c`, `cd5ee1291`, `16b21b5d3`, `6312d6af9`, `55b283292`.

CI does not catch it because `.circleci/config.yml` runs `npm install --legacy-peer-deps` rather than `npm ci`, so it re-resolves every run.

## What is the new behavior?

`package-lock.json` regenerated with `npm install --legacy-peer-deps`, the same command CI runs. `npm ci --legacy-peer-deps` succeeds again from a clean checkout.

The diff is 10 version updates and 11 removals, with nothing added. The removals are the transitive tree of the old `@nestjs/graphql` 13.x: `subscriptions-transport-ws` with its own `eventemitter3` and `ws`, `@apollo/server-plugin-landing-page-graphql-playground`, `@apollographql/graphql-playground-html`, `xss`, `cssfilter`, `backo2`, `lodash`, `symbol-observable`. The first two are deprecated packages. Every removal is `dev: true`, and no `os` or `cpu` constrained package was pruned, so nothing changes for contributors on other platforms. `lockfileVersion` stays at 3.

Unit tests (277 files, 2772 tests), `npm run build` and `npm run lint` all pass on the regenerated tree.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This unblocks a fresh checkout, and on its own it will drift again. Being explicit about that rather than presenting it as a complete fix.

Renovate runs a plain `npm install` when it regenerates the lockfile, so it hits the `graphql@17.0.2` versus `@apollo/server@5.5.1` peer conflict that `--legacy-peer-deps` exists to paper over. #17590, #17593 and #17595 each carry its "Artifact update problem" comment saying the lockfile could not be updated, and each merged anyway because `renovate.json` enables automerge for devDependencies. That is the mechanism that produced the six mismatches above, and #17610 is currently open with the same comment.

Two ways to stop it recurring, both maintainer calls, so neither is in this PR:

- resolve the peer range, by holding `graphql` at 16.x or moving to an `@apollo/server` that accepts 17
- give Renovate the same flag the rest of the project already uses, so its own install succeeds and it can maintain the lockfile

Happy to follow up with whichever you prefer.
