### PR TITLE
refactor(common): dedupe stripProtoKeys logic into shared util

### DIFF
--- a/packages/common/pipes/standard-schema-validation.pipe.ts
+++ b/packages/common/pipes/standard-schema-validation.pipe.ts
@@ -1,5 +1,4 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { types } from 'util';
 import { Injectable } from '../decorators/core/injectable.decorator.js';
 import { Optional } from '../decorators/core/optional.decorator.js';
 import { HttpStatus } from '../enums/http-status.enum.js';
@@ -11,12 +10,7 @@ import {
   ErrorHttpStatusCode,
   HttpErrorByCode,
 } from '../utils/http-error-by-code.util.js';
-
-/**
- * Built-in JavaScript types that should be excluded from prototype stripping
- * to avoid conflicts with test frameworks like Jest's useFakeTimers
- */
-const BUILT_IN_TYPES = [Date, RegExp, Error, Map, Set, WeakMap, WeakSet];
+import { stripProtoKeys } from '../utils/strip-proto-keys.util.js';
 
 /**
  * @publicApi
@@ -125,7 +119,7 @@ export class StandardSchemaValidationPipe implements PipeTransform {
       return value;
     }
 
-    this.stripProtoKeys(value);
+    stripProtoKeys(value);
 
     const result = await this.validate<T>(value, schema, this.validateOptions);
 
@@ -165,43 +159,10 @@ export class StandardSchemaValidationPipe implements PipeTransform {
     options?: Record<string, unknown>,
   ): Promise<StandardSchemaV1.Result<T>> | StandardSchemaV1.Result<T> {
     return schema['~standard'].validate(value, options) as
-      | Promise<StandardSchemaV1.Result<T>>
-      | StandardSchemaV1.Result<T>;
+      Promise<StandardSchemaV1.Result<T>> | StandardSchemaV1.Result<T>;
   }
 
-  /**
-   * Strips dangerous prototype pollution keys from an object.
-   */
-  protected stripProtoKeys(value: any) {
-    if (
-      value == null ||
-      typeof value !== 'object' ||
-      types.isTypedArray(value)
-    ) {
-      return;
-    }
-
-    if (BUILT_IN_TYPES.some(type => value instanceof type)) {
-      return;
-    }
-
-    if (Array.isArray(value)) {
-      for (const v of value) {
-        this.stripProtoKeys(v);
-      }
-      return;
-    }
-
-    delete value.__proto__;
-    delete value.prototype;
-
-    const constructorType = value?.constructor;
-    if (constructorType && !BUILT_IN_TYPES.includes(constructorType)) {
-      delete value.constructor;
-    }
-
-    for (const key in value) {
-      this.stripProtoKeys(value[key]);
-    }
+  protected stripProtoKeys(value: any): void {
+    stripProtoKeys(value);
   }
 }

--- a/packages/common/pipes/validation.pipe.ts
+++ b/packages/common/pipes/validation.pipe.ts
@@ -1,5 +1,4 @@
 import { iterate } from 'iterare';
-import { types } from 'util';
 import { Injectable } from '../decorators/core/index.js';
 import { Optional } from '../decorators/index.js';
 import { HttpStatus } from '../enums/http-status.enum.js';
@@ -20,6 +19,7 @@ import {
 } from '../utils/http-error-by-code.util.js';
 import { loadPackage } from '../utils/load-package.util.js';
 import { isNil, isUndefined } from '../utils/shared.utils.js';
+import { stripProtoKeys } from '../utils/strip-proto-keys.util.js';
 
 /**
  * @publicApi
@@ -55,12 +55,6 @@ export interface ValidationPipeOptions extends ValidatorOptions {
 
 let classValidator: any = {} as any;
 let classTransformer: any = {} as any;
-
-/**
- * Built-in JavaScript types that should be excluded from prototype stripping
- * to avoid conflicts with test frameworks like Jest's useFakeTimers
- */
-const BUILT_IN_TYPES = [Date, RegExp, Error, Map, Set, WeakMap, WeakSet];
 
 /**
  * @see [Validation](https://docs.nestjs.com/techniques/validation)
@@ -157,7 +151,7 @@ export class ValidationPipe implements PipeTransform {
 
     const isNil = value !== originalValue;
     const isPrimitive = this.isPrimitive(value);
-    this.stripProtoKeys(value);
+    stripProtoKeys(value);
     let entity = classTransformer.plainToInstance(
       metatype,
       value,
@@ -296,44 +290,12 @@ export class ValidationPipe implements PipeTransform {
     return '';
   }
 
-  protected stripProtoKeys(value: any) {
-    if (
-      value == null ||
-      typeof value !== 'object' ||
-      types.isTypedArray(value)
-    ) {
-      return;
-    }
-
-    // Skip built-in JavaScript primitives to avoid Jest useFakeTimers conflicts
-    if (BUILT_IN_TYPES.some(type => value instanceof type)) {
-      return;
-    }
-
-    if (Array.isArray(value)) {
-      for (const v of value) {
-        this.stripProtoKeys(v);
-      }
-      return;
-    }
-
-    // Delete dangerous prototype pollution keys
-    delete value.__proto__;
-    delete value.prototype;
-
-    // Only delete constructor if it's NOT a built-in type
-    const constructorType = value?.constructor;
-    if (constructorType && !BUILT_IN_TYPES.includes(constructorType)) {
-      delete value.constructor;
-    }
-
-    for (const key in value) {
-      this.stripProtoKeys(value[key]);
-    }
-  }
-
   protected isPrimitive(value: unknown): boolean {
     return ['number', 'boolean', 'string'].includes(typeof value);
+  }
+
+  protected stripProtoKeys(value: any): void {
+    stripProtoKeys(value);
   }
 
   protected validate(

--- a/packages/common/test/pipes/standard-schema-validation.pipe.spec.ts
+++ b/packages/common/test/pipes/standard-schema-validation.pipe.spec.ts
@@ -414,4 +414,18 @@ describe('StandardSchemaValidationPipe', () => {
       });
     });
   });
+
+  describe('subclass compatibility', () => {
+    it('should allow subclasses to call super.stripProtoKeys', () => {
+      class CustomPipe extends StandardSchemaValidationPipe {
+        public callSuperStripProtoKeys(value: any) {
+          super.stripProtoKeys(value);
+        }
+      }
+      const customPipe = new CustomPipe();
+      const value = { constructor: 'malicious' };
+      expect(() => customPipe.callSuperStripProtoKeys(value)).not.toThrow();
+      expect(value).not.toHaveProperty('constructor');
+    });
+  });
 });

--- a/packages/common/test/pipes/validation.pipe.spec.ts
+++ b/packages/common/test/pipes/validation.pipe.spec.ts
@@ -699,135 +699,6 @@ describe('ValidationPipe', () => {
       expect(await target.transform(testObj, m)).toEqual(testObj);
     });
   });
-  describe('stripProtoKeys', () => {
-    beforeEach(() => {
-      target = new ValidationPipe();
-    });
-
-    describe('with built-in JavaScript primitives', () => {
-      it('should not throw error when processing Date objects', () => {
-        const value = { date: new Date() };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should not throw error when processing RegExp objects', () => {
-        const value = { regex: /test/i };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should not throw error when processing Error objects', () => {
-        const value = { error: new Error('test') };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should not throw error when processing Map objects', () => {
-        const value = { map: new Map() };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should not throw error when processing Set objects', () => {
-        const value = { set: new Set() };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should preserve Date object properties', () => {
-        const date = new Date();
-        const value = { date };
-        target['stripProtoKeys'](value);
-        expect(value.date).toBe(date);
-        expect(value.date.constructor).toBe(Date);
-      });
-    });
-
-    describe('with plain objects', () => {
-      it('should still strip constructor from regular objects', () => {
-        const value = { nested: { constructor: 'malicious' } };
-        target['stripProtoKeys'](value);
-        // Check if 'constructor' is NOT an own property
-        expect(value.nested).not.toHaveProperty('constructor');
-      });
-
-      it('should strip __proto__ from objects', () => {
-        const value = { __proto__: { malicious: 'code' } };
-        target['stripProtoKeys'](value);
-        expect(value).not.toHaveProperty('__proto__');
-      });
-
-      it('should strip prototype from objects', () => {
-        const value = { prototype: { malicious: 'code' } };
-        target['stripProtoKeys'](value);
-        expect(value).not.toHaveProperty('prototype');
-      });
-
-      it('should recursively strip nested objects', () => {
-        const value = {
-          level1: {
-            constructor: 'malicious',
-            level2: {
-              constructor: 'alsoMalicious',
-            },
-          },
-        };
-        target['stripProtoKeys'](value);
-        expect(value.level1).not.toHaveProperty('constructor');
-        expect(value.level1.level2).not.toHaveProperty('constructor');
-      });
-    });
-
-    describe('with arrays', () => {
-      it('should process arrays recursively', () => {
-        const value = {
-          items: [
-            { constructor: 'malicious' },
-            { constructor: 'alsoMalicious' },
-          ],
-        };
-        target['stripProtoKeys'](value);
-        expect(value.items[0]).not.toHaveProperty('constructor');
-        expect(value.items[1]).not.toHaveProperty('constructor');
-      });
-
-      it('should not throw error when array contains Date objects', () => {
-        const value = { dates: [new Date(), new Date()] };
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-    });
-
-    describe('Issue #16195: Jest useFakeTimers compatibility', () => {
-      beforeEach(() => {
-        target = new ValidationPipe();
-      });
-
-      it('should handle Date objects with non-configurable constructor', () => {
-        const value = { date: new Date() };
-
-        // Make constructor non-configurable like Jest does
-        Object.defineProperty(value.date, 'constructor', {
-          value: Date,
-          writable: false,
-          enumerable: false,
-          configurable: false,
-        });
-
-        // This should NOT throw "Cannot delete property 'constructor'"
-        expect(() => target['stripProtoKeys'](value)).not.toThrow();
-      });
-
-      it('should not attempt to delete constructor from built-in types', () => {
-        const testCases = [
-          { date: new Date() },
-          { regex: /test/i },
-          { error: new Error('test') },
-          { map: new Map() },
-          { set: new Set() },
-        ];
-
-        testCases.forEach(testCase => {
-          expect(() => target['stripProtoKeys'](testCase)).not.toThrow();
-        });
-      });
-    });
-  });
   describe('Issue #17398: when only ValidationPipe-specific options are provided', () => {
     it('should return the original value when exceptionFactory is provided', async () => {
       target = new ValidationPipe({
@@ -854,6 +725,20 @@ describe('ValidationPipe', () => {
       const testObj = { prop1: 'value1', prop2: 'value2' };
       const result = await target.transform(testObj, metadata);
       expect(result).toBe(testObj);
+    });
+  });
+
+  describe('subclass compatibility', () => {
+    it('should allow subclasses to call super.stripProtoKeys', () => {
+      class CustomPipe extends ValidationPipe {
+        public callSuperStripProtoKeys(value: any) {
+          super.stripProtoKeys(value);
+        }
+      }
+      const pipe = new CustomPipe();
+      const value = { constructor: 'malicious' };
+      expect(() => pipe.callSuperStripProtoKeys(value)).not.toThrow();
+      expect(value).not.toHaveProperty('constructor');
     });
   });
 });

--- a/packages/common/test/utils/strip-proto-keys.util.spec.ts
+++ b/packages/common/test/utils/strip-proto-keys.util.spec.ts
@@ -1,0 +1,117 @@
+import { stripProtoKeys } from '../../utils/strip-proto-keys.util.js';
+
+describe('stripProtoKeys', () => {
+  describe('with built-in JavaScript primitives', () => {
+    it('should not throw error when processing Date objects', () => {
+      const value = { date: new Date() };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should not throw error when processing RegExp objects', () => {
+      const value = { regex: /test/i };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should not throw error when processing Error objects', () => {
+      const value = { error: new Error('test') };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should not throw error when processing Map objects', () => {
+      const value = { map: new Map() };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should not throw error when processing Set objects', () => {
+      const value = { set: new Set() };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should preserve Date object properties', () => {
+      const date = new Date();
+      const value = { date };
+      stripProtoKeys(value);
+      expect(value.date).toBe(date);
+      expect(value.date.constructor).toBe(Date);
+    });
+  });
+
+  describe('with plain objects', () => {
+    it('should still strip constructor from regular objects', () => {
+      const value = { nested: { constructor: 'malicious' } };
+      stripProtoKeys(value);
+      expect(value.nested).not.toHaveProperty('constructor');
+    });
+
+    it('should strip __proto__ from objects', () => {
+      const value = { __proto__: { malicious: 'code' } };
+      stripProtoKeys(value);
+      expect(value).not.toHaveProperty('__proto__');
+    });
+
+    it('should strip prototype from objects', () => {
+      const value = { prototype: { malicious: 'code' } };
+      stripProtoKeys(value);
+      expect(value).not.toHaveProperty('prototype');
+    });
+
+    it('should recursively strip nested objects', () => {
+      const value = {
+        level1: {
+          constructor: 'malicious',
+          level2: {
+            constructor: 'alsoMalicious',
+          },
+        },
+      };
+      stripProtoKeys(value);
+      expect(value.level1).not.toHaveProperty('constructor');
+      expect(value.level1.level2).not.toHaveProperty('constructor');
+    });
+  });
+
+  describe('with arrays', () => {
+    it('should process arrays recursively', () => {
+      const value = {
+        items: [{ constructor: 'malicious' }, { constructor: 'alsoMalicious' }],
+      };
+      stripProtoKeys(value);
+      expect(value.items[0]).not.toHaveProperty('constructor');
+      expect(value.items[1]).not.toHaveProperty('constructor');
+    });
+
+    it('should not throw error when array contains Date objects', () => {
+      const value = { dates: [new Date(), new Date()] };
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+  });
+
+  describe('Issue #16195: Jest useFakeTimers compatibility', () => {
+    it('should handle Date objects with non-configurable constructor', () => {
+      const value = { date: new Date() };
+
+      Object.defineProperty(value.date, 'constructor', {
+        value: Date,
+        writable: false,
+        enumerable: false,
+        configurable: false,
+      });
+
+      expect(() => stripProtoKeys(value)).not.toThrow();
+    });
+
+    it('should not attempt to delete constructor from built-in types', () => {
+      const testCases = [
+        { date: new Date() },
+        { regex: /test/i },
+        { error: new Error('test') },
+        { map: new Map() },
+        { set: new Set() },
+      ];
+
+      testCases.forEach(testCase => {
+        expect(() => stripProtoKeys(testCase)).not.toThrow();
+      });
+    });
+  });
+});

--- a/packages/common/utils/index.ts
+++ b/packages/common/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './forward-ref.util.js';
+export * from './strip-proto-keys.util.js';

--- a/packages/common/utils/strip-proto-keys.util.ts
+++ b/packages/common/utils/strip-proto-keys.util.ts
@@ -1,0 +1,43 @@
+import { types } from 'util';
+
+/**
+ * Built-in JavaScript types that should be excluded from prototype stripping
+ * to avoid conflicts with test frameworks like Jest's useFakeTimers
+ */
+const BUILT_IN_TYPES = [Date, RegExp, Error, Map, Set, WeakMap, WeakSet];
+
+/**
+ * Strips dangerous prototype pollution keys (__proto__, prototype, constructor)
+ * from an object recursively.
+ */
+export function stripProtoKeys(value: any): void {
+  if (value == null || typeof value !== 'object' || types.isTypedArray(value)) {
+    return;
+  }
+
+  // Skip built-in JavaScript primitives to avoid Jest useFakeTimers conflicts
+  if (BUILT_IN_TYPES.some(type => value instanceof type)) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const v of value) {
+      stripProtoKeys(v);
+    }
+    return;
+  }
+
+  // Delete dangerous prototype pollution keys
+  delete value.__proto__;
+  delete value.prototype;
+
+  // Only delete constructor if it's NOT a built-in type
+  const constructorType = value?.constructor;
+  if (constructorType && !BUILT_IN_TYPES.includes(constructorType)) {
+    delete value.constructor;
+  }
+
+  for (const key in value) {
+    stripProtoKeys(value[key]);
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`stripProtoKeys` and its `BUILT_IN_TYPES` constant are duplicated character-for-character across two pipes:
- `ValidationPipe` — `packages/common/pipes/validation.pipe.ts`
- `StandardSchemaValidationPipe` — `packages/common/pipes/standard-schema-validation.pipe.ts`

This logic prevents prototype-pollution attacks, but living in two copies means a future fix or hardening in one file could silently diverge from the other — weakening the guard in one path.

Issue Number: N/A

## What is the new behavior?

Extracted the duplicated `stripProtoKeys` logic and `BUILT_IN_TYPES` constant into a single shared utility:
- New: `packages/common/utils/strip-proto-keys.util.ts` (+ matching `packages/common/test/utils/strip-proto-keys.util.spec.ts`)

Both pipes now import and call this single source of truth, so the protection can no longer drift between them.

To avoid breaking downstream code, both `ValidationPipe` and `StandardSchemaValidationPipe` retain a thin `protected stripProtoKeys(value)` passthrough method, so existing subclasses that call `super.stripProtoKeys(value)` keep working without changes.

Behavior is otherwise identical — the code was moved, not rewritten. Subclass-compatibility tests were added for both pipes. Net diff is **-17 lines**; full `packages/common` suite passes and `oxlint packages/common` is clean.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
