### PR TITLE
fix(microservices): reset client state when reconnecting after close

### DIFF
--- a/packages/microservices/client/client-mqtt.ts
+++ b/packages/microservices/client/client-mqtt.ts
@@ -69,6 +69,8 @@ export class ClientMqtt extends ClientProxy<MqttEvents, MqttStatus> {
     }
     this.mqttClient = null;
     this.connectionPromise = null;
+    this.isInitialConnection = false;
+    this.subscriptionsCount.clear();
     this.pendingEventListeners = [];
   }
 

--- a/packages/microservices/client/client-redis.ts
+++ b/packages/microservices/client/client-redis.ts
@@ -60,6 +60,8 @@ export class ClientRedis extends ClientProxy<RedisEvents, RedisStatus> {
     this.subClient && (await this.subClient.quit());
     this.pubClient = this.subClient = null;
     this.connectionPromise = null;
+    this.isManuallyClosed = false;
+    this.wasInitialConnectionSuccessful = false;
     this.pendingEventListeners = [];
   }
 

--- a/packages/microservices/test/client/client-mqtt.spec.ts
+++ b/packages/microservices/test/client/client-mqtt.spec.ts
@@ -261,6 +261,34 @@ describe('ClientMqtt', () => {
       await client.close();
       expect(endSpy).not.toHaveBeenCalled();
     });
+
+    it('should reset connection state for a subsequent connection', async () => {
+      untypedClient.isInitialConnection = true;
+      untypedClient.subscriptionsCount.set('response/reply', 1);
+
+      await client.close();
+
+      expect(untypedClient.isInitialConnection).toBe(false);
+      expect(untypedClient.subscriptionsCount.size).toBe(0);
+    });
+
+    it('should register the response listener after close and reconnect', async () => {
+      const firstClient = { endAsync: vi.fn() };
+      const secondClient = { on: vi.fn() };
+      untypedClient.mqttClient = firstClient;
+      untypedClient.isInitialConnection = true;
+
+      await client.close();
+      client.registerConnectListener(secondClient);
+
+      const connectHandler = secondClient.on.mock.calls[0][1];
+      connectHandler();
+
+      expect(secondClient.on).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function),
+      );
+    });
   });
   describe('connect', () => {
     let createClientStub: ReturnType<typeof vi.fn>;

--- a/packages/microservices/test/client/client-redis.spec.ts
+++ b/packages/microservices/test/client/client-redis.spec.ts
@@ -281,6 +281,36 @@ describe('ClientRedis', () => {
       await client.close();
       expect(logError).not.toHaveBeenCalled();
     });
+
+    it('should reset connection state for a subsequent connection', async () => {
+      untypedClient.isManuallyClosed = false;
+      untypedClient.wasInitialConnectionSuccessful = true;
+
+      await client.close();
+
+      expect(untypedClient.isManuallyClosed).toBe(false);
+      expect(untypedClient.wasInitialConnectionSuccessful).toBe(false);
+    });
+
+    it('should register the response listener after close and reconnect', async () => {
+      const firstSubClient = { quit: vi.fn() };
+      const secondSubClient = { on: vi.fn() };
+      untypedClient.pubClient = { quit: vi.fn() };
+      untypedClient.subClient = firstSubClient;
+      untypedClient.wasInitialConnectionSuccessful = true;
+
+      await client.close();
+      untypedClient.subClient = secondSubClient;
+      client.registerReadyListener(secondSubClient);
+
+      const readyHandler = secondSubClient.on.mock.calls[0][1];
+      readyHandler();
+
+      expect(secondSubClient.on).toHaveBeenCalledWith(
+        'message',
+        expect.any(Function),
+      );
+    });
   });
   describe('connect', () => {
     let createClientSpy: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (not applicable)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other

## What is the current behavior?

Calling `close()` and then `connect()` again on the same MQTT or Redis client instance leaves part of the previous connection state in place.

For MQTT, `isInitialConnection` remains `true`, so the new MQTT client does not register the response `message` listener. The stale `subscriptionsCount` also causes response-channel subscriptions to be skipped after reconnecting.

For Redis, `isManuallyClosed` and `wasInitialConnectionSuccessful` remain set from the previous lifecycle. As a result, the new Redis subscriber may not register its response listener, and reconnect handlers can return early.

This causes RPC responses to stop being delivered after:

`connect() -> close() -> connect()`

Issue Number: N/A

## What is the new behavior?

Explicitly closing a client now resets all connection lifecycle state that is bound to the previous broker connection.

- MQTT resets `isInitialConnection` and clears `subscriptionsCount`.
- Redis resets `isManuallyClosed` and `wasInitialConnectionSuccessful`.

A subsequent `connect()` creates a fresh lifecycle and registers the response listener on the new MQTT/Redis client.

Regression unit tests were added for both transports.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No Docker or external MQTT/Redis broker is required. The regression coverage uses the existing mocked client unit-test setup.