### PR TITLE
fix(socket.io): keep the message stream alive when a handler throws

### DIFF
--- a/packages/platform-socket.io/adapters/io-adapter.ts
+++ b/packages/platform-socket.io/adapters/io-adapter.ts
@@ -2,9 +2,10 @@ import {
   AbstractWsAdapter,
   type MessageMappingProperties,
 } from '@nestjs/websockets';
-import { fromEvent, Observable } from 'rxjs';
-import { filter, first, map, mergeMap, share, takeUntil } from 'rxjs/operators';
+import { defer, EMPTY, fromEvent, Observable } from 'rxjs';
+import { catchError, filter, first, map, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { Namespace, Server, ServerOptions, Socket } from 'socket.io';
+import { Logger } from '@nestjs/common';
 import { isFunction, isNil } from '@nestjs/common/internal';
 import { DISCONNECT_EVENT } from '@nestjs/websockets/internal';
 
@@ -12,6 +13,7 @@ import { DISCONNECT_EVENT } from '@nestjs/websockets/internal';
  * @publicApi
  */
 export class IoAdapter extends AbstractWsAdapter {
+  protected readonly logger = new Logger(IoAdapter.name);
   private readonly disconnectMap = new WeakMap<Socket, Observable<any>>();
 
   public create(
@@ -51,9 +53,17 @@ export class IoAdapter extends AbstractWsAdapter {
       const source$ = fromEvent(socket, message).pipe(
         mergeMap((payload: any) => {
           const { data, ack } = this.mapPayload(payload);
-          return transform(callback(data, ack)).pipe(
+          // defer turns a sync throw into an error notification and catchError
+          // stops it from tearing down this event's stream, which would silence
+          // that event for the client. A handler whose error filter rethrows is
+          // an app bug, so the failure gets logged instead of dropped silently.
+          return defer(() => transform(callback(data, ack))).pipe(
             filter((response: any) => !isNil(response)),
             map((response: any) => [response, ack, isAckHandledManually]),
+            catchError(err => {
+              this.logger.error(err);
+              return EMPTY;
+            }),
           );
         }),
         takeUntil(disconnect$),

--- a/packages/platform-socket.io/test/io-adapter.spec.ts
+++ b/packages/platform-socket.io/test/io-adapter.spec.ts
@@ -1,5 +1,9 @@
-import { of } from 'rxjs';
+import { EventEmitter } from 'events';
+import { config, from, mergeAll, of } from 'rxjs';
 import { IoAdapter } from '../adapters/io-adapter.js';
+import { WsProxy } from '../../websockets/context/ws-proxy.js';
+import { WsExceptionsHandler } from '../../websockets/exceptions/ws-exceptions-handler.js';
+import { WebSocketsController } from '../../websockets/web-sockets-controller.js';
 
 describe('IoAdapter', () => {
   let adapter: IoAdapter;
@@ -43,6 +47,128 @@ describe('IoAdapter', () => {
         call => call[0] === 'test-event',
       );
       expect(messageCalls).toHaveLength(2);
+    });
+
+    it('should not let a throwing handler tear down the message stream', async () => {
+      const socket = new EventEmitter() as any;
+      let calls = 0;
+      const handler = {
+        message: 'test-event',
+        methodName: 'handleTestEvent',
+        callback: () => {
+          calls++;
+          if (calls === 1) {
+            throw new Error('handler blew up');
+          }
+          return { event: 'test-event-reply', data: 'recovered' };
+        },
+        isAckHandledManually: false,
+      };
+
+      const replies: any[] = [];
+      socket.on('test-event-reply', (payload: any) => replies.push(payload));
+
+      adapter.bindMessageHandlers(socket, [handler], (data: any) => of(data));
+
+      socket.emit('test-event', { data: {} });
+      socket.emit('test-event', { data: {} });
+
+      expect(calls).toBe(2);
+      expect(replies).toEqual(['recovered']);
+    });
+
+    it('should not ack a throwing message but keep acking the next one', () => {
+      const socket = new EventEmitter() as any;
+      let calls = 0;
+      const handler = {
+        message: 'test-event',
+        methodName: 'handleTestEvent',
+        callback: () => {
+          calls++;
+          if (calls === 1) {
+            throw new Error('handler blew up');
+          }
+          return { data: 'ok' };
+        },
+        isAckHandledManually: false,
+      };
+
+      const ack = vi.fn();
+      adapter.bindMessageHandlers(socket, [handler], (data: any) => of(data));
+
+      socket.emit('test-event', [{ a: 1 }, ack]);
+      expect(calls).toBe(1);
+      expect(ack).not.toHaveBeenCalled();
+
+      socket.emit('test-event', [{ a: 1 }, ack]);
+      expect(calls).toBe(2);
+      expect(ack).toHaveBeenCalledWith({ data: 'ok' });
+    });
+
+    it('should not let a rejected handler tear down the message stream', async () => {
+      const unhandled: unknown[] = [];
+      config.onUnhandledError = err => unhandled.push(err);
+      const logError = vi
+        .spyOn(adapter['logger'], 'error')
+        .mockImplementation(() => undefined);
+
+      // an app-level @Catch() filter that rethrows
+      const exceptionsHandler = new WsExceptionsHandler();
+      exceptionsHandler.setCustomFilters([
+        {
+          exceptionMetatypes: [],
+          func: (exception: any) => {
+            throw exception;
+          },
+        },
+      ] as any);
+
+      const socket = new EventEmitter() as any;
+      const replies: any[] = [];
+      socket.on('reply', (payload: any) => replies.push(payload));
+
+      let calls = 0;
+      const callback = new WsProxy()
+        .create(
+          async () => {
+            if (++calls === 1) throw new Error('handler blew up');
+            return { event: 'reply', data: 'ok' };
+          },
+          exceptionsHandler,
+          'test-event',
+        )
+        .bind(undefined, socket);
+
+      // same transform WebSocketsController.subscribeMessages passes in
+      const transform = (data: any) =>
+        from(WebSocketsController.prototype.pickResult.call(undefined, data)).pipe(
+          mergeAll(),
+        );
+
+      adapter.bindMessageHandlers(
+        socket,
+        [
+          {
+            message: 'test-event',
+            methodName: 'm',
+            callback,
+            isAckHandledManually: false,
+          },
+        ],
+        transform,
+      );
+
+      const flush = () => new Promise(resolve => setTimeout(resolve, 5));
+      socket.emit('test-event', {});
+      await flush();
+      socket.emit('test-event', {});
+      await flush();
+      config.onUnhandledError = null;
+
+      expect(calls).toBe(2);
+      expect(replies).toEqual(['ok']);
+      expect(unhandled).toEqual([]);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/platform-ws/adapters/ws-adapter.ts
+++ b/packages/platform-ws/adapters/ws-adapter.ts
@@ -4,7 +4,7 @@ import * as http from 'http';
 import { createRequire } from 'module';
 import type { Duplex } from 'stream';
 import { EMPTY, fromEvent, Observable } from 'rxjs';
-import { filter, first, mergeMap, share, takeUntil } from 'rxjs/operators';
+import { catchError, filter, first, mergeMap, share, takeUntil } from 'rxjs/operators';
 import { loadPackageSync, isNil, normalizePath } from '@nestjs/common/internal';
 import {
   CLOSE_EVENT,
@@ -159,6 +159,13 @@ export class WsAdapter extends AbstractWsAdapter {
       mergeMap(data =>
         this.bindMessageHandler(data, handlersMap, transform).pipe(
           filter(result => !isNil(result)),
+          // a handler that rejects through an error filter that rethrows
+          // would error the client's stream and silence every later message;
+          // that rethrow is an app bug, so it gets logged, not dropped silently
+          catchError(err => {
+            this.logger.error(err);
+            return EMPTY;
+          }),
         ),
       ),
       takeUntil(close$),

--- a/packages/platform-ws/test/ws-adapter.spec.ts
+++ b/packages/platform-ws/test/ws-adapter.spec.ts
@@ -1,6 +1,10 @@
+import { EventEmitter } from 'events';
 import { createServer } from 'http';
-import { lastValueFrom, of, toArray, type Observable } from 'rxjs';
+import { config, from, lastValueFrom, mergeAll, of, toArray, type Observable } from 'rxjs';
 import { WsAdapter } from '../adapters/ws-adapter.js';
+import { WsProxy } from '../../websockets/context/ws-proxy.js';
+import { WsExceptionsHandler } from '../../websockets/exceptions/ws-exceptions-handler.js';
+import { WebSocketsController } from '../../websockets/web-sockets-controller.js';
 
 describe('WsAdapter', () => {
   describe('bindMessageHandler', () => {
@@ -133,6 +137,78 @@ describe('WsAdapter', () => {
       );
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('bindMessageHandlers', () => {
+    const frame = (payload: unknown) => ({ data: JSON.stringify(payload) });
+
+    it('should not let a rejecting handler tear down the message stream', async () => {
+      const unhandled: unknown[] = [];
+      config.onUnhandledError = err => unhandled.push(err);
+
+      // an app-level @Catch() filter that rethrows
+      const exceptionsHandler = new WsExceptionsHandler();
+      exceptionsHandler.setCustomFilters([
+        {
+          exceptionMetatypes: [],
+          func: (exception: any) => {
+            throw exception;
+          },
+        },
+      ] as any);
+
+      const adapter = new WsAdapter();
+      const logError = vi
+        .spyOn(adapter['logger'], 'error')
+        .mockImplementation(() => undefined);
+
+      const client = new EventEmitter() as any;
+      client.readyState = 1; // OPEN_STATE
+      const replies: any[] = [];
+      client.send = (payload: string) => replies.push(JSON.parse(payload));
+
+      let calls = 0;
+      const callback = new WsProxy()
+        .create(
+          async () => {
+            if (++calls === 1) throw new Error('handler blew up');
+            return 'ok';
+          },
+          exceptionsHandler,
+          'known',
+        )
+        .bind(undefined, client);
+
+      // same transform WebSocketsController.subscribeMessages passes in
+      const realTransform = (data: any) =>
+        from(WebSocketsController.prototype.pickResult.call(undefined, data)).pipe(
+          mergeAll(),
+        );
+
+      adapter.bindMessageHandlers(
+        client,
+        [
+          {
+            message: 'known',
+            methodName: 'm',
+            callback,
+            isAckHandledManually: false,
+          },
+        ],
+        realTransform,
+      );
+
+      client.emit('message', frame({ event: 'known', data: {} }));
+      await new Promise(resolve => setTimeout(resolve, 5));
+      client.emit('message', frame({ event: 'known', data: {} }));
+      await new Promise(resolve => setTimeout(resolve, 5));
+      config.onUnhandledError = null;
+
+      expect(calls).toBe(2);
+      expect(replies).toEqual(['ok']);
+      expect(unhandled).toEqual([]);
+      expect(logError).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

in IoAdapter.bindMessageHandlers the gateway callback runs inside a mergeMap projection, unguarded, so when a message handler throws synchronously the error escapes the projection, rxjs errors the whole stream and unsubscribes the socket listener, from that point the client gets no response for that event anymore and the missing error handler surfaces the throw as an uncaught exception at the process level

Issue Number: #17624, #17635

### Steps to reproduce
1. bind a handler that throws synchronously through IoAdapter.bindMessageHandlers, then emit two messages (the spec case "should not let a throwing handler tear down the message stream" in packages/platform-socket.io/test/io-adapter.spec.ts). note the repro calls the adapter directly, gateways can't hit the sync path bcs the framework wiring always passes async callbacks (the async case is covered by the new spec too)
2. Expected: the first message is dropped, the stream stays alive, the second message still reaches the handler and gets its reply
3. Actual (raw output on untouched master, running npx vitest run packages/platform-socket.io/test/io-adapter.spec.ts):

```
Vitest caught 1 unhandled error during the test run.

⎯⎯⎯⎯⎯⎯⎯ Uncaught Exception ⎯⎯⎯⎯⎯⎯⎯
Error: handler blew up
 ❯ callback packages/platform-socket.io/test/io-adapter.spec.ts:58:19
 ❯ packages/platform-socket.io/adapters/io-adapter.ts:54:28
 ❯ doInnerSub node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js:22:31
 ❯ outerNext node_modules/rxjs/dist/cjs/internal/operators/mergeInternals.js:17:70
 ❯ EventEmitter.handler node_modules/rxjs/dist/cjs/internal/observable/fromEvent.js:59:31

 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
      Errors  1 error
```

## What is the new behavior?

the transform(callback(...)) call is now wrapped in defer() with a catchError on the inner observable in both platform-socket.io and platform-ws, so a throw turns into an error notification, gets logged and returns EMPTY inside the mergeMap instead of tearing the stream down, later messages from the same socket keep working. the guard sits on the inner observable so it catches the sync throw AND the async rejection case (a @Catch() filter that rethrows makes WsProxy.handleError reject inside the proxy), and defer turns a sync throw into an error notification so the try/catch shape went away. the rethrown filter error gets logged instead of silently dropped, following the lean in the review thread, the exact log-vs-swallow policy stays a maintainer call like in the #17624 thread

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

tested with:

- npx vitest run packages/platform-socket.io/test/io-adapter.spec.ts packages/platform-ws/test/ws-adapter.spec.ts -> 14 passed (incl the new async-teardown spec for the WsProxy.handleError rethrow case, the ack-path spec, and the ws mirror), and all 4 new tests fail on the untouched adapters without the fix
- npx vitest run packages/platform-socket.io packages/platform-ws packages/websockets -> 128 passed
- npx prettier --check and npx oxlint on the touched files -> clean