### PR TITLE
fix(core): Serialize errorCode for plain HttpException responses

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -37,6 +37,9 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
       : {
           statusCode: exception.getStatus(),
           message: res,
+          ...(exception.errorCode !== undefined && {
+            errorCode: exception.errorCode,
+          }),
         };
 
     const response = host.getArgByIndex(1);

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -148,6 +148,37 @@ describe('ExceptionsHandler', () => {
         expect(statusStub).toHaveBeenCalledWith(status);
         expect(jsonStub).toHaveBeenCalledWith({ message, statusCode: status });
       });
+      it('should preserve errorCode in the response body when the response is a string', () => {
+        const status = 403;
+        const message = 'Forbidden';
+
+        handler.next(
+          new HttpException(message, status, { errorCode: 'FORBIDDEN_ERR' }),
+          new ExecutionContextHost([0, response]),
+        );
+
+        expect(statusStub).toHaveBeenCalledWith(status);
+        expect(jsonStub).toHaveBeenCalledWith({
+          statusCode: status,
+          message,
+          errorCode: 'FORBIDDEN_ERR',
+        });
+      });
+      it('should not add errorCode to the response body when it is not set', () => {
+        const status = 403;
+        const message = 'Forbidden';
+
+        handler.next(
+          new HttpException(message, status),
+          new ExecutionContextHost([0, response]),
+        );
+
+        expect(statusStub).toHaveBeenCalledWith(status);
+        expect(jsonStub).toHaveBeenCalledWith({
+          statusCode: status,
+          message,
+        });
+      });
     });
     describe('when "invokeCustomFilters" returns true', () => {
       beforeEach(() => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

a plain `HttpException` built with a string body and an `errorCode` option sets `exception.errorCode`, but `BaseExceptionFilter` rebuilds the response body from `getResponse()` and drops the code, so these two behave differently today:

```ts
// built-in exceptions (fixed by #17615): errorCode IS in the body
throw new BadRequestException('Password is too weak', { errorCode: 'WEAK_PASSWORD' });
// -> { message, error, statusCode, errorCode }

// plain HttpException: errorCode is LOST
throw new HttpException('Forbidden', 403, { errorCode: 'FORBIDDEN_ERR' });
// -> { statusCode: 403, message: 'Forbidden' }  <- errorCode missing
```

this is the sibling gap the author of #17615 called out in that PR: "A plain `new HttpException('Forbidden', 403, { errorCode })` is unchanged, since its response is a bare string and `BaseExceptionFilter` rebuilds the body itself... I can add it here if you want it"

Issue Number: N/A (no dedicated issue, this completes the follow-up offered in #17615)

## What is the new behavior?

`BaseExceptionFilter` keeps `errorCode` in the rebuilt body when the exception response is a bare string:

```json
{
  "statusCode": 403,
  "message": "Forbidden",
  "errorCode": "FORBIDDEN_ERR"
}
```

nothing changes when no `errorCode` is set, and object responses are still passed through verbatim

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

verified: 2 new cases in `exceptions-handler.spec.ts`, the `errorCode` one fails without this change, the no-errorCode one asserts the body shape stays untouched, full exceptions suites pass (26 files / 209 tests), prettier + oxlint clean