### PR TITLE
fix(fastify): send responses for exceptions thrown from middleware

### DIFF
--- a/integration/hello-world/e2e/middleware-fastify.spec.ts
+++ b/integration/hello-world/e2e/middleware-fastify.spec.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Controller,
   Get,
   Injectable,
@@ -994,6 +995,78 @@ describe('Middleware (FastifyAdapter)', () => {
       afterEach(async () => {
         await app.close();
       });
+    });
+  });
+
+  describe('should handle exceptions thrown from a middleware', () => {
+    @Injectable()
+    class ThrowingMiddleware implements NestMiddleware {
+      use(
+        req: FastifyRequest['raw'] & { headers: Record<string, unknown> },
+        res,
+        next: () => void,
+      ) {
+        if (req.headers['x-throw'] === 'http-exception') {
+          throw new BadRequestException('middleware rejection');
+        }
+        if (req.headers['x-throw'] === 'unknown-error') {
+          throw new Error('middleware failure');
+        }
+        next();
+      }
+    }
+
+    @Controller('protected')
+    class ProtectedController {
+      @Get()
+      findAll() {
+        return 'protected';
+      }
+    }
+
+    @Module({
+      controllers: [ProtectedController],
+    })
+    class ThrowingMiddlewareModule implements NestModule {
+      configure(consumer: MiddlewareConsumer) {
+        consumer.apply(ThrowingMiddleware).forRoutes(ProtectedController);
+      }
+    }
+
+    beforeEach(async () => {
+      app = (
+        await Test.createTestingModule({
+          imports: [ThrowingMiddlewareModule],
+        }).compile()
+      ).createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    it('should send the HttpException response', () => {
+      return request(app.getHttpServer())
+        .get('/protected')
+        .set('x-throw', 'http-exception')
+        .expect(400, {
+          statusCode: 400,
+          message: 'middleware rejection',
+          error: 'Bad Request',
+        });
+    });
+
+    it('should send the internal server error response for unknown errors', () => {
+      return request(app.getHttpServer())
+        .get('/protected')
+        .set('x-throw', 'unknown-error')
+        .expect(500, {
+          statusCode: 500,
+          message: 'Internal server error',
+        });
+    });
+
+    afterEach(async () => {
+      await app.close();
     });
   });
 });

--- a/packages/platform-fastify/adapters/fastify-adapter.ts
+++ b/packages/platform-fastify/adapters/fastify-adapter.ts
@@ -35,7 +35,7 @@ import {
   RouteShorthandOptions,
   fastify,
 } from 'fastify';
-import * as Reply from 'fastify/lib/reply.js';
+import Reply from 'fastify/lib/reply.js';
 import fastifySymbols from 'fastify/lib/symbols.js';
 import * as http from 'http';
 import * as http2 from 'http2';


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (n/a)

## PR Type

- [x] Bugfix

## What is the current behavior?

Closes #17698.

With the Fastify adapter, an exception thrown from a Nest middleware never gets a response. The request hangs, and the process gets an unhandled rejection: `TypeError: Reply is not a constructor`.

Middleware receives the raw response, so the exception handler reaches the branch of `FastifyAdapter.reply()` that builds a Fastify `Reply` with `new Reply(...)`. The adapter imports it as a namespace:

```ts
import * as Reply from 'fastify/lib/reply.js';
```

Before the ESM migration (#16369), this compiled to `require('fastify/lib/reply')`, which returned the constructor. Under native ESM the binding is a module namespace object, and the constructor is its `default` export. The migration already switched the neighbouring `fastify/lib/symbols.js` import to a default import but missed this one. The module has no types, so the compiler couldn't flag it.

Since v12.0.0 this affects every exception thrown from a middleware, both `HttpException`s and unknown errors. Exceptions raised inside the route pipeline (controllers, guards, etc.) are not affected, because they already have a real `FastifyReply`.

### Why the existing tests did not catch it

The `reply()` unit tests only pass mocked `FastifyReply` objects, and no Fastify integration test threw from a middleware.

## What is the new behavior?

`Reply` is imported as the module's default export, so middleware exceptions get the standard error response again.

The new tests in `middleware-fastify.spec.ts` throw a `BadRequestException` and an unknown `Error` from a class middleware and check for the `400` and `500` responses. Without the fix, both time out with the `is not a constructor` rejection.

## Does this PR introduce a breaking change?

- [x] No
