### PR TITLE
fix(microservices): call RMQ listen callback once

### DIFF
--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -111,6 +111,7 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     callback?: (err?: unknown, ...optionalParams: unknown[]) => void,
   ) {
     this.server = await this.createClient();
+    let callbackCalled = false;
     this.server!.once(RmqEventsMap.CONNECT, () => {
       if (this.channel) {
         return;
@@ -118,7 +119,14 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
       this._status$.next(RmqStatus.CONNECTED);
       this.channel = this.server!.createChannel({
         json: false,
-        setup: (channel: Channel) => this.setupChannel(channel, callback!),
+        setup: (channel: Channel) =>
+          this.setupChannel(channel, () => {
+            if (callbackCalled) {
+              return;
+            }
+            callbackCalled = true;
+            callback?.();
+          }),
       });
     });
 

--- a/packages/microservices/server/server-rmq.ts
+++ b/packages/microservices/server/server-rmq.ts
@@ -111,7 +111,7 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
     callback?: (err?: unknown, ...optionalParams: unknown[]) => void,
   ) {
     this.server = await this.createClient();
-    let callbackCalled = false;
+    let listenCallback = callback;
     this.server!.once(RmqEventsMap.CONNECT, () => {
       if (this.channel) {
         return;
@@ -121,11 +121,9 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
         json: false,
         setup: (channel: Channel) =>
           this.setupChannel(channel, () => {
-            if (callbackCalled) {
-              return;
-            }
-            callbackCalled = true;
-            callback?.();
+            const cb = listenCallback;
+            listenCallback = undefined;
+            cb?.();
           }),
       });
     });
@@ -164,7 +162,9 @@ export class ServerRMQ extends Server<RmqEvents, RmqStatus> {
         }
         if (++this.connectionAttempts === maxConnectionAttempts) {
           await this.close();
-          callback?.(error.err ?? new Error(CONNECTION_FAILED_MESSAGE));
+          const cb = listenCallback;
+          listenCallback = undefined;
+          cb?.(error.err ?? new Error(CONNECTION_FAILED_MESSAGE));
         }
       },
     );

--- a/packages/microservices/test/server/server-rmq.spec.ts
+++ b/packages/microservices/test/server/server-rmq.spec.ts
@@ -60,6 +60,22 @@ describe('ServerRMQ', () => {
       await server.listen(callbackSpy);
       expect(onStub.mock.calls.map(call => call[0])).toContain('connectFailed');
     });
+    it('should call the callback once when channel setup runs again', async () => {
+      setupChannelStub.mockImplementation(async (_channel, setupCallback) => {
+        setupCallback();
+        setupCallback();
+      });
+      createChannelStub.mockImplementation(({ setup }) => {
+        void setup({});
+        void setup({});
+        return {};
+      });
+
+      await server.listen(callbackSpy);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(callbackSpy).toHaveBeenCalledOnce();
+    });
     describe('when "start" throws an exception', () => {
       it('should call callback with a thrown error as an argument', async () => {
         const error = new Error('random error');


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows the Nest conventions
- [x] Regression test added
- [x] No documentation change is needed for this internal fix

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue: #17673

`amqp-connection-manager` reruns a channel `setup` function whenever the broker reconnects. `ServerRMQ` passes the `listen()` callback through that setup function, so the callback runs again after reconnecting. In the reproduction, one broker reconnect caused four callback invocations instead of one.

## What is the new behavior?

The callback is guarded per `listen()` call and is invoked only once, while channel setup still runs normally on reconnect to restore queues and consumers. A regression test covers repeated setup execution.

## Does this PR introduce a breaking change?

- [x] No

Closes #17673

## Validation

- RMQ server tests: 38/38 passed
- microservices TypeScript build passed
- oxlint passed