### PR TITLE
feat(core): add support for array of global prefixes

### DIFF
--- a/packages/common/interfaces/nest-application.interface.ts
+++ b/packages/common/interfaces/nest-application.interface.ts
@@ -69,11 +69,15 @@ export interface INestApplication<
   /**
    * Registers a prefix for every HTTP route path.
    *
-   * @param {string} prefix The prefix for every HTTP route path (for example `/v1/api`)
+   * @param {string | string[]} prefix The prefix for every HTTP route path (for example `/v1/api`).
+   *   Can be an array of prefixes to register multiple prefixes (for example `['api', 'v1']`).
    * @param {GlobalPrefixOptions} options Global prefix options object
    * @returns {this}
    */
-  setGlobalPrefix(prefix: string, options?: GlobalPrefixOptions): this;
+  setGlobalPrefix(
+    prefix: string | string[],
+    options?: GlobalPrefixOptions,
+  ): this;
 
   /**
    * Register Ws Adapter which will be used inside Gateways.

--- a/packages/core/application-config.ts
+++ b/packages/core/application-config.ts
@@ -14,7 +14,7 @@ import { InstanceWrapper } from './injector/instance-wrapper.js';
 import { ExcludeRouteMetadata } from './router/interfaces/exclude-route-metadata.interface.js';
 
 export class ApplicationConfig {
-  private globalPrefix = '';
+  private globalPrefixes: string[] = [];
   private globalPrefixOptions: GlobalPrefixOptions<ExcludeRouteMetadata> = {};
   private globalPipes: Array<PipeTransform> = [];
   private globalFilters: Array<ExceptionFilter> = [];
@@ -33,12 +33,16 @@ export class ApplicationConfig {
 
   constructor(private ioAdapter: WebSocketAdapter | null = null) {}
 
-  public setGlobalPrefix(prefix: string) {
-    this.globalPrefix = prefix;
+  public setGlobalPrefix(prefix: string | string[]) {
+    this.globalPrefixes = Array.isArray(prefix) ? prefix : [prefix];
   }
 
-  public getGlobalPrefix() {
-    return this.globalPrefix;
+  public getGlobalPrefix(): string {
+    return this.globalPrefixes[0] ?? '';
+  }
+
+  public getGlobalPrefixes(): string[] {
+    return this.globalPrefixes;
   }
 
   public setGlobalPrefixOptions(

--- a/packages/core/middleware/route-info-path-extractor.ts
+++ b/packages/core/middleware/route-info-path-extractor.ts
@@ -13,18 +13,24 @@ import {
 
 export class RouteInfoPathExtractor {
   private readonly routePathFactory: RoutePathFactory;
-  private readonly prefixPath: string;
+  private readonly prefixPaths: string[];
   private readonly excludedGlobalPrefixRoutes: ExcludeRouteMetadata[];
   private readonly versioningConfig?: VersioningOptions;
 
   constructor(private readonly applicationConfig: ApplicationConfig) {
     this.routePathFactory = new RoutePathFactory(applicationConfig);
-    this.prefixPath = stripEndSlash(
-      addLeadingSlash(this.applicationConfig.getGlobalPrefix()),
-    );
+    const prefixes = this.applicationConfig.getGlobalPrefixes();
+    this.prefixPaths =
+      prefixes.length > 0
+        ? prefixes.map(p => stripEndSlash(addLeadingSlash(p)))
+        : [''];
     this.excludedGlobalPrefixRoutes =
       this.applicationConfig.getGlobalPrefixOptions().exclude!;
     this.versioningConfig = this.applicationConfig.getVersioning();
+  }
+
+  private get prefixPath(): string {
+    return this.prefixPaths[0];
   }
 
   public extractPathsFrom({ path, method, version }: RouteInfo): string[] {
@@ -33,14 +39,17 @@ export class RouteInfoPathExtractor {
     if (this.isAWildcard(path)) {
       const entries =
         versionPaths.length > 0
-          ? versionPaths
-              .map(versionPath => [
-                this.prefixPath + versionPath + '$',
-                this.prefixPath + versionPath + addLeadingSlash(path),
+          ? this.prefixPaths.flatMap(prefixPath =>
+              versionPaths.flatMap(versionPath => [
+                prefixPath + versionPath + '$',
+                prefixPath + versionPath + addLeadingSlash(path),
+              ]),
+            )
+          : this.prefixPaths[0]
+            ? this.prefixPaths.flatMap(prefixPath => [
+                prefixPath + '$',
+                prefixPath + addLeadingSlash(path),
               ])
-              .flat()
-          : this.prefixPath
-            ? [this.prefixPath + '$', this.prefixPath + addLeadingSlash(path)]
             : [addLeadingSlash(path)];
 
       return Array.isArray(this.excludedGlobalPrefixRoutes)
@@ -99,10 +108,14 @@ export class RouteInfoPathExtractor {
     }
 
     if (!versionPaths.length) {
-      return [this.prefixPath + addLeadingSlash(path)];
+      return this.prefixPaths.map(
+        prefixPath => prefixPath + addLeadingSlash(path),
+      );
     }
-    return versionPaths.map(
-      versionPath => this.prefixPath + versionPath + addLeadingSlash(path),
+    return this.prefixPaths.flatMap(prefixPath =>
+      versionPaths.map(
+        versionPath => prefixPath + versionPath + addLeadingSlash(path),
+      ),
     );
   }
 

--- a/packages/core/nest-application.ts
+++ b/packages/core/nest-application.ts
@@ -211,8 +211,11 @@ export class NestApplication
   public async registerRouter() {
     await this.registerMiddleware(this.httpAdapter);
 
-    const prefix = this.config.getGlobalPrefix();
-    const basePath = addLeadingSlash(prefix);
+    const prefixes = this.config.getGlobalPrefixes();
+    const basePaths =
+      prefixes.length > 0
+        ? prefixes.map(prefix => addLeadingSlash(prefix))
+        : [''];
 
     const conflictPolicy = this.config.getRouteConflictPolicy();
     const resolutionStrategy = this.config.getRouteResolutionStrategy();
@@ -227,7 +230,7 @@ export class NestApplication
     const adapterRejectsDuplicates = !adapterIsOrderSensitive;
 
     if (!conflictPolicy && !shouldSortBySpecificity) {
-      this.routesResolver.resolve(this.httpAdapter, basePath);
+      this.routesResolver.resolve(this.httpAdapter, basePaths);
       return;
     }
 
@@ -238,7 +241,7 @@ export class NestApplication
     // from `instance.route()` and would short-circuit both the resolve
     // loop and the aggregated `RouteConflictException`.
     const resolvedRoutes: ResolvedRoute[] = [];
-    this.routesResolver.resolve(this.httpAdapter, basePath, {
+    this.routesResolver.resolve(this.httpAdapter, basePaths, {
       onRouteResolved: route => resolvedRoutes.push(route),
       deferRegistration: true,
     });
@@ -467,7 +470,10 @@ export class NestApplication
     return `${this.getProtocol()}://${host}:${address.port}`;
   }
 
-  public setGlobalPrefix(prefix: string, options?: GlobalPrefixOptions): this {
+  public setGlobalPrefix(
+    prefix: string | string[],
+    options?: GlobalPrefixOptions,
+  ): this {
     this.config.setGlobalPrefix(prefix);
     if (options) {
       const exclude = options?.exclude

--- a/packages/core/router/interfaces/resolver.interface.ts
+++ b/packages/core/router/interfaces/resolver.interface.ts
@@ -5,7 +5,7 @@ import { RouteResolutionOptions } from './route-resolution-options.interface.js'
 export interface Resolver {
   resolve(
     applicationRef: HttpServer,
-    basePath: string,
+    basePath: string | string[],
     options?: RouteResolutionOptions,
   ): void;
   registerResolvedRoute(applicationRef: HttpServer, route: ResolvedRoute): void;

--- a/packages/core/router/interfaces/route-path-metadata.interface.ts
+++ b/packages/core/router/interfaces/route-path-metadata.interface.ts
@@ -14,8 +14,9 @@ export interface RoutePathMetadata {
 
   /**
    * Global route prefix specified with the "NestApplication#setGlobalPrefix" method.
+   * Can be a single prefix or an array of prefixes.
    */
-  globalPrefix?: string;
+  globalPrefix?: string | string[];
 
   /**
    * Module-level path registered through the "RouterModule".

--- a/packages/core/router/route-path-factory.ts
+++ b/packages/core/router/route-path-factory.ts
@@ -57,19 +57,27 @@ export class RoutePathFactory {
     paths = this.appendToAllIfDefined(paths, metadata.methodPath);
 
     if (metadata.globalPrefix) {
-      paths = paths.map(path => {
-        if (
-          this.isExcludedFromGlobalPrefix(
-            path,
-            requestMethod,
-            versionOrVersions,
-            metadata.versioningOptions,
-          )
-        ) {
-          return path;
-        }
-        return stripEndSlash(metadata.globalPrefix || '') + path;
-      });
+      const globalPrefixes = Array.isArray(metadata.globalPrefix)
+        ? metadata.globalPrefix
+        : [metadata.globalPrefix];
+
+      paths = flatten(
+        paths.map(path => {
+          if (
+            this.isExcludedFromGlobalPrefix(
+              path,
+              requestMethod,
+              versionOrVersions,
+              metadata.versioningOptions,
+            )
+          ) {
+            return [path];
+          }
+          return globalPrefixes.map(
+            prefix => stripEndSlash(prefix || '') + path,
+          );
+        }),
+      );
     }
 
     return paths

--- a/packages/core/router/routes-resolver.ts
+++ b/packages/core/router/routes-resolver.ts
@@ -68,7 +68,7 @@ export class RoutesResolver implements Resolver {
 
   public resolve<T extends HttpServer>(
     applicationRef: T,
-    globalPrefix: string,
+    globalPrefix: string | string[],
     options: RouteResolutionOptions = {},
   ) {
     const modules = this.container.getModules();
@@ -95,7 +95,7 @@ export class RoutesResolver implements Resolver {
   public registerRouters(
     routes: Map<string | symbol | Function, InstanceWrapper<Controller>>,
     moduleName: string,
-    globalPrefix: string,
+    globalPrefix: string | string[],
     modulePath: string,
     applicationRef: HttpServer,
     options: RouteResolutionOptions = {},

--- a/packages/core/test/application-config.spec.ts
+++ b/packages/core/test/application-config.spec.ts
@@ -16,6 +16,25 @@ describe('ApplicationConfig', () => {
 
       expect(appConfig.getGlobalPrefix()).toEqual(path);
     });
+    it('should set global path as array', () => {
+      const paths = ['api', 'v1'];
+      appConfig.setGlobalPrefix(paths);
+
+      expect(appConfig.getGlobalPrefix()).toEqual('api');
+      expect(appConfig.getGlobalPrefixes()).toEqual(paths);
+    });
+    it('should return all prefixes via getGlobalPrefixes', () => {
+      const paths = ['prefix1', 'prefix2', 'prefix3'];
+      appConfig.setGlobalPrefix(paths);
+
+      expect(appConfig.getGlobalPrefixes()).toEqual(paths);
+    });
+    it('should convert single string to array in getGlobalPrefixes', () => {
+      const path = 'test';
+      appConfig.setGlobalPrefix(path);
+
+      expect(appConfig.getGlobalPrefixes()).toEqual([path]);
+    });
     it('should set global path options', () => {
       const options: GlobalPrefixOptions<ExcludeRouteMetadata> = {
         exclude: [
@@ -32,6 +51,9 @@ describe('ApplicationConfig', () => {
     });
     it('should has empty string as a global path by default', () => {
       expect(appConfig.getGlobalPrefix()).toEqual('');
+    });
+    it('should return empty array as global prefixes by default', () => {
+      expect(appConfig.getGlobalPrefixes()).toEqual([]);
     });
     it('should has empty string as a global path option by default', () => {
       expect(appConfig.getGlobalPrefixOptions()).toEqual({});

--- a/packages/core/test/middleware/route-info-path-extractor.spec.ts
+++ b/packages/core/test/middleware/route-info-path-extractor.spec.ts
@@ -34,7 +34,7 @@ describe('RouteInfoPathExtractor', () => {
     });
 
     it(`should return correct paths when set global prefix`, () => {
-      Reflect.set(routeInfoPathExtractor, 'prefixPath', '/api');
+      Reflect.set(routeInfoPathExtractor, 'prefixPaths', ['/api']);
 
       expect(
         routeInfoPathExtractor.extractPathsFrom({
@@ -53,7 +53,7 @@ describe('RouteInfoPathExtractor', () => {
     });
 
     it(`should return correct paths when set global prefix and global prefix options`, () => {
-      Reflect.set(routeInfoPathExtractor, 'prefixPath', '/api');
+      Reflect.set(routeInfoPathExtractor, 'prefixPaths', ['/api']);
       Reflect.set(
         routeInfoPathExtractor,
         'excludedGlobalPrefixRoutes',
@@ -123,7 +123,7 @@ describe('RouteInfoPathExtractor', () => {
     });
 
     it(`should return correct path when set global prefix`, () => {
-      Reflect.set(routeInfoPathExtractor, 'prefixPath', '/api');
+      Reflect.set(routeInfoPathExtractor, 'prefixPaths', ['/api']);
 
       expect(
         routeInfoPathExtractor.extractPathFrom({
@@ -142,7 +142,7 @@ describe('RouteInfoPathExtractor', () => {
     });
 
     it(`should return correct path when set global prefix and global prefix options`, () => {
-      Reflect.set(routeInfoPathExtractor, 'prefixPath', '/api');
+      Reflect.set(routeInfoPathExtractor, 'prefixPaths', ['/api']);
       Reflect.set(
         routeInfoPathExtractor,
         'excludedGlobalPrefixRoutes',

--- a/packages/core/test/router/route-path-factory.spec.ts
+++ b/packages/core/test/router/route-path-factory.spec.ts
@@ -225,6 +225,61 @@ describe('RoutePathFactory', () => {
       ).toEqual(['/ctrlPath']);
       vi.restoreAllMocks();
     });
+
+    it('should return paths for each global prefix when array is provided', () => {
+      expect(
+        routePathFactory.create({
+          ctrlPath: '/ctrlPath/',
+          methodPath: '/methodPath/',
+          globalPrefix: ['api', 'v1'],
+        }),
+      ).toEqual(['/api/ctrlPath/methodPath', '/v1/ctrlPath/methodPath']);
+
+      expect(
+        routePathFactory.create({
+          ctrlPath: '/ctrlPath/',
+          methodPath: '/methodPath/',
+          modulePath: '/modulePath/',
+          globalPrefix: ['/prefix1', '/prefix2'],
+        }),
+      ).toEqual([
+        '/prefix1/modulePath/ctrlPath/methodPath',
+        '/prefix2/modulePath/ctrlPath/methodPath',
+      ]);
+    });
+
+    it('should handle single-element array same as string', () => {
+      const resultArray = routePathFactory.create({
+        ctrlPath: '/ctrlPath/',
+        methodPath: '/methodPath/',
+        globalPrefix: ['api'],
+      });
+
+      const resultString = routePathFactory.create({
+        ctrlPath: '/ctrlPath/',
+        methodPath: '/methodPath/',
+        globalPrefix: 'api',
+      });
+
+      expect(resultArray).toEqual(resultString);
+    });
+
+    it('should combine multiple prefixes with versioning', () => {
+      expect(
+        routePathFactory.create({
+          ctrlPath: '/ctrlPath/',
+          methodPath: '/methodPath/',
+          globalPrefix: ['api', 'v1'],
+          versioningOptions: {
+            type: VersioningType.URI,
+          },
+          controllerVersion: '1.0.0',
+        }),
+      ).toEqual([
+        '/api/v1.0.0/ctrlPath/methodPath',
+        '/v1/v1.0.0/ctrlPath/methodPath',
+      ]);
+    });
   });
 
   describe('isExcludedFromGlobalPrefix', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features): nestjs/docs.nestjs.com#3531 (draft until this PR is released)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #16095

`setGlobalPrefix()` only accepts a single string. Before v11, the same routes could be served under several base paths with a regex-style prefix such as `(prefixOne|prefixTwo)`, but path-to-regexp v8 no longer supports that.


## What is the new behavior?

`setGlobalPrefix()` also accepts an array, and every route is registered under each prefix:

```ts
app.setGlobalPrefix(['api', 'v1']);
// GET /api/cats and GET /v1/cats
```

- `ApplicationConfig#getGlobalPrefixes()` returns all prefixes.
- `ApplicationConfig#getGlobalPrefix()` is now marked `@deprecated` and will be removed in NestJS v13. Its JSDoc explains that it deliberately keeps returning only the first prefix (as a `string`) for backward compatibility, and points to `getGlobalPrefixes()` as the replacement.
- `RoutePathFactory` builds one path per prefix. Routes listed in `exclude` stay unprefixed, as before.
- `RouteInfoPathExtractor` builds middleware paths for every prefix, including versioned and wildcard routes.
- `NestApplication#registerRouter()` passes all prefixes to `RoutesResolver#resolve()`, both with and without route conflict detection.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

`getGlobalPrefix()` still returns a string (the first prefix, or `''`), so packages that read it, like `@nestjs/swagger`, keep working. When several prefixes are set, those packages only see the first one until they switch to `getGlobalPrefixes()`. That `globalPrefixes[0]` return is intentional and documented in the method's JSDoc; the method is marked `@deprecated` so consumers get an editor/compiler hint to migrate to `getGlobalPrefixes()` before it is removed in v13.


## Other information

This supersedes #16102 by @malkovitc, which stalled waiting for a rebase. I cherry-picked their commit onto the current `master` and kept them as the author. The conflicts in `registerRouter()` were resolved by keeping the route conflict detection and specificity ordering, with every prefix passed to both `resolve()` calls.

A deprecation note was left on `ApplicationConfig#getGlobalPrefix()` stating that returning only the first prefix is intentional to avoid a breaking change, that callers should migrate to `getGlobalPrefixes()`, and that the legacy method is scheduled for removal in NestJS v13. Core still calls `getGlobalPrefix()` in `registerParserMiddleware()`, `registerNotFoundHandler()` and `registerExceptionHandler()`, since those adapter hooks accept a single prefix; they are left as-is in this PR.




### Impact on `@nestjs/swagger`

I ran the current `@nestjs/swagger` `master` (v12.0.1) against the build from this branch (`node_modules/@nestjs/{core,common}` symlinked to this branch's packages). Its type-check (`tsc -p tsconfig.build.json`), unit suite (518 tests) and e2e suite (133 tests) all pass, so this PR does not break it.

However, swagger only ever sees the **first** prefix, because it reads `app.config.getGlobalPrefix()` through an untyped `any` cast (`lib/utils/get-global-prefix.ts`). With `app.setGlobalPrefix(['api', 'v1'])`:

- `SwaggerModule.createDocument()` lists `/api/cats` but not `/v1/cats`, even though core serves both.
- `SwaggerModule.setup(..., { useGlobalPrefix: true })` mounts the UI and the JSON/YAML documents under `/api/...` only; `/v1/docs-json` returns 404.
- `ignoreGlobalPrefix: true` and `exclude`d routes keep working as before.

Since swagger reaches the method via `any`, the `@deprecated` tag will not show up in its editor/compiler; the migration hint only reaches them through the JSDoc/changelog. The fix on their side is small: `RoutePathFactory#create()` already fans out when given `getGlobalPrefixes()` (verified: it returns `['/api/cats', '/v1/cats']`), and swagger already iterates multiple paths per route for versioning, so mostly the helper needs to return `string[]` (with a fallback to `getGlobalPrefix()` for older core versions) and `setup()` needs to loop over the prefixes. I'll open a follow-up issue on nestjs/swagger once this is merged.
