### PR TITLE
fix(core): clean up repeated shutdown signal listeners

### DIFF
--- a/packages/core/nest-application-context.ts
+++ b/packages/core/nest-application-context.ts
@@ -5,7 +5,6 @@ import {
   type LogLevel,
   ShutdownSignal,
 } from '@nestjs/common';
-import { iterate } from 'iterare';
 import { MESSAGES } from './constants.js';
 import { UnknownModuleException } from './errors/exceptions/index.js';
 import { createContextId } from './helpers/context-id-factory.js';
@@ -49,9 +48,12 @@ export class NestApplicationContext<
   });
 
   private shouldFlushLogsOnOverride = false;
-  private readonly activeShutdownSignals = new Array<string>();
+  private readonly shutdownCleanupRefs = new Map<
+    string,
+    (signal: string) => Promise<void>
+  >();
   private readonly moduleCompiler: ModuleCompiler;
-  private shutdownCleanupRef?: (...args: unknown[]) => unknown;
+  private receivedSignal = false;
   private _instanceLinksHost: InstanceLinksHost;
   private _moduleRefsForHooksByDistance?: Array<Module>;
   private initializationPromise?: Promise<void>;
@@ -317,19 +319,20 @@ export class NestApplicationContext<
     signals: (ShutdownSignal | string)[] = [],
     options: ShutdownHooksOptions = {},
   ): this {
-    if (!signals || isEmptyArray(signals)) {
-      signals = Object.values(ShutdownSignal);
-    } else {
-      // given signals array should be unique because
-      // process shouldn't listen to the same signal more than once.
-      signals = Array.from(new Set(signals));
+    if (this.shutdownCleanupRefs.size === 0) {
+      // Start a new shutdown cycle after the previous listeners were removed.
+      this.receivedSignal = false;
     }
 
-    signals = iterate(signals)
-      .map((signal: string) => signal.toString().toUpperCase().trim())
-      // filter out the signals which is already listening to
-      .filter(signal => !this.activeShutdownSignals.includes(signal))
-      .toArray();
+    if (!signals || isEmptyArray(signals)) {
+      signals = Object.values(ShutdownSignal);
+    }
+
+    signals = Array.from(
+      new Set(
+        signals.map((signal: string) => signal.toString().toUpperCase().trim()),
+      ),
+    ).filter(signal => !this.shutdownCleanupRefs.has(signal));
 
     this.listenToShutdownSignals(signals, options);
     return this;
@@ -358,22 +361,21 @@ export class NestApplicationContext<
     signals: string[],
     options: ShutdownHooksOptions = {},
   ) {
-    let receivedSignal = false;
     const cleanup = async (signal: string) => {
       try {
-        if (receivedSignal) {
+        if (this.receivedSignal) {
           // If we receive another signal while we're waiting
           // for the server to stop, just ignore it.
           return;
         }
-        receivedSignal = true;
+        this.receivedSignal = true;
         await this.initializationPromise;
         await this.prepareClose();
         await this.callDestroyHook();
         await this.callBeforeShutdownHook(signal);
         await this.dispose();
         await this.callShutdownHook(signal);
-        signals.forEach(sig => process.removeListener(sig, cleanup));
+        this.unsubscribeFromProcessSignals();
 
         if (options.useProcessExit) {
           // Use process.exit() to ensure the 'exit' event is properly triggered.
@@ -392,10 +394,8 @@ export class NestApplicationContext<
         process.exit(1);
       }
     };
-    this.shutdownCleanupRef = cleanup as (...args: unknown[]) => unknown;
-
     signals.forEach((signal: string) => {
-      this.activeShutdownSignals.push(signal);
+      this.shutdownCleanupRefs.set(signal, cleanup);
       process.on(signal as any, cleanup);
     });
   }
@@ -404,12 +404,10 @@ export class NestApplicationContext<
    * Unsubscribes from shutdown signals (process events)
    */
   protected unsubscribeFromProcessSignals() {
-    if (!this.shutdownCleanupRef) {
-      return;
-    }
-    this.activeShutdownSignals.forEach(signal => {
-      process.removeListener(signal, this.shutdownCleanupRef!);
+    this.shutdownCleanupRefs.forEach((cleanup, signal) => {
+      process.removeListener(signal, cleanup);
     });
+    this.shutdownCleanupRefs.clear();
   }
 
   /**

--- a/packages/core/test/nest-application-context.spec.ts
+++ b/packages/core/test/nest-application-context.spec.ts
@@ -62,7 +62,8 @@ describe('NestApplicationContext', () => {
       applicationContext.enableShutdownHooks([signal]);
 
       const waitProcessDown = new Promise(resolve => {
-        const shutdownCleanupRef = applicationContext['shutdownCleanupRef'];
+        const shutdownCleanupRef =
+          applicationContext['shutdownCleanupRefs'].get(signal);
         const handler = () => {
           if (
             !process
@@ -98,6 +99,153 @@ describe('NestApplicationContext', () => {
       hookStub.mockRestore();
       expect(processUp).toBe(false);
       expect(promisesResolved).toBe(true);
+    });
+
+    it('should normalize signals before removing duplicates', async () => {
+      const signal = 'SIGTERM';
+      const listeners = new Set(process.listeners(signal));
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+
+      try {
+        applicationContext.enableShutdownHooks(['sigterm', ' SIGTERM ']);
+
+        expect(process.listenerCount(signal)).toBe(listeners.size + 1);
+
+        await applicationContext.close();
+
+        expect(process.listenerCount(signal)).toBe(listeners.size);
+      } finally {
+        process.listeners(signal).forEach(listener => {
+          if (!listeners.has(listener)) {
+            process.removeListener(signal, listener);
+          }
+        });
+      }
+    });
+
+    it('should allow shutdown hooks to be enabled after close', async () => {
+      const signal = 'SIGTERM';
+      const listeners = new Set(process.listeners(signal));
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+
+      try {
+        applicationContext.enableShutdownHooks([signal]);
+        await applicationContext.close();
+
+        applicationContext.enableShutdownHooks([signal]);
+
+        expect(process.listenerCount(signal)).toBe(listeners.size + 1);
+
+        await applicationContext.close();
+        expect(process.listenerCount(signal)).toBe(listeners.size);
+      } finally {
+        process.listeners(signal).forEach(listener => {
+          if (!listeners.has(listener)) {
+            process.removeListener(signal, listener);
+          }
+        });
+      }
+    });
+
+    it('should allow shutdown hooks to run after being re-enabled', async () => {
+      const signal = 'SIGTERM';
+      const listeners = new Set(process.listeners(signal));
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+      const processKillStub = vi
+        .spyOn(process, 'kill')
+        .mockImplementation(() => true);
+      const hookStub = vi
+        .spyOn(applicationContext as any, 'callShutdownHook')
+        .mockImplementation(async () => undefined);
+
+      try {
+        applicationContext.enableShutdownHooks([signal]);
+        await applicationContext['shutdownCleanupRefs'].get(signal)!(signal);
+
+        applicationContext.enableShutdownHooks([signal]);
+        await applicationContext['shutdownCleanupRefs'].get(signal)!(signal);
+
+        expect(hookStub).toHaveBeenCalledTimes(2);
+        expect(processKillStub).toHaveBeenCalledTimes(2);
+      } finally {
+        hookStub.mockRestore();
+        processKillStub.mockRestore();
+        process.listeners(signal).forEach(listener => {
+          if (!listeners.has(listener)) {
+            process.removeListener(signal, listener);
+          }
+        });
+      }
+    });
+
+    it('should remove signal listeners registered by separate calls', async () => {
+      const signals = ['SIGTERM', 'SIGINT'];
+      const listeners = signals.map(
+        signal => new Set(process.listeners(signal)),
+      );
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+
+      try {
+        applicationContext.enableShutdownHooks([signals[0]]);
+        applicationContext.enableShutdownHooks([signals[1]]);
+
+        await applicationContext.close();
+
+        signals.forEach((signal, index) => {
+          expect(process.listenerCount(signal)).toBe(listeners[index].size);
+        });
+      } finally {
+        signals.forEach((signal, index) => {
+          process.listeners(signal).forEach(listener => {
+            if (!listeners[index].has(listener)) {
+              process.removeListener(signal, listener);
+            }
+          });
+        });
+      }
+    });
+
+    it('should run shutdown hooks once across separate registrations', async () => {
+      const signals = ['SIGTERM', 'SIGINT'];
+      const existingListeners = signals.map(
+        signal => new Set(process.listeners(signal)),
+      );
+      const applicationContext = await testHelper(A, Scope.DEFAULT);
+      const processKillStub = vi
+        .spyOn(process, 'kill')
+        .mockImplementation(() => true);
+      const hookStub = vi
+        .spyOn(applicationContext as any, 'callShutdownHook')
+        .mockImplementation(async () => undefined);
+
+      try {
+        applicationContext.enableShutdownHooks([signals[0]]);
+        applicationContext.enableShutdownHooks([signals[1]]);
+
+        const cleanupHandlers = signals.map((signal, index) =>
+          process
+            .listeners(signal)
+            .find(listener => !existingListeners[index].has(listener)),
+        );
+
+        await Promise.all([
+          cleanupHandlers[0]!(signals[0]),
+          cleanupHandlers[1]!(signals[1]),
+        ]);
+
+        expect(hookStub).toHaveBeenCalledTimes(1);
+        expect(processKillStub).toHaveBeenCalledTimes(1);
+      } finally {
+        hookStub.mockRestore();
+        processKillStub.mockRestore();
+        signals.forEach((signal, index) => {
+          process.listeners(signal).forEach(listener => {
+            if (!existingListeners[index].has(listener)) {
+              process.removeListener(signal, listener);
+            }
+          });
+        });
+      }
     });
 
     it('should defer shutdown until all init hooks are resolved', async () => {
@@ -176,7 +324,8 @@ describe('NestApplicationContext', () => {
         .spyOn(applicationContext as any, 'callShutdownHook')
         .mockImplementation(async () => undefined);
 
-      const shutdownCleanupRef = applicationContext['shutdownCleanupRef']!;
+      const shutdownCleanupRef =
+        applicationContext['shutdownCleanupRefs'].get(signal)!;
       await shutdownCleanupRef(signal);
 
       expect(processExitStub).toHaveBeenCalledWith(0);
@@ -204,7 +353,8 @@ describe('NestApplicationContext', () => {
         .spyOn(applicationContext as any, 'callShutdownHook')
         .mockImplementation(async () => undefined);
 
-      const shutdownCleanupRef = applicationContext['shutdownCleanupRef']!;
+      const shutdownCleanupRef =
+        applicationContext['shutdownCleanupRefs'].get(signal)!;
       await shutdownCleanupRef(signal);
 
       expect(processKillStub).toHaveBeenCalledWith(process.pid, signal);


### PR DESCRIPTION
## Summary

- track the cleanup handler registered for each shutdown signal
- remove every registered process listener when the application closes
- share the received-signal guard across registrations so concurrent signals run shutdown hooks once
- add regression coverage for repeated and separate calls to `enableShutdownHooks()`

## Testing

- focused shutdown regression tests (3 passed)
- existing process exit/kill shutdown tests (2 passed)
- `tsc -b packages/core --pretty false`
- `oxlint packages/core/nest-application-context.ts packages/core/test/nest-application-context.spec.ts`
- Prettier check and `git diff --check`
- public-API verification on Windows:
  - registering `SIGTERM` twice: listener count `0 -> 1 -> 0`
  - registering `SIGTERM` and `SIGINT` separately: both `0 -> 1 -> 0`

Closes #17623
