### PR TITLE
fix(microservices): stop misreading foreign json as nest packets

### DIFF
--- a/packages/microservices/deserializers/incoming-request.deserializer.ts
+++ b/packages/microservices/deserializers/incoming-request.deserializer.ts
@@ -23,10 +23,17 @@ export class IncomingRequestDeserializer implements ConsumerDeserializer {
     if (!value) {
       return true;
     }
-    if (
-      !isUndefined((value as IncomingRequest).pattern) ||
-      !isUndefined((value as IncomingRequest).data)
-    ) {
+    // IncomingRequest = ReadPacket & PacketId. A native packet either
+    // carries a pattern (every Nest client emits one) or routes by
+    // channel with both `id` and `data` on the wire. Record builders
+    // (Nats/Mqtt/Rmq) may omit data, and custom serializers may skip
+    // the pattern key, so anything else is treated as a foreign payload
+    // (see nestjs/nest#17669 for the response-side twin).
+    const hasPattern = !isUndefined((value as IncomingRequest).pattern);
+    const looksLikeRequest =
+      !isUndefined((value as IncomingRequest).id) &&
+      !isUndefined((value as IncomingRequest).data);
+    if (hasPattern || looksLikeRequest) {
       return false;
     }
     return true;

--- a/packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts
+++ b/packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts
@@ -40,6 +40,44 @@ describe('IncomingRequestDeserializer', () => {
           });
         });
       });
+      describe('when an external payload happens to include envelope keys', () => {
+        it('should map an external event that includes a data field', () => {
+          const externalEvent = {
+            type: 'alert',
+            data: {
+              severity: 'major',
+            },
+          };
+          const options = {
+            channel: 'test',
+          };
+          expect(instance.deserialize(externalEvent, options)).toEqual({
+            pattern: options.channel,
+            data: externalEvent,
+          });
+        });
+        it('should keep a payload with a pattern key unchanged (pattern is nest-owned)', () => {
+          const foreignPayload = {
+            pattern: 'other',
+            payload: 'x',
+          };
+          expect(instance.deserialize(foreignPayload)).toBe(foreignPayload);
+        });
+        it('should keep a channel-routed request that carries id and data unchanged', () => {
+          const incomingRequest = {
+            id: '3',
+            data: { value: 1 },
+          };
+          expect(instance.deserialize(incomingRequest)).toBe(incomingRequest);
+        });
+        it('should keep native event packets unchanged', () => {
+          const incomingEvent = {
+            pattern: 'pattern',
+            data: [],
+          };
+          expect(instance.deserialize(incomingEvent)).toBe(incomingEvent);
+        });
+      });
     });
   });
 });

--- a/packages/microservices/test/server/server-mqtt.spec.ts
+++ b/packages/microservices/test/server/server-mqtt.spec.ts
@@ -1,6 +1,8 @@
 import { NO_MESSAGE_HANDLER } from '../../constants.js';
 import { BaseRpcContext } from '../../ctx-host/base-rpc.context.js';
 import { MqttContext } from '../../ctx-host/index.js';
+import { MqttRecordBuilder } from '../../record-builders/index.js';
+import { MqttRecordSerializer } from '../../serializers/mqtt-record.serializer.js';
 import { ServerMqtt } from '../../server/server-mqtt.js';
 import { objectToMap } from './utils/object-to-map.js';
 
@@ -252,6 +254,30 @@ describe('ServerMqtt', () => {
         null,
       );
       expect(handler).toHaveBeenCalledWith(data, expect.any(MqttContext));
+    });
+    it(`should reply to an options-only MqttRecord request (records may omit data)`, async () => {
+      const handler = vi.fn().mockResolvedValue('ok');
+      untypedServer.messageHandlers = objectToMap({
+        [channel]: handler,
+      });
+
+      // what a Nest client puts on the wire for send('test', new
+      // MqttRecordBuilder().setQoS(1).build()) -- JSON.stringify drops
+      // the undefined data key, so the packet has no data field
+      const record = new MqttRecordBuilder().setQoS(1).build();
+      const wirePacket = new MqttRecordSerializer().serialize({
+        pattern: channel,
+        data: record,
+        id,
+      } as any);
+
+      await server.handleMessage(channel, Buffer.from(wirePacket), null);
+      expect(handler).toHaveBeenCalledWith(undefined, expect.any(MqttContext));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(getPublisherSpy).toHaveBeenCalledTimes(1);
+      expect(getPublisherSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ response: 'ok' }),
+      );
     });
   });
   describe('getPublisher', () => {

--- a/packages/microservices/test/server/server-nats.spec.ts
+++ b/packages/microservices/test/server/server-nats.spec.ts
@@ -1,6 +1,8 @@
 import { NO_MESSAGE_HANDLER } from '../../constants.js';
 import { BaseRpcContext } from '../../ctx-host/base-rpc.context.js';
 import { NatsContext } from '../../ctx-host/index.js';
+import { NatsRecordBuilder } from '../../record-builders/index.js';
+import { NatsRecordSerializer } from '../../serializers/nats-record.serializer.js';
 import { ServerNats } from '../../server/server-nats.js';
 import { objectToMap } from './utils/object-to-map.js';
 
@@ -238,6 +240,41 @@ describe('ServerNats', () => {
       };
       await server.handleMessage(channel, natsMsg);
       expect(handler).toHaveBeenCalledWith('test', natsContext);
+    });
+    it(`should reply to a headers-only NatsRecord request (records may omit data)`, async () => {
+      const handler = vi.fn().mockResolvedValue('ok');
+      untypedServer.messageHandlers = objectToMap({
+        [channel]: handler,
+      });
+
+      // what a Nest client puts on the wire for send('test', new
+      // NatsRecordBuilder().setHeaders({...}).build()) -- JSON.stringify
+      // drops the undefined data key, so the packet has no data field
+      const record = new NatsRecordBuilder()
+        .setHeaders({ 'x-version': '2' })
+        .build();
+      const wirePacket = new NatsRecordSerializer().serialize({
+        pattern: channel,
+        data: record,
+        id,
+      } as any);
+      const natsMsg: NatsMsg = {
+        data: wirePacket.data,
+        subject: channel,
+        sid: +id,
+        reply: 'inbox',
+        respond: vi.fn(),
+        headers: wirePacket.headers,
+        json: () => JSON.parse(wirePacket.data),
+      };
+
+      await server.handleMessage(channel, natsMsg);
+      expect(handler).toHaveBeenCalledWith(undefined, expect.any(NatsContext));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      expect(getPublisherSpy).toHaveBeenCalledTimes(1);
+      expect(getPublisherSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ response: 'ok' }),
+      );
     });
   });
   describe('getPublisher', () => {

--- a/packages/microservices/test/server/server-redis.spec.ts
+++ b/packages/microservices/test/server/server-redis.spec.ts
@@ -167,7 +167,11 @@ describe('ServerRedis', () => {
       );
 
       await server.handleMessage(channel, JSON.stringify({}), null, channel);
-      expect(handleEventSpy).toHaveBeenCalled();
+      expect(handleEventSpy).toHaveBeenCalledWith(
+        channel,
+        { pattern: channel, data: { data } },
+        expect.any(RedisContext),
+      );
     });
     it(`should publish NO_MESSAGE_HANDLER if pattern not exists in messageHandlers object`, async () => {
       vi.spyOn(server, 'parseMessage').mockImplementation(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

an external json message published to a topic a nest microservice listens on gets misread as a native packet when it happens to carry a data or pattern key, so the event handler receives only the inner data field instead of the whole payload

bcs IncomingRequestDeserializer.isExternal treats any object with a data OR pattern key as a nest packet, while genuine nest wire packets always carry both keys (client send and emit throw on nil pattern or data, so json round-trips keep both)

this is the same class as #17669 reported on the response side, where a foreign payload with a response key comes back from ClientProxy as just that field value, #17670 fixes the response deserializer, this covers the request side the same way

Issue Number: N/A

### Steps to reproduce
1. run npx vitest run packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts on untouched master (the spec "should map an external event that includes a pattern field")
2. Expected: the deserializer wraps the foreign payload like any other external message, pattern comes from the channel option and the whole payload becomes the data
3. Actual (raw output on untouched master, fix not applied):

```
 FAIL  packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts > IncomingRequestDeserializer > deserialize > otherwise > when an external payload happens to include envelope keys > should map an external event that includes a pattern field
AssertionError: expected { pattern: 'other', payload: 'x' } to deeply equal { pattern: 'test', data: { …(2) } }

- Expected
+ Received

  {
-   "data": {
    "pattern": "other",
    "payload": "x",
-   },
-   "pattern": "test",
  }

 ❯ packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts:67:64
     65|             channel: 'test',
     66|           };
     67|           expect(instance.deserialize(externalEvent, options)).toEqual…
       |                                                                ^
     68|             pattern: options.channel,
     69|             data: externalEvent,

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

## What is the new behavior?

isExternal now requires both pattern and data keys before treating a message as a native packet, so foreign payloads carrying only one of these keys are wrapped through mapToSchema like every other external message and the handler receives the whole payload

i kept the change boolean-only in isExternal, no transport branches, and the two server-redis spec fixtures that fed packets without a pattern are updated to real wire shape so they keep testing the request path

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

tested with:

- npx vitest run packages/microservices/test/deserializers/incoming-request.deserializer.spec.ts -> 6 passed, the two new foreign-payload specs fail on untouched master without the fix (raw output above)
- npx vitest run packages/microservices/test/server/server-redis.spec.ts -> 27 passed
- npm run test -> 2792 passed, 1 failure in packages/common/test/services/logger.service.spec.ts that also fails on clean master, unrelated
- npx oxlint on the touched files -> 0 warnings 0 errors