### PR TITLE
docs(core,common): document the HTTP adapter contract for custom adapters

### DIFF
--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -9,10 +9,14 @@ import {
  * Shape of the error-layer callback that Nest hands to
  * {@link HttpServer.setErrorHandler}.
  *
- * The adapter must invoke it whenever a route handler or middleware
- * registered through the adapter fails, passing the thrown value first.
- * `next` may be omitted when the underlying framework has no notion of an
- * error-continuation callback.
+ * The adapter invokes it with the error as the first argument. It is the
+ * safety net for errors that never went through Nest: route handlers and
+ * middleware registered by Nest already run their errors through the
+ * exception filters, so this callback receives what is left, such as failures
+ * of middleware registered directly on the framework (e.g. with `app.use()`),
+ * body-parser errors, and values passed to `next(err)`. `next` may be omitted
+ * when the underlying framework has no notion of an error-continuation
+ * callback.
  *
  * @publicApi
  */
@@ -27,10 +31,18 @@ export type ErrorHandler<TRequest = any, TResponse = any> = (
  * Shape of every callback Nest registers through the adapter: route handlers,
  * middleware, and the not-found handler.
  *
- * Nest always invokes these with three arguments. Adapters must forward a
- * working `next` because the host filter (`@Controller({ host })`) and the
- * version filter call it to skip a non-matching handler, and throw
- * `InternalServerErrorException` when it is missing.
+ * The adapter must invoke them as `(req, res, next)`, where `next` continues
+ * with the next matching middleware or route. Nest relies on it: middleware
+ * calls it to continue the chain, routes of a `@Controller({ host })` call it
+ * when the request host does not match (and the core throws
+ * `InternalServerErrorException` when it is missing), and the handlers
+ * returned by {@link HttpServer.applyVersionFilter} typically call it when the
+ * requested version does not match.
+ *
+ * The callbacks may return a promise. For route handlers it settles once
+ * {@link HttpServer.reply} (or `render`/`redirect`) has been called, so an
+ * adapter for a framework that expects the response to be ready when its
+ * handler returns must await it.
  *
  * @publicApi
  */
@@ -53,42 +65,78 @@ export type RequestHandler<TRequest = any, TResponse = any> = (
  *
  * ### Lifecycle
  *
- * 1. `NestFactory.create()` calls {@link HttpServer.initHttpServer} so that
+ * 1. `NestFactory.create()` awaits {@link HttpServer.init} before scanning the
+ *    module graph, then constructs the application, which calls
+ *    {@link HttpServer.initHttpServer} so that
  *    {@link HttpServer.getHttpServer} returns a native server before
- *    `app.init()` runs.
+ *    `app.init()` runs. `TestingModule.createNestApplication()` only
+ *    constructs the application, so it skips that first `init()` call.
  * 2. `app.init()` applies the `cors` option through
- *    {@link HttpServer.enableCors}, then awaits {@link HttpServer.init}, then
+ *    {@link HttpServer.enableCors}, awaits {@link HttpServer.init} again and
  *    calls {@link HttpServer.registerParserMiddleware} (unless
- *    `bodyParser: false`), then registers middleware through
- *    {@link HttpServer.createMiddlewareFactory}, then routes through the
- *    verb methods, and finally {@link HttpServer.setNotFoundHandler} and
- *    {@link HttpServer.setErrorHandler}.
- * 3. `app.listen()` calls {@link HttpServer.listen}.
- * 4. `app.close()` calls {@link HttpServer.beforeClose} before the shutdown
- *    hooks run, and {@link HttpServer.close} after every module has been
- *    disposed.
+ *    `bodyParser: false`). It then connects the WebSocket gateways (which
+ *    share the native server unless they set their own port), registers
+ *    middleware through {@link HttpServer.createMiddlewareFactory} and routes
+ *    through the verb methods, and runs the `OnModuleInit` hooks. Only then
+ *    does it call {@link HttpServer.setNotFoundHandler} and
+ *    {@link HttpServer.setErrorHandler}, before the `OnApplicationBootstrap`
+ *    hooks run.
+ * 3. `app.listen()` runs `app.init()` if that has not happened yet, then calls
+ *    {@link HttpServer.listen}.
+ * 4. `app.close()` awaits {@link HttpServer.beforeClose}, runs the
+ *    `OnModuleDestroy` and `BeforeApplicationShutdown` hooks, closes the
+ *    WebSocket gateways and the microservice clients, awaits
+ *    {@link HttpServer.close}, closes the connected microservices, and
+ *    finally runs the `OnApplicationShutdown` hooks.
  *
  * ### Requirements on the request, response and server objects
  *
- * The core treats `TRequest` and `TResponse` as opaque and always goes
- * through the adapter, with two exceptions that an implementation must be
- * aware of:
+ * Responses are written through the adapter, but the core also accesses the
+ * framework objects directly:
  *
- * - Server-Sent Events (`@Sse()`) write straight to the response object as a
- *   Node.js writable stream (`writeHead`, `write`, `end`, `writableEnded`) and
- *   read `request.socket` to detect client disconnects. `TResponse` must
- *   therefore be, or wrap and expose, a Node.js `ServerResponse`, and
- *   `TRequest` an `IncomingMessage`.
+ * - The route parameter decorators read properties of `TRequest`, so the
+ *   adapter must make sure they are set by the time a route handler runs
+ *   when the framework does not provide them: `body` (`@Body()`), `params`
+ *   (`@Param()`), `query` (`@Query()`), `headers` keyed by lower-case name
+ *   (`@Headers()`), `ip` (`@Ip()`) and, with the `rawBody` option, `rawBody`
+ *   (`@RawBody()`). `session`, `file` and `files` (`@Session()`,
+ *   `@UploadedFile()`, `@UploadedFiles()`) are usually set by third-party
+ *   middleware.
+ * - The core attaches its own properties to `TRequest`: `hosts` for
+ *   `@HostParam()`, the context id of request-scoped providers, and the abort
+ *   controller of `@Sse()` routes, so the request has to be an extensible
+ *   object. Request-scoped providers share one context between middleware
+ *   and the route handler only if both receive the same request object, or if
+ *   the handler's request exposes the middleware's one as `raw`.
+ * - Server-Sent Events (`@Sse()`) write straight to the Node.js response as a
+ *   writable stream (`writeHead`, `write`, `end`, `writableEnded`) and watch
+ *   `request.socket` to detect client disconnects. The core uses `res.raw`
+ *   and `req.raw` when present, and the objects themselves otherwise, so they
+ *   must be or expose a Node.js `ServerResponse` and `IncomingMessage`.
  * - The value returned by {@link HttpServer.getHttpServer} must behave like a
  *   Node.js `net.Server`: `app.listen()` subscribes to its `'error'` event and
  *   reads `address()`, and the WebSocket adapters attach to it.
  *
  * ### Optional members
  *
- * Members marked optional are checked for presence before being called; the
- * fallback behavior is described on each one. Note that `AbstractHttpAdapter`
- * declares several of them abstract, so a class-based adapter has to
- * implement them anyway.
+ * Most members marked optional are checked for presence before being called,
+ * and the fallback behavior is described on each one. The exceptions are
+ * {@link HttpServer.getRequestHostname}, {@link HttpServer.getRequestMethod}
+ * and {@link HttpServer.getRequestUrl}, which the core calls unconditionally
+ * in some code paths, so treat them as required. Note that
+ * `AbstractHttpAdapter` declares several optional members abstract, so a
+ * class-based adapter has to implement them anyway.
+ *
+ * ### Synchronous and asynchronous members
+ *
+ * The core awaits only {@link HttpServer.init},
+ * {@link HttpServer.createMiddlewareFactory}, {@link HttpServer.beforeClose}
+ * and {@link HttpServer.close}, as well as {@link HttpServer.reply} and
+ * {@link HttpServer.render} when the router calls them. Every other member is
+ * called synchronously and a returned promise is ignored. In particular, the
+ * registration methods (`use()`, the verb methods, the parser and CORS
+ * methods, ...) must take effect before they return, or the registration
+ * order the core relies on is lost.
  *
  * @typeParam TRequest - Type of the framework request object handed to
  * handlers and to the `getRequest*` helpers.
@@ -259,6 +307,10 @@ export interface HttpServer<
    * promise in that case. The core additionally subscribes to the `'error'`
    * event of {@link HttpServer.getHttpServer} while binding.
    *
+   * On success, the `app.listen()` promise only resolves if
+   * `getHttpServer().address()` returns a non-null value when the callback
+   * runs; otherwise it stays pending.
+   *
    * @param port Port number, or a string such as a pipe/socket path.
    * @param hostname Optional host to bind to.
    * @param callback Invoked as `(err?)` once listening or on failure.
@@ -266,9 +318,13 @@ export interface HttpServer<
   listen(port: number | string, callback?: () => void): any;
   listen(port: number | string, hostname: string, callback?: () => void): any;
   /**
-   * Sends the final response body. This is the single write path used by the
-   * router for every handler that does not use `@Res()`, and by the built-in
-   * exception filter, so it has to cover the following cases:
+   * Sends the final response body. The router calls it for every handler
+   * that does not take over the response with `@Res()` (without
+   * `passthrough: true`) or `@Next()`, except for `@Render()`, `@Redirect()`
+   * and `@Sse()` handlers, which go through {@link HttpServer.render},
+   * {@link HttpServer.redirect} and the raw response respectively. The
+   * built-in exception filter uses it as well, so it has to cover the
+   * following cases:
    *
    * - `statusCode` provided: apply it before sending.
    * - `body` is `null`/`undefined`: end the response with an empty body.
@@ -280,15 +336,19 @@ export interface HttpServer<
    * - `body` is an object or array: serialize as JSON.
    * - anything else: send `String(body)`.
    *
+   * The router awaits a returned promise, but the exception filter does not,
+   * so an asynchronous implementation must handle its own errors.
+   *
    * @param response Framework response object.
    * @param body Value returned by the route handler (after interceptors).
    * @param statusCode Status to apply, when the router determined one.
    */
   reply(response: any, body: any, statusCode?: number): any;
   /**
-   * Sets the status code without sending the response. Called before the
-   * handler runs with the status derived from `@HttpCode()` or the method
-   * default (`201` for `POST`, `200` otherwise).
+   * Sets the status code without sending the response. Called for every
+   * route once the guards have passed, before the interceptors and the
+   * handler run, with the status derived from `@HttpCode()` or the method
+   * default (`201` for `POST`, `200` otherwise). Not awaited.
    */
   status(response: any, statusCode: number): any;
   /**
@@ -312,12 +372,14 @@ export interface HttpServer<
   /**
    * Reports whether the response headers have already been flushed. The
    * exception layer checks it to decide between {@link HttpServer.reply} and
-   * {@link HttpServer.end}.
+   * {@link HttpServer.end}. It must return a boolean synchronously: the result
+   * is not awaited, and a promise is truthy, so every error response would be
+   * cut short through {@link HttpServer.end}.
    */
   isHeadersSent(response: any): boolean;
   /**
-   * Sets (replaces) a response header; called once per `@Header()` decorator
-   * before the handler runs.
+   * Sets (replaces) a response header; called once per `@Header()` decorator,
+   * right after {@link HttpServer.status}. Not awaited.
    */
   setHeader(response: any, name: string, value: string): any;
   /**
@@ -326,10 +388,15 @@ export interface HttpServer<
    * once, after every route has been registered, and skips it when not
    * implemented.
    *
-   * The handler must be reached by errors thrown from any route or
-   * middleware registered through the adapter. The passed value is first run
-   * through `AbstractHttpAdapter.mapException()` so framework-native errors
-   * can be translated to `HttpException`s.
+   * Errors thrown by the route handlers and middleware that Nest registers
+   * normally don't reach it, because the core already runs them through the
+   * exception filters. The adapter must route every other error to it:
+   * failures of middleware registered directly on the framework (e.g. with
+   * `app.use()`), body-parser errors, and values passed to `next(err)`. The
+   * handler first passes the error to the adapter's `mapException()` so
+   * framework-native errors can be translated to `HttpException`s; that method
+   * is defined by `AbstractHttpAdapter`, so an adapter implementing this
+   * interface directly must provide it too.
    *
    * @param handler The `(err, req, res, next)` callback.
    * @param prefix The global prefix (`app.setGlobalPrefix()`), when set.
@@ -345,7 +412,8 @@ export interface HttpServer<
    * The handler is a {@link RequestHandler} that throws `NotFoundException`
    * through the exception filters, so the adapter only has to make sure it
    * runs after all routes and middleware, and only for requests no route
-   * matched.
+   * matched. It builds its message with {@link HttpServer.getRequestMethod}
+   * and {@link HttpServer.getRequestUrl}, so both must be implemented.
    *
    * @param handler The `(req, res, next)` callback.
    * @param prefix The global prefix (`app.setGlobalPrefix()`), when set.
@@ -382,7 +450,9 @@ export interface HttpServer<
    * `RequestMethod.ALL`, the core already wraps `callback` to skip requests
    * whose {@link HttpServer.getRequestMethod} does not match (treating `HEAD`
    * as `GET`), so a framework that cannot register method-specific middleware
-   * may mount it for every method.
+   * may mount it for every method. Without
+   * {@link HttpServer.getRequestMethod}, that check never matches and such
+   * middleware silently never runs.
    *
    * May return a promise (e.g. when a middleware plugin has to be loaded
    * first); the core awaits it.
@@ -394,20 +464,25 @@ export interface HttpServer<
     | Promise<(path: string, callback: Function) => any>;
   /**
    * Returns the request host name (without port), used to match
-   * `@Controller({ host })`. Required whenever host filtering is used.
+   * `@Controller({ host })`. The core calls it without checking for its
+   * presence, so it is required whenever host filtering is used.
    */
   getRequestHostname?(request: TRequest): string;
   /**
    * Returns the request method as the upper-case verb (`'GET'`, `'HEAD'`,
-   * ...), i.e. a key of the `RequestMethod` enum. Used by the middleware
-   * module to filter by method and by the not-found handler message.
+   * ...), i.e. a key of the `RequestMethod` enum. Effectively required: the
+   * not-found handler and `MiddlewareConsumer.exclude()` call it without
+   * checking for its presence, and without it middleware bound to a specific
+   * method silently never runs.
    */
   getRequestMethod?(request: TRequest): string;
   /**
    * Returns the original request URL, including the query string and
    * independent of any router mount point (Express `req.originalUrl`, not
    * `req.url`). The core strips the query string itself when it needs the
-   * pathname, e.g. to evaluate `MiddlewareConsumer.exclude()`.
+   * pathname, e.g. to evaluate `MiddlewareConsumer.exclude()`. Effectively
+   * required: the not-found handler and `exclude()` call it without checking
+   * for its presence.
    */
   getRequestUrl?(request: TRequest): string;
   /**
@@ -443,7 +518,9 @@ export interface HttpServer<
   getHttpServer(): any;
   /**
    * Creates the native HTTP(S) server so that {@link HttpServer.getHttpServer}
-   * can return it. Called by `NestFactory.create()` before `app.init()`.
+   * can return it. Called once, synchronously, when the application is
+   * constructed (by `NestFactory.create()` or
+   * `TestingModule.createNestApplication()`), before `app.init()`.
    *
    * The adapter is responsible for honoring the relevant application
    * options: `httpsOptions` (create an HTTPS server),
@@ -454,15 +531,19 @@ export interface HttpServer<
   initHttpServer(options: NestApplicationOptions): void;
   /**
    * Stops the server and releases its resources. Called by `app.close()`
-   * after the WebSocket and microservice modules have been closed. May return
-   * a promise; the core awaits it.
+   * after the `OnModuleDestroy` and `BeforeApplicationShutdown` hooks and
+   * after the WebSocket gateways and microservice clients have been closed,
+   * but before connected microservices are closed and the
+   * `OnApplicationShutdown` hooks run. May return a promise; the core awaits
+   * it.
    */
   close(): any;
   /**
-   * Called by `app.close()` **before** the shutdown hooks (`OnModuleDestroy`,
-   * `BeforeApplicationShutdown`, ...) run, so the adapter can flip into a
-   * "shutting down" state, e.g. start answering `503` when
-   * `return503OnClosing` is enabled. May return a promise.
+   * Called by `app.close()` **before** any shutdown hook (`OnModuleDestroy`,
+   * `BeforeApplicationShutdown`, `OnApplicationShutdown`) runs, so the
+   * adapter can flip into a "shutting down" state, e.g. start answering `503`
+   * when `return503OnClosing` is enabled. May return a promise; the core
+   * awaits it.
    */
   beforeClose?(): any;
   /**
@@ -474,10 +555,14 @@ export interface HttpServer<
    */
   getType(): string;
   /**
-   * Asynchronous setup hook. Awaited at the start of `app.init()`, after the
-   * `cors` option has been applied and before the parsers, middleware and
-   * routes are registered. Use it for work that cannot happen in the
-   * constructor, such as loading a plugin.
+   * Asynchronous setup hook for work that cannot happen in the constructor,
+   * such as loading a plugin. It can run twice: `NestFactory.create()` awaits
+   * it before the module graph is scanned (and before
+   * {@link HttpServer.initHttpServer}), and `app.init()` awaits it again after
+   * the `cors` option has been applied and before the parsers, middleware and
+   * routes are registered. `TestingModule.createNestApplication()` only
+   * triggers the second call. Implementations must therefore be idempotent,
+   * e.g. by guarding the work with a flag as `FastifyAdapter` does.
    */
   init?(): Promise<void>;
   /**

--- a/packages/common/interfaces/http/http-server.interface.ts
+++ b/packages/common/interfaces/http/http-server.interface.ts
@@ -5,105 +5,523 @@ import {
   VersioningOptions,
 } from '../version-options.interface.js';
 
+/**
+ * Shape of the error-layer callback that Nest hands to
+ * {@link HttpServer.setErrorHandler}.
+ *
+ * The adapter must invoke it whenever a route handler or middleware
+ * registered through the adapter fails, passing the thrown value first.
+ * `next` may be omitted when the underlying framework has no notion of an
+ * error-continuation callback.
+ *
+ * @publicApi
+ */
 export type ErrorHandler<TRequest = any, TResponse = any> = (
   error: any,
   req: TRequest,
   res: TResponse,
   next?: Function,
 ) => any;
+
+/**
+ * Shape of every callback Nest registers through the adapter: route handlers,
+ * middleware, and the not-found handler.
+ *
+ * Nest always invokes these with three arguments. Adapters must forward a
+ * working `next` because the host filter (`@Controller({ host })`) and the
+ * version filter call it to skip a non-matching handler, and throw
+ * `InternalServerErrorException` when it is missing.
+ *
+ * @publicApi
+ */
 export type RequestHandler<TRequest = any, TResponse = any> = (
   req: TRequest,
   res: TResponse,
   next?: Function,
 ) => any;
 
+/**
+ * Contract between the Nest core (`NestApplication`, the router, the
+ * middleware module and the exception layer) and an HTTP platform such as
+ * Express or Fastify.
+ *
+ * Implementations normally extend `AbstractHttpAdapter` from `@nestjs/core`,
+ * which supplies defaults for the methods that can simply delegate to the
+ * underlying framework instance. This interface is the source of truth for
+ * *when* the core calls each method and *what* it expects back; the class
+ * documents only what it adds on top.
+ *
+ * ### Lifecycle
+ *
+ * 1. `NestFactory.create()` calls {@link HttpServer.initHttpServer} so that
+ *    {@link HttpServer.getHttpServer} returns a native server before
+ *    `app.init()` runs.
+ * 2. `app.init()` applies the `cors` option through
+ *    {@link HttpServer.enableCors}, then awaits {@link HttpServer.init}, then
+ *    calls {@link HttpServer.registerParserMiddleware} (unless
+ *    `bodyParser: false`), then registers middleware through
+ *    {@link HttpServer.createMiddlewareFactory}, then routes through the
+ *    verb methods, and finally {@link HttpServer.setNotFoundHandler} and
+ *    {@link HttpServer.setErrorHandler}.
+ * 3. `app.listen()` calls {@link HttpServer.listen}.
+ * 4. `app.close()` calls {@link HttpServer.beforeClose} before the shutdown
+ *    hooks run, and {@link HttpServer.close} after every module has been
+ *    disposed.
+ *
+ * ### Requirements on the request, response and server objects
+ *
+ * The core treats `TRequest` and `TResponse` as opaque and always goes
+ * through the adapter, with two exceptions that an implementation must be
+ * aware of:
+ *
+ * - Server-Sent Events (`@Sse()`) write straight to the response object as a
+ *   Node.js writable stream (`writeHead`, `write`, `end`, `writableEnded`) and
+ *   read `request.socket` to detect client disconnects. `TResponse` must
+ *   therefore be, or wrap and expose, a Node.js `ServerResponse`, and
+ *   `TRequest` an `IncomingMessage`.
+ * - The value returned by {@link HttpServer.getHttpServer} must behave like a
+ *   Node.js `net.Server`: `app.listen()` subscribes to its `'error'` event and
+ *   reads `address()`, and the WebSocket adapters attach to it.
+ *
+ * ### Optional members
+ *
+ * Members marked optional are checked for presence before being called; the
+ * fallback behavior is described on each one. Note that `AbstractHttpAdapter`
+ * declares several of them abstract, so a class-based adapter has to
+ * implement them anyway.
+ *
+ * @typeParam TRequest - Type of the framework request object handed to
+ * handlers and to the `getRequest*` helpers.
+ * @typeParam TResponse - Type of the framework response object handed to
+ * handlers and to the `reply`/`status`/`setHeader` family.
+ * @typeParam ServerInstance - Type of the framework application instance
+ * returned by {@link HttpServer.getInstance} (e.g. the Express `Application`),
+ * as opposed to the native HTTP server returned by
+ * {@link HttpServer.getHttpServer}.
+ *
+ * @see [HTTP adapter](https://docs.nestjs.com/faq/http-adapter)
+ *
+ * @publicApi
+ */
 export interface HttpServer<
   TRequest = any,
   TResponse = any,
   ServerInstance = any,
 > {
+  /**
+   * Registers a global middleware, optionally mounted under `path`.
+   *
+   * Called by `app.use()`, by the core when registering the parser and
+   * exception layers, and as the fallback route registrar when an optional
+   * HTTP-verb method (e.g. `propfind`) is not implemented, in which case the
+   * route matches every method.
+   *
+   * The handler may be a {@link RequestHandler} or an {@link ErrorHandler};
+   * Express-style adapters distinguish them by arity.
+   */
   use(
     handler:
-      | RequestHandler<TRequest, TResponse>
-      | ErrorHandler<TRequest, TResponse>,
+      RequestHandler<TRequest, TResponse> | ErrorHandler<TRequest, TResponse>,
   ): any;
   use(
     path: string,
     handler:
-      | RequestHandler<TRequest, TResponse>
-      | ErrorHandler<TRequest, TResponse>,
+      RequestHandler<TRequest, TResponse> | ErrorHandler<TRequest, TResponse>,
   ): any;
+  /**
+   * Registers an additional body parser, called by `app.useBodyParser()`.
+   *
+   * The core inserts the application's `rawBody` option as the **second**
+   * argument, so the effective call is
+   * `useBodyParser(type, rawBody, ...userArgs)`. When `rawBody` is `true` the
+   * parser must expose the unparsed payload as `req.rawBody` (see
+   * `RawBodyRequest`).
+   *
+   * When not implemented, `app.useBodyParser()` logs a warning and does
+   * nothing.
+   */
   useBodyParser?(...args: any[]): any;
+  /**
+   * Registers a `GET` route.
+   *
+   * Every verb method receives the already normalized path (see
+   * {@link HttpServer.normalizePath}) and a {@link RequestHandler} that the
+   * adapter must invoke as `(req, res, next)`. Routes are registered in the
+   * order the core resolves them; see
+   * {@link HttpServer.isRouteOrderSensitive}.
+   */
   get(handler: RequestHandler<TRequest, TResponse>): any;
   get(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `POST` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   post(handler: RequestHandler<TRequest, TResponse>): any;
   post(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `HEAD` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   head(handler: RequestHandler<TRequest, TResponse>): any;
   head(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `DELETE` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   delete(handler: RequestHandler<TRequest, TResponse>): any;
   delete(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `PUT` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   put(handler: RequestHandler<TRequest, TResponse>): any;
   put(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `PATCH` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   patch(handler: RequestHandler<TRequest, TResponse>): any;
   patch(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `PROPFIND` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   propfind?(handler: RequestHandler<TRequest, TResponse>): any;
   propfind?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `PROPPATCH` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   proppatch?(handler: RequestHandler<TRequest, TResponse>): any;
   proppatch?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `MKCOL` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   mkcol?(handler: RequestHandler<TRequest, TResponse>): any;
   mkcol?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `COPY` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   copy?(handler: RequestHandler<TRequest, TResponse>): any;
   copy?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `MOVE` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   move?(handler: RequestHandler<TRequest, TResponse>): any;
   move?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `LOCK` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   lock?(handler: RequestHandler<TRequest, TResponse>): any;
   lock?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a WebDAV `UNLOCK` route. Optional: when not implemented the
+   * core falls back to {@link HttpServer.use}, which matches every method.
+   */
   unlock?(handler: RequestHandler<TRequest, TResponse>): any;
   unlock?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a route for every HTTP method (`@All()`). See
+   * {@link HttpServer.get} for the handler contract.
+   */
   all(path: string, handler: RequestHandler<TRequest, TResponse>): any;
   all(handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers an `OPTIONS` route. See {@link HttpServer.get} for the handler
+   * contract.
+   */
   options(handler: RequestHandler<TRequest, TResponse>): any;
   options(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `SEARCH` route. Optional: when not implemented the core falls
+   * back to {@link HttpServer.use}, which matches every method.
+   */
   search?(handler: RequestHandler<TRequest, TResponse>): any;
   search?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Registers a `QUERY` route. Optional: when not implemented the core falls
+   * back to {@link HttpServer.use}, which matches every method.
+   */
   query?(handler: RequestHandler<TRequest, TResponse>): any;
   query?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+  /**
+   * Starts accepting connections; called by `app.listen()` once the
+   * application has been initialized.
+   *
+   * The core always appends its own callback as the **last** argument, and
+   * strips any callback the user passed to `app.listen()`. The adapter must
+   * invoke that callback once the server is listening, or with an `Error` as
+   * first argument when it failed to bind; the core rejects the `listen()`
+   * promise in that case. The core additionally subscribes to the `'error'`
+   * event of {@link HttpServer.getHttpServer} while binding.
+   *
+   * @param port Port number, or a string such as a pipe/socket path.
+   * @param hostname Optional host to bind to.
+   * @param callback Invoked as `(err?)` once listening or on failure.
+   */
   listen(port: number | string, callback?: () => void): any;
   listen(port: number | string, hostname: string, callback?: () => void): any;
+  /**
+   * Sends the final response body. This is the single write path used by the
+   * router for every handler that does not use `@Res()`, and by the built-in
+   * exception filter, so it has to cover the following cases:
+   *
+   * - `statusCode` provided: apply it before sending.
+   * - `body` is `null`/`undefined`: end the response with an empty body.
+   * - `body` is a `StreamableFile`: set `Content-Type`, `Content-Disposition`
+   *   and `Content-Length` from `body.getHeaders()` unless already present,
+   *   pipe `body.getStream()` into the response, route stream errors to
+   *   `body.errorHandler(err, response)` and log write errors through
+   *   `body.errorLogger(err)`.
+   * - `body` is an object or array: serialize as JSON.
+   * - anything else: send `String(body)`.
+   *
+   * @param response Framework response object.
+   * @param body Value returned by the route handler (after interceptors).
+   * @param statusCode Status to apply, when the router determined one.
+   */
   reply(response: any, body: any, statusCode?: number): any;
+  /**
+   * Sets the status code without sending the response. Called before the
+   * handler runs with the status derived from `@HttpCode()` or the method
+   * default (`201` for `POST`, `200` otherwise).
+   */
   status(response: any, statusCode: number): any;
+  /**
+   * Terminates the response, optionally writing `message` first. The
+   * exception layer uses it when {@link HttpServer.isHeadersSent} reports that
+   * a reply already started, so the adapter must not attempt to set headers
+   * or a status here.
+   */
   end(response: any, message?: string): any;
+  /**
+   * Renders a view template; called for handlers decorated with `@Render()`
+   * with the (awaited) handler result as `options`.
+   */
   render(response: any, view: string, options: any): any;
+  /**
+   * Issues a redirect; called for handlers decorated with `@Redirect()`.
+   * `statusCode` is always provided (defaults to `302`), and `url` may come
+   * from the handler result `{ url, statusCode }` overriding the decorator.
+   */
   redirect(response: any, statusCode: number, url: string): any;
+  /**
+   * Reports whether the response headers have already been flushed. The
+   * exception layer checks it to decide between {@link HttpServer.reply} and
+   * {@link HttpServer.end}.
+   */
   isHeadersSent(response: any): boolean;
+  /**
+   * Sets (replaces) a response header; called once per `@Header()` decorator
+   * before the handler runs.
+   */
   setHeader(response: any, name: string, value: string): any;
+  /**
+   * Installs the global exception layer: an {@link ErrorHandler} that
+   * forwards errors to the registered exception filters. The core calls it
+   * once, after every route has been registered, and skips it when not
+   * implemented.
+   *
+   * The handler must be reached by errors thrown from any route or
+   * middleware registered through the adapter. The passed value is first run
+   * through `AbstractHttpAdapter.mapException()` so framework-native errors
+   * can be translated to `HttpException`s.
+   *
+   * @param handler The `(err, req, res, next)` callback.
+   * @param prefix The global prefix (`app.setGlobalPrefix()`), when set.
+   * Routes excluded from the prefix still live at the root, so an adapter that
+   * scopes error handlers by path must cover both.
+   */
   setErrorHandler?(handler: Function, prefix?: string): any;
+  /**
+   * Installs the catch-all handler for unmatched requests. The core calls it
+   * once, after every route has been registered, and skips it when not
+   * implemented.
+   *
+   * The handler is a {@link RequestHandler} that throws `NotFoundException`
+   * through the exception filters, so the adapter only has to make sure it
+   * runs after all routes and middleware, and only for requests no route
+   * matched.
+   *
+   * @param handler The `(req, res, next)` callback.
+   * @param prefix The global prefix (`app.setGlobalPrefix()`), when set.
+   */
   setNotFoundHandler?(handler: Function, prefix?: string): any;
+  /**
+   * Serves static files; pass-through for `app.useStaticAssets()`. The
+   * arguments are platform-specific. When not implemented,
+   * `app.useStaticAssets()` silently does nothing.
+   */
   useStaticAssets?(...args: any[]): this;
+  /**
+   * Sets the directory (or directories) where view templates live;
+   * pass-through for `app.setBaseViewsDir()`. When not implemented,
+   * `app.setBaseViewsDir()` silently does nothing.
+   */
   setBaseViewsDir?(path: string | string[]): this;
+  /**
+   * Configures the template engine used by {@link HttpServer.render};
+   * pass-through for `app.setViewEngine()`. The argument is
+   * platform-specific (an engine name for Express, an options object for
+   * Fastify). When not implemented, `app.setViewEngine()` silently does
+   * nothing.
+   */
   setViewEngine?(engineOrOptions: any): this;
+  /**
+   * Returns a function the middleware module uses to mount Nest middleware
+   * (`MiddlewareConsumer`) for one HTTP method.
+   *
+   * The returned function is called as `(path, callback)` once per route
+   * path the middleware applies to, where `callback` is a
+   * {@link RequestHandler} that calls `next()` to continue the chain. The core
+   * passes `/` for empty or root paths. When `method` is not
+   * `RequestMethod.ALL`, the core already wraps `callback` to skip requests
+   * whose {@link HttpServer.getRequestMethod} does not match (treating `HEAD`
+   * as `GET`), so a framework that cannot register method-specific middleware
+   * may mount it for every method.
+   *
+   * May return a promise (e.g. when a middleware plugin has to be loaded
+   * first); the core awaits it.
+   */
   createMiddlewareFactory(
     method: RequestMethod,
   ):
     | ((path: string, callback: Function) => any)
     | Promise<(path: string, callback: Function) => any>;
+  /**
+   * Returns the request host name (without port), used to match
+   * `@Controller({ host })`. Required whenever host filtering is used.
+   */
   getRequestHostname?(request: TRequest): string;
+  /**
+   * Returns the request method as the upper-case verb (`'GET'`, `'HEAD'`,
+   * ...), i.e. a key of the `RequestMethod` enum. Used by the middleware
+   * module to filter by method and by the not-found handler message.
+   */
   getRequestMethod?(request: TRequest): string;
+  /**
+   * Returns the original request URL, including the query string and
+   * independent of any router mount point (Express `req.originalUrl`, not
+   * `req.url`). The core strips the query string itself when it needs the
+   * pathname, e.g. to evaluate `MiddlewareConsumer.exclude()`.
+   */
   getRequestUrl?(request: TRequest): string;
+  /**
+   * Returns the framework application instance (e.g. the Express
+   * `Application`) that the adapter delegates to. Exposed to users through
+   * `app.getHttpAdapter().getInstance()`.
+   */
   getInstance(): ServerInstance;
+  /**
+   * Registers the default body parsers. Called once during `app.init()`
+   * unless the application was created with `bodyParser: false`, as
+   * `registerParserMiddleware(globalPrefix, rawBody)`.
+   *
+   * Implementations should register JSON and URL-encoded parsers, and, when
+   * `rawBody` is `true`, expose the unparsed payload as `req.rawBody` (see
+   * `RawBodyRequest`). Because users may register the same parsers
+   * beforehand, this should be idempotent.
+   */
   registerParserMiddleware(...args: any[]): any;
+  /**
+   * Enables CORS. Called by `app.enableCors(options)` and during
+   * `app.init()` when the `cors` application option is set; `options` is
+   * then either the `CorsOptions`/delegate the user provided, or `undefined`
+   * for `cors: true`.
+   */
   enableCors(options: any): any;
+  /**
+   * Returns the native HTTP server created by
+   * {@link HttpServer.initHttpServer}. It must behave like a Node.js
+   * `net.Server` (`listen`, `close`, `address`, `on('error')`), since
+   * `app.listen()` and the WebSocket adapters use it directly.
+   */
   getHttpServer(): any;
+  /**
+   * Creates the native HTTP(S) server so that {@link HttpServer.getHttpServer}
+   * can return it. Called by `NestFactory.create()` before `app.init()`.
+   *
+   * The adapter is responsible for honoring the relevant application
+   * options: `httpsOptions` (create an HTTPS server),
+   * `forceCloseConnections` (track sockets so {@link HttpServer.close} can
+   * destroy them) and `return503OnClosing` (reject requests once
+   * {@link HttpServer.beforeClose} ran).
+   */
   initHttpServer(options: NestApplicationOptions): void;
+  /**
+   * Stops the server and releases its resources. Called by `app.close()`
+   * after the WebSocket and microservice modules have been closed. May return
+   * a promise; the core awaits it.
+   */
   close(): any;
+  /**
+   * Called by `app.close()` **before** the shutdown hooks (`OnModuleDestroy`,
+   * `BeforeApplicationShutdown`, ...) run, so the adapter can flip into a
+   * "shutting down" state, e.g. start answering `503` when
+   * `return503OnClosing` is enabled. May return a promise.
+   */
   beforeClose?(): any;
+  /**
+   * Returns a stable identifier for the platform (`'express'`, `'fastify'`).
+   * The core does not read it, but ecosystem packages (e.g. `@nestjs/swagger`,
+   * `@nestjs/serve-static`) branch on it to pick platform-specific code
+   * paths, so custom adapters wrapping one of the built-in frameworks should
+   * return the matching value.
+   */
   getType(): string;
+  /**
+   * Asynchronous setup hook. Awaited at the start of `app.init()`, after the
+   * `cors` option has been applied and before the parsers, middleware and
+   * routes are registered. Use it for work that cannot happen in the
+   * constructor, such as loading a plugin.
+   */
   init?(): Promise<void>;
+  /**
+   * Wraps a route handler so that it only runs for requests carrying a
+   * matching version. Called once per versioned route for the `HEADER`,
+   * `MEDIA_TYPE` and `CUSTOM` versioning types; URI versioning is expressed
+   * in the path and never reaches this method.
+   *
+   * Two strategies are valid:
+   * - return a `(req, res, next)` function that extracts the requested
+   *   version, invokes `handler` when it matches and calls `next()` otherwise
+   *   (Express), or
+   * - return `handler` itself, annotated so the framework's own routing can
+   *   apply the constraint (Fastify).
+   *
+   * @param handler The route handler to guard.
+   * @param version Version(s) the route serves: a string, an array of
+   * strings, or `VERSION_NEUTRAL`. An array may include `VERSION_NEUTRAL`,
+   * meaning the route also serves requests that carry no version.
+   * @param versioningOptions The options passed to `app.enableVersioning()`.
+   */
   applyVersionFilter(
     handler: Function,
     version: VersionValue,
     versioningOptions: VersioningOptions,
   ): (req: TRequest, res: TResponse, next: () => void) => Function;
+  /**
+   * Converts a Nest route path into the syntax the underlying router
+   * expects, and validates it. Called once per route path (already prefixed
+   * and versioned) before it is handed to a verb method; should throw when
+   * the path is invalid so misconfigured routes fail at startup. When not
+   * implemented the path is used verbatim.
+   */
   normalizePath?(path: string): string;
+  /**
+   * Tells the core whether the underlying router picks the **first**
+   * registered route that matches (`true`, e.g. Express) or the most specific
+   * one regardless of order (`false`, e.g. Fastify). Defaults to `true` when
+   * not implemented.
+   *
+   * When `true` and the `specificity` route resolution strategy is enabled,
+   * the core sorts routes before registering them. A `false` value is
+   * currently also taken to mean that the router rejects duplicate
+   * `(method, path)` registrations itself.
+   */
   isRouteOrderSensitive?(): boolean;
 }

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -29,11 +29,12 @@ import type { NestApplicationOptions } from '@nestjs/common';
  * not declared on this class; implement them when the platform supports
  * them (see {@link HttpServer} for what the core does when they are absent).
  *
- * Keep in mind that the router writes Server-Sent Events directly to the
- * response object as a Node.js writable stream and reads `request.socket`,
- * and that `app.listen()` and the WebSocket adapters use the value returned
- * by {@link AbstractHttpAdapter.getHttpServer} as a Node.js `net.Server`;
- * see the {@link HttpServer} documentation for details.
+ * Keep in mind that the core also reads and writes properties of the request
+ * object (`body`, `params`, `query`, `headers`, ...), that Server-Sent Events
+ * write directly to the Node.js response, and that `app.listen()` and the
+ * WebSocket adapters use the value returned by
+ * {@link AbstractHttpAdapter.getHttpServer} as a Node.js `net.Server`; see the
+ * {@link HttpServer} documentation for details.
  *
  * @typeParam TServer - Type of the native HTTP server stored in `httpServer`
  * (e.g. `http.Server | https.Server`).
@@ -69,8 +70,8 @@ export abstract class AbstractHttpAdapter<
   constructor(protected instance?: any) {}
 
   /**
-   * Asynchronous setup hook awaited at the start of `app.init()`. No-op by
-   * default.
+   * Asynchronous setup hook, awaited by `NestFactory.create()` and again by
+   * `app.init()`, so overrides must be idempotent. No-op by default.
    *
    * @see {@link HttpServer.init}
    */
@@ -422,7 +423,7 @@ export abstract class AbstractHttpAdapter<
   /**
    * Creates the native server and stores it in `httpServer`, honoring the
    * `httpsOptions`, `forceCloseConnections` and `return503OnClosing`
-   * application options. Called by `NestFactory.create()`.
+   * application options. Called once when the application is constructed.
    *
    * @see {@link HttpServer.initHttpServer}
    */
@@ -503,7 +504,8 @@ export abstract class AbstractHttpAdapter<
    */
   abstract setNotFoundHandler(handler: Function, prefix?: string);
   /**
-   * Reports whether response headers have already been flushed.
+   * Reports whether response headers have already been flushed. Must return
+   * synchronously.
    *
    * @see {@link HttpServer.isHeadersSent}
    */

--- a/packages/core/adapters/http-adapter.ts
+++ b/packages/core/adapters/http-adapter.ts
@@ -7,6 +7,41 @@ import type { RequestHandler, VersionValue } from '@nestjs/common/internal';
 import type { NestApplicationOptions } from '@nestjs/common';
 
 /**
+ * Base class for HTTP platform adapters (see `ExpressAdapter` and
+ * `FastifyAdapter` for reference implementations).
+ *
+ * It implements the {@link HttpServer} contract that the Nest core relies on,
+ * and that interface is where each method's calling conventions are
+ * documented: when the core invokes it, with which arguments, and what it
+ * expects back. This class only adds:
+ *
+ * - default implementations that delegate to the wrapped framework
+ *   `instance` (`use()`, the HTTP-verb methods, `listen()`) or are inert
+ *   (`init()`, `normalizePath()`, `mapException()`, `beforeClose()`, the
+ *   `setOn*Hook()` setters);
+ * - storage for the native server (`httpServer`) and the framework instance
+ *   (`instance`), with their accessors;
+ * - the introspection hooks used by instrumentation tooling.
+ *
+ * Every remaining {@link HttpServer} member is declared abstract here, even
+ * the ones the interface marks optional, so subclasses cannot forget them.
+ * `setBaseViewsDir()`, `useBodyParser()` and `isRouteOrderSensitive()` are
+ * not declared on this class; implement them when the platform supports
+ * them (see {@link HttpServer} for what the core does when they are absent).
+ *
+ * Keep in mind that the router writes Server-Sent Events directly to the
+ * response object as a Node.js writable stream and reads `request.socket`,
+ * and that `app.listen()` and the WebSocket adapters use the value returned
+ * by {@link AbstractHttpAdapter.getHttpServer} as a Node.js `net.Server`;
+ * see the {@link HttpServer} documentation for details.
+ *
+ * @typeParam TServer - Type of the native HTTP server stored in `httpServer`
+ * (e.g. `http.Server | https.Server`).
+ * @typeParam TRequest - Type of the framework request object.
+ * @typeParam TResponse - Type of the framework response object.
+ *
+ * @see [HTTP adapter](https://docs.nestjs.com/faq/http-adapter)
+ *
  * @publicApi
  */
 export abstract class AbstractHttpAdapter<
@@ -14,193 +49,522 @@ export abstract class AbstractHttpAdapter<
   TRequest = any,
   TResponse = any,
 > implements HttpServer<TRequest, TResponse> {
+  /**
+   * Native HTTP server created by {@link AbstractHttpAdapter.initHttpServer}
+   * and returned by {@link AbstractHttpAdapter.getHttpServer}.
+   */
   protected httpServer: TServer;
+  /**
+   * Callback registered through
+   * {@link AbstractHttpAdapter.setOnRouteTriggered}, if any.
+   */
   protected onRouteTriggered:
-    | ((requestMethod: RequestMethod, path: string) => void)
-    | undefined;
+    ((requestMethod: RequestMethod, path: string) => void) | undefined;
 
+  /**
+   * @param instance The framework application instance to delegate to (e.g.
+   * an Express `Application`). Subclasses typically create a default one
+   * when none is given.
+   */
   constructor(protected instance?: any) {}
 
+  /**
+   * Asynchronous setup hook awaited at the start of `app.init()`. No-op by
+   * default.
+   *
+   * @see {@link HttpServer.init}
+   */
   public async init() {}
 
+  /**
+   * Registers a global middleware by delegating to `instance.use(...args)`.
+   *
+   * @see {@link HttpServer.use}
+   */
   public use(...args: any[]) {
     return this.instance.use(...args);
   }
 
+  /**
+   * Registers a `GET` route by delegating to `instance.get(...args)`.
+   *
+   * @see {@link HttpServer.get}
+   */
   public get(handler: RequestHandler);
   public get(path: any, handler: RequestHandler);
   public get(...args: any[]) {
     return this.instance.get(...args);
   }
 
+  /**
+   * Registers a `POST` route by delegating to `instance.post(...args)`.
+   *
+   * @see {@link HttpServer.post}
+   */
   public post(handler: RequestHandler);
   public post(path: any, handler: RequestHandler);
   public post(...args: any[]) {
     return this.instance.post(...args);
   }
 
+  /**
+   * Registers a `HEAD` route by delegating to `instance.head(...args)`.
+   *
+   * @see {@link HttpServer.head}
+   */
   public head(handler: RequestHandler);
   public head(path: any, handler: RequestHandler);
   public head(...args: any[]) {
     return this.instance.head(...args);
   }
 
+  /**
+   * Registers a `DELETE` route by delegating to `instance.delete(...args)`.
+   *
+   * @see {@link HttpServer.delete}
+   */
   public delete(handler: RequestHandler);
   public delete(path: any, handler: RequestHandler);
   public delete(...args: any[]) {
     return this.instance.delete(...args);
   }
 
+  /**
+   * Registers a `PUT` route by delegating to `instance.put(...args)`.
+   *
+   * @see {@link HttpServer.put}
+   */
   public put(handler: RequestHandler);
   public put(path: any, handler: RequestHandler);
   public put(...args: any[]) {
     return this.instance.put(...args);
   }
 
+  /**
+   * Registers a `PATCH` route by delegating to `instance.patch(...args)`.
+   *
+   * @see {@link HttpServer.patch}
+   */
   public patch(handler: RequestHandler);
   public patch(path: any, handler: RequestHandler);
   public patch(...args: any[]) {
     return this.instance.patch(...args);
   }
 
+  /**
+   * Registers a WebDAV `PROPFIND` route by delegating to
+   * `instance.propfind(...args)`. Override when the framework exposes the
+   * verb under a different API.
+   *
+   * @see {@link HttpServer.propfind}
+   */
   public propfind(handler: RequestHandler);
   public propfind(path: any, handler: RequestHandler);
   public propfind(...args: any[]) {
     return this.instance.propfind(...args);
   }
 
+  /**
+   * Registers a WebDAV `PROPPATCH` route by delegating to
+   * `instance.proppatch(...args)`. Override when the framework exposes the
+   * verb under a different API.
+   *
+   * @see {@link HttpServer.proppatch}
+   */
   public proppatch(handler: RequestHandler);
   public proppatch(path: any, handler: RequestHandler);
   public proppatch(...args: any[]) {
     return this.instance.proppatch(...args);
   }
 
+  /**
+   * Registers a WebDAV `MKCOL` route by delegating to
+   * `instance.mkcol(...args)`. Override when the framework exposes the verb
+   * under a different API.
+   *
+   * @see {@link HttpServer.mkcol}
+   */
   public mkcol(handler: RequestHandler);
   public mkcol(path: any, handler: RequestHandler);
   public mkcol(...args: any[]) {
     return this.instance.mkcol(...args);
   }
 
+  /**
+   * Registers a WebDAV `COPY` route by delegating to
+   * `instance.copy(...args)`. Override when the framework exposes the verb
+   * under a different API.
+   *
+   * @see {@link HttpServer.copy}
+   */
   public copy(handler: RequestHandler);
   public copy(path: any, handler: RequestHandler);
   public copy(...args: any[]) {
     return this.instance.copy(...args);
   }
 
+  /**
+   * Registers a WebDAV `MOVE` route by delegating to
+   * `instance.move(...args)`. Override when the framework exposes the verb
+   * under a different API.
+   *
+   * @see {@link HttpServer.move}
+   */
   public move(handler: RequestHandler);
   public move(path: any, handler: RequestHandler);
   public move(...args: any[]) {
     return this.instance.move(...args);
   }
 
+  /**
+   * Registers a WebDAV `LOCK` route by delegating to
+   * `instance.lock(...args)`. Override when the framework exposes the verb
+   * under a different API.
+   *
+   * @see {@link HttpServer.lock}
+   */
   public lock(handler: RequestHandler);
   public lock(path: any, handler: RequestHandler);
   public lock(...args: any[]) {
     return this.instance.lock(...args);
   }
 
+  /**
+   * Registers a WebDAV `UNLOCK` route by delegating to
+   * `instance.unlock(...args)`. Override when the framework exposes the verb
+   * under a different API.
+   *
+   * @see {@link HttpServer.unlock}
+   */
   public unlock(handler: RequestHandler);
   public unlock(path: any, handler: RequestHandler);
   public unlock(...args: any[]) {
     return this.instance.unlock(...args);
   }
 
+  /**
+   * Registers a route for every HTTP method by delegating to
+   * `instance.all(...args)`.
+   *
+   * @see {@link HttpServer.all}
+   */
   public all(handler: RequestHandler);
   public all(path: any, handler: RequestHandler);
   public all(...args: any[]) {
     return this.instance.all(...args);
   }
 
+  /**
+   * Registers a `SEARCH` route by delegating to `instance.search(...args)`.
+   * Override when the framework exposes the verb under a different API.
+   *
+   * @see {@link HttpServer.search}
+   */
   public search(handler: RequestHandler);
   public search(path: any, handler: RequestHandler);
   public search(...args: any[]) {
     return this.instance.search(...args);
   }
 
+  /**
+   * Registers a `QUERY` route by delegating to `instance.query(...args)`.
+   * Override when the framework exposes the verb under a different API.
+   *
+   * @see {@link HttpServer.query}
+   */
   public query(handler: RequestHandler);
   public query(path: any, handler: RequestHandler);
   public query(...args: any[]) {
     return this.instance.query(...args);
   }
 
+  /**
+   * Registers an `OPTIONS` route by delegating to
+   * `instance.options(...args)`.
+   *
+   * @see {@link HttpServer.options}
+   */
   public options(handler: RequestHandler);
   public options(path: any, handler: RequestHandler);
   public options(...args: any[]) {
     return this.instance.options(...args);
   }
 
+  /**
+   * Starts listening by delegating to
+   * `instance.listen(port, hostname, callback)`. The core always passes its
+   * own callback as the last argument and expects it to be invoked once the
+   * server is bound, or with an `Error` on failure. Override when the
+   * framework instance does not expose a Node-style `listen()`, e.g. to call
+   * `httpServer.listen()` instead.
+   *
+   * @see {@link HttpServer.listen}
+   */
   public listen(port: string | number, callback?: () => void);
   public listen(port: string | number, hostname: string, callback?: () => void);
   public listen(port: any, hostname?: any, callback?: any) {
     return this.instance.listen(port, hostname, callback);
   }
 
+  /**
+   * Returns the native HTTP server stored by
+   * {@link AbstractHttpAdapter.initHttpServer} (or
+   * {@link AbstractHttpAdapter.setHttpServer}).
+   *
+   * @see {@link HttpServer.getHttpServer}
+   */
   public getHttpServer(): TServer {
     return this.httpServer;
   }
 
+  /**
+   * Replaces the native HTTP server returned by
+   * {@link AbstractHttpAdapter.getHttpServer}. Mostly useful for tests and
+   * for adapters that obtain the server from elsewhere.
+   */
   public setHttpServer(httpServer: TServer) {
     this.httpServer = httpServer;
   }
 
+  /**
+   * Replaces the framework application instance that the default method
+   * implementations delegate to.
+   */
   public setInstance<T = any>(instance: T) {
     this.instance = instance;
   }
 
+  /**
+   * Returns the framework application instance passed to the constructor
+   * (or set through {@link AbstractHttpAdapter.setInstance}).
+   *
+   * @see {@link HttpServer.getInstance}
+   */
   public getInstance<T = any>(): T {
     return this.instance as T;
   }
 
+  /**
+   * Converts and validates a route path before registration. Returns the
+   * path unchanged by default; override to translate Nest's path syntax to
+   * the router's and to throw on invalid paths.
+   *
+   * @see {@link HttpServer.normalizePath}
+   */
   public normalizePath(path: string): string {
     return path;
   }
 
+  /**
+   * Registers a callback that the router invokes right before each route
+   * handler runs, with the resolved `RequestMethod` and the route path as
+   * declared (before {@link AbstractHttpAdapter.normalizePath}). The router
+   * wraps every handler at registration time, so the callback must be set
+   * before `app.init()` to take effect. Intended for instrumentation and
+   * devtools; there is no need to override it.
+   */
   public setOnRouteTriggered(
     onRouteTriggered: (requestMethod: RequestMethod, path: string) => void,
   ) {
     this.onRouteTriggered = onRouteTriggered;
   }
 
+  /**
+   * Returns the callback registered through
+   * {@link AbstractHttpAdapter.setOnRouteTriggered}, if any. Read by the
+   * router when registering routes.
+   */
   public getOnRouteTriggered() {
     return this.onRouteTriggered;
   }
 
+  /**
+   * Registers a hook to run at the start of every request. No-op by default;
+   * the built-in adapters accept a `(req, res, done) => void | Promise<void>`
+   * function and call `done()` to continue processing. Intended for
+   * instrumentation and devtools.
+   */
   public setOnRequestHook(onRequestHook: Function): void {}
 
+  /**
+   * Registers a hook to run once a response has been sent. No-op by default;
+   * the built-in adapters accept a `(req, res) => void | Promise<void>`
+   * function. Intended for instrumentation and devtools.
+   */
   public setOnResponseHook(onResponseHook: Function): void {}
 
+  /**
+   * Called by `app.close()` before the shutdown hooks run. No-op by default;
+   * override to enter a "shutting down" state.
+   *
+   * @see {@link HttpServer.beforeClose}
+   */
   public beforeClose(): void {}
 
+  /**
+   * Translates a framework-native error into something the exception filters
+   * understand. Invoked by the global exception layer with every error it
+   * receives, before it reaches the filters; the returned value is what the
+   * filters see. Returns the error unchanged by default. The built-in
+   * adapters map, for instance, body-parser `SyntaxError`s to
+   * `BadRequestException`.
+   */
   public mapException(error: unknown): unknown {
     return error;
   }
 
+  /**
+   * Stops the server; called by `app.close()`. May return a promise.
+   *
+   * @see {@link HttpServer.close}
+   */
   abstract close();
+  /**
+   * Creates the native server and stores it in `httpServer`, honoring the
+   * `httpsOptions`, `forceCloseConnections` and `return503OnClosing`
+   * application options. Called by `NestFactory.create()`.
+   *
+   * @see {@link HttpServer.initHttpServer}
+   */
   abstract initHttpServer(options: NestApplicationOptions);
+  /**
+   * Serves static files; pass-through for `app.useStaticAssets()`.
+   *
+   * @see {@link HttpServer.useStaticAssets}
+   */
   abstract useStaticAssets(...args: any[]);
+  /**
+   * Configures the template engine used by
+   * {@link AbstractHttpAdapter.render}; pass-through for
+   * `app.setViewEngine()`.
+   *
+   * @see {@link HttpServer.setViewEngine}
+   */
   abstract setViewEngine(engine: string);
+  /**
+   * Returns the request host name, used for `@Controller({ host })`.
+   *
+   * @see {@link HttpServer.getRequestHostname}
+   */
   abstract getRequestHostname(request: any);
+  /**
+   * Returns the upper-case request method (`'GET'`, `'POST'`, ...).
+   *
+   * @see {@link HttpServer.getRequestMethod}
+   */
   abstract getRequestMethod(request: any);
+  /**
+   * Returns the original request URL, including the query string.
+   *
+   * @see {@link HttpServer.getRequestUrl}
+   */
   abstract getRequestUrl(request: any);
+  /**
+   * Sets the status code without sending the response.
+   *
+   * @see {@link HttpServer.status}
+   */
   abstract status(response: any, statusCode: number);
+  /**
+   * Sends the response body, handling empty bodies, `StreamableFile`,
+   * objects (as JSON) and primitives.
+   *
+   * @see {@link HttpServer.reply}
+   */
   abstract reply(response: any, body: any, statusCode?: number);
+  /**
+   * Terminates the response, optionally writing `message` first.
+   *
+   * @see {@link HttpServer.end}
+   */
   abstract end(response: any, message?: string);
+  /**
+   * Renders a view template (`@Render()`).
+   *
+   * @see {@link HttpServer.render}
+   */
   abstract render(response: any, view: string, options: any);
+  /**
+   * Issues a redirect (`@Redirect()`).
+   *
+   * @see {@link HttpServer.redirect}
+   */
   abstract redirect(response: any, statusCode: number, url: string);
+  /**
+   * Installs the global exception layer.
+   *
+   * @see {@link HttpServer.setErrorHandler}
+   */
   abstract setErrorHandler(handler: Function, prefix?: string);
+  /**
+   * Installs the catch-all handler for unmatched requests.
+   *
+   * @see {@link HttpServer.setNotFoundHandler}
+   */
   abstract setNotFoundHandler(handler: Function, prefix?: string);
+  /**
+   * Reports whether response headers have already been flushed.
+   *
+   * @see {@link HttpServer.isHeadersSent}
+   */
   abstract isHeadersSent(response: any);
+  /**
+   * Reads a response header that was set earlier. Not used by the core
+   * router; part of the base class so ecosystem packages can read headers
+   * through the adapter regardless of the platform.
+   */
   abstract getHeader(response: any, name: string);
+  /**
+   * Sets (replaces) a response header (`@Header()`).
+   *
+   * @see {@link HttpServer.setHeader}
+   */
   abstract setHeader(response: any, name: string, value: string);
+  /**
+   * Appends a value to a response header, turning it into a multi-value
+   * header (e.g. several `Set-Cookie` entries) instead of replacing it. Not
+   * used by the core router; part of the base class so ecosystem packages
+   * can append headers through the adapter regardless of the platform.
+   */
   abstract appendHeader(response: any, name: string, value: string);
+  /**
+   * Registers the default JSON and URL-encoded body parsers, exposing
+   * `req.rawBody` when `rawBody` is `true`.
+   *
+   * @see {@link HttpServer.registerParserMiddleware}
+   */
   abstract registerParserMiddleware(prefix?: string, rawBody?: boolean);
+  /**
+   * Enables CORS. The core currently calls this with `options` only; the
+   * `prefix` parameter is reserved.
+   *
+   * @see {@link HttpServer.enableCors}
+   */
   abstract enableCors(options?: any, prefix?: string);
+  /**
+   * Returns the function used to mount Nest middleware for one HTTP method.
+   * May be asynchronous.
+   *
+   * @see {@link HttpServer.createMiddlewareFactory}
+   */
   abstract createMiddlewareFactory(
     requestMethod: RequestMethod,
   ):
     | ((path: string, callback: Function) => any)
     | Promise<(path: string, callback: Function) => any>;
+  /**
+   * Returns the platform identifier (`'express'`, `'fastify'`) that
+   * ecosystem packages branch on.
+   *
+   * @see {@link HttpServer.getType}
+   */
   abstract getType(): string;
+  /**
+   * Guards a route handler by request version for header, media-type and
+   * custom versioning.
+   *
+   * @see {@link HttpServer.applyVersionFilter}
+   */
   abstract applyVersionFilter(
     handler: Function,
     version: VersionValue,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features): N/A, comments only
- [ ] Docs have been added / updated (for bug fixes / features): N/A, this PR is the (JSDoc) documentation


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation (JSDoc only)

## What is the current behavior?

Issue Number: N/A

`HttpServer` (`@nestjs/common`) and `AbstractHttpAdapter` (`@nestjs/core`) are the contract every HTTP platform adapter implements, but neither has any JSDoc.

We don't plan to maintain more official adapters (#13013, #15524, #15990), and we point people to community packages built on `AbstractHttpAdapter` instead, such as [`@kiyasov/platform-hono`](https://www.npmjs.com/package/@kiyasov/platform-hono). Authors of those packages have to reverse-engineer from the core what each method is called with, when, and what it must do. Several requirements aren't visible from the types at all, for example:

- the route parameter decorators read `req.body`, `req.params`, `req.query`, `req.headers`, `req.ip`, ... directly, so an adapter for a framework whose request object lacks them has to add them;
- `init()` is awaited twice for applications created with `NestFactory.create()`, so it must be idempotent;
- `isHeadersSent()` is not awaited, so an async implementation makes the exception filter cut every error response short;
- `getRequestMethod()` and `getRequestUrl()` are optional in the type but called without a presence check, and without `getRequestMethod()` method-specific middleware silently never runs.


## What is the new behavior?

The goal of this PR is to improve the DX for anyone writing their own HTTP platform adapter: the contract is now documented where they will look for it, in the editor hover of the interface and base class they implement.

- `HttpServer` is the source of truth for the per-method contract. Its top-level JSDoc covers:
  - the lifecycle: which adapter methods `NestFactory.create()`, `app.init()`, `app.listen()` and `app.close()` call, and in which order relative to the lifecycle hooks;
  - what the core expects from the request, response and native server objects (request properties it reads or attaches, SSE writing to the Node.js response, `getHttpServer()` behaving like a `net.Server`);
  - which optional members are effectively required;
  - which members the core awaits, and which must be synchronous.
- Every `HttpServer` member documents when the core calls it, with which arguments, and what happens with its result or when it is missing: the `reply()` cases, the `use()` fallback for unimplemented verbs, the `listen()` callback, the error and not-found handlers, `createMiddlewareFactory()`, `applyVersionFilter()`, `normalizePath()`, `isRouteOrderSensitive()`, `getType()`, and so on.
- `AbstractHttpAdapter` documents only what it adds on top: the default implementations, the stored server and framework instance, the introspection hooks (`setOnRouteTriggered()`, `setOnRequestHook()`, `setOnResponseHook()`), `mapException()`, and `getHeader()`/`appendHeader()`. Each abstract member links back to `HttpServer`.
- `HttpServer`, `RequestHandler` and `ErrorHandler` are tagged `@publicApi`.

Every statement was checked against the current core sources (`NestFactory`, `NestApplication`, `RoutesResolver`, `RouterExplorer`, `RouterExecutionContext`, `RouterResponseController`, `RouteParamsFactory`, `MiddlewareModule`, `BaseExceptionFilter`) and the Express and Fastify adapters.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Comments only. The only non-comment diff is Prettier re-wrapping three union types.


## Other information

Possible follow-ups, left out to keep this PR comment-only:

- `RequestHandler` and `ErrorHandler` are tagged `@publicApi` but aren't exported from the `@nestjs/common` entry point (`RequestHandler` is only in `@nestjs/common/internal`). The same goes for `VersionValue`, which `applyVersionFilter()` needs. Exporting them would be non-breaking.
- Community adapters import deep paths such as `@nestjs/common/interfaces` (e.g. `@kiyasov/platform-hono`), which don't resolve under the `exports` map on `master`. Documenting the supported import paths would help adapter authors.
- A "Writing a custom HTTP adapter" page on docs.nestjs.com. The existing `faq/http-adapter` page is about using `HttpAdapterHost`.
- A reusable adapter conformance test suite, built on the integration tests that already run against Express and Fastify.
