### PR TITLE
test(common): cover remaining branches in core and http decorators

### DIFF
--- a/packages/common/test/decorators/create-param-decorator.spec.ts
+++ b/packages/common/test/decorators/create-param-decorator.spec.ts
@@ -309,4 +309,31 @@ describe('createParamDecorator', () => {
       });
     });
   });
+
+  describe('when enhancers are passed', () => {
+    it('should apply each enhancer to the decorated parameter', () => {
+      const factoryFn = (data, req) => true;
+      const enhancer = vi.fn();
+      const anotherEnhancer = vi.fn();
+      const Decorator = createParamDecorator(factoryFn, [
+        enhancer,
+        anotherEnhancer,
+      ]);
+
+      class Test {
+        public test(@Decorator() param) {}
+      }
+
+      expect(enhancer).toHaveBeenCalledExactlyOnceWith(
+        Test.prototype,
+        'test',
+        0,
+      );
+      expect(anotherEnhancer).toHaveBeenCalledExactlyOnceWith(
+        Test.prototype,
+        'test',
+        0,
+      );
+    });
+  });
 });

--- a/packages/common/test/decorators/dependencies.decorator.spec.ts
+++ b/packages/common/test/decorators/dependencies.decorator.spec.ts
@@ -1,15 +1,21 @@
-import { Dependencies } from '../../decorators/core/dependencies.decorator.js';
+import {
+  Dependencies,
+  flatten,
+} from '../../decorators/core/dependencies.decorator.js';
 import { PARAMTYPES_METADATA } from '../../constants.js';
 
 describe('@Dependencies', () => {
   const dep = 'test',
-    dep2 = 'test2';
+    dep2 = 'test2',
+    dep3 = 'test3';
   const deps = [dep, dep2];
 
   @Dependencies(deps)
   class Test {}
   @Dependencies(dep, dep2)
   class Test2 {}
+  @Dependencies([dep, [dep2, [dep3]]])
+  class Test3 {}
 
   it('should enhance class with expected dependencies array', () => {
     const metadata = Reflect.getMetadata(PARAMTYPES_METADATA, Test);
@@ -19,5 +25,16 @@ describe('@Dependencies', () => {
   it('should makes passed array flatten', () => {
     const metadata = Reflect.getMetadata(PARAMTYPES_METADATA, Test2);
     expect(metadata).toEqual([dep, dep2]);
+  });
+
+  it('should flatten deeply nested dependency arrays', () => {
+    const metadata = Reflect.getMetadata(PARAMTYPES_METADATA, Test3);
+    expect(metadata).toEqual([dep, dep2, dep3]);
+  });
+});
+
+describe('flatten', () => {
+  it('should flatten arrays nested at any depth', () => {
+    expect(flatten([1, [2, [3, [4]]]])).toEqual([1, 2, 3, 4]);
   });
 });

--- a/packages/common/test/decorators/inject.decorator.spec.ts
+++ b/packages/common/test/decorators/inject.decorator.spec.ts
@@ -21,4 +21,32 @@ describe('@Inject', () => {
     ];
     expect(metadata).toEqual(expectedMetadata);
   });
+
+  describe('when used on a constructor parameter without a token', () => {
+    class Dependency {}
+
+    class TestWithInferredToken {
+      constructor(@Inject() param: Dependency) {}
+    }
+
+    class TestWithUndefinedToken {
+      constructor(@Inject(undefined) param: Dependency) {}
+    }
+
+    it('should infer the token from the parameter type when called without arguments', () => {
+      const metadata = Reflect.getMetadata(
+        SELF_DECLARED_DEPS_METADATA,
+        TestWithInferredToken,
+      );
+      expect(metadata).toEqual([{ index: 0, param: Dependency }]);
+    });
+
+    it('should not infer the token when an explicit undefined token is passed', () => {
+      const metadata = Reflect.getMetadata(
+        SELF_DECLARED_DEPS_METADATA,
+        TestWithUndefinedToken,
+      );
+      expect(metadata).toEqual([{ index: 0, param: undefined }]);
+    });
+  });
 });

--- a/packages/common/test/decorators/route-params.decorator.spec.ts
+++ b/packages/common/test/decorators/route-params.decorator.spec.ts
@@ -1,10 +1,18 @@
-import { ROUTE_ARGS_METADATA } from '../../constants.js';
 import {
+  RESPONSE_PASSTHROUGH_METADATA,
+  ROUTE_ARGS_METADATA,
+} from '../../constants.js';
+import {
+  assignMetadata,
   Body,
   HostParam,
   Param,
   Query,
+  RawBody,
+  Res,
   Search,
+  UploadedFile,
+  UploadedFiles,
 } from '../../decorators/index.js';
 import { RequestMethod } from '../../enums/request-method.enum.js';
 import { RouteParamtypes } from '../../enums/route-paramtypes.enum.js';
@@ -16,6 +24,7 @@ import {
   Lock,
   Mkcol,
   Move,
+  ParseFilePipe,
   ParseIntPipe,
   Patch,
   Post,
@@ -1090,5 +1099,189 @@ describe('@Param with ParameterDecoratorOptions', () => {
     expect(metadata[key].data).toBeUndefined();
     expect(metadata[key].pipes).toHaveLength(1);
     expect(metadata[key].schema).toBeUndefined();
+  });
+});
+
+describe('@Res', () => {
+  it('should enhance param with response metadata', () => {
+    class Test {
+      public test(@Res() res) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RESPONSE}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+    });
+    expect(
+      Reflect.getMetadata(RESPONSE_PASSTHROUGH_METADATA, Test, 'test'),
+    ).toBeUndefined();
+  });
+
+  it('should enable passthrough when "passthrough" option is true', () => {
+    class Test {
+      public test(@Res({ passthrough: true }) res) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RESPONSE}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+    });
+    expect(
+      Reflect.getMetadata(RESPONSE_PASSTHROUGH_METADATA, Test, 'test'),
+    ).toBe(true);
+  });
+});
+
+describe('@UploadedFile', () => {
+  it('should enhance param with file metadata', () => {
+    class Test {
+      public test(@UploadedFile() file) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.FILE}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+    });
+  });
+
+  it('should enhance param with file key and pipes', () => {
+    class Test {
+      public test(@UploadedFile('avatar', ParseFilePipe) file) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.FILE}:0`]).toEqual({
+      index: 0,
+      data: 'avatar',
+      pipes: [ParseFilePipe],
+    });
+  });
+
+  it('should not confuse a pipe passed as the first argument with a file key', () => {
+    const pipe = new ParseFilePipe();
+    class Test {
+      public test(@UploadedFile(pipe) file) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.FILE}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [pipe],
+    });
+  });
+});
+
+describe('@UploadedFiles', () => {
+  it('should enhance param with files metadata', () => {
+    class Test {
+      public test(@UploadedFiles() files) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.FILES}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+    });
+  });
+
+  it('should enhance param with pipes', () => {
+    const pipe = new ParseFilePipe();
+    class Test {
+      public test(@UploadedFiles(pipe) files) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.FILES}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [pipe],
+    });
+  });
+});
+
+describe('@RawBody', () => {
+  const mockSchema = {
+    '~standard': {
+      version: 1 as const,
+      vendor: 'test',
+      validate: (v: unknown) => ({ value: v }),
+    },
+  };
+
+  it('should enhance param with raw body metadata', () => {
+    class Test {
+      public test(@RawBody() rawBody) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RAW_BODY}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+    });
+  });
+
+  it('should not confuse a pipe instance with options', () => {
+    const pipe = new ParseIntPipe();
+    class Test {
+      public test(@RawBody(pipe) rawBody) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RAW_BODY}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [pipe],
+    });
+  });
+
+  it('should enhance param with schema when options passed as the only argument', () => {
+    class Test {
+      public test(@RawBody({ schema: mockSchema }) rawBody) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RAW_BODY}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [],
+      schema: mockSchema,
+    });
+  });
+
+  it('should enhance param with pipes when options with pipes passed as the only argument', () => {
+    class Test {
+      public test(
+        @RawBody({ schema: mockSchema, pipes: [ParseIntPipe] }) rawBody,
+      ) {}
+    }
+    const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'test');
+    expect(metadata[`${RouteParamtypes.RAW_BODY}:0`]).toEqual({
+      index: 0,
+      data: undefined,
+      pipes: [ParseIntPipe],
+      schema: mockSchema,
+    });
+  });
+});
+
+describe('assignMetadata', () => {
+  describe('when called with the legacy positional signature', () => {
+    it('should use a non-object argument as data', () => {
+      expect(assignMetadata({}, RouteParamtypes.BODY, 0, 'role')).toEqual({
+        [`${RouteParamtypes.BODY}:0`]: { index: 0, data: 'role', pipes: [] },
+      });
+    });
+
+    it('should not read an object argument as options when pipes are passed positionally', () => {
+      const data = { data: 'role' };
+      expect(
+        assignMetadata({}, RouteParamtypes.BODY, 0, data, ParseIntPipe),
+      ).toEqual({
+        [`${RouteParamtypes.BODY}:0`]: {
+          index: 0,
+          data,
+          pipes: [ParseIntPipe],
+        },
+      });
+    });
   });
 });

--- a/packages/common/test/decorators/sse-signal.decorator.spec.ts
+++ b/packages/common/test/decorators/sse-signal.decorator.spec.ts
@@ -1,0 +1,33 @@
+import { ROUTE_ARGS_METADATA } from '../../constants.js';
+import {
+  SSE_ABORT_CONTROLLER,
+  SseSignal,
+} from '../../decorators/http/sse-signal.decorator.js';
+
+describe('@SseSignal', () => {
+  class Test {
+    public stream(@SseSignal() signal) {}
+  }
+
+  const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Test, 'stream');
+  const { factory } = metadata[Object.keys(metadata)[0]];
+  const createContext = (request: unknown) =>
+    ({
+      switchToHttp: () => ({ getRequest: () => request }),
+    }) as any;
+
+  it('should return the signal of the abort controller attached to the request', () => {
+    const controller = new AbortController();
+    const request = { [SSE_ABORT_CONTROLLER]: controller };
+
+    expect(factory(undefined, createContext(request))).toBe(controller.signal);
+  });
+
+  it('should return undefined when no abort controller is attached to the request', () => {
+    expect(factory(undefined, createContext({}))).toBeUndefined();
+  });
+
+  it('should return undefined when there is no request', () => {
+    expect(factory(undefined, createContext(undefined))).toBeUndefined();
+  });
+});

--- a/packages/common/test/decorators/sse.decorator.spec.ts
+++ b/packages/common/test/decorators/sse.decorator.spec.ts
@@ -36,4 +36,23 @@ describe('@Sse', () => {
     const metadata = Reflect.getMetadata(SSE_METADATA, Test.testUsingOptions);
     expect(metadata).toEqual(true);
   });
+
+  it('should set path on "/" by default', () => {
+    class TestWithoutPath {
+      @Sse()
+      public static test() {}
+
+      @Sse('')
+      public static testUsingEmptyPath() {}
+    }
+
+    const path = Reflect.getMetadata(PATH_METADATA, TestWithoutPath.test);
+    expect(path).toEqual('/');
+
+    const emptyPath = Reflect.getMetadata(
+      PATH_METADATA,
+      TestWithoutPath.testUsingEmptyPath,
+    );
+    expect(emptyPath).toEqual('/');
+  });
 });

--- a/packages/common/test/decorators/use-guards.decorator.spec.ts
+++ b/packages/common/test/decorators/use-guards.decorator.spec.ts
@@ -37,10 +37,26 @@ describe('@UseGuards', () => {
   });
 
   it('should throw exception when object is invalid', () => {
+    let error = undefined;
     try {
-      UseGuards('test' as any)(() => {});
+      UseGuards('test' as any)({ name: 'target' } as any);
     } catch (e) {
-      expect(e).toBeInstanceOf(InvalidDecoratorItemException);
+      error = e;
     }
+    expect(error).toBeInstanceOf(InvalidDecoratorItemException);
+  });
+
+  it('should not throw exception when object is a guard instance', () => {
+    let error = undefined;
+    try {
+      UseGuards({
+        canActivate() {
+          return true;
+        },
+      })({ name: 'target' } as any);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeUndefined();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: tests only

## What is the current behavior?

### `packages/common/decorators/core`

<img width="1910" height="366" alt="Screenshot 2026-09-12 at 17 33 42" src="https://github.com/user-attachments/assets/d3e94890-5c74-441d-b166-9e056be42076" />


Unit coverage stops at 99.08% statements and 93.1% branches. Three branches never run:

- `flatten()` never recurses, because no `@Dependencies()` test nests arrays more than one level deep.
- No unit test covers `@Inject()` with no arguments on a constructor parameter, where the token is inferred from `design:paramtypes`.
- `@UseGuards()` never validates a guard *instance* (`isFunction(guard.canActivate)`).

The existing `@UseGuards` test "should throw exception when object is invalid" could also never fail. It decorated an anonymous arrow function, whose empty `name` makes `validateEach()` skip validation, and its only assertion was inside `catch`.

### `packages/common/decorators/http`

Unit coverage stops at 90.07% statements, 89% branches, 80.55% functions and 90.69% lines:

- `@Res()`, `@UploadedFile()`, `@UploadedFiles()` and `@RawBody()` never run in the unit suite.
- No test calls `assignMetadata()` with its legacy positional signature, `(args, paramtype, index, data?, ...pipes)`.
- No test passes `enhancers` to `createParamDecorator()`, so the loop that applies them never runs.
- `@SseSignal()` is only used by the SSE integration tests, which the unit coverage run doesn't include, so its factory never runs.
- Every `@Sse()` test passes a path, so the fallback to `/` never runs.

### `packages/common/decorators/modules`

Unit coverage stops at 50% branches (1/2):

- `@Module()` copies metadata in a `for...in` loop guarded by `Object.hasOwn()`, but every `@Module()` test passes a plain object literal, so the guard never skips an inherited key.

Issue Number: N/A


## What is the new behavior?

Only spec files change.

<img width="2684" height="966" alt="image" src="https://github.com/user-attachments/assets/3a510a8b-4b24-4e71-86fb-3426f1a73e0c" />


### `packages/common/decorators/core`

Coverage reaches 100% statements, branches, functions and lines:

- `dependencies.decorator.spec.ts`: covers deeply nested `@Dependencies()` arrays, plus a direct `flatten()` test.
- `inject.decorator.spec.ts`: `@Inject()` infers the token from the parameter type, and `@Inject(undefined)` does not.
- `use-guards.decorator.spec.ts`: the invalid-guard test now decorates a named target and asserts outside `catch`, and a new test covers guard instances.

For each new test, I temporarily removed its target branch from the source and confirmed the test fails.

### `packages/common/decorators/http`

Coverage reaches 100% statements (131/131), functions (36/36) and lines (129/129), and 99% branches (99/100):

- `route-params.decorator.spec.ts`: covers `@Res()` with and without `passthrough`, `@UploadedFile()`, `@UploadedFiles()`, `@RawBody()` with pipes and with a `schema`, and the legacy `assignMetadata()` signature with and without positional pipes.
- `create-param-decorator.spec.ts`: each enhancer passed to `createParamDecorator()` is applied to the decorated parameter.
- `sse-signal.decorator.spec.ts` (new): the factory returns the request's `AbortSignal`, or `undefined` when the request has no abort controller or there is no request.
- `sse.decorator.spec.ts`: `@Sse()` and `@Sse('')` both set the path to `/`.

I checked these the same way, with 11 temporary source mutations. Each one failed exactly the tests meant to catch it.

### `packages/common/decorators/modules`

Coverage reaches 100% statements (8/8), branches (2/2), functions (4/4) and lines (8/8):

- `module.decorator.spec.ts`: a key inherited through the metadata object's prototype does not become module metadata, while the object's own keys still do.

I checked this the same way: with the `Object.hasOwn()` guard removed from the source, the new test fails.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The one branch still uncovered in `decorators/http` is the `pipes ?? []` fallback at `route-params.decorator.ts:118`. That line only runs when a pipe is passed as the first argument of `@UploadedFile()`, `@Query()`, `@Body()` or `@Param()`, and all four always pass `pipes` as an array. Covering it would take a source change, which this PR avoids.

`exception-filters.decorator.spec.ts` and `use-pipes.decorator.spec.ts` also assert inside `catch`. Other tests already cover those branches, so fixing them is left for a follow-up.

