### PR TITLE
refactor(core): extract duplicate isDebugMode() into shared injector helper

### DIFF
--- a/packages/core/injector/helpers/is-debug-mode.util.ts
+++ b/packages/core/injector/helpers/is-debug-mode.util.ts
@@ -1,0 +1,3 @@
+export function isDebugMode(): boolean {
+  return !!process.env.NEST_DEBUG;
+}

--- a/packages/core/injector/injector.ts
+++ b/packages/core/injector/injector.ts
@@ -31,6 +31,7 @@ import { UnknownDependenciesException } from '../errors/exceptions/unknown-depen
 import { Barrier } from '../helpers/barrier.js';
 import { makeSafeInstanceDecorator } from '../helpers/safe-instance-decorator.js';
 import { STATIC_CONTEXT } from './constants.js';
+import { isDebugMode } from './helpers/is-debug-mode.util.js';
 import { INQUIRER } from './inquirer/index.js';
 import {
   ContextId,
@@ -1268,7 +1269,7 @@ export class Injector {
     token: InjectionToken,
     inquirer?: InstanceWrapper,
   ): void {
-    if (!this.isDebugMode()) {
+    if (!isDebugMode()) {
       return;
     }
     const tokenName = this.getTokenName(token);
@@ -1289,7 +1290,7 @@ export class Injector {
     token: InjectionToken,
     moduleRef: Module,
   ): void {
-    if (!this.isDebugMode()) {
+    if (!isDebugMode()) {
       return;
     }
     const tokenName = this.getTokenName(token);
@@ -1305,7 +1306,7 @@ export class Injector {
     token: InjectionToken,
     moduleRef: Module,
   ): void {
-    if (!this.isDebugMode()) {
+    if (!isDebugMode()) {
       return;
     }
     const tokenName = this.getTokenName(token);
@@ -1315,10 +1316,6 @@ export class Injector {
         ' in ',
       )}${clc.magentaBright(moduleRefName)}`,
     );
-  }
-
-  private isDebugMode(): boolean {
-    return !!process.env.NEST_DEBUG;
   }
 
   private getContextId(

--- a/packages/core/injector/instance-wrapper.ts
+++ b/packages/core/injector/instance-wrapper.ts
@@ -17,6 +17,7 @@ import {
 import { iterate } from 'iterare';
 import { UuidFactory } from '../inspector/uuid-factory.js';
 import { STATIC_CONTEXT } from './constants.js';
+import { isDebugMode } from './helpers/is-debug-mode.util.js';
 import {
   isClassProvider,
   isFactoryProvider,
@@ -90,8 +91,7 @@ export class InstanceWrapper<T = any> {
   private readonly [INSTANCE_METADATA_SYMBOL]: InstanceMetadataStore = {};
   private readonly [INSTANCE_ID_SYMBOL]: string;
   private transientMap?:
-    | Map<string, WeakMap<ContextId, InstancePerContext<T>>>
-    | undefined;
+    Map<string, WeakMap<ContextId, InstancePerContext<T>>> | undefined;
   private isTreeStatic: boolean | undefined;
   private isTreeDurable: boolean | undefined;
   private _hierarchyLevel = 0;
@@ -553,7 +553,7 @@ export class InstanceWrapper<T = any> {
   }
 
   private printIntrospectedAsRequestScoped() {
-    if (!this.isDebugMode() || this.name === 'REQUEST') {
+    if (!isDebugMode() || this.name === 'REQUEST') {
       return;
     }
     if (isString(this.name)) {
@@ -566,7 +566,7 @@ export class InstanceWrapper<T = any> {
   }
 
   private printIntrospectedAsDurable() {
-    if (!this.isDebugMode()) {
+    if (!isDebugMode()) {
       return;
     }
     if (isString(this.name)) {
@@ -576,10 +576,6 @@ export class InstanceWrapper<T = any> {
         )}${clc.magentaBright('durable')}`,
       );
     }
-  }
-
-  private isDebugMode(): boolean {
-    return !!process.env.NEST_DEBUG;
   }
 
   private generateUuid(): string {


### PR DESCRIPTION
Closes #17636

`isDebugMode()` was defined as a byte-identical private method 
in both `Injector` and `InstanceWrapper`. Extracted to 
`packages/core/injector/helpers/is-debug-mode.util.ts` 
and imported by both. No behavior change.
