### PR TITLE
fix(core): discover factory providers with discovery decorators

### DIFF
--- a/packages/core/discovery/discoverable-meta-host-collection.ts
+++ b/packages/core/discovery/discoverable-meta-host-collection.ts
@@ -81,6 +81,15 @@ export class DiscoverableMetaHostCollection {
   ) {
     if (collection.has(metaKey)) {
       const wrappers = collection.get(metaKey)!;
+      // provider wrappers are re-created between registration and instantiation
+      // (the prototype phase replaces the map entry with a copy), so entries
+      // are keyed by the wrapper instance id to keep one entry per provider
+      for (const existing of wrappers) {
+        if (existing.id === instanceWrapper.id) {
+          wrappers.delete(existing);
+          break;
+        }
+      }
       wrappers.add(instanceWrapper);
     } else {
       const wrappers = new Set<InstanceWrapper>();

--- a/packages/core/injector/instance-loader.ts
+++ b/packages/core/injector/instance-loader.ts
@@ -1,4 +1,5 @@
 import { Logger, type LoggerService } from '@nestjs/common';
+import { DiscoverableMetaHostCollection } from '../discovery/discoverable-meta-host-collection.js';
 import { MODULE_INIT_MESSAGE } from '../helpers/messages.js';
 import { GraphInspector } from '../inspector/graph-inspector.js';
 import { NestContainer } from './container.js';
@@ -72,6 +73,14 @@ export class InstanceLoader<TInjector extends Injector = Injector> {
       wrappers.map(async item => {
         await this.injector.loadProvider(item, moduleRef);
         this.graphInspector.inspectInstanceWrapper(item, moduleRef);
+        if (!item.isAlias) {
+          // an alias wrapper is factory-shaped, so inspecting it would
+          // discover the aliased provider twice
+          DiscoverableMetaHostCollection.inspectProvider(
+            this.container.getModules(),
+            item,
+          );
+        }
       }),
     );
   }

--- a/packages/core/test/discovery/discoverable-meta-host-collection.spec.ts
+++ b/packages/core/test/discovery/discoverable-meta-host-collection.spec.ts
@@ -82,6 +82,29 @@ describe('DiscoverableMetaHostCollection', () => {
       expect(collection.get(metaKey)!.has(instanceWrapper1)).toBe(true);
       expect(collection.get(metaKey)!.has(instanceWrapper2)).toBe(true);
     });
+
+    it('should keep one entry when a wrapper is re-inserted as a copy sharing the same instance id', () => {
+      const collection = new Map<string, Set<InstanceWrapper>>();
+      const original = new InstanceWrapper({
+        token: 'TestToken',
+        name: 'TestProvider',
+      });
+      // the prototype phase replaces the map entry with a copy that keeps
+      // the same instance id
+      const copy = new InstanceWrapper(original);
+      const metaKey = 'test-key';
+
+      DiscoverableMetaHostCollection.insertByMetaKey(
+        metaKey,
+        original,
+        collection,
+      );
+      DiscoverableMetaHostCollection.insertByMetaKey(metaKey, copy, collection);
+
+      expect(collection.get(metaKey)!.size).toBe(1);
+      expect(collection.get(metaKey)!.has(copy)).toBe(true);
+      expect(copy.id).toBe(original.id);
+    });
   });
 
   describe('getProvidersByMetaKey', () => {

--- a/packages/core/test/discovery/discovery-service.spec.ts
+++ b/packages/core/test/discovery/discovery-service.spec.ts
@@ -1,3 +1,5 @@
+import { Injectable, Module as NestModule } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
 import { DiscoverableMetaHostCollection } from '../../discovery/discoverable-meta-host-collection.js';
 import { DiscoveryService } from '../../discovery/discovery-service.js';
 import { InstanceWrapper } from '../../injector/instance-wrapper.js';
@@ -566,6 +568,87 @@ describe('DiscoveryService', () => {
 
       const modules = (discoveryService as any).getModules({ include: [] });
       expect(modules).toHaveLength(0);
+    });
+  });
+
+  describe('discovery of wrappers inspected after instantiation', () => {
+    it('should discover a provider registered via useFactory with a discovery decorator', async () => {
+      const TestDecorator = DiscoveryService.createDecorator();
+
+      @TestDecorator()
+      @Injectable()
+      class FactoryService {}
+
+      @NestModule({
+        providers: [
+          DiscoveryService,
+          { provide: FactoryService, useFactory: () => new FactoryService() },
+        ],
+      })
+      class AppModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      const providers = moduleRef
+        .get(DiscoveryService)
+        .getProviders({ metadataKey: TestDecorator.KEY });
+
+      expect(providers).toHaveLength(1);
+      expect(providers[0].instance).toBeInstanceOf(FactoryService);
+    });
+
+    it('should discover a decorated useClass provider exactly once (the prototype phase replaces its wrapper with a copy)', async () => {
+      const TestDecorator = DiscoveryService.createDecorator();
+
+      @TestDecorator()
+      @Injectable()
+      class ClassService {}
+
+      @NestModule({
+        providers: [DiscoveryService, ClassService],
+      })
+      class AppModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      const providers = moduleRef
+        .get(DiscoveryService)
+        .getProviders({ metadataKey: TestDecorator.KEY });
+
+      expect(providers).toHaveLength(1);
+      expect(providers[0].instance).toBeInstanceOf(ClassService);
+    });
+
+    it('should not discover an alias wrapper in addition to the provider it points at', async () => {
+      const TestDecorator = DiscoveryService.createDecorator();
+
+      @TestDecorator()
+      @Injectable()
+      class AliasedService {}
+
+      @NestModule({
+        providers: [
+          DiscoveryService,
+          AliasedService,
+          { provide: 'ALIAS', useExisting: AliasedService },
+        ],
+      })
+      class AppModule {}
+
+      const moduleRef = await Test.createTestingModule({
+        imports: [AppModule],
+      }).compile();
+
+      const providers = moduleRef
+        .get(DiscoveryService)
+        .getProviders({ metadataKey: TestDecorator.KEY });
+
+      expect(providers).toHaveLength(1);
+      expect(providers[0].instance).toBeInstanceOf(AliasedService);
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

a provider registered via useFactory is never returned by discoveryService.getProviders({ metadataKey }) when the factory returns a class decorated with a custom DiscoveryService decorator, the same class registered as a plain provider (useClass) is returned fine

bcs the discovery meta host inspection runs once at registration time (Container.addProvider) and a factory provider has no instance yet at that point, so the lookup keys on the factory function instead of the decorated class, and nothing inspects the wrapper again after the instance is created

this is the same gap #17617 reported for useValue, fixed by #17618, whose own comment says factory providers should resolve through wrapper.instance.constructor too — that intent is unreachable today bcs the inspection never re-runs post-instantiation

Issue Number: N/A

### Steps to reproduce
1. run npx vitest run packages/core/test/discovery/discovery-service.spec.ts on untouched master (the spec "should discover a provider decorated with a discovery decorator")
2. Expected: the decorated provider registered via useFactory is discovered like its useClass sibling
3. Actual (raw output on untouched master, fix stashed):

```
 FAIL  packages/core/test/discovery/discovery-service.spec.ts > Discovery of providers registered via useFactory > should discover a provider decorated with a discovery decorator
AssertionError: expected [] to have a length of 1 but got +0

- Expected
+ Received

- 1
+ 0

 ❯ packages/core/test/discovery/discovery-service.spec.ts:601:23
    599|       .getProviders({ metadataKey: TestDecorator.KEY });
    600|
    601|     expect(providers).toHaveLength(1);
    602|     expect(providers[0].instance).toBeInstanceOf(FactoryService);
    603|

      Tests  1 failed | 28 passed (29)
```

## What is the new behavior?

InstanceLoader.createInstancesOfProviders now re-inspects each provider wrapper right after its instance is created, so useFactory behaves the same as useClass and useValue, and a decorated class is discoverable no matter which registration style delivered it

i kept the registration-time inspection in place and the re-insertion is a Set add, so wrappers already registered are untouched and nothing gets duplicated, and the lookup stays keyed under the same modules container the registration path uses (lazy loading included)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

tested with:

- npx vitest run packages/core/test/discovery/discovery-service.spec.ts -> 29 passed, and the new spec fails on untouched master without the fix (raw output above)
- npm run test -> 2790 passed, 1 failure in packages/common/test/services/logger.service.spec.ts that also fails on clean master, unrelated
- npx prettier --check and npx oxlint on the touched files -> clean