### PR TITLE
chore: add workflow to flag malicious pull request content

### DIFF
--- a/.github/workflows/pr-content-guard.yml
+++ b/.github/workflows/pr-content-guard.yml
@@ -1,0 +1,191 @@
+name: PR content guard
+
+# Flags pull requests that carry repository-poisoning malware patterns, such as
+# the PolinRider campaign: a hidden `.vscode/tasks.json` task that runs when the
+# folder is opened and executes JavaScript disguised as a font file. The point
+# is to warn maintainers before anyone checks such a branch out locally.
+#
+# Security model: `pull_request_target` always runs this file as it exists on
+# the base branch, so a pull request cannot edit the check away. The pull
+# request's code is never checked out or executed; changed files are read
+# through the REST API as data only. Keep it that way: no checkout of the head
+# ref, no package installs, and no `${{ }}` expressions in `run:` scripts.
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] -- PR content is only read as API data, see above
+
+permissions: {}
+
+concurrency:
+  group: pr-content-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Scan changed files
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write # sticky comment when something is found
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Scan
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          work="$RUNNER_TEMP/pr-content-guard"
+          mkdir -p "$work"
+
+          cat > "$work/lib.jq" <<'JQ'
+          # Hex prefix that a font or image with each extension must start with.
+          def signatures: {
+            woff: "^774f4646", woff2: "^774f4632",
+            ttf: "^(00010000|74727565|4f54544f)", otf: "^(4f54544f|00010000)", eot: "^.{68}4c50",
+            png: "^89504e470d0a1a0a", jpg: "^ffd8ff", jpeg: "^ffd8ff",
+            gif: "^474946383[79]61", ico: "^00000100", webp: "^52494646.{8}57454250"
+          };
+          def ext: (.filename | ascii_downcase | capture("\\.(?<e>[a-z0-9]+)$").e) // "";
+          def added: (.patch // "") | split("\n")[] | select(startswith("+")) | .[1:];
+          def removed: (.patch // "") | split("\n")[] | select(startswith("-")) | .[1:];
+          def finding($level; $rule; $detail): {$level, $rule, file: .filename, $detail};
+          JQ
+
+          # Changed files with their diffs (GitHub lists at most 3000).
+          gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/files?per_page=100" --jq '.[]' |
+            jq -s '.' > "$work/files.json"
+
+          # Top-level entries of the base branch.
+          gh api "repos/$REPO/git/trees/$BASE_SHA" --jq '[.tree[].path]' > "$work/root.json"
+
+          # First 48 bytes (as hex) of every added or modified font/image, keyed by blob SHA.
+          jq -L "$work" -r 'include "lib";
+            .[] | select(.status != "removed") | ext as $e | select(signatures | has($e)) | .sha
+          ' "$work/files.json" |
+            sort -u |
+            while read -r sha; do
+              [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || continue
+              hex=$(gh api "repos/$REPO/git/blobs/$sha" --jq '.content | gsub("\\s"; "") | .[0:64]' |
+                base64 -d | od -An -tx1 -v | tr -d ' \n')
+              jq -n --arg sha "$sha" --arg hex "$hex" '{($sha): $hex}'
+            done |
+            jq -s 'add // {}' > "$work/heads.json"
+
+          cat > "$work/rules.jq" <<'JQ'
+          include "lib";
+
+          ($heads[0]) as $heads
+          | ($root[0]) as $root
+          | [
+              (if length >= 3000 then
+                {level: "error", rule: "incomplete-scan", file: "", detail: "GitHub lists at most 3000 files per pull request, so the scan is incomplete."}
+              else empty end),
+
+              (.[] | select(.status != "removed") | (
+                # Editor and devcontainer configs can run commands as soon as the folder is opened.
+                (select(.filename | test("(^|/)\\.(vscode|devcontainer|idea)/|\\.code-workspace$"))
+                  | finding("error"; "editor-autorun-config"; "Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.")),
+
+                # Un-ignoring those folders is how such configs get committed.
+                (select(.filename | test("(^|/)\\.gitignore$"))
+                  | select(any(removed; test("\\.(vscode|devcontainer|idea)|code-workspace"))
+                      or any(added; test("^\\s*!.*(\\.(vscode|devcontainer|idea)|code-workspace)")))
+                  | finding("error"; "gitignore-unignores-editor-config"; "Stops ignoring editor/devcontainer configuration.")),
+
+                # Fonts and images must start with their format's magic bytes.
+                (ext as $e | select(signatures | has($e))
+                  | select(($heads[.sha] // "") | test(signatures[$e]) | not)
+                  | finding("error"; "disguised-binary"; "Content does not match the .\($e) format (e.g. JavaScript renamed to a font).")),
+
+                # Whitespace runs push code off-screen in diff views; very long lines hide minified payloads.
+                (select(.filename | test("\\.svg$"; "i") | not)
+                  | select(any(added; test("[ \\t]{100,}") or length > 2000))
+                  | finding("error"; "hidden-code-layout"; "Adds a line with 100+ consecutive spaces/tabs or over 2000 characters.")),
+
+                # Strings from PolinRider payloads and the configs that launch them.
+                (select(.filename != ".github/workflows/pr-content-guard.yml")
+                  | ([added | match("\"runOn\"\\s*:\\s*\"folderOpen\"|allowAutomaticTasks|global\\[['\"](!|_V)['\"]\\]|_\\$_1e42|rmcej%otb%|temp_(auto|interactive)_push\\.bat|branch_structure\\.json|(^|/)config\\.bat\\b"; "g").string] | unique) as $hits
+                  | select($hits != [])
+                  | finding("error"; "malware-indicator"; "Contains known malware strings: \($hits | join(", ")).")),
+
+                # Content GitHub cannot diff (binary or too large) is not scanned line by line.
+                (select(.patch == null and (.status != "renamed" or .changes > 0))
+                  | ext as $e | select(signatures | has($e) | not)
+                  | finding("warning"; "not-scanned"; "No text diff available (binary or too large), so the content was not scanned."))
+              )),
+
+              # A new top-level directory or file is unusual for this repository.
+              ([.[] | select(.status == "added") | .filename | split("/")[0]] | unique[]
+                | select(. as $top | any($root[]; . == $top) | not)
+                | {level: "warning", rule: "new-top-level-entry", file: ., detail: "Adds a new top-level path."})
+            ]
+          | sort_by(.level != "error", .file, .rule)
+          JQ
+
+          jq -L "$work" --slurpfile heads "$work/heads.json" --slurpfile root "$work/root.json" \
+            -f "$work/rules.jq" "$work/files.json" > "$work/findings.json"
+
+          errors=$(jq '[.[] | select(.level == "error")] | length' "$work/findings.json")
+          warnings=$(jq '[.[] | select(.level == "warning")] | length' "$work/findings.json")
+          {
+            echo "errors=$errors"
+            echo "warnings=$warnings"
+          } >> "$GITHUB_OUTPUT"
+
+          # One annotation per finding; escaping keeps file names from injecting workflow commands.
+          jq -r '.[]
+            | "::\(.level) title=PR content guard (\(.rule))::\(if .file == "" then "" else .file + ": " end)\(.detail)"
+            | gsub("%"; "%25") | gsub("\r"; "%0D") | gsub("\n"; "%0A")
+          ' "$work/findings.json"
+
+          jq -r --arg head "$HEAD_SHA" '
+            def code: "`" + gsub("[`\r\n]"; "?") + "`";
+            (map(select(.level == "error")) | length) as $errors
+            | "<!-- pr-content-guard -->",
+              "### PR content guard",
+              "",
+              (if $errors > 0 then
+                "⚠️ This pull request matches patterns used by repository-poisoning malware, such as JavaScript disguised as a font and launched by `.vscode/tasks.json` when the folder is opened. **Do not check this branch out or open it in an editor** until a maintainer has reviewed the diff on GitHub."
+              elif length > 0 then "No blocking findings. Warnings for reviewers:"
+              else "No suspicious patterns found." end),
+              "",
+              (.[] | "- **\(.level)** \(.rule | code)\(if .file == "" then "" else " in " + (.file | code) end): \(.detail)"),
+              "",
+              "<sub>Scanned commit \($head[0:7]). Rules live in `.github/workflows/pr-content-guard.yml`.</sub>"
+          ' "$work/findings.json" > "$work/report.md"
+          cat "$work/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+          # Clean runs only leave a log line; nothing is posted to the pull request.
+          if [[ "$errors" == "0" ]]; then
+            echo "No suspicious changes found in ${HEAD_SHA:0:7} ($(jq length "$work/files.json") files, $warnings warnings)."
+          fi
+
+      - name: Comment on pull request
+        if: steps.scan.outputs.errors != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$RUNNER_TEMP/pr-content-guard/report.md"
+          comment_id=$(gh api --paginate "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | startswith("<!-- pr-content-guard -->"))) | .id' |
+            tail -n 1)
+
+          # Update the earlier warning instead of adding a new comment on every push.
+          if [[ -n "$comment_id" ]]; then
+            gh api --method PATCH "repos/$REPO/issues/comments/$comment_id" -F "body=@$body" > /dev/null
+          else
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" -F "body=@$body" > /dev/null
+          fi
+
+      - name: Fail on findings
+        if: steps.scan.outputs.errors != '0'
+        shell: bash
+        run: |
+          echo "::error title=PR content guard::Suspicious changes found (see the job summary). Do not check this branch out locally until a maintainer has reviewed it."
+          exit 1


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

#17639 looked like a small bugfix, but its head commit (`f86e99b`) was force-pushed from a compromised fork and carried [PolinRider](https://github.com/OpenSourceMalware/PolinRider) malware:

- `.vscode/tasks.json` added a hidden task that runs `node ./public/fonts/fa-solid-500.woff2` as soon as the folder is opened in VS Code.
- `public/fonts/fa-solid-500.woff2` is not a font. It's an obfuscated JavaScript loader, preceded by 273 spaces so it sits off-screen in diff views.
- `.vscode/settings.json` turned on `task.allowAutomaticTasks`, and `.gitignore` stopped ignoring `/.vscode`.

Every existing check on that PR was green:

- CircleCI `build-and-test` builds, tests and lints `packages/`. Nothing in it reads `.vscode/` or `public/`, and nothing runs the loader.
- CodeQL looks for vulnerable data flows in source code. It doesn't analyse editor config or font files, and it reported "No new alerts in code changed by this pull request".

The payload doesn't target CI or `master`. It targets whoever checks the branch out and opens it in a trusted VS Code workspace, which is usually a reviewer, before anything is merged.

Issue Number: N/A


## What is the new behavior?

Adds `.github/workflows/pr-content-guard.yml`, which scans the changed files of every pull request for these patterns.

### When it runs

- On `pull_request_target`, for pull requests against any branch, when they're opened, reopened or receive new commits (the event's default activity types). A new push cancels the run still in progress for the same PR.
- `pull_request_target` always uses the workflow file from the base branch, so a pull request can't edit or disable the check. It also means **this PR won't run it**: the first runs will be on pull requests opened or updated after it's merged.
- The pull request's code is never checked out, installed or executed. The job reads the changed files through the GitHub REST API as data. It uses no third-party actions and no repository secrets, and its token only has `contents: read` and `pull-requests: write` (for the comment).

### What it checks

Errors (the check fails):

| Rule | What it flags |
| --- | --- |
| `editor-autorun-config` | Added or changed files under `.vscode/`, `.devcontainer/` or `.idea/`, or `*.code-workspace` files, at any depth. They can run commands when a folder is opened, and this repository doesn't track any. |
| `gitignore-unignores-editor-config` | A `.gitignore` change that removes an ignore rule for those files or adds a `!` exception for them. |
| `disguised-binary` | A `.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.ico` or `.webp` file whose first bytes don't match that format. |
| `hidden-code-layout` | An added line with 100 or more consecutive spaces/tabs, or longer than 2,000 characters. `.svg` files are skipped. |
| `malware-indicator` | Strings from PolinRider payloads and launchers: `"runOn": "folderOpen"`, `allowAutomaticTasks`, `global['!']`, `global['_V']`, `_$_1e42`, `rmcej%otb%`, `temp_auto_push.bat`, `temp_interactive_push.bat`, `branch_structure.json`, `config.bat`. The workflow file itself is exempt from this rule. |
| `incomplete-scan` | 3,000 or more changed files. The REST API lists at most 3,000, so the rest can't be scanned. |

Warnings (reported, but the check still passes):

| Rule | What it flags |
| --- | --- |
| `not-scanned` | A file GitHub has no text diff for (binary or too large), with no format signature to check it against. |
| `new-top-level-entry` | A new file or directory at the repository root. |

The thresholds leave plenty of room above what `master` contains today. None of its ~2,300 tracked files is under `.vscode/`, `.devcontainer/` or `.idea/`. Its only image (`sample/29-file-upload/resources/nestjs.jpg`) is a real JPEG. The longest run of whitespace in any line is 28 characters, and the longest line outside an `.svg` is 643 characters.

### What it produces

When nothing is found:

- The check passes and nothing is posted on the pull request.
- The job log prints one line, for example on #17692: `No suspicious changes found in 676044e (5 files, 0 warnings).`
- The job summary says "No suspicious patterns found.". If there are warnings, it lists them instead, and they also appear as warning annotations.

When something is found:

- Each finding becomes an `error` or `warning` annotation on the workflow run, and the job summary lists them all.
- `github-actions[bot]` comments on the pull request with the findings and a warning not to check the branch out or open it in an editor until a maintainer has reviewed the diff on GitHub. If a later push still has problems, that same comment is updated instead of adding a new one.
- A final step fails the job, so the check is red.
- If a later push removes every problem, the check goes green again, but the earlier comment is left as it was.

If the scan itself can't run (for example, the API is unavailable), the job fails without commenting.

<details>
<summary>The comment it would post on #17639's head commit (produced locally by the workflow's scan step)</summary>

<!-- pr-content-guard -->
### PR content guard

⚠️ This pull request matches patterns used by repository-poisoning malware, such as JavaScript disguised as a font and launched by `.vscode/tasks.json` when the folder is opened. **Do not check this branch out or open it in an editor** until a maintainer has reviewed the diff on GitHub.

- **error** `gitignore-unignores-editor-config` in `.gitignore`: Stops ignoring editor/devcontainer configuration.
- **error** `malware-indicator` in `.gitignore`: Contains known malware strings: branch_structure.json, temp_auto_push.bat, temp_interactive_push.bat.
- **error** `editor-autorun-config` in `.vscode/extensions.json`: Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.
- **error** `editor-autorun-config` in `.vscode/launch.json`: Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.
- **error** `editor-autorun-config` in `.vscode/settings.json`: Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.
- **error** `malware-indicator` in `.vscode/settings.json`: Contains known malware strings: "runOn": "folderOpen", allowAutomaticTasks.
- **error** `editor-autorun-config` in `.vscode/spellright.dict`: Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.
- **error** `editor-autorun-config` in `.vscode/tasks.json`: Adds or changes editor/devcontainer configuration, which can run commands when the folder is opened.
- **error** `malware-indicator` in `.vscode/tasks.json`: Contains known malware strings: "runOn": "folderOpen".
- **error** `disguised-binary` in `public/fonts/fa-solid-500.woff2`: Content does not match the .woff2 format (e.g. JavaScript renamed to a font).
- **error** `hidden-code-layout` in `public/fonts/fa-solid-500.woff2`: Adds a line with 100+ consecutive spaces/tabs or over 2000 characters.
- **error** `malware-indicator` in `public/fonts/fa-solid-500.woff2`: Contains known malware strings: global['_V'].
- **warning** `new-top-level-entry` in `.vscode`: Adds a new top-level path.
- **warning** `new-top-level-entry` in `public`: Adds a new top-level path.
- **warning** `not-scanned` in `public/fonts/fa-brands-400.svg`: No text diff available (binary or too large), so the content was not scanned.
- **warning** `not-scanned` in `public/fonts/fa-regular-400.svg`: No text diff available (binary or too large), so the content was not scanned.
- **warning** `not-scanned` in `public/fonts/fa-solid-900.svg`: No text diff available (binary or too large), so the content was not scanned.

<sub>Scanned commit f86e99b. Rules live in `.github/workflows/pr-content-guard.yml`.</sub>

</details>

### What it relies on

At runtime the job only uses tools preinstalled on GitHub's `ubuntu-latest` runner:

- `gh` (GitHub CLI) to call the REST API for the pull request's changed files and diffs, the base branch's top-level entries, and the first bytes of each font or image.
- `jq` for the rules and the report.
- `base64` and `od` to turn those first bytes into hex.

The tools below were used to validate the workflow before opening this PR. **None of them runs as part of the workflow.**

- [zizmor](https://docs.zizmor.sh), a security linter for GitHub Actions, reports no findings. Its [`dangerous-triggers`](https://docs.zizmor.sh/audits/#dangerous-triggers) audit, which flags any use of `pull_request_target`, is ignored inline, because this job never checks out or runs pull request code.
- [actionlint](https://github.com/rhysd/actionlint) and [ShellCheck](https://www.shellcheck.net) (on the `run:` scripts) report no issues.
- Prettier passes with this repository's config.
- A throwaway local script ran the scan step against real pull requests through the API:
  - #17639 triggers every error rule except `incomplete-scan`, and only on the malicious files. The real fonts and the `ws-adapter.ts` change are not flagged.
  - The 40 most recently merged pull requests (#17571 to #17692), plus #14881, which added a real JPEG, produce no errors. They include Dependabot and Renovate lockfile updates and a CodeQL workflow bump.
  - Breaking each rule in a copy of the workflow, and the "no comment when clean" behaviour, made those tests fail (all 9 cases).

### Can it be improved over time?

Yes. The rules are plain `jq` inside the workflow file, so changing them is an ordinary PR. Because of `pull_request_target`, changes only take effect once merged. Ideas:

- Add indicator strings as new PolinRider variants or similar campaigns are published (e.g. by [OpenSourceMalware](https://github.com/OpenSourceMalware/PolinRider) or [Socket](https://socket.dev/blog/polinrider-north-korea-linked-supply-chain-campaign-expands)).
- Add formats to the signature table, or tune the thresholds if they turn out noisy.
- Cover other auto-run vectors, such as changes to npm lifecycle scripts (`preinstall`, `postinstall`, `prepare`) or invisible Unicode characters in source files.
- Run zizmor and actionlint in CI for changes under `.github/workflows/`.
- Make `PR content guard / Scan changed files` a required status check. This PR doesn't change branch protection.

### False positives

Every error deserves a maintainer's look, but not every error is malware. The rules are heuristics, so false positives are possible:

- A contributor committing their own `.vscode/settings.json`, or editing `.gitignore` to allow it.
- A generated or minified file, a long base64 data URI, or text padded with 100+ spaces.
- A mislabelled but harmless asset, such as a PNG saved as `.jpg`, or a truncated font.
- Documentation that mentions one of the indicator strings, such as a security write-up that includes `config.bat`.

None of these came up in the 41 merged pull requests above. When one does, a maintainer can check the flagged file in GitHub's diff view and merge anyway, since the check isn't required.

False negatives are possible too. The rules target automated campaigns like PolinRider, so a payload written to look like ordinary TypeScript, or disguised as a file type that isn't in the signature table, won't be caught. This complements code review; it doesn't replace it.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Only one file is added: `.github/workflows/pr-content-guard.yml`. Nothing under `packages/` changes.

References:

- PolinRider research and IOCs: https://github.com/OpenSourceMalware/PolinRider
- VS Code automatic tasks (`runOn: folderOpen`, `task.allowAutomaticTasks`): https://code.visualstudio.com/docs/debugtest/tasks
