### PR TITLE
fix(ws): remove the upgrade listener on dispose

### DIFF
--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -2,6 +2,7 @@ import { type INestApplicationContext, Logger } from '@nestjs/common';
 import { AbstractWsAdapter } from '@nestjs/websockets';
 import * as http from 'http';
 import { createRequire } from 'module';
+import type { Duplex } from 'stream';
 import { EMPTY, fromEvent, Observable } from 'rxjs';
 import { filter, first, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { loadPackageSync, isNil, normalizePath } from '@nestjs/common/internal';
@@ -25,6 +26,11 @@ type HttpServerRegistryKey = number;
 type HttpServerRegistryEntry = any;
 type WsServerRegistryKey = number;
 type WsServerRegistryEntry = any[];
+type UpgradeListener = (
+  request: http.IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+) => void;
 type WsData = string | Buffer | ArrayBuffer | Buffer[];
 type WsMessageParser = (data: WsData) => { event: string; data: any } | void;
 type WsAdapterOptions = {
@@ -45,6 +51,10 @@ export class WsAdapter extends AbstractWsAdapter {
   protected readonly wsServersRegistry = new Map<
     WsServerRegistryKey,
     WsServerRegistryEntry
+  >();
+  private readonly upgradeListenersRegistry = new Map<
+    HttpServerRegistryKey,
+    UpgradeListener
   >();
   protected messageParser: WsMessageParser = (data: WsData) => {
     return JSON.parse(data.toString());
@@ -209,9 +219,17 @@ export class WsAdapter extends AbstractWsAdapter {
       .filter(([port]) => port !== UNDERLYING_HTTP_SERVER_PORT)
       .map(([_, server]) => new Promise(resolve => server.close(resolve)));
 
+    // A server passed in by the caller outlives this adapter, so the listener
+    // added to it has to be taken off explicitly. Servers created here are
+    // closed above and take their listeners with them.
+    this.upgradeListenersRegistry.forEach((listener, port) =>
+      this.httpServersRegistry.get(port)?.off('upgrade', listener),
+    );
+
     await Promise.all(closeEventSignals);
     this.httpServersRegistry.clear();
     this.wsServersRegistry.clear();
+    this.upgradeListenersRegistry.clear();
   }
 
   public setMessageParser(parser: WsMessageParser) {
@@ -227,7 +245,7 @@ export class WsAdapter extends AbstractWsAdapter {
     }
     this.httpServersRegistry.set(port, httpServer);
 
-    httpServer.on('upgrade', (request, socket, head) => {
+    const upgradeListener: UpgradeListener = (request, socket, head) => {
       try {
         const baseUrl = 'ws://' + request.headers.host + '/';
         const pathname = new URL(request.url!, baseUrl).pathname;
@@ -249,7 +267,9 @@ export class WsAdapter extends AbstractWsAdapter {
       } catch (err) {
         socket.end(`HTTP/1.1 400\r\n${err.message}`);
       }
-    });
+    };
+    httpServer.on('upgrade', upgradeListener);
+    this.upgradeListenersRegistry.set(port, upgradeListener);
     return httpServer;
   }
 

--- a/packages/platform-ws/test/ws-adapter.spec.ts
+++ b/packages/platform-ws/test/ws-adapter.spec.ts
@@ -1,0 +1,30 @@
+import { createServer } from 'http';
+import { WsAdapter } from '../adapters/ws-adapter.js';
+
+describe('WsAdapter', () => {
+  describe('dispose', () => {
+    it('should remove the upgrade listener it added to a caller-supplied server', async () => {
+      const httpServer = createServer();
+      const adapter = new WsAdapter(httpServer);
+
+      adapter.create(0, { path: '/live' });
+      expect(httpServer.listenerCount('upgrade')).toBe(1);
+
+      await adapter.dispose();
+
+      expect(httpServer.listenerCount('upgrade')).toBe(0);
+    });
+
+    it('should not accumulate upgrade listeners across adapters sharing a server', async () => {
+      const httpServer = createServer();
+
+      for (let i = 0; i < 3; i++) {
+        const adapter = new WsAdapter(httpServer);
+        adapter.create(0, { path: '/live' });
+        await adapter.dispose();
+      }
+
+      expect(httpServer.listenerCount('upgrade')).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17629

When `WsAdapter` is given an HTTP server, `dispose()` does not remove the
`'upgrade'` listener it attached to it. `ensureHttpServerExists` adds it as an
anonymous function and keeps no reference:

```ts
httpServer.on('upgrade', (request, socket, head) => {
  // ...
  if (!isRequestDelegated) {
    socket.destroy();
  }
});
```

`dispose()` closes the servers the adapter created, which takes their listeners
with them, but it deliberately skips a server passed in by the caller, since
closing one it does not own would be wrong. Nothing removes the listener there,
and no reference is left to remove it with.

The listener outlives `app.close()` and still answers upgrades. Once a later app
registers a gateway on a different path, the stale listener finds no match and
calls `socket.destroy()`, so the live gateway never sees the connection.

## What is the new behavior?

The handler is kept and taken off in `dispose()`.

```
                                     before   after
upgrade listeners after 3 cycles          3       0
live gateway behind a closed app       fails   replies
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Servers the adapter creates were already closed on dispose and still take their
listeners with them.

## Other information

**Scope.** Only a `WsAdapter` constructed with an external HTTP server. When the
adapter creates its own, `dispose()` closes it and the listener goes with it.

**Who runs into this.** Anything that creates and closes several apps in one
process against a shared server: e2e suites, `Test.createTestingModule` per spec
file, or a host process that restarts an app.

**Tests.** `packages/platform-ws/test/ws-adapter.spec.ts` covers the listener
being removed, and listeners not accumulating across adapters sharing a server.
Both fail on master — `expected 1 to be 0` and `expected 3 to be 0`.

The issue has a full reproduction showing the second symptom: a closed app
breaking the sockets of a live one.
