### PR TITLE
fix(core): restore logger after silent lazy module load

### DIFF
--- a/packages/core/injector/lazy-module-loader/lazy-module-loader.ts
+++ b/packages/core/injector/lazy-module-loader/lazy-module-loader.ts
@@ -20,38 +20,43 @@ export class LazyModuleLoader {
 
   public async load(
     loaderFn: () =>
-      | Promise<Type<unknown> | DynamicModule>
-      | Type<unknown>
-      | DynamicModule,
+      Promise<Type<unknown> | DynamicModule> | Type<unknown> | DynamicModule,
     loadOpts?: LazyModuleLoaderLoadOptions,
   ): Promise<ModuleRef> {
-    this.registerLoggerConfiguration(loadOpts);
+    const originalLogger = (this.instanceLoader as any).logger;
+    try {
+      this.registerLoggerConfiguration(loadOpts);
 
-    const moduleClassOrDynamicDefinition = await loaderFn();
-    const moduleInstances = await this.dependenciesScanner.scanForModules({
-      moduleDefinition: moduleClassOrDynamicDefinition,
-      overrides: this.moduleOverrides,
-      lazy: true,
-    });
-    if (moduleInstances.length === 0) {
-      // The module has been loaded already. In this case, we must
-      // retrieve a module reference from the existing container.
-      const { token } = await this.moduleCompiler.compile(
-        moduleClassOrDynamicDefinition,
+      const moduleClassOrDynamicDefinition = await loaderFn();
+      const moduleInstances = await this.dependenciesScanner.scanForModules({
+        moduleDefinition: moduleClassOrDynamicDefinition,
+        overrides: this.moduleOverrides,
+        lazy: true,
+      });
+      if (moduleInstances.length === 0) {
+        // The module has been loaded already. In this case, we must
+        // retrieve a module reference from the existing container.
+        const { token } = await this.moduleCompiler.compile(
+          moduleClassOrDynamicDefinition,
+        );
+        const moduleInstance = this.modulesContainer.get(token)!;
+        return moduleInstance && this.getTargetModuleRef(moduleInstance);
+      }
+      const lazyModulesContainer =
+        this.createLazyModulesContainer(moduleInstances);
+      await this.dependenciesScanner.scanModulesForDependencies(
+        lazyModulesContainer,
       );
-      const moduleInstance = this.modulesContainer.get(token)!;
-      return moduleInstance && this.getTargetModuleRef(moduleInstance);
+      await this.instanceLoader.createInstancesOfDependencies(
+        lazyModulesContainer,
+      );
+      const [targetModule] = moduleInstances;
+      return this.getTargetModuleRef(targetModule);
+    } finally {
+      if (loadOpts?.logger === false) {
+        this.instanceLoader.setLogger(originalLogger);
+      }
     }
-    const lazyModulesContainer =
-      this.createLazyModulesContainer(moduleInstances);
-    await this.dependenciesScanner.scanModulesForDependencies(
-      lazyModulesContainer,
-    );
-    await this.instanceLoader.createInstancesOfDependencies(
-      lazyModulesContainer,
-    );
-    const [targetModule] = moduleInstances;
-    return this.getTargetModuleRef(targetModule);
   }
 
   private registerLoggerConfiguration(loadOpts?: LazyModuleLoaderLoadOptions) {

--- a/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
+++ b/packages/core/test/injector/lazy-module-loader/lazy-module-loader.spec.ts
@@ -82,6 +82,25 @@ describe('LazyModuleLoader', () => {
       });
     });
 
+    describe('when logger option is false', () => {
+      @Module({})
+      class ModuleWithLogA {}
+
+      @Module({})
+      class ModuleWithLogB {}
+
+      it('should not permanently silence logs for subsequent load() calls', async () => {
+        const logger = instanceLoader['logger'];
+        const logSpy = vitest.spyOn(logger, 'log');
+
+        await lazyModuleLoader.load(() => ModuleWithLogA, { logger: false });
+        expect(logSpy).not.toHaveBeenCalled();
+
+        await lazyModuleLoader.load(() => ModuleWithLogB);
+        expect(logSpy).toHaveBeenCalled();
+      });
+    });
+
     describe('singleton sharing and repeated loading (#17428)', () => {
       let constructionsCount = 0;
       let globalConstructionsCount = 0;


### PR DESCRIPTION
Fixes #17628

### What was wrong
Calling `lazyModuleLoader.load(ModuleA, { logger: false })` replaced the shared `InstanceLoader`'s logger with a `SilentLogger`, but this was never reverted. As a result, passing `{ logger: false }` once permanently silenced `InstanceLoader` logging for every subsequent lazy module load in the application's lifetime.

### Why it happened
`registerLoggerConfiguration` only ever set the logger to `SilentLogger` when `logger === false` — it never captured the original logger or restored it afterward:

```ts
private registerLoggerConfiguration(loadOpts?: LazyModuleLoaderLoadOptions) {
  if (loadOpts?.logger === false) {
    this.instanceLoader.setLogger(new SilentLogger());
  }
}
```

Since `instanceLoader` is a shared, application-scoped singleton, this mutation persisted across all future `load()` calls, regardless of their own `logger` option.

### What was changed
`load()` now captures the `InstanceLoader`'s logger before silencing it, and restores it in a `finally` block once the current `load()` call completes — ensuring the silencing is scoped to that single invocation, even if an error is thrown during loading.

### How it was tested
- Added a regression test in `lazy-module-loader.spec.ts` verifying that a `load()` call with `{ logger: false }` does not emit logs, and a subsequent `load()` call without it does.
- Ran the full lazy-module-loader test suite locally (9 tests) — all pass, including the pre-existing regression tests for #17428 and #17462.
- Ran scoped linting on the changed files — 0 warnings, 0 errors.

### Why the change is safe
The change only affects the logger reference held by `InstanceLoader` during and immediately after a `load()` call with `{ logger: false }`. Calls without that option are unaffected, since no silencing (and therefore no restoration) occurs for them.