### PR TITLE
fix(ws): stop discarding parser and handler lookup failures silently

### DIFF
--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -177,15 +177,37 @@ export class WsAdapter extends AbstractWsAdapter {
     handlersMap: Map<string, MessageMappingProperties>,
     transform: (data: any) => Observable<any>,
   ): Observable<any> {
+    let message: ReturnType<WsMessageParser>;
     try {
-      const message = this.messageParser(buffer.data);
-      if (!message) {
-        return EMPTY;
+      message = this.messageParser(buffer.data);
+    } catch (err) {
+      // A custom parser that throws is an application bug, and swallowing it
+      // leaves no trace of it anywhere. The default parser, on the other hand,
+      // throws on client-controlled input, so reporting that one would turn a
+      // public socket into a log flood target. A custom parser that wants a
+      // frame dropped silently can return nothing, which is handled below.
+      if (this.messageParser !== defaultMessageParser) {
+        this.logger.error(err);
       }
-      const messageHandler = handlersMap.get(message.event)!;
-      const { callback } = messageHandler;
-      return transform(callback(message.data, message.event));
+      return EMPTY;
+    }
+    if (!message) {
+      return EMPTY;
+    }
+
+    const messageHandler = handlersMap.get(message.event);
+    if (!messageHandler) {
+      // An unrecognised event is an expected condition on a public socket,
+      // not an error. It used to reach the catch below as a TypeError.
+      return EMPTY;
+    }
+
+    try {
+      return transform(messageHandler.callback(message.data, message.event));
     } catch {
+      // Kept deliberately: a synchronous throw here would otherwise propagate
+      // through the mergeMap in bindMessageHandlers and tear down the client's
+      // source stream, silencing every subsequent message from that client.
       return EMPTY;
     }
   }

--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -39,6 +39,12 @@ type WsAdapterOptions = {
 
 const UNDERLYING_HTTP_SERVER_PORT = 0;
 
+// Kept out of the class so that an adapter can be compared against it to tell
+// whether the parser in use is still the built-in one.
+const defaultMessageParser: WsMessageParser = (data: WsData) => {
+  return JSON.parse(data.toString());
+};
+
 /**
  * @publicApi
  */
@@ -56,9 +62,7 @@ export class WsAdapter extends AbstractWsAdapter {
     HttpServerRegistryKey,
     UpgradeListener
   >();
-  protected messageParser: WsMessageParser = (data: WsData) => {
-    return JSON.parse(data.toString());
-  };
+  protected messageParser: WsMessageParser = defaultMessageParser;
 
   constructor(
     appOrHttpServer?: INestApplicationContext | object,

--- a/packages/platform-ws/test/ws-adapter.spec.ts
+++ b/packages/platform-ws/test/ws-adapter.spec.ts
@@ -1,7 +1,141 @@
 import { createServer } from 'http';
+import { lastValueFrom, of, toArray, type Observable } from 'rxjs';
 import { WsAdapter } from '../adapters/ws-adapter.js';
 
 describe('WsAdapter', () => {
+  describe('bindMessageHandler', () => {
+    const collect = (source: Observable<any>) =>
+      lastValueFrom(source.pipe(toArray()));
+    const transform = (data: any) => of(data);
+    const frame = (payload: unknown) => ({ data: JSON.stringify(payload) });
+    const handlersFor = (event: string, callback: (...args: any[]) => any) =>
+      new Map([
+        [
+          event,
+          {
+            message: event,
+            methodName: event,
+            callback,
+            isAckHandledManually: false,
+          },
+        ],
+      ]) as any;
+    const silenceLogger = (adapter: WsAdapter) =>
+      vi.spyOn(adapter['logger'], 'error').mockImplementation(() => undefined);
+
+    it('should report a custom message parser that throws', async () => {
+      const adapter = new WsAdapter(undefined, {
+        messageParser: () => {
+          throw new Error('parser blew up');
+        },
+      });
+      const logError = silenceLogger(adapter);
+
+      const result = await collect(
+        adapter.bindMessageHandler({ data: 'anything' }, new Map(), transform),
+      );
+
+      expect(result).toEqual([]);
+      expect(logError).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report a throwing parser installed through setMessageParser', async () => {
+      const adapter = new WsAdapter();
+      adapter.setMessageParser(() => {
+        throw new Error('parser blew up');
+      });
+      const logError = silenceLogger(adapter);
+
+      const result = await collect(
+        adapter.bindMessageHandler({ data: 'anything' }, new Map(), transform),
+      );
+
+      expect(result).toEqual([]);
+      expect(logError).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stay silent when the default parser rejects a malformed frame', async () => {
+      const adapter = new WsAdapter();
+      const logError = silenceLogger(adapter);
+
+      const result = await collect(
+        adapter.bindMessageHandler({ data: 'not json' }, new Map(), transform),
+      );
+
+      expect(result).toEqual([]);
+      expect(logError).not.toHaveBeenCalled();
+    });
+
+    it('should drop an unregistered event without invoking any handler', async () => {
+      const adapter = new WsAdapter();
+      const callback = vi.fn();
+      const logError = silenceLogger(adapter);
+
+      const result = await collect(
+        adapter.bindMessageHandler(
+          frame({ event: 'nope', data: {} }),
+          handlersFor('known', callback),
+          transform,
+        ),
+      );
+
+      expect(result).toEqual([]);
+      expect(callback).not.toHaveBeenCalled();
+      expect(logError).not.toHaveBeenCalled();
+    });
+
+    it('should drop the frame when the parser returns nothing', async () => {
+      const adapter = new WsAdapter(undefined, {
+        messageParser: () => undefined,
+      });
+      const callback = vi.fn();
+
+      const result = await collect(
+        adapter.bindMessageHandler(
+          { data: 'anything' },
+          handlersFor('known', callback),
+          transform,
+        ),
+      );
+
+      expect(result).toEqual([]);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('should invoke the registered handler with the payload and the event name', async () => {
+      const adapter = new WsAdapter();
+      const callback = vi.fn().mockReturnValue('reply');
+
+      const result = await collect(
+        adapter.bindMessageHandler(
+          frame({ event: 'known', data: { a: 1 } }),
+          handlersFor('known', callback),
+          transform,
+        ),
+      );
+
+      expect(callback).toHaveBeenCalledWith({ a: 1 }, 'known');
+      expect(result).toEqual(['reply']);
+    });
+
+    it('should not let a throwing handler tear down the message stream', async () => {
+      const adapter = new WsAdapter();
+      const callback = () => {
+        throw new Error('handler blew up');
+      };
+
+      const result = await collect(
+        adapter.bindMessageHandler(
+          frame({ event: 'known', data: {} }),
+          handlersFor('known', callback),
+          transform,
+        ),
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('dispose', () => {
     it('should remove the upgrade listener it added to a caller-supplied server', async () => {
       const httpServer = createServer();


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17624

`WsAdapter.bindMessageHandler` wraps its whole body in a single `try` with an empty `catch`, so three unrelated failures are indistinguishable from a dropped packet — no reply, no log, no exception filter:

1. a custom `messageParser` that throws — the application's own bug, invisible
2. a malformed frame — the default parser throws `SyntaxError`
3. an event with no registered handler — `handlersMap.get(...)!` returns `undefined` and the destructure on the next line throws a `TypeError`

The `WsProxy` / `WsExceptionsHandler` path fixed in #16366 only covers exceptions raised *inside* a registered handler, which is downstream of all three above.

For what it's worth, the empty `catch` doesn't look like a deliberate error policy: it dates back to 53687ba46 (2018), and the unknown-event `TypeError` predates the `Map` — it was already there when the lookup was `handlers.find(...)`. 8c7718e38 later swapped `find` for `get` for performance and kept the shape as it was.

## What is the new behavior?

The single `try` becomes three explicit blocks, one per failure origin.

**Handler lookup.** `get(...)!` + destructure is replaced by a plain guard on the result. An unrecognised event now returns `EMPTY` because the code says so, not because a `TypeError` happens to be caught. This keeps the single map lookup from 8c7718e38 — I deliberately did not use `has()` + `get()`, which would double the lookups in the hot path.

**Parser failures.** A custom parser that throws is now reported through `this.logger.error`. The default parser stays silent: it throws on client-controlled input, and logging that would turn a public socket into a log flood target — the concern raised in the issue. Telling the two apart is a reference comparison against the extracted `defaultMessageParser`, which also covers a subclass assigning the protected field directly.

A custom parser that wants a frame dropped quietly can still return nothing — `WsMessageParser` is typed `=> { event, data } | void` and the `void` case was already handled. So "throw" can mean "something is wrong" without that being the only way to reject a frame.

**Unknown events stay silent**, as suggested in the issue — dropping unrecognised traffic is a reasonable default for a public socket, and this keeps the change behaviour-preserving there.

**One thing worth flagging that isn't in the issue:** removing the outer `try` outright is not safe. A synchronous throw from `callback` currently becomes `EMPTY`; without a `try` it propagates through the `mergeMap` in `bindMessageHandlers` and tears down the client's `source$`, so that client silently stops receiving *every* subsequent message, not just the failing one. That catch is kept, just separated from the parse one, and there is a test pinning it.

Verified end-to-end against a real `ws` client — after an unknown event, a malformed frame, a throwing parser and a throwing handler in sequence, the connection still answers the next valid message.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Externally observable behaviour is unchanged in every case except one: a throwing **custom** parser is now logged. Unknown events, malformed frames on the default parser, and throwing handlers all behave exactly as before.

## Other information

Tests live in `packages/platform-ws/test/ws-adapter.spec.ts`, extending the file added with the `dispose` fix. Seven cases: throwing custom parser (constructor and `setMessageParser`), malformed frame on the default parser, unknown event, void parser, happy path, and the throwing-handler case that pins the teardown risk above.

One open question I did not want to decide unilaterally: **should a throwing `callback` also be logged?** I left it at the current behaviour (`EMPTY`, no log) to keep the diff behaviour-preserving, but it is reachable from client input, so the logging policy there felt like a maintainer call. Happy to add it in a follow-up commit if you want it.
