### PR TITLE
fix(common): treat empty string as array input in ParseArrayPipe

### DIFF
--- a/packages/common/pipes/parse-array.pipe.ts
+++ b/packages/common/pipes/parse-array.pipe.ts
@@ -82,7 +82,7 @@ export class ParseArrayPipe implements PipeTransform {
    * @param metadata contains metadata about the currently processed route argument
    */
   async transform(value: unknown, metadata: ArgumentMetadata): Promise<any> {
-    if (!value && !this.options.optional) {
+    if (isNil(value) && !this.options.optional) {
       throw this.exceptionFactory(VALIDATION_ERROR_MESSAGE);
     } else if (isNil(value) && this.options.optional) {
       return value;

--- a/packages/common/test/pipes/parse-array.pipe.spec.ts
+++ b/packages/common/test/pipes/parse-array.pipe.spec.ts
@@ -36,6 +36,27 @@ describe('ParseArrayPipe', () => {
       });
     });
 
+    describe('when empty string', () => {
+      describe('and optional disabled', () => {
+        it('should parse to a single empty item', async () => {
+          target = new ParseArrayPipe({ optional: false });
+
+          expect(
+            await target.transform('', {} as ArgumentMetadata),
+          ).toEqual(['']);
+        });
+      });
+      describe('and optional enabled', () => {
+        it('should parse to a single empty item', async () => {
+          target = new ParseArrayPipe({ optional: true });
+
+          expect(
+            await target.transform('', {} as ArgumentMetadata),
+          ).toEqual(['']);
+        });
+      });
+    });
+
     describe('when value is not parseable', () => {
       beforeEach(() => {
         target = new ParseArrayPipe();


### PR DESCRIPTION
## What this fixes

`ParseArrayPipe` treated an empty string as “no value”, because the first check was `!value`.

`!''` is `true`, so a required pipe threw `Validation failed (parsable array expected)` and never called `split`.

Empty string is still a string. “Not provided” should only be `null` / `undefined` (`isNil`), same as the other parse pipes.

A CSV that already has empty pieces is accepted today (`'1,2.0,3,{},true,null,,'`). A string that is only `''` should just become `['']`.

Closes #17701

## What I changed

- First check in `transform`: `isNil(value)` instead of `!value`
- Tests: required and optional empty string both parse to `['']`

## How to check

```bash
npx vitest run packages/common/test/pipes/parse-array.pipe.spec.ts
```
