### PR TITLE
fix(core): stop exposing third-party errors that carry a status code

### DIFF
--- a/packages/core/exceptions/base-exception-filter.ts
+++ b/packages/core/exceptions/base-exception-filter.ts
@@ -109,7 +109,14 @@ export class BaseExceptionFilter<T = any> implements ExceptionFilter<T> {
     }
 
     // Plain "http error"-shaped values (e.g. objects thrown by third-party
-    // middleware) that carry a status code and a message
-    return !!(err.statusCode && err.message);
+    // middleware) that carry a status code and a message.
+    // Real `Error` instances are deliberately excluded: SDK errors such as
+    // Elasticsearch's `ResponseError` also carry a `statusCode`, and surfacing
+    // them would leak internal failures to the client.
+    return (
+      !(err instanceof Error) &&
+      typeof err.statusCode === 'number' &&
+      !!err.message
+    );
   }
 }

--- a/packages/core/test/exceptions/exceptions-handler.spec.ts
+++ b/packages/core/test/exceptions/exceptions-handler.spec.ts
@@ -82,25 +82,10 @@ describe('ExceptionsHandler', () => {
         message: 'Internal server error',
       });
     });
-    it('should treat fastify errors as http errors', () => {
-      const fastifyError = fastifyErrors.createError(
-        'FST_ERR_CTP_EMPTY_JSON_BODY',
-        "Body cannot be empty when content-type is set to 'application/json'",
-        400,
-      )();
-      handler.next(fastifyError, new ExecutionContextHost([0, response]));
-
-      expect(statusStub).toHaveBeenCalledWith(400);
-      expect(jsonStub).toHaveBeenCalledWith({
-        statusCode: 400,
-        message:
-          "Body cannot be empty when content-type is set to 'application/json'",
-      });
-    });
-    it('should not treat errors from external API calls as errors from "http-errors" library', () => {
+    it('should not treat errors carrying a "statusCode" as errors from "http-errors" library', () => {
       const apiCallError = Object.assign(
         new Error('Some external API call failed'),
-        { status: 400 },
+        { statusCode: 400 },
       );
       handler.next(apiCallError, new ExecutionContextHost([0, response]));
 
@@ -108,6 +93,36 @@ describe('ExceptionsHandler', () => {
       expect(jsonStub).toHaveBeenCalledWith({
         statusCode: 500,
         message: 'Internal server error',
+      });
+    });
+    it('should not expose SDK errors that extend Error and carry a "statusCode"', () => {
+      // Mirrors the shape of Elasticsearch's `ResponseError`
+      class ResponseError extends Error {
+        readonly statusCode = 404;
+        constructor() {
+          super('index_not_found_exception');
+          this.name = 'ResponseError';
+        }
+      }
+      handler.next(
+        new ResponseError(),
+        new ExecutionContextHost([0, response]),
+      );
+
+      expect(statusStub).toHaveBeenCalledWith(500);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 500,
+        message: 'Internal server error',
+      });
+    });
+    it('should treat plain "http error"-shaped objects as http errors', () => {
+      const middlewareError = { statusCode: 400, message: 'Malformed body' };
+      handler.next(middlewareError, new ExecutionContextHost([0, response]));
+
+      expect(statusStub).toHaveBeenCalledWith(400);
+      expect(jsonStub).toHaveBeenCalledWith({
+        statusCode: 400,
+        message: 'Malformed body',
       });
     });
     describe('when exception is instantiated by "http-errors" library', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (n/a)

## PR Type

- [x] Bugfix

## What is the current behavior?

Closes #17695 (reopens the root cause of #14738).

`isHttpError` ends with a permissive fallback:

```ts
// Plain "http error"-shaped values (e.g. objects thrown by third-party
// middleware) that carry a status code and a message
return !!(err.statusCode && err.message);
```

This is equivalent to the pre-#14753 implementation. Because it runs *after* the `FastifyError` and `http-errors` guards, any value matching the loose shape returns `true` regardless, which makes those stricter guards redundant.

The practical effect is that third-party SDK errors are surfaced verbatim to the client. Elasticsearch's [`ResponseError`](https://github.com/elastic/elastic-transport-js/blob/b44dd134cc9bf1fbca5204851ec38030cdfd06e9/src/errors.ts#L162) carries `statusCode`, so a failed query answers the request with the SDK's own status and message:

| Thrown value | Expected | Current |
|---|---|---|
| `ResponseError { statusCode: 404, message: 'index_not_found_exception' }` | `500` / `Internal server error` | **`404` / `index_not_found_exception`** |
| `Object.assign(new Error('Some external API call failed'), { statusCode: 400 })` | `500` / `Internal server error` | **`400` / `Some external API call failed`** |

Internal failure details from backing services reach end users, with statuses that misrepresent the outcome of the request.

### Why the existing tests did not catch it

The two regression tests added in #14753 build their errors with a `status` property, but the fallback only reads `statusCode` — so they pass vacuously. They were also duplicated verbatim by a bad merge resolution in 4ec944577.

Removing the fallback entirely leaves the full `packages/core` suite (1092 tests) green, i.e. no test covers it today.

## What is the new behavior?

The fallback now excludes real `Error` instances:

```ts
return (
  !(err instanceof Error) &&
  typeof err.statusCode === 'number' &&
  !!err.message
);
```

`Error`-ness is what separates the two cases the shape alone cannot distinguish:

- **Plain objects thrown by third-party middleware** — the case the fallback was added for — are not `Error` instances, so they keep working unchanged.
- **SDK errors such as `ResponseError`** extend `Error`, so they fall through to the `500` branch.

An `Error` subclass carrying `statusCode` but no `http-errors` / Fastify signature is indistinguishable from an arbitrary SDK error, so it now defaults to the safe outcome.

Tests: the duplicated pair is collapsed, the external-API case switches to `statusCode`, and two cases are added — an Elasticsearch-shaped `ResponseError`, and a plain `{ statusCode, message }` object that pins the middleware behaviour the fallback must preserve (this one fails if the fallback is dropped outright).

## Does this PR introduce a breaking change?

- [x] Yes

Applications that throw an `Error` subclass carrying a `statusCode` and rely on it being sent to the client will now receive `500`. That is the intent of #14738 and #14753 — those errors were never distinguishable from SDK failures. `HttpException`, `http-errors` instances, `FastifyError`, and plain `{ statusCode, message }` objects are all unaffected.

## Other information

@kamilmysliwiec — the fallback was introduced in e2557553 (`chore: resolve conflicts, minor fixes`) alongside the `err.constructor?.name` fix, and it is untested, so it reads as a conflict-resolution artifact rather than a deliberate change. If it was in fact added for a reported case I've missed, the `!(err instanceof Error)` guard here is the narrowest change that keeps plain middleware objects working while closing the leak — happy to adjust if you have a case in mind that this misses.
