### PR TITLE
fix(microservices): run the mqtt listen callback once

### DIFF
--- a/packages/microservices/server/server-mqtt.ts
+++ b/packages/microservices/server/server-mqtt.ts
@@ -80,7 +80,7 @@ export class ServerMqtt extends Server<MqttEvents, MqttStatus> {
     this.pendingEventListeners = [];
     this.bindEvents(this.mqttClient);
 
-    this.mqttClient.on(MqttEventsMap.CONNECT, () => callback());
+    this.mqttClient.once(MqttEventsMap.CONNECT, () => callback());
   }
 
   public bindEvents(mqttClient: MqttClient) {

--- a/packages/microservices/test/server/server-mqtt.spec.ts
+++ b/packages/microservices/test/server/server-mqtt.spec.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { NO_MESSAGE_HANDLER } from '../../constants.js';
 import { BaseRpcContext } from '../../ctx-host/base-rpc.context.js';
 import { MqttContext } from '../../ctx-host/index.js';
@@ -14,13 +15,16 @@ describe('ServerMqtt', () => {
   });
   describe('listen', () => {
     let onSpy: ReturnType<typeof vi.fn>;
+    let onceSpy: ReturnType<typeof vi.fn>;
     let client: any;
     let callbackSpy: ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
       onSpy = vi.fn();
+      onceSpy = vi.fn();
       client = {
         on: onSpy,
+        once: onceSpy,
       };
       vi.spyOn(server, 'createMqttClient').mockImplementation(() => client);
       callbackSpy = vi.fn();
@@ -48,6 +52,24 @@ describe('ServerMqtt', () => {
     it('should bind "message" event to handler', async () => {
       await server.listen(callbackSpy);
       expect(onSpy.mock.calls[5][0]).toBe('message');
+    });
+    it('should bind the callback with "once"', async () => {
+      await server.listen(callbackSpy);
+
+      expect(onceSpy).toHaveBeenCalledWith('connect', expect.any(Function));
+    });
+    it('should run the callback once, as mqtt reconnects on the same client', async () => {
+      // A real emitter, because mqtt re-emits "connect" on the same client
+      // after every reconnect.
+      const emitter: any = new EventEmitter();
+      vi.spyOn(server, 'createMqttClient').mockImplementation(() => emitter);
+
+      await server.listen(callbackSpy);
+      emitter.emit('connect');
+      emitter.emit('connect');
+      emitter.emit('connect');
+
+      expect(callbackSpy).toHaveBeenCalledExactlyOnceWith();
     });
     describe('when "start" throws an exception', () => {
       it('should call callback with a thrown error as an argument', async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #17640

`ServerMqtt.listen` binds the bootstrap callback with `on`, not `once`:

```ts
this.mqttClient.on(MqttEventsMap.CONNECT, () => callback());
```

mqtt reconnects on the same client object. `_reconnect()` calls
`this.connect()`, which emits `connect` again, and a listener bound with `on`
stays. Nest thus runs the callback again each time the broker comes back.

`NestMicroservice.listen` puts `flushLogs()` and the "Nest microservice
successfully started" line in that callback. A broker that restarts three times
therefore reports four starts. The service started once.

## What is the new behavior?

The callback runs once, as it does on the other transports.

```
                                           before   after
one start plus two reconnects                   3       1
```

The status listener keeps `on`: it must follow every reconnect, and it does not
change.

MQTT was the only transport that bound this callback with `on`:

| Transport | How it runs the `listen()` callback |
|---|---|
| TCP | `server.listen(port, host, callback)` — Node runs it once |
| RabbitMQ | `.once(RmqEventsMap.CONNECT, ...)` |
| Redis, NATS, Kafka | called inline, once |
| **MQTT** | **`.on(...)`** |

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

A service starts once. Running the bootstrap callback again on a reconnect was
not behavior to depend on.

## Other information

**Tests.** The new test uses a real `EventEmitter`, because mqtt re-emits
`connect` on the same client. It fails on master with
`expected called once, but got 3 times`.

**Reproduction.**
[`mqtt-listen-callback-reconnect`](https://github.com/johnnyhuirilef/nestjs-repros/tree/main/mqtt-listen-callback-reconnect)
runs the broker in-process, thus no external broker is needed. It prints `BUG`
or `FIXED` for the version it runs against.
