### PR TITLE
fix(microservices): fail requests whose reply subscription is rejected

### DIFF
--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -242,8 +242,14 @@ export class ClientMqtt extends ClientProxy<MqttEvents, MqttStatus> {
 
       let subscriptionsCount =
         this.subscriptionsCount.get(responseChannel) || 0;
+      let isPublished = false;
+      let isTornDown = false;
 
       const publishPacket = () => {
+        if (isTornDown) {
+          return;
+        }
+        isPublished = true;
         subscriptionsCount = this.subscriptionsCount.get(responseChannel) || 0;
         this.subscriptionsCount.set(responseChannel, subscriptionsCount + 1);
         this.routingMap.set(packet.id, callback);
@@ -264,15 +270,18 @@ export class ClientMqtt extends ClientProxy<MqttEvents, MqttStatus> {
       };
 
       if (subscriptionsCount <= 0) {
-        this.mqttClient!.subscribe(
-          responseChannel,
-          (err: any) => !err && publishPacket(),
+        this.mqttClient!.subscribe(responseChannel, (err: any) =>
+          err ? callback({ err }) : publishPacket(),
         );
       } else {
         publishPacket();
       }
 
       return () => {
+        isTornDown = true;
+        if (!isPublished) {
+          return;
+        }
         this.unsubscribeFromChannel(responseChannel);
         this.routingMap.delete(packet.id);
       };

--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -295,8 +295,14 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
       const responseChannel = this.getReplyPattern(pattern);
       let subscriptionsCount =
         this.subscriptionsCount.get(responseChannel) || 0;
+      let isPublished = false;
+      let isTornDown = false;
 
       const publishPacket = () => {
+        if (isTornDown) {
+          return;
+        }
+        isPublished = true;
         subscriptionsCount = this.subscriptionsCount.get(responseChannel) || 0;
         this.subscriptionsCount.set(responseChannel, subscriptionsCount + 1);
         this.routingMap.set(packet.id, callback);
@@ -307,15 +313,18 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
       };
 
       if (subscriptionsCount <= 0) {
-        this.subClient.subscribe(
-          responseChannel,
-          (err: any) => !err && publishPacket(),
+        this.subClient.subscribe(responseChannel, (err: any) =>
+          err ? callback({ err }) : publishPacket(),
         );
       } else {
         publishPacket();
       }
 
       return () => {
+        isTornDown = true;
+        if (!isPublished) {
+          return;
+        }
         this.unsubscribeFromChannel(responseChannel);
         this.routingMap.delete(packet.id);
       };

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -91,6 +91,43 @@ describe('ClientMqtt', () => {
         expect(callback.mock.calls[0][0].err).toBeInstanceOf(Error);
       });
     });
+    describe('when subscribing to the response pattern fails', () => {
+      it('should call callback with the error and not publish', () => {
+        client['subscriptionsCount'].clear();
+        client['routingMap'].clear();
+        const error = new Error('client disconnecting');
+        subscribeSpy.mockImplementation((name, fn) => fn(error));
+        const callback = vi.fn();
+
+        client['publish'](msg, callback);
+
+        expect(callback).toHaveBeenCalledWith({ err: error });
+        expect(publishSpy).not.toHaveBeenCalled();
+        expect(client['routingMap'].size).toBe(0);
+      });
+    });
+    describe('when disposed before the subscription is confirmed', () => {
+      it('should not publish, count the subscription, nor unsubscribe', () => {
+        client['subscriptionsCount'].clear();
+        client['routingMap'].clear();
+        let confirmSubscription: () => void = () => {};
+        subscribeSpy.mockImplementation((name, fn) => {
+          confirmSubscription = () => fn();
+        });
+        const callback = vi.fn();
+
+        const dispose = client['publish'](msg, callback);
+        dispose();
+        confirmSubscription();
+
+        expect(publishSpy).not.toHaveBeenCalled();
+        expect(client['routingMap'].size).toBe(0);
+        expect(client['subscriptionsCount'].has(`${pattern}/reply`)).toBe(
+          false,
+        );
+        expect(unsubscribeSpy).not.toHaveBeenCalled();
+      });
+    });
     describe('dispose callback', () => {
       let getResponsePatternStub: ReturnType<typeof vi.fn>;
       let callback: ReturnType<typeof vi.fn>, subscription;

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -81,6 +81,43 @@ describe('ClientRedis', () => {
         expect(callback.mock.calls[0][0].err).toBeInstanceOf(Error);
       });
     });
+    describe('when subscribing to the response pattern fails', () => {
+      it('should call callback with the error and not publish', () => {
+        client['subscriptionsCount'].clear();
+        client['routingMap'].clear();
+        const error = new Error('Connection is closed.');
+        subscribeSpy.mockImplementation((name, fn) => fn(error));
+        const callback = vi.fn();
+
+        client['publish'](msg, callback);
+
+        expect(callback).toHaveBeenCalledWith({ err: error });
+        expect(publishSpy).not.toHaveBeenCalled();
+        expect(client['routingMap'].size).toBe(0);
+      });
+    });
+    describe('when disposed before the subscription is confirmed', () => {
+      it('should not publish, count the subscription, nor unsubscribe', () => {
+        client['subscriptionsCount'].clear();
+        client['routingMap'].clear();
+        let confirmSubscription: () => void = () => {};
+        subscribeSpy.mockImplementation((name, fn) => {
+          confirmSubscription = () => fn();
+        });
+        const callback = vi.fn();
+
+        const dispose = client['publish'](msg, callback);
+        dispose();
+        confirmSubscription();
+
+        expect(publishSpy).not.toHaveBeenCalled();
+        expect(client['routingMap'].size).toBe(0);
+        expect(client['subscriptionsCount'].has(`${pattern}.reply`)).toBe(
+          false,
+        );
+        expect(unsubscribeSpy).not.toHaveBeenCalled();
+      });
+    });
     describe('dispose callback', () => {
       let assignStub: ReturnType<typeof vi.fn>,
         getReplyPatternStub: ReturnType<typeof vi.fn>;
@@ -246,10 +283,9 @@ describe('ClientRedis', () => {
     });
     it('should call pending callbacks with connection closed error', async () => {
       await client.close();
-      expect(
-        callback).toHaveBeenCalledWith({
-          err: expect.objectContaining({ message: 'Connection closed' }),
-        });
+      expect(callback).toHaveBeenCalledWith({
+        err: expect.objectContaining({ message: 'Connection closed' }),
+      });
     });
     it('should have isManuallyClosed set to true when "end" event is handled during close', async () => {
       let endHandler: Function | undefined;
@@ -351,10 +387,9 @@ describe('ClientRedis', () => {
 
       expect(client['routingMap'].size).toBe(0);
       expect(client['subscriptionsCount'].size).toBe(0);
-      expect(
-        callback).toHaveBeenCalledWith({
-          err: expect.objectContaining({ message: 'Connection closed' }),
-        });
+      expect(callback).toHaveBeenCalledWith({
+        err: expect.objectContaining({ message: 'Connection closed' }),
+      });
     });
   });
   describe('registerReadyListener', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`ClientRedis.publish` and `ClientMqtt.publish` subscribe to the reply channel before publishing the request, but the subscribe callback ignores its error argument:

```ts
this.subClient.subscribe(responseChannel, (err: any) => !err && publishPacket());
```

When the broker rejects the subscription, the request is never published, nothing is written to the routing map, and the observable returned by `send()` never settles: no error, no completion. Callers only recover if they added their own `timeout()`.

Two ways this happens with real brokers, both reproduced against the published `@nestjs/microservices@12`:

- Redis 7 with an ACL user that may not access the reply channel (`ACL SETUSER nest on >secret ~* +@all &allowed.*`): `SUBSCRIBE ping.reply` is answered with `NOPERM No permissions to access a channel`, and `send('ping', {})` hangs.
- EMQX 5.8 with an authorization rule `{deny, {username, "nest"}, subscribe, ["ping/reply"]}`: the SUBACK carries reason code `0x87 Not authorized` (MQTT 5) or `0x80` (MQTT 3.1.1), which mqtt.js turns into `Subscribe error: ...` in the subscribe callback, and `send('ping', {})` hangs. mqtt.js reports `client disconnecting` through the same callback when a request races with `close()`.

A second, smaller problem sits in the same code path. The teardown returned by `publish` always runs `unsubscribeFromChannel` and clears the routing map, even when the request was disposed before the subscription was confirmed. The packet was never published in that case, so the counter entry does not exist yet: the teardown writes `NaN` into it, and when the subscribe callback finally fires it still publishes the request and registers a callback for an observable nobody listens to. Measured against Redis 7 with `@nestjs/microservices@12`, after cancelling one request inside that window: `subscriptionsCount` reads `{"ping.reply": 1}` and the routing map holds the cancelled request's callback; after a second, normal request on the same pattern completes, the counter still reads `1`, so the reply channel is never unsubscribed. With this change both reads are `0` and the routing map is empty.

## What is the new behavior?

- The subscribe error is passed to the request callback, so `send()` errors immediately with the broker's error (`ReplyError: NOPERM No permissions to access a channel`, `ErrorWithSubackPacket: Subscribe error: Not authorized`).
- The teardown only unsubscribes and cleans the routing map when the packet was actually published, and a subscription confirmed after disposal no longer publishes anything.

Measured with the reproduction scripts, with a 5 s `timeout()` guard on `send()`:

| Broker | Before | After |
|---|---|---|
| Redis 7, ACL user | `TimeoutError` after 5026 ms | `NOPERM No permissions to access a channel` after 1 ms |
| EMQX 5.8, MQTT 5 | `TimeoutError` after 5025 ms | `Subscribe error: Not authorized` after 2 ms |
| EMQX 5.8, MQTT 3.1.1 | `TimeoutError` after 5026 ms | `Subscribe error: Unspecified error` after 2 ms |

Verification against the published package, without any `timeout()`: the same ACL scenario leaves `send()` with no `next`, no `error` and no `complete` after 15 s, while `ioredis` alone reports `NOPERM No permissions to access a channel` to its subscribe callback for the same channel. With this change `send()` errors after 1 ms.

Unit tests added for both clients: a rejected subscription calls the callback with the error and publishes nothing; disposing before the subscription is confirmed publishes nothing, leaves the subscription counter untouched and does not unsubscribe. The whole `packages/microservices` suite passes (760 tests).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Mosquitto is not affected by the ACL scenario: it accepts the SUBSCRIBE and silently drops the messages instead of returning a failure code, so the MQTT reproduction uses EMQX. The happy path is unchanged: when the subscription succeeds, the request is published exactly as before.
