### PR TITLE
refactor: use native `Object.hasOwn` API instead of `Object.prototype.hasOwnProperty.call`

### DIFF
--- a/integration/hello-world/e2e/interceptors.spec.ts
+++ b/integration/hello-world/e2e/interceptors.spec.ts
@@ -48,7 +48,7 @@ export class HeaderInterceptor {
     const ctx = context.switchToHttp();
     const res = ctx.getResponse();
     for (const key in this.headers) {
-      if (Object.prototype.hasOwnProperty.call(this.headers, key)) {
+      if (Object.hasOwn(this.headers, key)) {
         res.header(key, this.headers[key]);
       }
     }

--- a/packages/common/decorators/modules/module.decorator.ts
+++ b/packages/common/decorators/modules/module.decorator.ts
@@ -21,7 +21,7 @@ export function Module(metadata: ModuleMetadata): ClassDecorator {
 
   return (target: Function) => {
     for (const property in metadata) {
-      if (Object.hasOwnProperty.call(metadata, property)) {
+      if (Object.hasOwn(metadata, property)) {
         Reflect.defineMetadata(property, (metadata as any)[property], target);
       }
     }

--- a/packages/common/utils/shared.utils.ts
+++ b/packages/common/utils/shared.utils.ts
@@ -13,7 +13,7 @@ export const isPlainObject = (fn: unknown): fn is object => {
     return true;
   }
   const ctor =
-    Object.prototype.hasOwnProperty.call(proto, 'constructor') &&
+    Object.hasOwn(proto, 'constructor') &&
     proto.constructor;
   return (
     typeof ctor === 'function' &&

--- a/packages/core/injector/module.ts
+++ b/packages/core/injector/module.ts
@@ -329,7 +329,7 @@ export class Module {
   public isCustomValue(provider: any): provider is ValueProvider {
     return (
       isObject(provider) &&
-      Object.prototype.hasOwnProperty.call(provider, 'useValue')
+      Object.hasOwn(provider, 'useValue')
     );
   }
 

--- a/packages/microservices/client/client-grpc.ts
+++ b/packages/microservices/client/client-grpc.ts
@@ -371,7 +371,7 @@ export class ClientGrpcProxy
 
   protected getClient(name: string): any {
     return this.grpcClients.find(client =>
-      Object.hasOwnProperty.call(client, name),
+      Object.hasOwn(client, name),
     );
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The repository uses verbose `Object.prototype.hasOwnProperty.call(...)` and `Object.hasOwnProperty.call(...)` patterns to check own properties.

Issue Number: N/A


## What is the new behavior?

All five usages now use the native `Object.hasOwn(value, key)` API. Unlike the old `Object.prototype.hasOwnProperty.call(value, key)` pattern, this expresses the operation directly instead of borrowing a method from `Object.prototype` and invoking it with `call`. That makes the check harder to misuse at each call site while preserving the same robust semantics: it checks only own properties, including on null-prototype objects and objects that shadow `hasOwnProperty`. It also avoids the unsafe alternative of calling `value.hasOwnProperty(...)`, which may be missing or overridden.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Nest supports Node.js >= 20 and targets ES2023, so `Object.hasOwn` is available in every supported runtime and in the project's TypeScript standard-library typings. This refactor is therefore safe to adopt now without compatibility code or a platform support change. It has no runtime behavior or public API impact.