### PR TITLE
fix(common): validate UUID v3 variant

### DIFF
--- a/packages/common/pipes/parse-uuid.pipe.ts
+++ b/packages/common/pipes/parse-uuid.pipe.ts
@@ -47,7 +47,7 @@ export interface ParseUUIDPipeOptions {
 @Injectable()
 export class ParseUUIDPipe implements PipeTransform {
   protected static uuidRegExps = {
-    3: /^[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[0-9A-F]{4}-[0-9A-F]{12}$/i,
+    3: /^[0-9A-F]{8}-[0-9A-F]{4}-3[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
     4: /^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
     5: /^[0-9A-F]{8}-[0-9A-F]{4}-5[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,
     7: /^[0-9A-F]{8}-[0-9A-F]{4}-7[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i,

--- a/packages/common/test/pipes/parse-uuid.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-uuid.pipe.spec.ts
@@ -78,6 +78,16 @@ describe('ParseUUIDPipe', () => {
         ).rejects.toThrow(TestException);
       });
 
+      it('should throw an error for a UUID v3 with an invalid variant', async () => {
+        target = new ParseUUIDPipe({ version: '3', exceptionFactory });
+        await expect(
+          target.transform(
+            'e8b5a51d-11c8-3310-06ab-367563f20686',
+            {} as ArgumentMetadata,
+          ),
+        ).rejects.toThrow(TestException);
+      });
+
       it('should throw an error - v4', async () => {
         target = new ParseUUIDPipe({ version: '4', exceptionFactory });
         await expect(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (not applicable: this change does not modify the public API or configuration)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`ParseUUIDPipe` validates the version nibble of UUID v3 values but does not validate their variant nibble.

The existing UUID v3 regular expression accepts any hexadecimal character at the beginning of the fourth group. As a result, a value such as the following passes validation with `new ParseUUIDPipe({ version: '3' })`:

```text
e8b5a51d-11c8-3310-06ab-367563f20686
```

Its variant nibble is `0`, which does not represent the RFC/IETF UUID variant. RFC 9562 requires the variant bits to be `10`, represented by hexadecimal values `8`, `9`, `A`, or `B`.

The UUID v4, v5, and v7 patterns already enforce this constraint using `[89AB]`.

Issue Number: N/A

## What is the new behavior?

The UUID v3 regular expression now restricts the variant nibble to `8`, `9`, `A`, or `B`, matching the validation already applied to UUID v4, v5, and v7.

A regression test verifies that a UUID v3-shaped value with an invalid variant is rejected, while the existing valid UUID v3 test continues to pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This change only rejects values that were previously accepted as UUID v3 despite not having a valid RFC/IETF variant.

## Other information

Reference: [[RFC 9562, Section 4.1 — Variant Field](https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1)](https://www.rfc-editor.org/rfc/rfc9562.html#section-4.1)

Validation performed:

- `npx --no-install vitest run packages/common/test/pipes/parse-uuid.pipe.spec.ts`
  - 1 test file passed
  - 11 tests passed
- `npx --no-install tsc -p packages/common/tsconfig.build.json --noEmit --tsBuildInfoFile /tmp/nest-common.tsbuildinfo --pretty false`
- `npx --no-install oxlint packages/common/pipes/parse-uuid.pipe.ts packages/common/test/pipes/parse-uuid.pipe.spec.ts`
- `npx --no-install prettier --check packages/common/pipes/parse-uuid.pipe.ts packages/common/test/pipes/parse-uuid.pipe.spec.ts`