### PR TITLE
fix(common): Support numeric string values in ParseEnumPipe

### DIFF
--- a/packages/common/pipes/parse-enum.pipe.ts
+++ b/packages/common/pipes/parse-enum.pipe.ts
@@ -76,11 +76,36 @@ export class ParseEnumPipe<T = any> implements PipeTransform<T> {
         'Validation failed (enum string is expected)',
       );
     }
+    if (this.isNumeric(value)) {
+      const enumValues = this.getEnumValues();
+      if (!enumValues.includes(value) && enumValues.includes(Number(value))) {
+        return Number(value) as T;
+      }
+    }
     return value as T;
   }
 
   protected isEnum(value: unknown): boolean {
-    const enumValues = Object.keys(this.enumType as object)
+    const enumValues = this.getEnumValues();
+    if (enumValues.includes(value)) {
+      return true;
+    }
+    if (this.isNumeric(value)) {
+      return enumValues.includes(Number(value));
+    }
+    return false;
+  }
+
+  protected isNumeric(value: unknown): boolean {
+    return (
+      ['string', 'number'].includes(typeof value) &&
+      /^-?\d+(\.\d+)?$/.test(String(value)) &&
+      isFinite(value as any)
+    );
+  }
+
+  protected getEnumValues(): any[] {
+    return Object.keys(this.enumType as object)
       .filter(key => {
         const enumValue = (this.enumType as any)[key];
         return !(
@@ -89,6 +114,5 @@ export class ParseEnumPipe<T = any> implements PipeTransform<T> {
         );
       })
       .map(key => (this.enumType as any)[key]);
-    return enumValues.includes(value);
   }
 }

--- a/packages/common/test/pipes/parse-enum.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-enum.pipe.spec.ts
@@ -92,6 +92,30 @@ describe('ParseEnumPipe', () => {
       ).toBe(Status.Inactive);
     });
 
+    it('should return numeric enum value when the numeric value is passed as a string', async () => {
+      expect(
+        await numericTarget.transform('0' as any, {} as ArgumentMetadata),
+      ).toBe(Status.Active);
+      expect(
+        await numericTarget.transform('1' as any, {} as ArgumentMetadata),
+      ).toBe(Status.Inactive);
+    });
+
+    it('should throw when an invalid numeric string is passed', async () => {
+      await expect(
+        numericTarget.transform('2' as any, {} as ArgumentMetadata),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('should throw when an empty or whitespace string is passed', async () => {
+      await expect(
+        numericTarget.transform('' as any, {} as ArgumentMetadata),
+      ).rejects.toThrow(HttpException);
+      await expect(
+        numericTarget.transform('   ' as any, {} as ArgumentMetadata),
+      ).rejects.toThrow(HttpException);
+    });
+
     it('should throw when a reverse-mapped key name is passed instead of the value', async () => {
       try {
         await numericTarget.transform('Active' as any, {} as ArgumentMetadata);
@@ -99,6 +123,49 @@ describe('ParseEnumPipe', () => {
       } catch (err) {
         expect(err).toBeInstanceOf(HttpException);
       }
+    });
+  });
+
+  describe('when enum is numeric with negative values', () => {
+    enum Temperature {
+      Freezing = -5,
+      Zero = 0,
+      Boiling = 100,
+    }
+    let target: ParseEnumPipe;
+
+    beforeEach(() => {
+      target = new ParseEnumPipe(Temperature);
+    });
+
+    it('should parse negative numeric string and return number', async () => {
+      expect(await target.transform('-5' as any, {} as ArgumentMetadata)).toBe(
+        Temperature.Freezing,
+      );
+      expect(await target.transform('0' as any, {} as ArgumentMetadata)).toBe(
+        Temperature.Zero,
+      );
+      expect(await target.transform('100' as any, {} as ArgumentMetadata)).toBe(
+        Temperature.Boiling,
+      );
+    });
+  });
+
+  describe('when enum has string values with digit characters', () => {
+    enum DigitString {
+      Zero = '0',
+      One = '1',
+    }
+    let target: ParseEnumPipe;
+
+    beforeEach(() => {
+      target = new ParseEnumPipe(DigitString);
+    });
+
+    it('should preserve string type and not coerce to number', async () => {
+      const result = await target.transform('0', {} as ArgumentMetadata);
+      expect(result).toBe('0');
+      expect(typeof result).toBe('string');
     });
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using `ParseEnumPipe` with numeric TypeScript enums on HTTP route parameters (such as `@Query()` or `@Param()`), values are received as strings (e.g. `'0'`). Because `ParseEnumPipe.isEnum()` uses strict equality checking against numeric enum values (`[0, 1].includes('0')`), it throws a `400 Bad Request: "Validation failed (enum string is expected)"`.

Issue Number: Fixes #17638

## What is the new behavior?
1. `ParseEnumPipe.isEnum()` now supports numeric string values when the underlying enum values are numeric.
2. `ParseEnumPipe.transform()` coerces numeric string values to numbers (`Number(value)`), ensuring the returned value matches the TypeScript numeric enum type instead of remaining a raw string.
3. String enums with digit characters (e.g. `enum Digit { Zero = '0' }`) preserve their string type and are not coerced.
4. Comprehensive unit tests added covering numeric strings, negative values, digit string enums, and invalid/empty strings.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
- All 194 unit tests in `packages/common/test/pipes` passed.
- Linted with `oxlint` and formatted with `prettier`.
